### PR TITLE
Icon format set to PNG by default for Classic UI

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -124,6 +124,7 @@
         <bundle start-level="80">mvn:org.openhab.core/org.openhab.ui.classicui/${project.version}</bundle>
         <config name="org.eclipse.smarthome.classicui">
             defaultSitemap = _default
+            iconType = png
         </config>
     </feature>
 


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>