### PR TITLE
Refactoring of package handling

### DIFF
--- a/bundles/org.openhab.core.karaf/ESH-INF/config/config.xml
+++ b/bundles/org.openhab.core.karaf/ESH-INF/config/config.xml
@@ -6,16 +6,6 @@
         http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
     <config-description uri="system:addons">
-        <parameter name="package" type="text" required="true">
-            <label>Base Package</label>
-            <description>The runtime package to use for this openHAB instance</description>
-            <options>
-                <option value="minimal">Minimal</option>
-                <option value="standard">Standard</option>
-                <option value="demo">Demo</option>
-            </options>
-            <default>standard</default>
-        </parameter>
         <parameter name="remote" type="boolean" required="true">
             <label>Access Remote Repositories</label>
             <description>Defines whether the runtime should access remote repositories for extensions.</description>
@@ -24,11 +14,6 @@
         <parameter name="legacy" type="boolean" required="true">
             <label>Include Legacy 1.x Bindings</label>
             <description>Also allows the installation of 1.x bindings for which there is already a 2.x version available (requires remote repo access).</description>
-            <default>false</default>
-        </parameter>
-        <parameter name="experimental" type="boolean" required="true">
-            <label>Include Experimental Extensions</label>
-            <description>Also allows the installation of extensions that are not (yet) part of the official distribution and need further testing (requires remote repo access).</description>
             <default>false</default>
         </parameter>
     </config-description>

--- a/bundles/org.openhab.core.karaf/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.karaf/META-INF/MANIFEST.MF
@@ -14,7 +14,10 @@ Import-Package: com.google.common.collect,
  org.apache.karaf.shell.api.action.lifecycle,
  org.apache.karaf.shell.support.ansi,
  org.apache.karaf.wrapper,
+ org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.extension,
+ org.openhab.core,
  org.osgi.service.cm,
  org.osgi.service.event,
  org.slf4j
+Bundle-ActivationPolicy: lazy

--- a/bundles/org.openhab.core.karaf/OSGI-INF/featureinstaller.xml
+++ b/bundles/org.openhab.core.karaf/OSGI-INF/featureinstaller.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" configuration-policy="require" modified="modified" name="org.openhab.addons">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" configuration-policy="require" immediate="true" modified="modified" name="org.openhab.addons">
    <implementation class="org.openhab.core.karaf.internal.FeatureInstaller"/>
    <reference bind="setFeaturesService" cardinality="1..1" interface="org.apache.karaf.features.FeaturesService" name="FeaturesService" policy="static" unbind="unsetFeaturesService"/>
    <reference bind="setConfigurationAdmin" cardinality="1..1" interface="org.osgi.service.cm.ConfigurationAdmin" name="ConfigurationAdmin" policy="static" unbind="unsetConfigurationAdmin"/>      
@@ -21,4 +21,5 @@
       <provide interface="org.openhab.core.karaf.internal.FeatureInstaller"/>
       <provide interface="org.osgi.service.cm.ConfigurationListener"/>
    </service>
+   <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
 </scr:component>

--- a/bundles/org.openhab.core.karaf/OSGI-INF/karafextensionservice.xml
+++ b/bundles/org.openhab.core.karaf/OSGI-INF/karafextensionservice.xml
@@ -9,10 +9,11 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.core.karafextension">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.core.karafextension">
    <implementation class="org.openhab.core.karaf.internal.KarafExtensionService"/>
-   <reference bind="setFeaturesService" cardinality="1..1" interface="org.apache.karaf.features.FeaturesService" name="FeaturesService" policy="static" unbind="unsetFeaturesService"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.extension.ExtensionService"/>
    </service>
+   <reference bind="setFeaturesService" cardinality="1..1" interface="org.apache.karaf.features.FeaturesService" name="FeaturesService" policy="static" unbind="unsetFeaturesService"/>
+   <reference bind="setFeatureInstaller" cardinality="1..1" interface="org.openhab.core.karaf.internal.FeatureInstaller" name="FeatureInstaller" policy="static" unbind="unsetFeatureInstaller"/>
 </scr:component>

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/OpenHAB.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/OpenHAB.java
@@ -18,6 +18,13 @@ import org.osgi.framework.FrameworkUtil;
  *
  */
 public class OpenHAB {
+
+    /** the service pid used for the definition of the base package and addons */
+    public static final String ADDONS_SERVICE_PID = "org.openhab.addons";
+
+    /** the configuraton parameter name used for the base package */
+    public static final String CFG_PACKAGE = "package";
+
     /**
      * Returns the current openHAB version, retrieving the information from the core bundle version.
      *

--- a/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
@@ -5,12 +5,15 @@ Bundle-SymbolicName: org.openhab.ui.dashboard
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/dashboardservice.xml
+Service-Component: OSGI-INF/*.xml
 Import-Package: javax.servlet,
  javax.servlet.http,
  org.apache.commons.io,
+ org.openhab.core,
  org.osgi.framework,
+ org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.http,
  org.slf4j
 Export-Package: org.openhab.ui.dashboard
+Bundle-ActivationPolicy: lazy

--- a/bundles/org.openhab.ui.dashboard/OSGI-INF/dashboardservice.xml
+++ b/bundles/org.openhab.ui.dashboard/OSGI-INF/dashboardservice.xml
@@ -13,4 +13,5 @@
    <implementation class="org.openhab.ui.dashboard.internal.DashboardService"/>
    <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unsetHttpService"/>
    <reference bind="addDashboardTile" cardinality="0..n" interface="org.openhab.ui.dashboard.DashboardTile" name="DashboardTile" policy="dynamic" unbind="removeDashboardTile"/>
+   <reference bind="setConfigurationAdmin" cardinality="1..1" interface="org.osgi.service.cm.ConfigurationAdmin" name="ConfigurationAdmin" policy="static" unbind="unsetConfigurationAdmin"/>
 </scr:component>

--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardServlet.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardServlet.java
@@ -9,6 +9,8 @@
 package org.openhab.ui.dashboard.internal;
 
 import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.Set;
 
 import javax.servlet.ServletException;
@@ -16,12 +18,17 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.openhab.core.OpenHAB;
 import org.openhab.ui.dashboard.DashboardTile;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This servlet constructs the main HTML page for the dashboard, listing all DashboardTiles
  * that are registered as a service.
- * 
+ *
  * @author Kai Kreuzer
  *
  */
@@ -29,22 +36,39 @@ public class DashboardServlet extends HttpServlet {
 
     private static final long serialVersionUID = -5154582000538034381L;
 
+    private final Logger logger = LoggerFactory.getLogger(DashboardServlet.class);
+
+    private ConfigurationAdmin configurationAdmin;
+
     private String indexTemplate;
 
     private String entryTemplate;
 
+    private String setupTemplate;
+
     private Set<DashboardTile> tiles;
 
-    public DashboardServlet(String indexTemplate, String entryTemplate, Set<DashboardTile> tiles) {
+    public DashboardServlet(ConfigurationAdmin configurationAdmin, String indexTemplate, String entryTemplate,
+            String setupTemplate, Set<DashboardTile> tiles) {
+        this.configurationAdmin = configurationAdmin;
         this.indexTemplate = indexTemplate;
         this.entryTemplate = entryTemplate;
+        this.setupTemplate = setupTemplate;
         this.tiles = tiles;
     }
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        StringBuilder entries = new StringBuilder();        
-        for(DashboardTile tile : tiles) {
+        if (isSetup()) {
+            serveDashboard(req, resp);
+        } else {
+            serveSetup(req, resp);
+        }
+    }
+
+    private void serveDashboard(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        StringBuilder entries = new StringBuilder();
+        for (DashboardTile tile : tiles) {
             String entry = entryTemplate.replace("<!--name-->", tile.getName());
             entry = entry.replace("<!--url-->", tile.getUrl());
             entry = entry.replace("<!--overlay-->", tile.getOverlay());
@@ -54,5 +78,43 @@ public class DashboardServlet extends HttpServlet {
         resp.setContentType("text/html;charset=UTF-8");
         resp.getWriter().append(indexTemplate.replace("<!--entries-->", entries.toString()));
         resp.getWriter().close();
+    }
+
+    private void serveSetup(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        if (req.getParameter("type") != null) {
+            setPackage(req.getParameter("type"));
+            resp.sendRedirect(req.getRequestURI());
+        } else {
+            resp.setContentType("text/html;charset=UTF-8");
+            resp.getWriter().append(setupTemplate);
+            resp.getWriter().close();
+        }
+    }
+
+    private void setPackage(String parameter) {
+        try {
+            Configuration cfg = configurationAdmin.getConfiguration(OpenHAB.ADDONS_SERVICE_PID);
+            Dictionary<String, Object> props = cfg.getProperties();
+            if (props == null) {
+                props = new Hashtable<>();
+            }
+            props.put(OpenHAB.CFG_PACKAGE, parameter);
+            cfg.setBundleLocation(null);
+            cfg.update(props);
+        } catch (IOException e) {
+            logger.error("Error while accessing the configuration admin: {}", e.getMessage());
+        }
+    }
+
+    private boolean isSetup() {
+        try {
+            Configuration cfg = configurationAdmin.getConfiguration(OpenHAB.ADDONS_SERVICE_PID);
+            if (cfg != null && cfg.getProperties() != null && cfg.getProperties().get(OpenHAB.CFG_PACKAGE) != null) {
+                return true;
+            }
+        } catch (IOException e) {
+            logger.error("Error while accessing the configuration admin: {}", e.getMessage());
+        }
+        return false;
     }
 }

--- a/bundles/org.openhab.ui.dashboard/templates/index.html
+++ b/bundles/org.openhab.ui.dashboard/templates/index.html
@@ -3,6 +3,7 @@
 <head>
 
 <meta charset="utf-8" />
+<meta http-equiv="refresh" content="10">
 <meta name="viewport"
 	content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <title>openHAB</title>

--- a/bundles/org.openhab.ui.dashboard/templates/setup.html
+++ b/bundles/org.openhab.ui.dashboard/templates/setup.html
@@ -1,0 +1,102 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+
+<meta charset="utf-8" />
+<meta name="viewport"
+	content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<title>openHAB 2.0 - Setup</title>
+<link type="text/css" href="fonts/icomoon.css" rel="stylesheet" media="all">
+<link type="text/css" href="bootstrap.min.css" rel="stylesheet"></link>
+<link type="text/css" href="main.css" rel="stylesheet"></link>
+<link rel="shortcut icon" href="favicon.ico" type="image/x-icon"><link>
+</head>
+
+<body>
+    <header>
+        <div class="container">
+            <img src="img/openhab-logo.png" />
+        </div>
+    </header>
+    <section class="container">
+        <h1>Welcome to openHAB 2.0 - Initial Setup</h1>
+        <div class="line">
+            <div class="decorator"></div>
+            <div>
+                <p><br/>Please choose your installation type:</p>
+            </div>
+            <hr />
+        </div>
+        <div class="links row">
+            <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
+                <div class="link" onclick="location.href = 'index?type=minimal'">    
+                    <div class="body">
+                        <div class="overlay">
+                            Minimal
+                        </div>
+                    </div>
+                    <div class="footer">
+                        <p>Core runtime only</p>
+                    </div>
+                </div>
+            </div>
+            <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
+                <div class="link" onclick="location.href = 'index?type=simple'">    
+                    <div class="body">
+                        <div class="overlay">
+                            Simple
+                        </div>
+                    </div>
+                    <div class="footer">
+                        <p>purely UI</p>
+                    </div>
+                </div>
+            </div>
+            <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
+                <div class="link" onclick="location.href = 'index?type=standard'">    
+                    <div class="body">
+                        <div class="overlay">
+                            Standard
+                        </div>
+                    </div>
+                    <div class="footer">
+                        <p>Recommended setup</p>
+                    </div>
+                </div>
+            </div>
+            <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
+                <div class="link" onclick="location.href = 'index?type=expert'">    
+                    <div class="body">
+                        <div class="overlay">
+                            Expert
+                        </div>
+                    </div>
+                    <div class="footer">
+                        <p>Best for 1.x users</p>
+                    </div>
+                </div>
+            </div>
+            <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
+                <div class="link" onclick="location.href = 'index?type=demo'">    
+                    <div class="body">
+                        <div class="overlay">
+                            Demo
+                        </div>
+                    </div>
+                    <div class="footer">
+                        <p>Sample setup</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="line">
+            <div class="decorator"></div>
+            <hr />
+        </div>
+        Getting started? Please refer to the <a href="http://docs.openhab.org/">online documentation</a>.             
+    </section>
+    <footer>
+        <p>www.openHAB.org</p>
+    </footer>
+</body>
+</html>

--- a/bundles/org.openhab.ui.dashboard/web/main.css
+++ b/bundles/org.openhab.ui.dashboard/web/main.css
@@ -79,7 +79,7 @@ section {
     background: linear-gradient(to bottom, rgba(0,0,0,0.65) 0%,rgba(0,0,0,0) 100%);
     opacity: 1;
     z-index: 10;
-    font-size: 80px;
+    font-size: 50px;
     color: white;
     line-height: 150px;
 }

--- a/features/openhab-core-resources/.project
+++ b/features/openhab-core-resources/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>demo-resources</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/features/openhab-core-resources/pom.xml
+++ b/features/openhab-core-resources/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openhab.core</groupId>
+        <artifactId>pom-features</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>openhab-core-resources</artifactId>
+    <packaging>pom</packaging>
+
+    <name>openHAB Core Feature Resources</name>
+    <description>openHAB Core Feature Resources</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifact</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact><file>src/main/resources/addons-minimal.cfg</file><type>cfg</type><classifier>addons-minimal</classifier></artifact>
+                                <artifact><file>src/main/resources/addons-simple.cfg</file><type>cfg</type><classifier>addons-simple</classifier></artifact>
+                                <artifact><file>src/main/resources/addons-standard.cfg</file><type>cfg</type><classifier>addons-standard</classifier></artifact>
+                                <artifact><file>src/main/resources/addons-expert.cfg</file><type>cfg</type><classifier>addons-expert</classifier></artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/features/openhab-core-resources/src/main/resources/.gitattributes
+++ b/features/openhab-core-resources/src/main/resources/.gitattributes
@@ -1,0 +1,6 @@
+*.items linguist-language=Xtend
+*.persist linguist-language=Xtend
+*.sitemap linguist-language=Xtend
+*.things linguist-language=Xtend
+*.map linguist-language=Xtend
+*.cfg linguist-language=INI

--- a/features/openhab-core-resources/src/main/resources/.gitignore
+++ b/features/openhab-core-resources/src/main/resources/.gitignore
@@ -1,0 +1,6 @@
+# This file is only relevant, if you decide to track your configuration in a git repository.
+# If you are going to upload your configuration to GitHub or another public place, be sure to
+# hide your sensitive data, examples may be:
+
+#services/pushover.cfg  # may contain your login credentials
+#things/astro.things    # may contain your physical location

--- a/features/openhab-core-resources/src/main/resources/addons-expert.cfg
+++ b/features/openhab-core-resources/src/main/resources/addons-expert.cfg
@@ -1,0 +1,4 @@
+package = expert
+ui = classic,basic,paper,habpanel,habmin
+misc = restdocs
+transformation = map,regex,xslt

--- a/features/openhab-core-resources/src/main/resources/addons-minimal.cfg
+++ b/features/openhab-core-resources/src/main/resources/addons-minimal.cfg
@@ -1,0 +1,1 @@
+package = minimal

--- a/features/openhab-core-resources/src/main/resources/addons-simple.cfg
+++ b/features/openhab-core-resources/src/main/resources/addons-simple.cfg
@@ -1,0 +1,3 @@
+package = simple
+ui = paper,habpanel
+misc = ruleengine

--- a/features/openhab-core-resources/src/main/resources/addons-standard.cfg
+++ b/features/openhab-core-resources/src/main/resources/addons-standard.cfg
@@ -1,0 +1,3 @@
+package = standard
+ui = basic,paper,habpanel
+misc = restdocs

--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -28,12 +28,14 @@
         <feature>esh-io-javasound</feature>
         <feature>esh-io-webaudio</feature>
         <feature>openhab-runtime-certificate</feature>
+        <feature>openhab-transport-mdns</feature>
         <feature dependency="true">shell</feature>
         <bundle start-level="90">mvn:org.openhab.core/org.openhab.core/${project.version}</bundle>
         <bundle prerequisite="true">mvn:org.apache.karaf.shell/org.apache.karaf.shell.core/${karaf.version}</bundle>
         <bundle prerequisite="true">mvn:org.apache.karaf.wrapper/org.apache.karaf.wrapper.core/${karaf.version}</bundle>
         <bundle>mvn:org.openhab.core/org.openhab.core.karaf/${project.version}</bundle>
         <bundle>mvn:org.openhab.core/org.openhab.io.sound/${project.version}</bundle>
+        <bundle>mvn:org.openhab.core/org.openhab.ui.dashboard/${project.version}</bundle>
         <config name="org.eclipse.smarthome.audio">
             defaultSink = enhancedjavasound
         </config>
@@ -48,20 +50,38 @@
 
     <feature name="openhab-package-minimal" description="openHAB Minimal Package" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-dashboard</feature>
+        <configfile finalname="${openhab.userdata}/etc/org.openhab.addons.cfg" override="true">mvn:${project.groupId}/openhab-core-resources/${project.version}/cfg/addons-minimal</configfile>
+        <config name="org.eclipse.smarthome.links">
+			autoLinks = false
+        </config>
+    </feature>
+
+    <feature name="openhab-package-simple" description="openHAB Simple Package" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <configfile finalname="${openhab.userdata}/etc/org.openhab.addons.cfg" override="true">mvn:${project.groupId}/openhab-core-resources/${project.version}/cfg/addons-simple</configfile>
+        <config name="org.eclipse.smarthome.links">
+			autoLinks = true
+        </config>
     </feature>
 
     <feature name="openhab-package-standard" description="openHAB Standard Package" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-transport-mdns</feature>
-        <feature>openhab-dashboard</feature>
-        <feature>openhab-misc-restdocs</feature>
-        <feature>openhab-ui-paper</feature>
-        <feature>openhab-ui-basic</feature>
-        <feature>openhab-ui-classic</feature>
+        <configfile finalname="${openhab.userdata}/etc/org.openhab.addons.cfg" override="true">mvn:${project.groupId}/openhab-core-resources/${project.version}/cfg/addons-standard</configfile>
+        <config name="org.eclipse.smarthome.links">
+			autoLinks = false
+        </config>
     </feature>
 
-    <feature name="openhab-runtime-compat1x" description="Compatibility layer for openHAB 1 addons" version="${project.version}">
+    <feature name="openhab-package-expert" description="openHAB Expert Package" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>openhab-runtime-compat1x</feature>
+        <configfile finalname="${openhab.userdata}/etc/org.openhab.addons.cfg" override="true">mvn:${project.groupId}/openhab-core-resources/${project.version}/cfg/addons-expert</configfile>
+        <config name="org.eclipse.smarthome.links">
+			autoLinks = false
+        </config>
+    </feature>
+
+    <feature name="openhab-runtime-compat1x" description="Compatibility layer for openHAB 1 add-ons" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>esh-model-item</feature>
         <feature>esh-model-persistence</feature>
@@ -89,22 +109,29 @@
     </feature>
 
     <feature name="openhab-misc-restdocs" description="REST Documentation" version="${project.version}">
-        <feature>esh-base</feature>
+        <feature>openhab-runtime-base</feature>
         <requirement>esh.tp;filter:="(feature=jax-rs-provider-swagger)"</requirement>
-        <feature>openhab-dashboard</feature>
         <bundle>mvn:org.openhab.core/org.openhab.io.rest.docs/${project.version}</bundle>
+    </feature>
+
+    <feature name="openhab-misc-ruleengine" description="Rule Engine (Experimental)" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <feature>esh-automation-api</feature>
+        <feature>esh-automation-commands</feature>
+        <feature>esh-automation-core</feature>
+        <feature>esh-automation-module-core</feature>
+        <feature>esh-automation-module-script</feature>
+        <feature>esh-automation-module-script-defaultscope</feature>
+        <feature>esh-automation-module-timer</feature>
+        <feature>esh-automation-parser-gson</feature>
+        <feature>esh-automation-providers</feature>
+        <feature>esh-automation-rest</feature>
     </feature>
 
     <!-- ui -->
 
-    <feature name="openhab-dashboard" description="Dashboard" version="${project.version}">
-        <feature>esh-base</feature>
-        <bundle>mvn:org.openhab.core/org.openhab.ui.dashboard/${project.version}</bundle>
-    </feature>
-
     <feature name="openhab-ui-basic" description="Basic UI" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-dashboard</feature>
         <feature>esh-ui-basic</feature>
         <feature>esh-ui-icon</feature>
         <feature>esh-ui-iconset-classic</feature>
@@ -117,7 +144,6 @@
 
     <feature name="openhab-ui-classic" description="Classic UI" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-dashboard</feature>
         <feature>esh-ui-classic</feature>
         <feature>esh-ui-icon</feature>
         <feature>esh-ui-iconset-classic</feature>
@@ -129,7 +155,6 @@
 
     <feature name="openhab-ui-paper" description="Paper UI" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>openhab-dashboard</feature>
         <feature>esh-ui-paper</feature>
         <bundle start-level="80">mvn:org.openhab.core/org.openhab.ui.paperui/${project.version}</bundle>
     </feature>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -15,6 +15,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>openhab-core-resources</module>
         <module>openhab-core</module>
         <module>openhab-esh-addons</module>
         <module>verify-karaf</module>


### PR DESCRIPTION
* adapted FeatureInstaller to adapt addons info in ConfigAdmin, so that this info is stored in a file
* removed experimental features
* removed package selection from UI as it is meant to be only set once
* introduced new packages: minimal, simple and expert
* introduced a setup page on the dashboard, if no package is set (and thus openHAB is uninitialized)
* added auto-refresh of dashboard to have new entries appear automatically

Signed-off-by: Kai Kreuzer <kai@openhab.org>