### PR TITLE
allow spaces in the list of add-ons in addons.cfg

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -298,7 +298,9 @@ public class FeatureInstaller implements ConfigurationListener {
                 String[] addons = ((String) install).split(",");
                 installFeatures(service, type, addons);
                 Set<String> addonsToUninstall = getAllAddonsOfType(type);
-                addonsToUninstall.removeAll(Arrays.asList(addons));
+                for (String addon : addons) {
+                    addonsToUninstall.remove(addon.trim());
+                }
                 uninstallFeatures(service, type, addonsToUninstall.toArray(new String[addonsToUninstall.size()]));
             }
         }


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>