### PR TITLE
removed rest-docs from standard package

### DIFF
--- a/features/openhab-core-resources/src/main/resources/addons-standard.cfg
+++ b/features/openhab-core-resources/src/main/resources/addons-standard.cfg
@@ -1,3 +1,2 @@
 package = standard
 ui = basic,paper,habpanel
-misc = restdocs


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>