### PR TITLE
also removed io.transport.serial from p2 repo

### DIFF
--- a/features/p2/feature.xml
+++ b/features/p2/feature.xml
@@ -31,12 +31,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.openhab.io.transport.serial"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
          id="org.openhab.core.compat1x"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>