### PR TITLE
Add bindings profile to sat.

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -247,6 +247,26 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>check-bindings</id>
+      <activation>
+        <file>
+          <exists>ESH-INF/binding/binding.xml</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+              <groupId>org.openhab.tools</groupId>
+              <artifactId>static-code-analysis</artifactId>
+              <version>${sat.version}</version>
+          </plugin>
+          <configuration>
+            <checkstyleProperties>src/sat/binding.properties</checkstyleProperties>
+          </configuration>
+        </plugins>
+      </build>
+    </profile>
     </profiles>
 
     <pluginRepositories>

--- a/src/sat/README.md
+++ b/src/sat/README.md
@@ -1,0 +1,7 @@
+------------------------------------------
+Static Analysis Tool - Properties files 
+------------------------------------------
+
+Contains properties files for the static-analysis-tool - https://github.com/openhab/static-code-analysis.
+
+These properties files will be used by the tool to override the default configurtion of the tool or to apply profile specific settings (e.g. URLs to resources, change the priority of a check and etc..)


### PR DESCRIPTION
Contains:
- add bindings Maven profile to the Static Code Analysis tool;
- create an empty properties files, that will include configuration of the
  checks that will be applied only for bindings;
- short readme file with link to the sat repo.

See https://github.com/openhab/static-code-analysis/issues/58#issuecomment-292948113

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>