### PR TITLE
Remove properties file for sat bindings profile

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -259,10 +259,7 @@
           <plugin>
               <groupId>org.openhab.tools</groupId>
               <artifactId>static-code-analysis</artifactId>
-              <version>${sat.version}</version>
-              <configuration>
-                 <checkstyleProperties>src/sat/binding.properties</checkstyleProperties>
-              </configuration>
+              <version>${sat.version}</version>              
           </plugin>
         </plugins>
       </build>

--- a/src/sat/README.md
+++ b/src/sat/README.md
@@ -1,7 +1,0 @@
-------------------------------------------
-Static Analysis Tool - Properties files 
-------------------------------------------
-
-Contains properties files for the static-analysis-tool - https://github.com/openhab/static-code-analysis.
-
-These properties files will be used by the tool to override the default configurtion of the tool or to apply profile specific settings (e.g. URLs to resources, change the priority of a check and etc..)


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/135#issuecomment-292998383

@kaikreuzer I apologize for #135 and for the further complications that it caused, but even after your addition (#136), the OH2 build is failing locally with:

>[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 40.148s
[INFO] Finished at: Tue Apr 11 11:35:24 EEST 2017
[INFO] Final Memory: 73M/721M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.openhab.tools:static-code-analysis:0.0.4:checkstyle (default) on project org.openhab.binding.airquality: Unable to execute mo
jo: An error has occurred in Checkstyle report generation. Failed during checkstyle execution: Failed to get overriding properties: Could not find resource 'C:\
prj\openHAB\EclipseIDE\git\openhab2-addons\src\sat\binding.properties'. -> [Help 1]

This is the not right place for this properties file at all, this is why I would like to remove it in this PR, I will move it to the sat tool.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>