### PR TITLE
Set Groovy compiler level to "i don't care" so eclipse problems vanish

### DIFF
--- a/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+groovy.compiler.level=-1


### PR DESCRIPTION
Set Groovy compiler level to "i don't care" so eclipse problems vanish.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>