### PR TITLE
Made dashboard component to be activated immediately and improved logging

### DIFF
--- a/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Service-Component: OSGI-INF/*.xml
 Import-Package: javax.servlet,
  javax.servlet.http,
  org.apache.commons.io,
+ org.eclipse.smarthome.core.net,
  org.openhab.core,
  org.osgi.framework,
  org.osgi.service.cm,

--- a/bundles/org.openhab.ui.dashboard/OSGI-INF/dashboardservice.xml
+++ b/bundles/org.openhab.ui.dashboard/OSGI-INF/dashboardservice.xml
@@ -9,9 +9,12 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.openhab.ui.dashboard">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.dashboard">
    <implementation class="org.openhab.ui.dashboard.internal.DashboardService"/>
    <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unsetHttpService"/>
    <reference bind="addDashboardTile" cardinality="0..n" interface="org.openhab.ui.dashboard.DashboardTile" name="DashboardTile" policy="dynamic" unbind="removeDashboardTile"/>
    <reference bind="setConfigurationAdmin" cardinality="1..1" interface="org.osgi.service.cm.ConfigurationAdmin" name="ConfigurationAdmin" policy="static" unbind="unsetConfigurationAdmin"/>
+   <service>
+      <provide interface="org.openhab.ui.dashboard.internal.DashboardService"/>
+   </service>
 </scr:component>

--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
@@ -18,6 +18,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
 import org.apache.commons.io.IOUtils;
+import org.eclipse.smarthome.core.net.HttpServiceUtil;
+import org.eclipse.smarthome.core.net.NetUtil;
 import org.openhab.ui.dashboard.DashboardTile;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -55,7 +57,15 @@ public class DashboardService {
             httpService.registerServlet(DASHBOARD_ALIAS + "/" + SERVLET_NAME, createServlet(), props,
                     httpService.createDefaultHttpContext());
             httpService.registerResources(DASHBOARD_ALIAS, "web", null);
-            logger.info("Started dashboard at " + DASHBOARD_ALIAS);
+
+            if (HttpServiceUtil.getHttpServicePort(bundleContext) > 0) {
+                logger.info("Started dashboard at http://{}:{}", NetUtil.getLocalIpv4HostAddress(),
+                        HttpServiceUtil.getHttpServicePort(bundleContext));
+            }
+            if (HttpServiceUtil.getHttpServicePortSecure(bundleContext) > 0) {
+                logger.info("Started dashboard at https://{}:{}", NetUtil.getLocalIpv4HostAddress(),
+                        HttpServiceUtil.getHttpServicePortSecure(bundleContext));
+            }
         } catch (NamespaceException | ServletException e) {
             logger.error("Error during dashboard startup: {}", e.getMessage());
         }


### PR DESCRIPTION
There is now a line with an absolute Url using the primary IPv4 interface about where openHAB is accessible (both for http & https).

Signed-off-by: Kai Kreuzer <kai@openhab.org>