### PR TITLE
moved the swagger servlet registration to its own component

### DIFF
--- a/bundles/org.openhab.io.rest.docs/OSGI-INF/swaggerservice.xml
+++ b/bundles/org.openhab.io.rest.docs/OSGI-INF/swaggerservice.xml
@@ -9,9 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.io.rest.docs.dashboardtile">
-   <implementation class="org.openhab.io.rest.docs.internal.RESTDashboardTile"/>
-   <service>
-      <provide interface="org.openhab.ui.dashboard.DashboardTile"/>
-   </service>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.io.rest.docs.swaggerservice">
+   <implementation class="org.openhab.io.rest.docs.internal.SwaggerService"/>
+   <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static" unbind="unsetHttpService"/>
 </scr:component>

--- a/bundles/org.openhab.io.rest.docs/src/main/java/org/openhab/io/rest/docs/internal/RESTDashboardTile.java
+++ b/bundles/org.openhab.io.rest.docs/src/main/java/org/openhab/io/rest/docs/internal/RESTDashboardTile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015-2016 by the respective copyright holders.
+ * Copyright (c) 2015-2017 by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,44 +9,19 @@
 package org.openhab.io.rest.docs.internal;
 
 import org.openhab.ui.dashboard.DashboardTile;
-import org.osgi.service.http.HttpService;
-import org.osgi.service.http.NamespaceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The dashboard tile for the REST API,
- * also registers the Swagger UI as a web resource on the HTTP service
  *
  * @author Kai Kreuzer
  *
  */
 public class RESTDashboardTile implements DashboardTile {
 
-    private static final String ALIAS = "/doc";
-
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-    private HttpService httpService;
-
-    protected void setHttpService(HttpService httpService) {
-        this.httpService = httpService;
-    }
-
-    protected void unsetHttpService(HttpService httpService) {
-        this.httpService = null;
-    }
-
     protected void activate() {
-        try {
-            httpService.registerResources(ALIAS, "swagger", httpService.createDefaultHttpContext());
-        } catch (NamespaceException e) {
-            logger.error("Could not start up REST documentation service: {}", e.getMessage());
-        }
     }
 
     protected void deactivate() {
-        httpService.unregister(ALIAS);
     }
 
     @Override

--- a/bundles/org.openhab.io.rest.docs/src/main/java/org/openhab/io/rest/docs/internal/SwaggerService.java
+++ b/bundles/org.openhab.io.rest.docs/src/main/java/org/openhab/io/rest/docs/internal/SwaggerService.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.io.rest.docs.internal;
+
+import org.osgi.service.http.HttpService;
+import org.osgi.service.http.NamespaceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This service registers the Swagger UI as a web resource on the HTTP service.
+ *
+ * @author Kai Kreuzer
+ *
+ */
+public class SwaggerService {
+
+    private static final String ALIAS = "/doc";
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private HttpService httpService;
+
+    protected void setHttpService(HttpService httpService) {
+        this.httpService = httpService;
+    }
+
+    protected void unsetHttpService(HttpService httpService) {
+        this.httpService = null;
+    }
+
+    protected void activate() {
+        try {
+            httpService.registerResources(ALIAS, "swagger", httpService.createDefaultHttpContext());
+        } catch (NamespaceException e) {
+            logger.error("Could not start up REST documentation service: {}", e.getMessage());
+        }
+    }
+
+    protected void deactivate() {
+        httpService.unregister(ALIAS);
+    }
+
+}


### PR DESCRIPTION
This should avoid potential circular dependencies at startup as the dashboard tile does not depend on HttpService anymore.

Signed-off-by: Kai Kreuzer <kai@openhab.org>