### PR TITLE
switched to Karaf 4.1.2 and Jetty 9.3.14

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -58,8 +58,8 @@
         <ohdr.version>1.0.12</ohdr.version>
         <esh.version>0.9.0-SNAPSHOT</esh.version>
         <repo.version>2.2.x</repo.version>
-        <karaf.version>4.0.8</karaf.version>
-        <jetty.version>9.2.19.v20160908</jetty.version>
+        <karaf.version>4.1.2</karaf.version>
+        <jetty.version>9.3.14.v20161028</jetty.version>
         <jackson.version>1.9.13</jackson.version>
         <sat.version>0.2.0</sat.version>
         <nrjavaserial.version>3.12.0.OH</nrjavaserial.version>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>