### PR TITLE
changed cardinality for tiles back to 0..n

### DIFF
--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
@@ -113,7 +113,7 @@ public class DashboardService {
         this.networkAddressService = null;
     }
 
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void addDashboardTile(DashboardTile tile) {
         tiles.add(tile);
     }


### PR DESCRIPTION
This had been accidentially changed to 0..1 through https://github.com/openhab/openhab-core/pull/191.

Signed-off-by: Kai Kreuzer <kai@openhab.org>