### PR TITLE
Revert "Add Saxon dependency because of static-code-analysis setting …

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -153,13 +153,6 @@
                             <supportedProjectType>eclipse-plugin</supportedProjectType>
                         </supportedProjectTypes>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>net.sourceforge.saxon</groupId>
-                            <artifactId>saxon</artifactId>
-                            <version>9.1.0.8</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
…a system property (#196)"

The system property is removed in version 0.3.0 of the tool.

This reverts commit 778ce5b5dad01017692eb74058e12edacd0dacdd.