### PR TITLE
Add versions plugin for automated updating of version properties

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -167,6 +167,57 @@
                     </dependency>
                   </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.4</version>
+                    <configuration>
+                      <properties>
+                        <property>
+                          <name>esh.version</name>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.eclipse.smarthome</groupId>
+                              <artifactId>smarthome</artifactId>
+                            </dependency>
+                          </dependencies>
+                        </property>
+                        <property>
+                          <name>ohc.version</name>
+                          <searchReactor>true</searchReactor>
+                          <preferReactor>true</preferReactor>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.openhab</groupId>
+                              <artifactId>pom</artifactId>
+                            </dependency>
+                          </dependencies>
+                        </property>
+                        <property>
+                          <name>oh2.version</name>
+                          <searchReactor>true</searchReactor>
+                          <preferReactor>true</preferReactor>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.openhab</groupId>
+                              <artifactId>pom</artifactId>
+                            </dependency>
+                          </dependencies>
+                        </property>
+                        <property>
+                          <name>oh1.version</name>
+                          <searchReactor>true</searchReactor>
+                          <preferReactor>true</preferReactor>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.openhab</groupId>
+                              <artifactId>pom-addons1</artifactId>
+                            </dependency>
+                          </dependencies>
+                        </property>
+                      </properties>
+                    </configuration>
+                  </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This adds the maven versions plugin and makes it possible to automatically update version properties like `esh.version` or `oh2.version` within the pom.xml, e.g. by using the _versions:update-properties_ or _versions:update-property_ goal.

- http://www.mojohaus.org/versions-maven-plugin/update-properties-mojo.html
- http://www.mojohaus.org/versions-maven-plugin/update-property-mojo.html

Signed-off-by: Patrick Fink <mail@pfink.de>