### PR TITLE
[compat1x] Fix ChartProvider API break

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/ui/chart/internal/ChartProviderDelegate.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/ui/chart/internal/ChartProviderDelegate.java
@@ -37,7 +37,7 @@ public class ChartProviderDelegate implements org.eclipse.smarthome.ui.chart.Cha
 
     @Override
     public BufferedImage createChart(String service, String theme, Date startTime, Date endTime, int height, int width,
-            String items, String groups) throws ItemNotFoundException {
+            String items, String groups, Integer dpi, Boolean legend) throws ItemNotFoundException {
         try {
             return provider.createChart(service, theme, startTime, endTime, height, width, items, groups);
         } catch (org.openhab.core.items.ItemNotFoundException e) {


### PR DESCRIPTION
The ESH PR https://github.com/eclipse/smarthome/pull/4291 introduced a change in the ChartProvider API.
This commit changes the compat1x `ChartProviderDelegate` to compile with these changes.

This should be merged when a new ESH stable is built, otherwise it would cause build failure of `openhab-core`.