### PR TITLE
Final changes for initial release automation process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
               <groupId>com.itemis.maven.plugins</groupId>
               <artifactId>unleash-maven-plugin</artifactId>
-              <version>2.6.0</version>
+              <version>2.7.2</version>
               <dependencies>
                 <dependency>
                   <groupId>com.itemis.maven.plugins</groupId>

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -158,7 +158,7 @@
                 <plugin>
                   <groupId>com.itemis.maven.plugins</groupId>
                   <artifactId>unleash-maven-plugin</artifactId>
-                  <version>2.6.0</version>
+                  <version>2.7.2</version>
                   <dependencies>
                     <dependency>
                       <groupId>com.itemis.maven.plugins</groupId>

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -170,54 +170,8 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.4</version>
-                    <configuration>
-                      <properties>
-                        <property>
-                          <name>esh.version</name>
-                          <dependencies>
-                            <dependency>
-                              <groupId>org.eclipse.smarthome</groupId>
-                              <artifactId>smarthome</artifactId>
-                            </dependency>
-                          </dependencies>
-                        </property>
-                        <property>
-                          <name>ohc.version</name>
-                          <searchReactor>true</searchReactor>
-                          <preferReactor>true</preferReactor>
-                          <dependencies>
-                            <dependency>
-                              <groupId>org.openhab</groupId>
-                              <artifactId>pom</artifactId>
-                            </dependency>
-                          </dependencies>
-                        </property>
-                        <property>
-                          <name>oh2.version</name>
-                          <searchReactor>true</searchReactor>
-                          <preferReactor>true</preferReactor>
-                          <dependencies>
-                            <dependency>
-                              <groupId>org.openhab</groupId>
-                              <artifactId>pom</artifactId>
-                            </dependency>
-                          </dependencies>
-                        </property>
-                        <property>
-                          <name>oh1.version</name>
-                          <searchReactor>true</searchReactor>
-                          <preferReactor>true</preferReactor>
-                          <dependencies>
-                            <dependency>
-                              <groupId>org.openhab</groupId>
-                              <artifactId>pom-addons1</artifactId>
-                            </dependency>
-                          </dependencies>
-                        </property>
-                      </properties>
-                    </configuration>
-                  </plugin>
+                    <version>2.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Hi there,
these should be the last changes necessary to get the initial release automation process running:

- Update the unleash plugin to the latest version
- Update the versions plugin to the latest version (makes the error-prone version-property mapping obsolete) as with version 2.5 the _set-property_ goal was introduced.

Signed-off-by: Patrick Fink <mail@pfink.de>