### PR TITLE
Changed the poms hierarchy in openhab core in order to enable …

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -2,10 +2,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
-    <groupId>org.openhab</groupId>
-    <artifactId>pom-tycho</artifactId>
+    <groupId>org.openhab.core</groupId>
+    <artifactId>pom</artifactId>
     <version>2.2.0-SNAPSHOT</version>
-    <relativePath>../poms/tycho/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -2,10 +2,10 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
-    <groupId>org.openhab</groupId>
-    <artifactId>pom-tycho</artifactId>
+    <groupId>org.openhab.core</groupId>
+    <artifactId>pom</artifactId>
     <version>2.2.0-SNAPSHOT</version>
-    <relativePath>../poms/tycho/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+	
+    <parent>
+        <groupId>org.openhab</groupId>
+        <artifactId>pom-tycho</artifactId>
+        <version>2.2.0-SNAPSHOT</version>
+        <relativePath>poms/tycho/pom.xml</relativePath>
+    </parent>
+	
     <groupId>org.openhab.core</groupId>
     <artifactId>pom</artifactId>
     <version>2.2.0-SNAPSHOT</version>
@@ -58,22 +65,12 @@
 
 
     <build>
-        <pluginManagement>
-          <plugins>
+        <plugins>
             <plugin>
-              <groupId>com.itemis.maven.plugins</groupId>
-              <artifactId>unleash-maven-plugin</artifactId>
-              <version>2.7.2</version>
-              <dependencies>
-                <dependency>
-                  <groupId>com.itemis.maven.plugins</groupId>
-                  <artifactId>unleash-scm-provider-git</artifactId>
-                  <version>2.1.0</version>
-                </dependency>
-              </dependencies>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
             </plugin>
-          </plugins>
-        </pluginManagement>
-     </build>
+        </plugins>
+    </build>
 
 </project>

--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -78,9 +78,25 @@
     <packaging>pom</packaging>
 
     <build>
-
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <artifactId>directory-maven-plugin</artifactId>
+                    <version>0.2</version>
+                    <executions>
+                        <execution>
+                            <id>directories</id>
+                            <goals>
+                                <goal>highest-basedir</goal>
+                            </goals>
+                            <phase>initialize</phase>
+                            <configuration>
+                                <property>basedirRoot</property>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
@@ -281,7 +297,7 @@
           <plugin>
               <groupId>org.openhab.tools</groupId>
               <artifactId>static-code-analysis</artifactId>
-              <version>${sat.version}</version>              
+              <version>${sat.version}</version>
           </plugin>
         </plugins>
       </build>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.openhab</groupId>
-    <artifactId>pom-tycho</artifactId>
+    <groupId>org.openhab.core</groupId>
+    <artifactId>pom</artifactId>
     <version>2.2.0-SNAPSHOT</version>
-    <relativePath>../poms/tycho/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.openhab.core</groupId>


### PR DESCRIPTION
... specific configuration for openhab core.

Also added the directory-maven-plugin which will be used to locate static-code-analysis config files in the root folder. See eclipse/smarthome#4240 openhab/static-code-analysis#184

If this gets merged I will also add a config file for the static-code-analysis tool similar to this: openhab/openhab2-addons#2810

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>