### PR TITLE
Fix crowdin incompatibility

### DIFF
--- a/bundles/org.openhab.ui.dashboard/ESH-INF/i18n/dashboard.properties
+++ b/bundles/org.openhab.ui.dashboard/ESH-INF/i18n/dashboard.properties
@@ -25,6 +25,4 @@ entry.install-running = Please stand by while UIs are being installed. This can 
 warn.exposed = <p><b>WARNING - YOUR HOME IS EXPOSED!</b></p> \
 <p>It seems that you have configured your network in a way that you can remotely access your openHAB server. Unfortunately, it is not just you - almost <b>everybody on the Internet can access it!</b></p> \
 <p>If this wasn't your plan, please act immediately. Stop the port forwarding of your router or make sure that you have a secure authentication mechanism in place, e.g. by using NGINX as a reverse proxy inbetween.</p> \
-<p>If you have read and understood this message and you have taken appropriate actions, please \
-<a href="?warn=ihavelearnedmylesson" style="color: #DDDDDD">click here</a> \ 
-to make this message disappear again.</p>
+<p>If you have read and understood this message and you have taken appropriate actions, please <a href="?warn=ihavelearnedmylesson" style="color: #DDDDDD">click here</a> to make this message disappear again.</p>


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/2870104/33582943-2ef69660-d958-11e7-90ea-7cae19fcecac.png)


@lolodomo this fixes the immediate issue.
I do wonder if we should break down `warn.exposed` to three-four substrings. The strings shouldn't be as complicated and the magic anchor should definitely not be part of it. The same goes for other strings. There are also cases like "Select a package:" where I'd suggest to move the colon out of the string. Wdyt?

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)