### PR TITLE
[Dashboard] support special words in dashboard tile URL's.

### DIFF
--- a/bundles/org.openhab.ui.dashboard/README.md
+++ b/bundles/org.openhab.ui.dashboard/README.md
@@ -14,6 +14,15 @@ Links can be added to the dashboard by editing the `$OPENHAB_CONF/services/dashb
 
 Where `<unique-name>` is link unique identifier (see examples).
 
+Link-url and link-imageurl support following special words:
+
+| Special word                | Replaced to                  |
+|-----------------------------|------------------------------|
+| $DOMAINNAME                 | fully qualified domain name  |
+| $HOSTNAME                   | host name                    |
+| $HOSTADDRESS                | host IP address              |
+
+
 ### Image
 
 A png image of 350px width and 200-250px height are recommended.
@@ -29,6 +38,10 @@ frontail.link-imageurl=../static/image.png
 
 nodered.link-name=Node-RED
 nodered.link-url=http://<server-adddress>:1880
+nodered.link-imageurl=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXwAAACfCAIAAA...QmCC
+
+nodered.link-name=Node-RED
+nodered.link-url=http://$HOSTNAME:1880
 nodered.link-imageurl=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXwAAACfCAIAAA...QmCC
 
 ```

--- a/bundles/org.openhab.ui.dashboard/README.md
+++ b/bundles/org.openhab.ui.dashboard/README.md
@@ -14,13 +14,12 @@ Links can be added to the dashboard by editing the `$OPENHAB_CONF/services/dashb
 
 Where `<unique-name>` is link unique identifier (see examples).
 
-Link-url and link-imageurl support following special words:
+Link-url support following special words:
 
-| Special word                | Replaced to                  |
-|-----------------------------|------------------------------|
-| $DOMAINNAME                 | fully qualified domain name  |
-| $HOSTNAME                   | host name                    |
-| $HOSTADDRESS                | host IP address              |
+| Special word                | Replaced to                               |
+|-----------------------------|-------------------------------------------|
+| {HOST}                      | host name including possible port number  |
+| {HOSTNAME}                  | host name                                 |
 
 
 ### Image
@@ -41,7 +40,7 @@ nodered.link-url=http://<server-adddress>:1880
 nodered.link-imageurl=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXwAAACfCAIAAA...QmCC
 
 nodered.link-name=Node-RED
-nodered.link-url=http://$HOSTNAME:1880
+nodered.link-url=http://{HOSTNAME}:1880
 nodered.link-imageurl=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAXwAAACfCAIAAA...QmCC
 
 ```

--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
@@ -9,9 +9,7 @@
 package org.openhab.ui.dashboard.internal;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
@@ -22,7 +20,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
 import org.apache.commons.io.IOUtils;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.net.HttpServiceUtil;
@@ -72,10 +69,6 @@ public class DashboardService {
     private final static String LINK_NAME = "link-name";
     private final static String LINK_URL = "link-url";
     private final static String LINK_IMAGEURL = "link-imageurl";
-
-    private final static String DOMAINNAME = "$DOMAINNAME";
-    private final static String HOSTNAME = "$HOSTNAME";
-    private final static String HOSTADDRESS = "$HOSTADDRESS";
 
     @Activate
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
@@ -227,55 +220,13 @@ public class DashboardService {
                     String url = (String) properties.get(linkname + LINK_URL);
                     String imageUrl = (String) properties.get(linkname + LINK_IMAGEURL);
 
-                    url = fillMagicWords(url);
-                    imageUrl = fillMagicWords(imageUrl);
+                    logger.debug("Add link: {}", name);
 
-                    if (url != null && !url.isEmpty()) {
-                        logger.debug("Add link: {}", name);
-
-                        addDashboardTile(new ExternalServiceTile.DashboardTileBuilder().withName(name).withUrl(url)
-                                .withImageUrl(imageUrl).build());
-                    } else {
-                        logger.warn("Ignoring empty URL link for tile '{}'", name);
-                    }
+                    addDashboardTile(new ExternalServiceTile.DashboardTileBuilder().withName(name).withUrl(url)
+                            .withImageUrl(imageUrl).build());
                 }
             }
         }
-    }
-
-    private @Nullable String fillMagicWords(@Nullable String linkname) {
-        String newlinkname = linkname;
-
-        if (newlinkname != null) {
-            if (newlinkname.contains(DOMAINNAME)) {
-                try {
-                    newlinkname = newlinkname.replace(DOMAINNAME, InetAddress.getLocalHost().getCanonicalHostName());
-                } catch (UnknownHostException e) {
-                    // domain name not available, let's try to fall back to host name
-                    newlinkname = newlinkname.replace(DOMAINNAME, HOSTNAME);
-                }
-            }
-
-            if (newlinkname.contains(HOSTNAME)) {
-                try {
-                    newlinkname = newlinkname.replace(HOSTNAME, InetAddress.getLocalHost().getHostName());
-                } catch (UnknownHostException e) {
-                    // host name not available, let's try to fall back to host address
-                    newlinkname = newlinkname.replace(HOSTNAME, HOSTADDRESS);
-                }
-            }
-
-            if (newlinkname.contains(HOSTADDRESS)) {
-                try {
-                    newlinkname = newlinkname.replace(HOSTADDRESS, InetAddress.getLocalHost().getHostAddress());
-                } catch (UnknownHostException e) {
-                    // host address not available, link won't work so let's return null
-                    newlinkname = null;
-                }
-            }
-        }
-
-        return newlinkname;
     }
 
     /**

--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardService.java
@@ -9,7 +9,9 @@
 package org.openhab.ui.dashboard.internal;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
@@ -20,6 +22,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.net.HttpServiceUtil;
@@ -69,6 +72,10 @@ public class DashboardService {
     private final static String LINK_NAME = "link-name";
     private final static String LINK_URL = "link-url";
     private final static String LINK_IMAGEURL = "link-imageurl";
+
+    private final static String DOMAINNAME = "$DOMAINNAME";
+    private final static String HOSTNAME = "$HOSTNAME";
+    private final static String HOSTADDRESS = "$HOSTADDRESS";
 
     @Activate
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
@@ -220,13 +227,55 @@ public class DashboardService {
                     String url = (String) properties.get(linkname + LINK_URL);
                     String imageUrl = (String) properties.get(linkname + LINK_IMAGEURL);
 
-                    logger.debug("Add link: {}", name);
+                    url = fillMagicWords(url);
+                    imageUrl = fillMagicWords(imageUrl);
 
-                    addDashboardTile(new ExternalServiceTile.DashboardTileBuilder().withName(name).withUrl(url)
-                            .withImageUrl(imageUrl).build());
+                    if (url != null && !url.isEmpty()) {
+                        logger.debug("Add link: {}", name);
+
+                        addDashboardTile(new ExternalServiceTile.DashboardTileBuilder().withName(name).withUrl(url)
+                                .withImageUrl(imageUrl).build());
+                    } else {
+                        logger.warn("Ignoring empty URL link for tile '{}'", name);
+                    }
                 }
             }
         }
+    }
+
+    private @Nullable String fillMagicWords(@Nullable String linkname) {
+        String newlinkname = linkname;
+
+        if (newlinkname != null) {
+            if (newlinkname.contains(DOMAINNAME)) {
+                try {
+                    newlinkname = newlinkname.replace(DOMAINNAME, InetAddress.getLocalHost().getCanonicalHostName());
+                } catch (UnknownHostException e) {
+                    // domain name not available, let's try to fall back to host name
+                    newlinkname = newlinkname.replace(DOMAINNAME, HOSTNAME);
+                }
+            }
+
+            if (newlinkname.contains(HOSTNAME)) {
+                try {
+                    newlinkname = newlinkname.replace(HOSTNAME, InetAddress.getLocalHost().getHostName());
+                } catch (UnknownHostException e) {
+                    // host name not available, let's try to fall back to host address
+                    newlinkname = newlinkname.replace(HOSTNAME, HOSTADDRESS);
+                }
+            }
+
+            if (newlinkname.contains(HOSTADDRESS)) {
+                try {
+                    newlinkname = newlinkname.replace(HOSTADDRESS, InetAddress.getLocalHost().getHostAddress());
+                } catch (UnknownHostException e) {
+                    // host address not available, link won't work so let's return null
+                    newlinkname = null;
+                }
+            }
+        }
+
+        return newlinkname;
     }
 
     /**

--- a/bundles/org.openhab.ui.dashboard/templates/entry.html
+++ b/bundles/org.openhab.ui.dashboard/templates/entry.html
@@ -1,10 +1,10 @@
             <div class="link-wrapper col-md-3 col-sm-6 col-xs-6">
-                <div class="link" onclick="location.href = '${url}'">
+                <a class="link" style="text-decoration: none;" href="${url}">
                     <div class="body" style="background-image: url('${icon}')">
                          <div class="overlay icon-${overlay}"></div>
                     </div>
                     <div class="footer">
                         <p>${name}</p>
                     </div>
-                </div>
+                </a>
             </div>

--- a/bundles/org.openhab.ui.dashboard/templates/index.html
+++ b/bundles/org.openhab.ui.dashboard/templates/index.html
@@ -14,6 +14,25 @@
 
 <script type="text/javascript" src="js/jquery.min.js"></script>
 <script type="text/javascript" src="js/geolocation.js"></script>
+<script>
+$(function(){
+    var url = new URL(window.location.href);
+    console.log( "url: " + url.host );
+    $('div[class="link"]').each(function(index,item){
+        if ($(item).attr('onclick').indexOf('{HOST}') >= 0) {
+            console.log( 'orginal onclick: ' + $(item).attr('onclick') );
+            $(item).attr('onclick', $(item).attr('onclick').replace('{HOST}', url.host));
+            console.log( 'modified onclick: ' + $(item).attr('onclick') );
+        }
+        if ($(item).attr('onclick').indexOf('{HOSTNAME}') >= 0) {
+            console.log( 'orginal onclick: ' + $(item).attr('onclick') );
+            $(item).attr('onclick', $(item).attr('onclick').replace('{HOSTNAME}', url.hostname));
+            console.log( 'modified onclick: ' + $(item).attr('onclick') );
+        }
+    });
+ });
+</script>
+
 </head>
 
 <body>

--- a/bundles/org.openhab.ui.dashboard/templates/index.html
+++ b/bundles/org.openhab.ui.dashboard/templates/index.html
@@ -14,23 +14,16 @@
 
 <script type="text/javascript" src="js/jquery.min.js"></script>
 <script type="text/javascript" src="js/geolocation.js"></script>
-<script>
-$(function(){
-    var url = new URL(window.location.href);
-    console.log( "url: " + url.host );
-    $('div[class="link"]').each(function(index,item){
-        if ($(item).attr('onclick').indexOf('{HOST}') >= 0) {
-            console.log( 'orginal onclick: ' + $(item).attr('onclick') );
-            $(item).attr('onclick', $(item).attr('onclick').replace('{HOST}', url.host));
-            console.log( 'modified onclick: ' + $(item).attr('onclick') );
-        }
-        if ($(item).attr('onclick').indexOf('{HOSTNAME}') >= 0) {
-            console.log( 'orginal onclick: ' + $(item).attr('onclick') );
-            $(item).attr('onclick', $(item).attr('onclick').replace('{HOSTNAME}', url.hostname));
-            console.log( 'modified onclick: ' + $(item).attr('onclick') );
-        }
+<script type="text/javascript">
+$(document).ready(function() {
+    $('a.link').each(function(index) {
+        var href = $(this)
+            .attr('href')
+            .replace(/{HOST}/g, window.location.host)
+            .replace(/{HOSTNAME}/g, window.location.hostname);
+        $(this).attr('href', href);
     });
- });
+});
 </script>
 
 </head>


### PR DESCRIPTION
DOMAINNAME, HOSTNAME and HOSTADDRESS special words are supported.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>