### PR TITLE
reduce the esh release version to 0.9.0 to make sure that snapshots are taken

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -58,7 +58,7 @@
 
         <ohdr.version>1.0.19</ohdr.version>
         <esh.version>0.10.0-SNAPSHOT</esh.version>
-        <esh.releaseVersion>0.10.0.b1</esh.releaseVersion>
+        <esh.releaseVersion>0.9.0</esh.releaseVersion>
         <repo.version>2.2.x</repo.version>
         <karaf.version>4.1.3</karaf.version>
         <jetty.version>9.3.22.v20171030</jetty.version>


### PR DESCRIPTION
The version 0.10.0.b1 was badly chosen - it should have been 0.10.0-b1 instead.
According to Maven versioning, 0.10.0.b1 is a release and thus considered NEWER than any snapshot.
As we include ESH release + snapshot repos in the openHAB snapshot build, this means that 0.10.0-SNAPSHOTS are now ignored and 0.10.0.b1 is used instead. This leads to issues [like this one](https://github.com/openhab/openhab2-addons/pull/3078#issuecomment-359721434).

Signed-off-by: Kai Kreuzer <kai@openhab.org>