### PR TITLE
Changed SAT artifact ID to correct one

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -297,7 +297,7 @@
         <plugins>
           <plugin>
               <groupId>org.openhab.tools.sat</groupId>
-              <artifactId>${sat.plugin}</artifactId>
+              <artifactId>sat-plugin</artifactId>
               <version>${sat.version}</version>
           </plugin>
         </plugins>


### PR DESCRIPTION
No property "${sat.plugin}" exists.

Fix for warning logs in openhab-2 addons project, as it inherits this pom.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>