### PR TITLE
compat1.x Update RollershutterItem.java

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/items/RollershutterItem.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/items/RollershutterItem.java
@@ -60,14 +60,7 @@ public class RollershutterItem extends GenericItem {
 
     @Override
     public void setState(State state) {
-        // we map UP/DOWN values to the percent values 0 and 100
-        if (state == UpDownType.UP) {
-            super.setState(PercentType.ZERO);
-        } else if (state == UpDownType.DOWN) {
-            super.setState(PercentType.HUNDRED);
-        } else {
             super.setState(state);
-        }
     }
 
     @Override


### PR DESCRIPTION
Remove mapping for 0 & 100 % as it make it impossible to use the item with position feedback

Actual no ruling on the Rollershutter Item for 1.x bindings is possible,
as the previous percent stage is always be changed with the command,
and can't be set by the feedback of the binding or correctly interpreted by a rule.

Please also reference to the 2.x functionally which does not have these set of the percent feedback.

For my opinion this functionality has to be implemented in the binding's if necessary,
not in the core library.