### PR TITLE
updated to latest dependencies that are compatible with the latest sm…

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -56,7 +56,7 @@
         <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
         <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
 
-        <ohdr.version>1.0.19</ohdr.version>
+        <ohdr.version>1.0.21</ohdr.version>
         <esh.version>0.10.0-SNAPSHOT</esh.version>
         <esh.releaseVersion>0.9.0</esh.releaseVersion>
         <repo.version>2.2.x</repo.version>


### PR DESCRIPTION
…arthome.test bundle which required Mockito 2.0

Signed-off-by: Kai Kreuzer <kai@openhab.org>