### PR TITLE
Fix duplicate directory-maven-plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,6 @@
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.commonjava.maven.plugins</groupId>
-                <artifactId>directory-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The openhab-core POM has two declarations of the directory-maven-plugin resulting in the following warning:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openhab.core:pom-bundles:pom:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.commonjava.maven.plugins:directory-maven-plugin @ org.openhab.core:pom:2.3.0-SNAPSHOT, /home/wouter/git/openhab/openhab-core/pom.xml, line 84, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openhab.core:pom:pom:2.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.commonjava.maven.plugins:directory-maven-plugin @ line 84, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[WARNING] No explicit target runtime environment configuration. Build is platform dependent.
```