### PR TITLE
added support for QuantityType in the compatibility layer

### DIFF
--- a/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
@@ -8,12 +8,16 @@ Bundle-Version: 2.3.0.qualifier
 Fragment-Host: org.openhab.core.compat1x
 Import-Package: 
  groovy.lang,
+ javax.measure.quantity,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
+ org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
- org.junit
+ org.junit,
+ tec.uom.lib.common,
+ tec.uom.se

--- a/bundles/org.openhab.core.compat1x.test/src/test/java/org/openhab/core/compat1x/internal/TypeMapperTest.java
+++ b/bundles/org.openhab.core.compat1x.test/src/test/java/org/openhab/core/compat1x/internal/TypeMapperTest.java
@@ -10,6 +10,10 @@ package org.openhab.core.compat1x.internal;
 
 import static org.junit.Assert.assertEquals;
 
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.junit.Test;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.library.tel.types.CallType;
@@ -28,5 +32,12 @@ public class TypeMapperTest {
         CallType ohType1 = new CallType("123##456");
         CallType ohType2 = (CallType) TypeMapper.mapToOpenHABType(TypeMapper.mapToESHType(ohType1));
         assertEquals(ohType1, ohType2);
+    }
+
+    @Test
+    public void testQuantityType() {
+        QuantityType<Temperature> eshType1 = new QuantityType<>("10 °C");
+        DecimalType eshType2 = (DecimalType) TypeMapper.mapToESHType(TypeMapper.mapToOpenHABType(eshType1));
+        assertEquals(eshType1.as(DecimalType.class), eshType2);
     }
 }

--- a/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
@@ -65,6 +65,7 @@ Export-Package:
  org.openhab.ui.items
 Import-Package: 
  com.google.common.base,
+ javax.measure,
  javax.servlet,
  javax.servlet.http,
  javax.sound.sampled,

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/compat1x/internal/TypeMapper.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/compat1x/internal/TypeMapper.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.PointType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringListType;
 import org.eclipse.smarthome.core.library.types.StringType;
@@ -69,6 +70,8 @@ public class TypeMapper {
             result = new org.openhab.core.library.types.StringType(type.toString());
         } else if (typeClass.equals(DecimalType.class)) {
             result = new org.openhab.core.library.types.DecimalType(type.toString());
+        } else if (typeClass.equals(QuantityType.class)) {
+            result = new org.openhab.core.library.types.DecimalType(((QuantityType<?>) type).toBigDecimal());
         } else if (typeClass.equals(HSBType.class)) {
             result = new org.openhab.core.library.types.HSBType(type.toString());
         } else if (typeClass.equals(PercentType.class)) {


### PR DESCRIPTION
This specifically makes the QuantityType backward compatible and makes it treated as a simple DecimalType in any 1.x add-ons, such as specifically the persistence services.

Signed-off-by: Kai Kreuzer <kai@openhab.org>