### PR TITLE
Null annotations: Disable unchecked conversion warning

### DIFF
--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -104,7 +104,7 @@
                             <!--
                             <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>
                             -->
-                            <arg>-warn:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
+                            <arg>-warn:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+null,+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
                         </compilerArgs>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Sync maven settings with IDE settings again.

Found during review in https://github.com/openhab/openhab2-addons/pull/3087#issuecomment-379549320

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>