### PR TITLE
added proper logging in error case

### DIFF
--- a/bundles/org.openhab.io.sound/src/main/java/org/openhab/io/sound/internal/EnhancedJavaSoundAudioSink.java
+++ b/bundles/org.openhab.io.sound/src/main/java/org/openhab/io/sound/internal/EnhancedJavaSoundAudioSink.java
@@ -33,7 +33,7 @@ import javazoom.jl.player.Player;
  */
 public class EnhancedJavaSoundAudioSink extends JavaSoundAudioSink {
 
-    private final Logger logger = LoggerFactory.getLogger(EnhancedJavaSoundAudioSink.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnhancedJavaSoundAudioSink.class);
 
     private static AudioFormat mp3 = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_MP3, null, null,
             null, null);
@@ -81,7 +81,7 @@ public class EnhancedJavaSoundAudioSink extends JavaSoundAudioSink {
                         streamPlayer = new Player(audioStream);
                         playInThread(streamPlayer);
                     } catch (JavaLayerException e) {
-                        logger.error("An exception occurred while playing url audio stream : '{}'", e.getMessage());
+                        LOGGER.error("An exception occurred while playing url audio stream : '{}'", e.getMessage());
                     }
                     return;
                 }
@@ -90,7 +90,7 @@ public class EnhancedJavaSoundAudioSink extends JavaSoundAudioSink {
                 try {
                     playInThread(new Player(audioStream));
                 } catch (JavaLayerException e) {
-                    logger.error("An exception occurred while playing audio : '{}'", e.getMessage());
+                    LOGGER.error("An exception occurred while playing audio : '{}'", e.getMessage());
                 }
             }
         }
@@ -109,7 +109,7 @@ public class EnhancedJavaSoundAudioSink extends JavaSoundAudioSink {
                 try {
                     player.play();
                 } catch (Exception e) {
-                    throw new RuntimeException(e.getMessage());
+                    LOGGER.error("An exception occurred while playing audio : '{}'", e.getMessage());
                 } finally {
                     player.close();
                 }


### PR DESCRIPTION
The current code actually causes output in the shell, not only in the log like:
```
Exception in thread "Thread-62362" java.lang.RuntimeException: Bitstream errorcode 102
        at org.openhab.io.sound.internal.EnhancedJavaSoundAudioSink$1.run(EnhancedJavaSoundAudioSink.java:112)
```
I replaced it by proper logging - for this, I had to declare the logger statically.

Signed-off-by: Kai Kreuzer <kai@openhab.org>