### PR TITLE
Update unleash-maven-plugin to version 2.8.0

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -181,7 +181,7 @@
                 <plugin>
                   <groupId>com.itemis.maven.plugins</groupId>
                   <artifactId>unleash-maven-plugin</artifactId>
-                  <version>2.7.3</version>
+                  <version>2.8.0</version>
                   <dependencies>
                     <dependency>
                       <groupId>com.itemis.maven.plugins</groupId>


### PR DESCRIPTION
Version 2.8.0 of the unleash-maven-plugin will, in conjunction with another PR that I plan for openhab-distro, reduce the number of options I need to pass for the release build and therefore simplify the release build execution a little bit. It has no side effect on current CI processes and can be directly merged.

Signed-off-by: Patrick Fink <mail@pfink.de>