### PR TITLE
added new methods for breaking ESH change

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/item/DefaultSitemapProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/item/DefaultSitemapProvider.java
@@ -15,6 +15,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
+import org.eclipse.smarthome.model.core.ModelRepositoryChangeListener;
 import org.eclipse.smarthome.model.sitemap.Sitemap;
 import org.eclipse.smarthome.model.sitemap.SitemapFactory;
 import org.eclipse.smarthome.model.sitemap.SitemapProvider;
@@ -100,6 +101,14 @@ public class DefaultSitemapProvider implements SitemapProvider {
     @Override
     public Set<String> getSitemapNames() {
         return Collections.singleton(SITEMAP_NAME);
+    }
+
+    @Override
+    public void addModelChangeListener(ModelRepositoryChangeListener listener) {
+    }
+
+    @Override
+    public void removeModelChangeListener(ModelRepositoryChangeListener listener) {
     }
 
 }


### PR DESCRIPTION
See https://openhab.ci.cloudbees.com/job/openHAB2-Bundles/338/console

I don't think implementing change notifications is relevant (or easily feasible) for this sitemap - so at least as a quick measure, I merely added the methods for now.

Signed-off-by: Kai Kreuzer <kai@openhab.org>