### PR TITLE
Remove obsolete esh.releaseVersion property

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -58,7 +58,6 @@
 
         <ohdr.version>1.0.25</ohdr.version>
         <esh.version>0.10.0-SNAPSHOT</esh.version>
-        <esh.releaseVersion>0.9.0</esh.releaseVersion>
         <repo.version>2.2.x</repo.version>
         <karaf.version>4.1.5</karaf.version>
         <jetty.version>9.3.21.v20170918</jetty.version>

--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -234,7 +234,7 @@
                 <!-- SmartHome p2 release repository -->
                 <repository>
                     <id>p2-smarthome-release</id>
-                    <url>http://download.eclipse.org/smarthome/updates-release/${esh.releaseVersion}</url>
+                    <url>http://download.eclipse.org/smarthome/updates-release/${esh.version}</url>
                     <layout>p2</layout>
                     <releases>
                         <enabled>true</enabled>


### PR DESCRIPTION
The `esh.releaseVersion` property became obsolete after PR #321. 

openhab/openhab2-addons#3562 should be merged together with this PR.

Signed-off-by: Patrick Fink <mail@pfink.de>