### PR TITLE
made http transport part of core installation

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -28,6 +28,7 @@
         <feature>esh-storage-json</feature>
         <feature>openhab-runtime-certificate</feature>
         <feature>openhab-transport-mdns</feature>
+        <feature>openhab-transport-http</feature>
         <feature prerequisite="true">shell</feature>
         <feature prerequisite="true">wrapper</feature>
         <bundle start-level="90">mvn:org.openhab.core/org.openhab.core/${project.version}</bundle>
@@ -62,7 +63,11 @@
         <bundle>mvn:org.openhab.core/org.openhab.core.compat1x/${project.version}</bundle>
     </feature>
 
-    <feature name="openhab-httpclient" version="${project.version}">
+    <feature name="openhab-transport-coap" description="CoAP Transport" version="${project.version}">
+        <feature>esh-io-transport-coap</feature>
+    </feature>
+
+    <feature name="openhab-transport-http" description="HTTP Transport" version="${project.version}">
         <capability>esh.tp;feature=httpclient;version=${jetty.version}</capability>
         <bundle dependency="true">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-client/${jetty.version}</bundle>
@@ -73,15 +78,6 @@
         <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-api/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-common/${jetty.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty.websocket/websocket-client/${jetty.version}</bundle>
-    </feature>
-
-    <feature name="openhab-transport-coap" description="CoAP Transport" version="${project.version}">
-        <feature>esh-io-transport-coap</feature>
-    </feature>
-
-    <feature name="openhab-transport-http" description="HTTP Transport" version="${project.version}">
-        <feature>openhab-httpclient</feature>
-        <feature>esh-io-transport-http</feature>
     </feature>
 
     <feature name="openhab-transport-mdns" description="mDNS Transport" version="${project.version}">


### PR DESCRIPTION
With the change of https://github.com/openhab/openhab-distro/pull/706, I noticed that installing the websocket client during runtime causes the whole UPnP+Jetty stack (including http server) to restart, which causes all kinds of issues.

As the http transport only adds 2 additional bundles (the rest is usually already there), I think it is the better option to simply include those in the core installation already.

Signed-off-by: Kai Kreuzer <kai@openhab.org>