### PR TITLE
Don't lose stacktrace when rethrowing

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/internal/BindingConfigReaderDelegate.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/internal/BindingConfigReaderDelegate.java
@@ -38,9 +38,7 @@ public class BindingConfigReaderDelegate implements BindingConfigReader {
         try {
             reader.validateItemType(getOpenHABItem(itemType), bindingConfig);
         } catch (org.openhab.model.item.binding.BindingConfigParseException e) {
-            BindingConfigParseException ex = new BindingConfigParseException(e.getMessage());
-            ex.fillInStackTrace();
-            throw ex;
+            throw new BindingConfigParseException(e.getMessage(), e);
         }
     }
 
@@ -50,9 +48,7 @@ public class BindingConfigReaderDelegate implements BindingConfigReader {
         try {
             reader.processBindingConfiguration(context, getOpenHABItem(itemType, itemName), bindingConfig);
         } catch (org.openhab.model.item.binding.BindingConfigParseException e) {
-            BindingConfigParseException ex = new BindingConfigParseException(e.getMessage());
-            ex.fillInStackTrace();
-            throw ex;
+            throw new BindingConfigParseException(e.getMessage(), e);
         }
     }
 

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/internal/BindingConfigReaderDelegate.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/internal/BindingConfigReaderDelegate.java
@@ -38,9 +38,10 @@ public class BindingConfigReaderDelegate implements BindingConfigReader {
         try {
             reader.validateItemType(getOpenHABItem(itemType), bindingConfig);
         } catch (org.openhab.model.item.binding.BindingConfigParseException e) {
-            throw new BindingConfigParseException(e.getMessage());
+            BindingConfigParseException ex = new BindingConfigParseException(e.getMessage());
+            ex.fillInStackTrace();
+            throw ex;
         }
-
     }
 
     @Override
@@ -49,9 +50,10 @@ public class BindingConfigReaderDelegate implements BindingConfigReader {
         try {
             reader.processBindingConfiguration(context, getOpenHABItem(itemType, itemName), bindingConfig);
         } catch (org.openhab.model.item.binding.BindingConfigParseException e) {
-            throw new BindingConfigParseException(e.getMessage());
+            BindingConfigParseException ex = new BindingConfigParseException(e.getMessage());
+            ex.fillInStackTrace();
+            throw ex;
         }
-
     }
 
     private org.openhab.core.items.Item getOpenHABItem(String itemType) throws BindingConfigParseException {


### PR DESCRIPTION
Don't destroy the stacktrace information of a caught exception that's about to be rethrown.

This arises from my attempts to debug [OH1-Addons issue 5537](https://github.com/openhab/openhab1-addons/issues/5597), where the source of the error is getting lost...

Signed-off-by: Chris Carman <namraccr@gmail.com> (github: 9037568)
