### PR TITLE
include swagger feature directly in rest-docs

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -98,20 +98,10 @@
         <feature>esh-io-transport-upnp</feature>
     </feature>
 
-    <feature name="openhab-misc-ruleengine" description="Rule Engine (Experimental)" version="${project.version}">
+    <feature name="openhab-misc-restdocs" description="REST Documentation" version="${project.version}">
         <feature>openhab-runtime-base</feature>
-        <feature>esh-automation-api</feature>
-        <feature>esh-automation-commands</feature>
-        <feature>esh-automation-core</feature>
-        <feature>esh-automation-module-core</feature>
-        <feature>esh-automation-module-media</feature>
-        <feature>esh-automation-module-script</feature>
-        <feature>esh-automation-module-script-defaultscope</feature>
-        <feature>esh-automation-module-script-rulesupport</feature>
-        <feature>esh-automation-module-timer</feature>
-        <feature>esh-automation-parser-gson</feature>
-        <feature>esh-automation-providers</feature>
-        <feature>esh-automation-rest</feature>
+        <feature>esh.tp-swagger-jax-rs-provider</feature>
+        <bundle>mvn:org.openhab.core/org.openhab.io.rest.docs/${project.version}</bundle>
     </feature>
 
     <feature name="openhab-ui-homebuilder" description="Home Builder" version="${project.version}">


### PR DESCRIPTION
also move out the rule engine from openhab-core and put it in openhab-distro instead
fixes #361

Signed-off-by: Kai Kreuzer <kai@openhab.org>