### PR TITLE
Add Automatic-Module-Name entry to manifests

### DIFF
--- a/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.core.compat1x.test
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB 1.x Compatibility Layer Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.core.compat1x
 Bundle-Activator: org.openhab.core.compat1x.internal.CompatibilityActiva
  tor
 Bundle-ClassPath: 

--- a/bundles/org.openhab.core/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.core
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.openhab.core.internal.CoreActivator
 Bundle-DocURL: http://www.openhab.org

--- a/bundles/org.openhab.io.jetty.certificate/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.io.jetty.certificate/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.jetty.certificate
 Bundle-Activator: org.openhab.io.jetty.certificate.internal.CertificateG
  enerator
 Bundle-Classpath: .,lib/bcpkix-jdk15on-1.52.jar,lib/bcprov-jdk15on-1.52.

--- a/bundles/org.openhab.io.rest.docs/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.io.rest.docs/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.rest.docs
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB REST Documentation

--- a/bundles/org.openhab.io.sound/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.io.sound/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.io.sound
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  lib/jl1.0.1.jar,

--- a/bundles/org.openhab.ui.basicui/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.basicui/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.ui.basicui
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  patch/,

--- a/bundles/org.openhab.ui.classicui/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.classicui/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.ui.classicui
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  patch/,

--- a/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.ui.dashboard
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: openHAB Dashboard UI

--- a/bundles/org.openhab.ui.homebuilder/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.homebuilder/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.ui.homebuilder
 Bundle-ManifestVersion: 2
 Bundle-Name: HomeBuilder User Interface
 Bundle-SymbolicName: org.openhab.ui.homebuilder

--- a/bundles/org.openhab.ui.paperui/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.ui.paperui/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: org.openhab.ui.paperui
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: 
  patch/,


### PR DESCRIPTION
See also https://github.com/eclipse/smarthome/issues/5822.