### PR TITLE
Changed constructors DecimalType to work the same as ESH DecimalType

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -38,11 +38,11 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     }
 
     public DecimalType(long value) {
-        this.value = new BigDecimal(value);
+        this.value = BigDecimal.valueOf(value);
     }
 
     public DecimalType(double value) {
-        this.value = new BigDecimal(value);
+        this.value = BigDecimal.valueOf(value);
     }
 
     public DecimalType(String value) {


### PR DESCRIPTION
The constructors of DecimalType in ESH use BigDecimal.valueOf instead of new BigDecimal. Using valueOf is better because the new constuctors causes undesired rounding. For example the value 0.32 becomes: 0.320000000000000006661338147750939242541790008544921875. With valueOf this doesn't happen. This change will make it work the same as the ESH DecimalType
Closes #371

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>