### PR TITLE
include rfc2217 support in serial API

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -89,7 +89,7 @@
     </feature>
 
     <feature name="openhab-transport-serial" description="Serial Transport" version="${project.version}">
-        <feature>esh-io-transport-serial</feature>
+        <feature>esh-io-transport-serial-rfc2217</feature>
         <feature>esh-config-serial</feature>
         <feature>esh-config-discovery-usbserial</feature>
     </feature>


### PR DESCRIPTION
related to https://github.com/eclipse/smarthome/pull/5560

Signed-off-by: Kai Kreuzer <kai@openhab.org>