### PR TITLE
Changed SAT configuration to enable parallel builds

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -350,13 +350,20 @@
               <version>${sat.version}</version>
               <executions>
                 <execution>
+                  <id>verify</id>
                   <goals>
                     <goal>checkstyle</goal>
                     <goal>pmd</goal>
                     <goal>spotbugs</goal>
-                    <goal>report</goal>
                   </goals>
                   <phase>verify</phase>
+                </execution>
+                <execution>
+                  <id>report</id>
+                  <goals>
+                    <goal>report</goal>
+                  </goals>
+                  <phase>install</phase>
                 </execution>
               </executions>
             </plugin>


### PR DESCRIPTION
See openhab/static-code-analysis#200.
In order for the parallel builds to work spotbugs should be skipped with `-Dspotbugs.skip`

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>