### PR TITLE
Remove Eclipse project specific settings and some Groovy leftovers

### DIFF
--- a/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/org.openhab.core.compat1x.test/.settings/org.eclipse.pde.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-pluginProject.equinox=false
-pluginProject.extensions=false
-resolve.requirebundle=false

--- a/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
+++ b/bundles/org.openhab.core.compat1x.test/META-INF/MANIFEST.MF
@@ -8,12 +8,7 @@ Bundle-Vendor: openHAB
 Bundle-Version: 2.4.0.qualifier
 Fragment-Host: org.openhab.core.compat1x
 Import-Package: 
- groovy.lang,
  javax.measure.quantity,
- org.codehaus.groovy.reflection,
- org.codehaus.groovy.runtime,
- org.codehaus.groovy.runtime.callsite,
- org.codehaus.groovy.runtime.typehandling,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.library.types,

--- a/bundles/org.openhab.core.compat1x/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.core.compat1x/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.core.compat1x/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/org.openhab.core.compat1x/.settings/org.eclipse.pde.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-pluginProject.equinox=false
-pluginProject.extensions=false
-resolve.requirebundle=false

--- a/bundles/org.openhab.core.karaf/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.core.karaf/.settings/org.eclipse.jdt.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning

--- a/bundles/org.openhab.core.karaf/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.karaf/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.karaf/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/org.openhab.core.karaf/.settings/org.eclipse.pde.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-pluginProject.equinox=false
-pluginProject.extensions=false
-resolve.requirebundle=false

--- a/bundles/org.openhab.core/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.core/.settings/org.maven.ide.eclipse.prefs
+++ b/bundles/org.openhab.core/.settings/org.maven.ide.eclipse.prefs
@@ -1,9 +1,0 @@
-#Fri Feb 19 21:35:42 CET 2010
-activeProfiles=
-eclipse.preferences.version=1
-fullBuildGoals=process-test-resources
-includeModules=false
-resolveWorkspaceProjects=true
-resourceFilterGoals=process-resources resources\:testResources
-skipCompilerPlugin=true
-version=1

--- a/bundles/org.openhab.io.jetty.certificate/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.io.jetty.certificate/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.io.rest.docs/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.io.rest.docs/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.io.sound/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.io.sound/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.ui.basicui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.ui.basicui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.ui.basicui/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/org.openhab.ui.basicui/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/bundles/org.openhab.ui.classicui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.ui.classicui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.7

--- a/bundles/org.openhab.ui.classicui/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/org.openhab.ui.classicui/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/bundles/org.openhab.ui.dashboard/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.ui.dashboard/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.ui.dashboard/.settings/org.eclipse.pde.core.prefs
+++ b/bundles/org.openhab.ui.dashboard/.settings/org.eclipse.pde.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-pluginProject.equinox=false
-pluginProject.extensions=false
-resolve.requirebundle=false

--- a/bundles/org.openhab.ui.paperui/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/org.openhab.ui.paperui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/org.openhab.ui.paperui/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/org.openhab.ui.paperui/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1


### PR DESCRIPTION
Most of the Eclipse project specific settings are unnecessary. They may even cause issues because they have the wrong values or cause issues when the project defaults change one day.

See also: https://github.com/openhab/openhab2-addons/pull/3472
