### PR TITLE
Fix maven-scr-plugin does not generate XML for DS annotations in test bundles

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -264,6 +264,7 @@
           <configuration>
             <supportedProjectTypes>
               <supportedProjectType>eclipse-plugin</supportedProjectType>
+              <supportedProjectType>eclipse-test-plugin</supportedProjectType>
             </supportedProjectTypes>
           </configuration>
         </plugin>

--- a/poms/tycho/pom.xml
+++ b/poms/tycho/pom.xml
@@ -468,6 +468,27 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <outputDirectory>${project.basedir}/OSGI-INF</outputDirectory>
+              <overwrite>true</overwrite>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/target/classes/OSGI-INF</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The maven-resources-plugin is used to copy back the generated XML to the OSGI-INF directory so it is on the classpath in tests.

The `outputDirectory` configuration parameter of the maven-scr-plugin is not used because when it is set to `${project.basedir}` it empties the OSGI-INF dir and would remove non-generated SCR XML files.

Fixes #318