### PR TITLE
Upgrade to Karaf 4.2.1

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -64,8 +64,8 @@
     <ohdr.version>1.0.31</ohdr.version>
     <esh.version>0.10.0-SNAPSHOT</esh.version>
     <repo.version>2.4.x</repo.version>
-    <karaf.version>4.1.5</karaf.version>
-    <jetty.version>9.3.21.v20170918</jetty.version>
+    <karaf.version>4.2.1</karaf.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
     <jackson.version>1.9.13</jackson.version>
     <sat.version>0.5.0</sat.version>
     <nrjavaserial.version>3.14.0</nrjavaserial.version>


### PR DESCRIPTION
The openhab-core related changes regaring upgrading to Karaf 4.2.1.

Should be merged simultaneously with: https://github.com/openhab/openhab-distro/pull/761.