### PR TITLE
fixes potential NPE in async execution

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -363,7 +363,7 @@ public class FeatureInstaller implements ConfigurationListener {
             if (install instanceof String) {
                 String[] entries = ((String) install).split(",");
                 try {
-                    Feature[] features = featuresService.listInstalledFeatures();
+                    Feature[] features = service.listInstalledFeatures();
                     for (String addon : entries) {
                         if (!StringUtils.isEmpty(addon)) {
                             String id = PREFIX + type + "-" + addon.trim();
@@ -375,7 +375,7 @@ public class FeatureInstaller implements ConfigurationListener {
                     }
 
                     // we collect all installed addons
-                    for (String addon : getAllAddonsOfType(type)) {
+                    for (String addon : getAllAddonsOfType(service, type)) {
                         if (!StringUtils.isEmpty(addon)) {
                             String id = PREFIX + type + "-" + addon.trim();
                             if (isInstalled(features, id)) {
@@ -404,7 +404,7 @@ public class FeatureInstaller implements ConfigurationListener {
         }
     }
 
-    private Set<String> getAllAddonsOfType(String type) {
+    private Set<String> getAllAddonsOfType(FeaturesService featuresService, String type) {
         Set<String> addons = new HashSet<>();
         String prefix = FeatureInstaller.PREFIX + type + "-";
         try {


### PR DESCRIPTION
I came across this by seeing this in my logs:
```
 14:19:12.955 [ERROR] [.core.karaf.internal.FeatureInstaller] - Failed retrieving features: null
```
The NPE was triggered by the fact that the `featuresService` field was null, probably due to the component being already deactivated while the async process was still running.

It slightly concerns me that the component has been deactivated (for which I do not see any reason) and we might want to consider to cancel existing jobs instead of continuing them, but that should be the topic of a different PR.

Signed-off-by: Kai Kreuzer <kai@openhab.org>