### PR TITLE
mandatorily depend on orbit version of gson 2.7

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -12,6 +12,7 @@
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 
     <feature name="openhab-runtime-base" description="openHAB Runtime Base" version="${project.version}">
+        <bundle>mvn:org.eclipse.orbit.bundles/com.google.gson/2.7.0.v20170129-0911</bundle>
         <feature>esh-base</feature>
         <feature>esh-io-console-karaf</feature>
         <feature>esh-io-rest-sitemap</feature>


### PR DESCRIPTION
This PR makes sure that GSON 2.7 from Eclipse Orbit is present in the distro, so that gson consumers are resolved against this. 

This should address problems like the one described in https://github.com/eclipse/smarthome/issues/6250.

/cc @maggu2810 

Signed-off-by: Kai Kreuzer <kai@openhab.org>