### PR TITLE
Set maven-install-plugin version to 2.5.2

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -171,6 +171,10 @@
           <version>2.8.2</version>
         </plugin>
         <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
           <groupId>org.commonjava.maven.plugins</groupId>
           <artifactId>directory-maven-plugin</artifactId>
           <version>0.2</version>


### PR DESCRIPTION
Recently 3.0.0-M1 of the maven-install-plugin was released which now breaks the openhab2-addons build with:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install (default-install) on project openhab2-addons: NoFileAssignedException: The packaging plugin for this project did not assign a main file to the project but it has attachments. Change packaging to 'pom'. -> [Help 1]`