### PR TITLE
fixed Bintray release Maven repo url

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -104,7 +104,7 @@
       </snapshots>
       <id>bintray</id>
       <name>openHAB SmartHome Repository</name>
-      <url>https://api.bintray.com/maven/openhab/mvn/smarthome</url>
+      <url>https://dl.bintray.com/openhab/mvn/</url>
     </repository>
 
     <repository>


### PR DESCRIPTION
I'd assume that our release build failed due to this bug (https://ci.openhab.org/job/openhab2-release/56/) - the url that was used was for uploading artifacts (which requires authentication) and not the one for anonymously downloading artifacts.

Signed-off-by: Kai Kreuzer <kai@openhab.org>