### PR TITLE
upgraded to deps 1.0.35, which includes no_locks nrjavaserial library

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -61,7 +61,7 @@
     <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
     <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
 
-    <ohdr.version>1.0.34</ohdr.version>
+    <ohdr.version>1.0.35</ohdr.version>
     <esh.version>0.10.0-SNAPSHOT</esh.version>
     <repo.version>2.4.x</repo.version>
     <karaf.version>4.2.1</karaf.version>


### PR DESCRIPTION
See also https://community.openhab.org/t/rxtx-fhs-lock-error-opening-lock-file-var-lock-lck-ttyusb0-file-exists-it-is-mine/49117/34

Signed-off-by: Kai Kreuzer <kai@openhab.org>