### PR TITLE
Do not install node in target directory 

### DIFF
--- a/bundles/org.openhab.ui.homebuilder/pom.xml
+++ b/bundles/org.openhab.ui.homebuilder/pom.xml
@@ -47,6 +47,7 @@
             <npm_config_cache>${project.basedir}/npm_cache</npm_config_cache>
             <npm_config_tmp>${project.basedir}/npm_tmp</npm_config_tmp>
           </environmentVariables>
+          <installDirectory>target</installDirectory>
           <workingDirectory>web</workingDirectory>
         </configuration>
 


### PR DESCRIPTION
Do not install node in target directory to make sure we do not package node in our jar

Addresses: https://github.com/openhab/openhab-core/pull/417#issuecomment-440162069

I prefer to have it tested before merging, I might have time to test tomorrow.