### PR TITLE
fixed version of Guava to use to 18.0

### DIFF
--- a/features/openhab-core/src/main/feature/feature.xml
+++ b/features/openhab-core/src/main/feature/feature.xml
@@ -13,6 +13,7 @@
 
     <feature name="openhab-runtime-base" description="openHAB Runtime Base" version="${project.version}">
         <bundle>mvn:org.eclipse.orbit.bundles/com.google.gson/2.7.0.v20170129-0911</bundle>
+        <bundle>mvn:com.google.guava/guava/18.0</bundle>
         <feature>esh-base</feature>
         <feature>esh-io-console-karaf</feature>
         <feature>esh-io-rest-sitemap</feature>


### PR DESCRIPTION
Currently, the base openHAB Distro that is started installs the Xtext feature, which [uses Guava 15.0](https://github.com/eclipse/smarthome/blob/master/features/karaf/esh-tp/src/main/feature/feature.xml#L174), so that bundle is installed.
If the user now selects a package that contains the restdocs feature (e.g. "Expert" or "Demo"), [Guava 18](https://github.com/eclipse/smarthome/blob/master/features/karaf/esh-tp/src/main/feature/feature.xml#L233) gets installed, which causes the whole distro to more or less reboot, causing all kinds of issues in the log and briefly deactivating the HTTP server as well, so that the UI might just refresh when the server is not responding - all very undesired effects.

This PR simply adds Guava 18.0 as a bundle to the base installation, so that no restart should happen anymore.

Signed-off-by: Kai Kreuzer <kai@openhab.org>