### PR TITLE
Update SAT regex to 2.5.0 to fix build

### DIFF
--- a/tools/checkstyle.properties
+++ b/tools/checkstyle.properties
@@ -1,5 +1,5 @@
 checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} by the respective copyright holders\\.$\\n^ \\*$\\n^ \\* All rights reserved\\. This program and the accompanying materials$\\n^ \\* are made available under the terms of the Eclipse Public License v1\\.0$\\n^ \\* which accompanies this distribution, and is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-v10\\.html$
 checkstyle.headerCheck.values=2015,2018 
-checkstyle.pomXmlCheck.currentVersionRegex=^2\.4\.0
+checkstyle.pomXmlCheck.currentVersionRegex=^2\.5\.0
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common
 checkstyle.forbiddenPackageUsageCheck.exceptions=


### PR DESCRIPTION
The openhab2-addons [build fails](https://travis-ci.org/openhab/openhab2-addons/builds/468802512?utm_source=github_status&utm_medium=notification) after the 2.4.0 release because this regex was not updated:

```
[INFO] --- sat-plugin:0.5.0:report (default) @ org.openhab.binding.airquality ---
[INFO] Individual report appended to summary report.
[ERROR] Code Analysis Tool has found: 
 1 error(s)! 
 0 warning(s) 
 1 info(s)
[ERROR] .binding.airquality/META-INF/MANIFEST.MF:[0]
The manifest version did not match the requirements ^2.4.0
[INFO] Detailed report can be found at: file:////home/travis/build/openhab/openhab2-addons/addons/binding/org.openhab.binding.airquality/target/code-analysis/report.html
```