### PR TITLE
Upgrade Karaf to 4.2.2

### DIFF
--- a/poms/pom.xml
+++ b/poms/pom.xml
@@ -63,8 +63,8 @@
     <ohdr.version>1.0.38</ohdr.version>
     <esh.version>0.11.0-SNAPSHOT</esh.version>
     <repo.version>2.5.x</repo.version>
-    <karaf.version>4.2.1</karaf.version>
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <karaf.version>4.2.2</karaf.version>
+    <jetty.version>9.4.12.v20180830</jetty.version>
     <jna.version>4.5.2</jna.version>
     <jackson.version>1.9.13</jackson.version>
     <sat.version>0.5.0</sat.version>


### PR DESCRIPTION
The openhab-core related changes for upgrading to Karaf 4.2.2.

Should be merged simultaneously with: https://github.com/openhab/openhab-distro/pull/834.