### PR TITLE
Update californium dependencies to version 1.0.7

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -44,10 +44,10 @@
   </feature>
 
   <feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
-    <capability>openhab.tp;feature=coap;version=1.0.6</capability>
-    <bundle>mvn:org.eclipse.californium/californium-osgi/1.0.6</bundle>
-    <bundle>mvn:org.eclipse.californium/element-connector/1.0.6</bundle>
-    <bundle>mvn:org.eclipse.californium/scandium/1.0.6</bundle>
+    <capability>openhab.tp;feature=coap;version=1.0.7</capability>
+    <bundle>mvn:org.eclipse.californium/californium-osgi/1.0.7</bundle>
+    <bundle>mvn:org.eclipse.californium/element-connector/1.0.7</bundle>
+    <bundle>mvn:org.eclipse.californium/scandium/1.0.7</bundle>
   </feature>
 
   <feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">


### PR DESCRIPTION
- Update californium dependencies to version 1.0.7 (see https://github.com/eclipse/californium/releases/tag/1.0.7)

Closes openhab/openhab2-addons#4733

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>