### PR TITLE
Export all org.openhab packages (except internal ones)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@ Import-Package: \\
 -exportcontents: \\
   !*.internal.*,\\
   !*.impl.*, \\
-  org.openhab.core.*,\\
+  org.openhab.*,\\
   org.eclipse.smarthome.*
 -sources: false
 -contract: *


### PR DESCRIPTION
Makes e.g. `org.openhab.ui.dashboard` be exported, which was missing so far.

Signed-off-by: Kai Kreuzer <kai@openhab.org>