### PR TITLE
Keep persisted disabled status when thing is removed

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -484,7 +484,6 @@ public class ThingManagerImpl
             }
         }
 
-        storage.remove(thing.getUID().getAsString());
         this.things.remove(thing);
     }
 

--- a/itests/org.openhab.core.thing.tests/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -913,7 +913,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testStorageEntryRemovedOnThingRemoval() throws Exception {
+    public void testStorageEntryRetainedOnThingRemoval() throws Exception {
         registerThingTypeProvider();
 
         AtomicReference<ThingHandlerCallback> thingHandlerCallback = new AtomicReference<>();
@@ -981,8 +981,10 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         new Thread((Runnable) () -> managedThingProvider.remove(THING.getUID())).start();
 
         waitForAssert(() -> {
-            assertThat(storage.containsKey(THING_UID.getAsString()), is(false));
+            assertThat(thingRegistry.get(THING.getUID()), is(equalTo(null)));
         }, SafeCaller.DEFAULT_TIMEOUT - 100, 50);
+        
+        assertThat(storage.containsKey(THING_UID.getAsString()), is(true));
     }
 
     private void assertThingStatus(Map<String, Object> propsThing, Map<String, Object> propsChannel, ThingStatus status,


### PR DESCRIPTION
Ported over from https://github.com/eclipse/smarthome/pull/6870.

Also-By: Florian Stolte <fstolte@itemis.de>
Signed-off-by: Kai Kreuzer <kai@openhab.org>