### PR TITLE
add property to enable bnd resolver on Maven run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.openhab.core</groupId>
@@ -274,8 +274,8 @@ Import-Package: \\
           </executions>
         </plugin>
 
-        <!-- Define the version of the baseline plugin we use and avoid failing when no baseline jar exists. (for example
-        before the first release) -->
+        <!-- Define the version of the baseline plugin we use and avoid failing when no baseline jar exists. -->
+        <!-- (for example before the first release) -->
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-baseline-maven-plugin</artifactId>
@@ -473,8 +473,8 @@ Import-Package: \\
           </executions>
         </plugin>
 
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build
-        itself. -->
+        <!-- This plugin's configuration is used to store Eclipse m2e settings only. -->
+        <!-- It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
@@ -530,8 +530,35 @@ Import-Package: \\
         <module>itests</module>
       </modules>
     </profile>
+    <profile>
+      <id>with-bnd-resolver-resolve</id>
+      <activation>
+        <property>
+          <name>withResolver</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>biz.aQute.bnd</groupId>
+              <artifactId>bnd-resolver-maven-plugin</artifactId>
+              <version>${bnd.version}</version>
+              <executions>
+                <execution>
+                  <goals>
+                    <goal>resolve</goal>
+                  </goals>
+                  <phase>package</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
   </profiles>
-    
+
   <modules>
     <module>bom</module>
     <module>demo</module>


### PR DESCRIPTION
The property `withResolver` binds the `resolve` goal of the `bnd-resolver-maven-plugin` to the `package` phase.
