### PR TITLE
use release version of p2-maven-plugin

### DIFF
--- a/features/p2/repo/pom.xml
+++ b/features/p2/repo/pom.xml
@@ -26,7 +26,7 @@
         <plugin>
           <groupId>org.reficio</groupId>
           <artifactId>p2-maven-plugin</artifactId>
-          <version>1.2.0-SNAPSHOT</version>
+          <version>1.2.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Any reason to use a snapshot of that plugin?
There is a 1.2.0 and 1.3.0 release, I have chosen the "nearest" one.