### PR TITLE
Add registration for ScriptedCustomModuleHandlerFactory

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleHandlerFactory.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.handler.ModuleHandler;
+import org.openhab.core.automation.handler.ModuleHandlerFactory;
 import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedHandler;
 import org.osgi.service.component.annotations.Component;
 
@@ -31,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Simon Merschjohann
  *
  */
-@Component(immediate = true, service = ScriptedCustomModuleHandlerFactory.class)
+@Component(immediate = true, service = { ScriptedCustomModuleHandlerFactory.class, ModuleHandlerFactory.class })
 public class ScriptedCustomModuleHandlerFactory extends AbstractScriptedModuleHandlerFactory {
     private final HashMap<String, ScriptedHandler> typesHandlers = new HashMap<>();
 


### PR DESCRIPTION
This will properly register ScriptedCustomtModuleHandlerFactory, so that custom handlers can be used in JSR223 scripts. This corrects the issue at hand, but there appears to be more updates to get scripted automation up to date with ESH PR #[4668](https://github.com/eclipse/smarthome/pull/4468). The way the code sits now (even after this PR), TriggerHandlers appear to need to be added before the TriggerType.

I didn't see any tests to update, and I'm not prepared to add any ATM, but I will look into filling those gaps.

Fixes #517 

Signed-off-by: Scott Rushworth openhab@5iver.com (github: openhab-5iver)