### PR TITLE
(Temporarily) removed  DS requirements generation to make addon repos compile

### DIFF
--- a/features/p2/poms/pom.xml
+++ b/features/p2/poms/pom.xml
@@ -38,7 +38,7 @@
     <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
     <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
 
-    <ohdr.version>1.0.38</ohdr.version>
+    <ohdr.version>1.0.39</ohdr.version>
     <repo.version>2.5.x</repo.version>
     <karaf.version>4.2.2</karaf.version>
     <jetty.version>9.4.12.v20180830</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@ Import-Package: \\
   org.eclipse.smarthome.*
 -sources: false
 -contract: *
+-dsannotations-options: norequirements
 ]]></bnd>
             <!-- Bundle-SymbolicName: ${project.groupId}.${project.artifactId} -->
           </configuration>


### PR DESCRIPTION
Solves https://github.com/openhab/openhab-core/issues/528

@maggu2810 I very much hope you will approve this change - it makes the existing addons build work again without further issues and it is tedious to resolve them all considering that we anyhow want to change the build system of the addons repos soon. So I consider this PR to be a temporary measure only until we are fully on bnd.

Signed-off-by: Kai Kreuzer <kai@openhab.org>