### PR TITLE
[WIP] provide a better uninstall mechanism for synthetic bundles

### DIFF
--- a/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/BundleCloseable.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/BundleCloseable.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.test;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+
+/**
+ * A wrapper that uninstalls a bundle on close.
+ *
+ * <p>
+ * This wrapper allows the usage in try-with-resources blocks.
+ *
+ * @author Markus Rathgeb - Initial contribution and API
+ */
+public class BundleCloseable implements AutoCloseable {
+
+    private final Bundle bundle;
+
+    public BundleCloseable(final Bundle bundle) {
+        this.bundle = bundle;
+    }
+
+    @Override
+    public void close() throws BundleException {
+        bundle.uninstall();
+    }
+
+    public Bundle bundle() {
+        return bundle;
+    }
+}

--- a/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
@@ -315,6 +315,10 @@ public class SyntheticBundleInstaller {
     /**
      * Uninstalls the synthetic bundle (or bundle fragment), denoted by its name, from the test runtime.
      *
+     * <p>
+     * This method should only be used if the bundle itself provides a symbolic name.
+     * If possible you should use the uninstall method of the bundle itself.
+     *
      * @param bundleContext the bundle context of the test runtime
      * @param testBundleName the name of the test bundle to be uninstalled
      * @throws BundleException if error is met during the bundle uninstall


### PR DESCRIPTION
If a bundle misses a BSN the bundle cannot be installed.
We should provide a method to uninstall the bundle that has been created
by the synthetic installer itself.
