### PR TITLE
ConfigDescriptionParameter: limitToOptions

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
@@ -96,7 +96,7 @@ public class ConfigDescriptionParameter {
     private List<ParameterOption> options = new ArrayList<ParameterOption>();
     private List<FilterCriteria> filterCriteria = new ArrayList<FilterCriteria>();
 
-    private boolean limitToOptions = true;
+    private boolean limitToOptions = false;
     private boolean advanced = false;
     private boolean verify = false;
 


### PR DESCRIPTION
I just looked up the xml schema. limitToOptions is per default false.
The true default breaks a lot of configuration screens if the flag is correctly honored.

Signed-off-by: davidgraeff <david.graeff@web.de>