### PR TITLE
ConfigDescriptionParameterConverter: limitToOptions

### DIFF
--- a/bundles/org.openhab.core.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionParameterConverter.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionParameterConverter.java
@@ -119,7 +119,7 @@ public class ConfigDescriptionParameterConverter extends GenericUnmarshaller<Con
 
         Boolean advanced = valueMap.getBoolean("advanced", false);
         Boolean verify = valueMap.getBoolean("verify", false);
-        Boolean limitToOptions = valueMap.getBoolean("limitToOptions", true);
+        Boolean limitToOptions = valueMap.getBoolean("limitToOptions", false);
         Integer multipleLimit = valueMap.getInteger("multipleLimit");
         String unitLabel = null;
         if (unit == null) {


### PR DESCRIPTION
I just looked up the xml schema. limitToOptions is per default false.
The true default breaks a lot of configuration screens if the flag is correctly honored.

Signed-off-by: davidgraeff <david.graeff@web.de>