### PR TITLE
drop shade plugin use bnd instructions

### DIFF
--- a/bundles/org.openhab.core.io.jetty.certificate/bnd.bnd
+++ b/bundles/org.openhab.core.io.jetty.certificate/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-SymbolicName: ${project.artifactId}
 Bundle-Activator: org.openhab.io.jetty.certificate.internal.CertificateGenerator
-Import-Package: !org.bouncycastle.*,*
+Private-Package: org.bouncycastle.*

--- a/bundles/org.openhab.core.io.jetty.certificate/pom.xml
+++ b/bundles/org.openhab.core.io.jetty.certificate/pom.xml
@@ -16,49 +16,8 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.52</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>org.bouncycastle:*</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <artifact>org.bouncycastle:*</artifact>
-                  <excludes>
-                    <!-- Exclude the JAR signing files -->
-                    <exclude>META-INF/BCKEY.*</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-              <minimizeJar>true</minimizeJar>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <manifestEntries>
-                    <Bundle-Classpath>.</Bundle-Classpath>
-                  </manifestEntries>
-                </transformer>
-              </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>


### PR DESCRIPTION
We should not use the shade plugin if we want to create OSGi bundles
correctly and keep the IDE support.

* the added packages are not considered for the manifest generation
  If an added package needs other packages they are not added to the
  import-packages instructions.
* the IDE does not know the shade plugin (there is no m2e plugin)
  If the bundle gets rebuild in the IDE the shade goal is not executed
  and the build artifact misses the packages. So the bundle generated by
  the Eclipse IDE and the bundle generated by the Maven build differs.

About the missing imports:

The bundled BouncyCastle packages (potentially) uses classes of the
following packages:

* javax.crypto
* javax.crypto.interfaces
* javax.crypto.spec
* javax.naming
* javax.naming.directory
* javax.security.auth.x500

IIRC the openHAB distribution uses bootdelegation and so you will not
identify a CNF exception on runtime, but there should not be a
requirement that consumers needs to enable that instruction.
We should create working OSGi bundles without such requirements.

If we would like to reduce the bundled classes and imports we could use
the "-conditionalpackage" instruction instead. This can potentially
reduce the size of our bundle significantly.
But let's keep the old behaviour (add all BouncyCastle packages) to not
break any consumers.
