### PR TITLE
Remove outdated release profiles

### DIFF
--- a/features/p2/poms/pom.xml
+++ b/features/p2/poms/pom.xml
@@ -248,50 +248,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>prepare-release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-versions-plugin</artifactId>
-            <version>${tycho-version}</version>
-            <executions>
-              <execution>
-                <id>update-version</id>
-                <goals>
-                  <goal>set-version</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>prepare-next-snapshot</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-versions-plugin</artifactId>
-            <version>${tycho-version}</version>
-            <executions>
-              <execution>
-                <id>update-version</id>
-                <goals>
-                  <goal>set-version</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- static code analysis profiles -->
     <profile>
       <id>check</id>

--- a/features/p2/poms/tycho/pom.xml
+++ b/features/p2/poms/tycho/pom.xml
@@ -238,28 +238,6 @@
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>prepare-next-snapshot</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.tycho</groupId>
-            <artifactId>tycho-versions-plugin</artifactId>
-            <version>${tycho-version}</version>
-            <executions>
-              <execution>
-                <id>update-version</id>
-                <goals>
-                  <goal>set-version</goal>
-                </goals>
-                <phase>initialize</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
I think we can remove some outdated profiles that were used within the old release process.

@kaikreuzer: Could you check?

Signed-off-by: Patrick Fink <mail@pfink.de>