### PR TITLE
[automation] Adapt input type of ItemCommandAction

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/ItemActions.json
@@ -51,7 +51,7 @@
      "inputs":[
       {
         "name":"command",
-        "type":"org.eclipse.smarthome.core.types.Command",
+        "type":"org.openhab.core.types.Command",
         "label":"Command",
         "description":"command that will be sent to the item."
       }


### PR DESCRIPTION
Considering the bundle name has changed recently, changing this type should not be a breaking change

Signed-off-by: davidgraeff <david.graeff@web.de>