### PR TITLE
Make ChannelTypeRegistry immediate

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  */
 @NonNullByDefault
-@Component(service = ChannelTypeRegistry.class)
+@Component(service = ChannelTypeRegistry.class, immediate = true)
 public class ChannelTypeRegistry {
 
     private final List<ChannelTypeProvider> channelTypeProviders = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
In a build setup where the core.thing.test integration tests are run by the bnd test runner with the felix runtime we experienced a problem with service references being disposed w/o referencing services being disposed. This led to multiple service references being available during test execution and failing tests.
Although I could not track down the root cause of this, a solution is to make the `ChannelTypeRegistry` an immediate component. This way it stays active during all test executions. In addition I think it should really be immediately available also in the runtime.

Signed-off-by: Henning Treu <henning.treu@googlemail.com>