### PR TITLE
Replaces 'Eclipse SmartHome' with 'openHAB' in text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,10 @@
 
 Warning: Note that this is most likely not the project you are looking for.
 
-openHAB mainly consist out of the core components from Eclipse SmartHome (https://github.com/eclipse/smarthome),
-extensions that are openHAB1-compatible from https://github.com/openhab/openhab and extensions that are 
-openHAB2-compatible from https://github.com/openhab/openhab2. All is then packaged into a distribution in
+openHAB mainly consist out of the core components, extensions that are openHAB1-compatible from
+https://github.com/openhab/openhab1-addons and extensions that are openHAB2-compatible from
+https://github.com/openhab/openhab2-addons. All is then packaged into a distribution in
 https://github.com/openhab/openhab-distro.
-
-This project here only contains a few bundles of the core runtime that are openHAB specific and thus not contained
-in the Eclipse SmartHome project.
 
 ## Contribution guidelines
 

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -221,7 +221,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     /**
      * Implicit Grant (RFC 6749 section 4.2) is not implemented. It is directly interacting with user-agent
      * The implicit grant is not implemented. It usually involves browser/javascript redirection flows
-     * and is out of Eclipse SmartHome scope.
+     * and is out of openHAB scope.
      */
     @Override
     public AccessTokenResponse getAccessTokenByImplicit(@Nullable String redirectURI, @Nullable String scope,

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -576,7 +576,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     /**
-     * This method can be used in order to post events through the Eclipse SmartHome events bus. A common
+     * This method can be used in order to post events through the openHAB events bus. A common
      * use case is to notify event subscribers about the {@link Rule}'s status change.
      *
      * @param ruleUID the UID of the {@link Rule}, whose status is changed.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -295,7 +295,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
     }
 
     /**
-     * This method can be used in order to post events through the Eclipse SmartHome events bus. A common
+     * This method can be used in order to post events through the openHAB events bus. A common
      * use case is to notify event subscribers about the {@link Rule}'s status change.
      *
      * @param ruleUID    the UID of the {@link Rule}, whose status is changed.

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/events/internal/EventBridge.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/events/internal/EventBridge.java
@@ -37,7 +37,7 @@ import org.osgi.service.event.EventHandler;
 
 /**
  * This class acts as a bridge between events from openHAB 1.x (using "openhab" as a topic prefix) and
- * Eclipse SmartHome (using "smarthome" as a topic prefix).
+ * openHAB (using "smarthome" as a topic prefix).
  * It simply duplicates events with an updated topic prefix and works both ways.
  *
  * @author Kai Kreuzer - Initial contribution and API

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigConstants.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigConstants.java
@@ -13,7 +13,7 @@
 package org.eclipse.smarthome.config.core;
 
 /**
- * This class provides constants relevant for the configuration of Eclipse SmartHome
+ * This class provides constants relevant for the configuration of openHAB
  *
  * @author Kai Kreuzer - Initial contribution and API
  *

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * This OSGi service could be used to localize a config description using the I18N mechanism of the Eclipse SmartHome
+ * This OSGi service could be used to localize a config description using the I18N mechanism of the openHAB
  * framework.
  *
  * @author Markus Rathgeb - Move code from XML config description provider to separate service

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * <p/>
  * This discovery service is intended to be used by bindings that support USB devices, but do not directly talk to the
  * USB devices but rather use a serial port for the communication, where the serial port is provided by an operating
- * system driver outside the scope of Eclipse SmartHome. Examples for such USB devices are USB dongles that provide
+ * system driver outside the scope of openHAB. Examples for such USB devices are USB dongles that provide
  * access to wireless networks, like, e.g., Zigbeee or Zwave dongles.
  * <p/>
  * This discovery service provides functionality for discovering added and removed USB devices and the corresponding

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxAutoApprovePredicate.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxAutoApprovePredicate.java
@@ -29,8 +29,8 @@ import org.osgi.service.component.annotations.Component;
  * automatically approved (e.g., because another such {@link Predicate} returned <code>true</code>) - i.e., it is not
  * possible to veto the automatic approval of a {@link DiscoveryResult}.
  * <p/>
- * Please note that this interface is intended to be implemented by solutions integrating Eclipse SmartHome. This
- * interface is <em>not</em> intended to be implemented by Eclipse SmartHome addons (like, e.g., bindings).
+ * Please note that this interface is intended to be implemented by solutions integrating openHAB. This
+ * interface is <em>not</em> intended to be implemented by openHAB addons (like, e.g., bindings).
  *
  * @author Henning Sudbrock - initial contribution
  */

--- a/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/eclipse/smarthome/io/console/eclipse/internal/ConsoleSupportEclipse.java
+++ b/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/eclipse/smarthome/io/console/eclipse/internal/ConsoleSupportEclipse.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
- * This class provides access to Eclipse SmartHome functionality through the OSGi console
+ * This class provides access to openHAB functionality through the OSGi console
  * of Equinox. Unfortunately, there these command providers are not standardized
  * for OSGi, so we need different implementations for different OSGi containers.
  *

--- a/bundles/org.openhab.core.io.rest.log/README.md
+++ b/bundles/org.openhab.core.io.rest.log/README.md
@@ -1,6 +1,6 @@
 FORMAT: 1A
 
-# Eclipse SmartHome UI Logging Bundle
+# openHAB UI Logging Bundle
 
 This Bundle provides a resource at the REST API to enable a consumer to fetch the set log levels.
 It also receives log messages which will be logged to the server's log.

--- a/bundles/org.openhab.core.io.rest.optimize/src/main/java/org/eclipse/smarthome/io/rest/optimize/internal/ResourceFilterImpl.java
+++ b/bundles/org.openhab.core.io.rest.optimize/src/main/java/org/eclipse/smarthome/io/rest/optimize/internal/ResourceFilterImpl.java
@@ -65,7 +65,7 @@ public class ResourceFilterImpl implements ResourceFilter {
     private static final String[] WHITELIST = new String[] {
             // JAX-RS
             "javax.ws.rs.ext.MessageBodyReader", "javax.ws.rs.ext.MessageBodyWriter",
-            // Eclipse SmartHome
+            // openHAB
             "org.eclipse.smarthome.io.rest.internal.filter.ProxyFilter",
             "org.eclipse.smarthome.io.rest.internal.resources.RootResource",
             "org.eclipse.smarthome.io.rest.JSONResponse$ExceptionMapper", "org.eclipse.smarthome.io.rest.RESTResource",

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/SseActivator.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/SseActivator.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bundle activator for Eclipse SmartHome SSE bundle.
+ * Bundle activator for openHAB SSE bundle.
  *
  * @author Ivan Iliev - Initial Contribution and API
  *

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/listeners/SseEventSubscriber.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/listeners/SseEventSubscriber.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * The {@link SseEventSubscriber} is responsible for broadcasting Eclipse SmartHome events
+ * The {@link SseEventSubscriber} is responsible for broadcasting openHAB events
  * to currently listening SSE clients.
  *
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/ServiceDescription.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/ServiceDescription.java
@@ -31,10 +31,10 @@ public class ServiceDescription {
      * Constructor for a {@link ServiceDescription}, which takes all details as parameters
      * 
      * @param serviceType String service type, like "_smarthome-server._tcp.local."
-     * @param serviceName String service name, like "Eclipse SmartHome"
+     * @param serviceName String service name, like "openHAB"
      * @param servicePort Int service port, like 8080
      * @param serviceProperties Hashtable service props, like url = "/rest"
-     * @param serviceDescription String service description text, like "Eclipse SmartHome REST interface"
+     * @param serviceDescription String service description text, like "openHAB REST interface"
      */
     public ServiceDescription(String serviceType, String serviceName, int servicePort,
             Hashtable<String, String> serviceProperties) {

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -61,7 +61,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 
 /**
- * This class is the core of the Eclipse SmartHome rule engine.
+ * This class is the core of the openHAB rule engine.
  * It listens to changes to the rules folder, evaluates the trigger conditions of the rules and
  * schedules them for execution dependent on their triggering conditions.
  *

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/ServiceModule.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/ServiceModule.java
@@ -27,7 +27,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 
 /**
- * Guice module that binds Eclipse SmartHome services
+ * Guice module that binds openHAB services
  *
  * @author Simon Kaufmann - initial contribution and API.
  *

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/BusEvent.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/BusEvent.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The static methods of this class are made available as functions in the scripts.
- * This gives direct write access to the Eclipse SmartHome event bus from within scripts.
+ * This gives direct write access to the openHAB event bus from within scripts.
  * Items should not be updated directly (setting the state property), but updates should
  * be sent to the bus, so that all interested bundles are notified.
  *

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/engine/Script.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/engine/Script.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.model.script.engine;
 import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 
 /**
- * This interface is implemented by Eclipse SmartHome scripts.
+ * This interface is implemented by openHAB scripts.
  *
  * @author Kai Kreuzer - Initial contribution and API
  *

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptEngine.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptEngine.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.model.script.engine;
 import org.eclipse.xtext.xbase.XExpression;
 
 /**
- * The script engine is the main entrypoint for Eclipse SmartHome script use. It can build {@link Script} instances from
+ * The script engine is the main entrypoint for openHAB script use. It can build {@link Script} instances from
  * simple strings. These scripts can then be executed by the caller.
  *
  * @author Kai Kreuzer - Initial contribution and API

--- a/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceService.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.Item;
 
 /**
- * A persistence service which can be used to store data from Eclipse SmartHome.
+ * A persistence service which can be used to store data from openHAB.
  * This must not necessarily be a local database, a persistence service
  * can also be cloud-based or a simply data-export facility (e.g.
  * for sending data to an IoT (Internet of Things) service.

--- a/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/QueryablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/QueryablePersistenceService.java
@@ -19,7 +19,7 @@ import org.eclipse.smarthome.core.items.Item;
 
 /**
  * A queryable persistence service which can be used to store and retrieve
- * data from Eclipse SmartHome. This is most likely some kind of database system.
+ * data from openHAB. This is most likely some kind of database system.
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Chris Jackson - Added getItems method

--- a/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/binding/binding.xml
+++ b/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/binding/binding.xml
@@ -5,6 +5,6 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
 	<name>Magic Binding</name>
-	<description>This is the Magic binding for Eclipse SmartHome.</description>
+	<description>This is the Magic binding for openHAB.</description>
 
 </binding:binding>

--- a/bundles/org.openhab.core.test.magic/web/index.html
+++ b/bundles/org.openhab.core.test.magic/web/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<title>Eclipse SmartHome</title>
+<title>openHAB</title>
 <!-- CSS -->
 <link href="http://localhost:8080/paperui/css/bootstrap.min.css" type="text/css" rel="stylesheet" media="screen,projection" />
 <link href="./css/styles.css" rel="stylesheet" />
@@ -42,7 +42,7 @@
 
 	<section id="references" class="z-depth-1">
 		<div class="container">
-			<h2>Welcome to Eclipse SmartHome</h2>
+			<h2>Welcome to openHAB</h2>
 			<p>Here are a few useful links to start exploring your local instance:</p>
 			<div class="row scrollme animateme" data-when="enter" data-from="0.75" data-to="0" data-crop="false" data-opacity="0" data-scale="1.125">
 				<div class="col-lg-3 col-sm-12 col-md-6">

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BridgeHandler.java
@@ -17,7 +17,7 @@ import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 
 /**
- * A {@link BridgeHandler} handles the communication between the Eclipse SmartHome framework and
+ * A {@link BridgeHandler} handles the communication between the openHAB framework and
  * a <i>bridge</i> (a device that acts as a gateway to enable the communication with other devices)
  * represented by a {@link Bridge} instance.
  * <p>

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
@@ -28,7 +28,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * A {@link ThingHandler} handles the communication between the Eclipse SmartHome framework and an entity from the real
+ * A {@link ThingHandler} handles the communication between the openHAB framework and an entity from the real
  * world, e.g. a physical device, a web service, etc. represented by a {@link Thing}.
  * <p>
  * The communication is bidirectional. The framework informs a thing handler about commands, state and configuration

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ChannelTriggeredEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ChannelTriggeredEvent.java
@@ -16,7 +16,7 @@ import org.eclipse.smarthome.core.events.AbstractEvent;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 
 /**
- * {@link ChannelTriggeredEvent}s can be used to deliver triggers through the Eclipse SmartHome event bus.
+ * {@link ChannelTriggeredEvent}s can be used to deliver triggers through the openHAB event bus.
  * Trigger events must be created with the {@link ThingEventFactory}.
  *
  * @author Moritz Kammerer - Initial contribution

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoChangedEvent.java
@@ -17,7 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
 /**
- * {@link ThingStatusInfoChangedEvent}s will be delivered through the Eclipse SmartHome event bus if the status of a
+ * {@link ThingStatusInfoChangedEvent}s will be delivered through the openHAB event bus if the status of a
  * thing has changed. Thing status info objects must be created with the {@link ThingEventFactory}.
  *
  * @author Dennis Nobel - Initial contribution

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingStatusInfoEvent.java
@@ -17,7 +17,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
 /**
- * {@link ThingStatusInfoEvent}s will be delivered through the Eclipse SmartHome event bus if the status of a thing has
+ * {@link ThingStatusInfoEvent}s will be delivered through the openHAB event bus if the status of a thing has
  * been updated. Thing status info objects must be created with the {@link ThingEventFactory}.
  *
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * This OSGi service could be used to localize a {@link ChannelType} using the I18N mechanism of the Eclipse SmartHome
+ * This OSGi service could be used to localize a {@link ChannelType} using the I18N mechanism of the openHAB
  * framework.
  *
  * @author Markus Rathgeb - Move code from XML thing type provider to separate service

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * <p>
  * The {@link ThingStatusInfoI18nLocalizationService} can be used to localize the {@link ThingStatusInfo} of a thing
- * using the I18N mechanism of the Eclipse SmartHome framework. Currently the description of the {@link ThingStatusInfo}
+ * using the I18N mechanism of the openHAB framework. Currently the description of the {@link ThingStatusInfo}
  * is the single attribute which can be localized.
  *
  * <p>

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * This OSGi service could be used to localize a {@link ThingType} using the I18N mechanism of the Eclipse SmartHome
+ * This OSGi service could be used to localize a {@link ThingType} using the I18N mechanism of the openHAB
  * framework.
  *
  * @author Markus Rathgeb - Move code from XML thing type provider to separate service

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/ThreadFactoryBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/ThreadFactoryBuilder.java
@@ -98,7 +98,7 @@ public class ThreadFactoryBuilder {
      * incremented with each new thread, initialized to 1. If set to null, threads are named 'name-i'.
      * <p>
      * Defaults to the name prefix 'ESH'. Setting a name prefix different than the default one is intended to be used by
-     * solutions integrating Eclipse SmartHome.
+     * solutions integrating openHAB.
      *
      * @param namePrefix The name prefix (can be null)
      * @return this {@link ThreadFactoryBuilder} instance

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * <p>
- * This class provides a general mechanism to create thread pools. In general, no code of Eclipse SmartHome
+ * This class provides a general mechanism to create thread pools. In general, no code of openHAB
  * should deal with its own pools, but rather use this class.
  * The created thread pools have named threads, so that it is easy to find them in the debugger. Additionally, it is
  * possible to configure the pool sizes through the configuration admin service, so that solutions have the chance to

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -625,7 +625,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
     }
 
     /**
-     * This method can be used in a subclass in order to post events through the Eclipse SmartHome events bus. A common
+     * This method can be used in a subclass in order to post events through the openHAB events bus. A common
      * use case is to notify event subscribers about an element which has been added/removed/updated to the registry.
      *
      * @param event the event

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/Event.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/Event.java
@@ -13,7 +13,7 @@
 package org.eclipse.smarthome.core.events;
 
 /**
- * {@link Event} objects are delivered by the {@link EventPublisher} through the Eclipse SmartHome event bus.
+ * {@link Event} objects are delivered by the {@link EventPublisher} through the openHAB event bus.
  * The callback interface {@link EventSubscriber} can be implemented in order to receive such events.
  * 
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventPublisher.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventPublisher.java
@@ -13,7 +13,7 @@
 package org.eclipse.smarthome.core.events;
 
 /**
- * The {@link EventPublisher} posts {@link Event}s through the Eclipse SmartHome event bus in an asynchronous way.
+ * The {@link EventPublisher} posts {@link Event}s through the openHAB event bus in an asynchronous way.
  * Posted events can be received by implementing the {@link EventSubscriber} callback interface.
  *
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventSubscriber.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link EventSubscriber} defines the callback interface for receiving events from
- * the Eclipse SmartHome event bus.
+ * the openHAB event bus.
  *
  * @author Stefan Bußweiler - Initial contribution
  */
@@ -49,7 +49,7 @@ public interface EventSubscriber {
     EventFilter getEventFilter();
 
     /**
-     * Callback method for receiving {@link Event}s from the Eclipse SmartHome event bus. This method is called for
+     * Callback method for receiving {@link Event}s from the openHAB event bus. This method is called for
      * every event where the event subscriber is subscribed to and the event filter applies.
      *
      * @param event the received event (not null)

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/TopicEventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/TopicEventFilter.java
@@ -13,7 +13,7 @@
 package org.eclipse.smarthome.core.events;
 
 /**
- * The {@link TopicEventFilter} is a default Eclipse SmartHome {@link EventFilter} implementation that ensures filtering
+ * The {@link TopicEventFilter} is a default openHAB {@link EventFilter} implementation that ensures filtering
  * of events based on an event topic.
  * 
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handle Eclipse SmartHome events encapsulated by OSGi events.
+ * Handle openHAB events encapsulated by OSGi events.
  *
  * @author Markus Rathgeb - Initial contribution
  */

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.event.EventHandler;
 
 /**
- * The {@link OSGiEventManager} provides an OSGi based default implementation of the Eclipse SmartHome event bus.
+ * The {@link OSGiEventManager} provides an OSGi based default implementation of the openHAB event bus.
  *
  * The OSGiEventHandler tracks {@link EventSubscriber}s and {@link EventFactory}s, receives OSGi events (by
  * implementing the OSGi {@link EventHandler} interface) and dispatches the received OSGi events as ESH {@link Event}s

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventPublisher.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventPublisher.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.event.EventAdmin;
 
 /**
- * The {@link OSGiEventPublisher} provides an OSGi based default implementation of the Eclipse SmartHome event
+ * The {@link OSGiEventPublisher} provides an OSGi based default implementation of the openHAB event
  * publisher.
  *
  * Events are send in an asynchronous way via OSGi Event Admin mechanism.

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Handle Eclipse SmartHome events encapsulated by OSGi events in a separate thread.
+ * Handle openHAB events encapsulated by OSGi events in a separate thread.
  *
  * @author Markus Rathgeb - Initial contribution
  */

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
@@ -31,7 +31,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * <p>
- * This interface defines the core features of an Eclipse SmartHome item.
+ * This interface defines the core features of an openHAB item.
  *
  * <p>
  * Item instances are used for all stateful services and are especially important for the {@link ItemRegistry}.

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
@@ -24,7 +24,7 @@ import org.eclipse.smarthome.core.events.EventSubscriber;
 /**
  * <p>
  * The {@link AbstractItemEventSubscriber} defines an abstract implementation of the {@link EventSubscriber} interface
- * for receiving {@link ItemStateEvent}s and {@link ItemCommandEvent}s from the Eclipse SmartHome event bus.
+ * for receiving {@link ItemStateEvent}s and {@link ItemCommandEvent}s from the openHAB event bus.
  *
  * A subclass can implement the methods {@link #receiveUpdate(ItemStateEvent)} and
  * {@link #receiveCommand(ItemCommandEvent)} in order to receive and handle such events.
@@ -56,7 +56,7 @@ public abstract class AbstractItemEventSubscriber implements EventSubscriber {
     }
 
     /**
-     * Callback method for receiving item command events from the Eclipse SmartHome event bus.
+     * Callback method for receiving item command events from the openHAB event bus.
      *
      * @param commandEvent the item command event
      */
@@ -66,7 +66,7 @@ public abstract class AbstractItemEventSubscriber implements EventSubscriber {
     }
 
     /**
-     * Callback method for receiving item update events from the Eclipse SmartHome event bus.
+     * Callback method for receiving item update events from the openHAB event bus.
      *
      * @param updateEvent the item update event
      */

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.core.items.events;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * {@link GroupItemStateChangedEvent}s can be used to deliver group item state changes through the Eclipse SmartHome
+ * {@link GroupItemStateChangedEvent}s can be used to deliver group item state changes through the openHAB
  * event bus. In
  * contrast to the {@link GroupItemStateEvent} the {@link GroupItemStateChangedEvent} is only sent if the state changed.
  * State events must be created with the {@link ItemEventFactory}.

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemCommandEvent.java
@@ -16,7 +16,7 @@ import org.eclipse.smarthome.core.events.AbstractEvent;
 import org.eclipse.smarthome.core.types.Command;
 
 /**
- * {@link ItemCommandEvent}s can be used to deliver commands through the Eclipse SmartHome event bus.
+ * {@link ItemCommandEvent}s can be used to deliver commands through the openHAB event bus.
  * Command events must be created with the {@link ItemEventFactory}.
  * 
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
@@ -16,7 +16,7 @@ import org.eclipse.smarthome.core.events.AbstractEvent;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * {@link ItemStateChangedEvent}s can be used to deliver item state changes through the Eclipse SmartHome event bus. In
+ * {@link ItemStateChangedEvent}s can be used to deliver item state changes through the openHAB event bus. In
  * contrast to the {@link ItemStateEvent} the {@link ItemStateChangedEvent} is only sent if the state changed.
  * State events must be created with the {@link ItemEventFactory}.
  *

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
@@ -16,7 +16,7 @@ import org.eclipse.smarthome.core.events.AbstractEvent;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * {@link ItemStateEvent}s can be used to deliver item status updates through the Eclipse SmartHome event bus.
+ * {@link ItemStateEvent}s can be used to deliver item status updates through the openHAB event bus.
  * State events must be created with the {@link ItemEventFactory}.
  *
  * @author Stefan Bußweiler - Initial contribution

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/TypeParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/TypeParser.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 
 /**
- * This is a helper class that helps parsing a string into an Eclipse SmartHome type (state or command).
+ * This is a helper class that helps parsing a string into an openHAB type (state or command).
  *
  * @author Kai Kreuzer - Initial contribution and API
  *


### PR DESCRIPTION
Adapted CONTRIBUTING.md file.

P.s. not sure if the change in the `@author` tag is correct.