### PR TITLE
[DSL][automation][WIP] Added methods to retrieve and update thing configurations via rules

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/Things.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/Things.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.smarthome.model.script.actions;
 
+import java.util.Map;
+
+import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.ThingActions;
 import org.eclipse.smarthome.model.script.internal.engine.action.ThingActionService;
@@ -22,7 +25,7 @@ import org.eclipse.smarthome.model.script.internal.engine.action.ThingActionServ
  *
  * @author Maoliang Huang - Initial contribution
  * @author Kai Kreuzer - Extended for general thing access
- *
+ * @author Christoph Weitkamp - Added methods to retrieve and update thing configurations
  */
 public class Things {
 
@@ -34,6 +37,28 @@ public class Things {
      */
     public static ThingStatusInfo getThingStatusInfo(String thingUid) {
         return ThingActionService.getThingStatusInfo(thingUid);
+    }
+
+    /**
+     * Retrieves the configuration of a Thing
+     *
+     * @param thingUid The uid of the thing
+     * @return a map of configuration parameters
+     */
+    public static Map<String, Object> getThingConfiguration(String thingUid) {
+        return ThingActionService.getThingConfiguration(thingUid);
+    }
+
+    /**
+     * Updates the configuration of a Thing
+     *
+     * @param thingUid The uid of the thing
+     * @param configurationParameters map of changed configuration parameters
+     * @throws ConfigValidationException if one or more of the given configuration parameters do not match their
+     *             declarations in the configuration description
+     */
+    public static void updateThingConfiguration(String thingUid, Map<String, Object> configurationParameters) {
+        ThingActionService.updateThingConfiguration(thingUid, configurationParameters);
     }
 
     /**

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/internal/engine/action/ThingActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/internal/engine/action/ThingActionService.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Maoliang Huang - Initial contribution
  * @author Kai Kreuzer - Extended for general thing access
- *
+ * @author Christoph Weitkamp - Added methods to retrieve and update thing configurations
  */
 @Component(immediate = true)
 public class ThingActionService implements ActionService {
@@ -69,6 +69,25 @@ public class ThingActionService implements ActionService {
             return thing.getStatusInfo();
         } else {
             return null;
+        }
+    }
+
+    public static Map<String, Object> getThingConfiguration(String thingUid) {
+        Thing thing = thingRegistry.get(new ThingUID(thingUid));
+        Map<String, Object> propertiesMap = new HashMap<>();
+        if (thing != null) {
+            propertiesMap.putAll(thing.getConfiguration().getProperties());
+        }
+        return propertiesMap;
+    }
+
+    public static void updateThingConfiguration(String thingUid, Map<String, Object> configurationParameters) {
+        Thing thing = thingRegistry.get(new ThingUID(thingUid));
+        if (thing != null) {
+            ThingHandler handler = thing.getHandler();
+            if (handler != null) {
+                handler.handleConfigurationUpdate(configurationParameters);
+            }
         }
     }
 


### PR DESCRIPTION
- Added methods to retrieve and update thing configurations via rules

Instead of submitting an issue for discussion, I wrote some lines of codes as a base for the discussion.

First proposal for exposing thing configurations to rules. The idea behind this PR is to allow the user to access and maybe edit thing configurations via rules. I reused existing methods from `ThingHandler` interface to provide similar functionality (e.g. validation of configuration parameters).

Now there are some questions to discuss:

1. Is this approach the way to go?
2. Should we expose the whole configuration to the user?
3. Is the user allowed to modify all configuration parameters - except read-only ones - via rules during runtime?

I am not sure if the validation of edited configuration parameters is sufficient as I did not find any unit tests for it. Can someone point me to them - or do I have to extend / implement those.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>