### PR TITLE
workround m2e indexer hickup, build local openhab index

### DIFF
--- a/bom/openhab-core-index/pom.xml
+++ b/bom/openhab-core-index/pom.xml
@@ -34,6 +34,24 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-indexer-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>simple-local-index</id>
+            <goals>
+              <goal>local-index</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <inputDir>${project.basedir}/../../bundles</inputDir>
+              <outputFile>${project.build.directory}/local-index.xml</outputFile>
+              <indexFiles>
+                <include>*/target/*.jar</include>
+                <exclude>*/target/*-javadoc.jar</exclude>
+                <exclude>*/target/*-sources.jar</exclude>
+              </indexFiles>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/demo/app/app.bndrun
+++ b/demo/app/app.bndrun
@@ -1,6 +1,6 @@
 -standalone: \
     ../../bom/runtime-index/target/index.xml;name="org.openhab.core.bom.runtime-index",\
-    ../../bom/openhab-core-index/target/index.xml;name="org.openhab.core.bom.openhab-core-index"
+    ../../bom/openhab-core-index/target/local-index.xml;name="org.openhab.core.bom.openhab-core-index"
 
 -resolve.effective: active
 

--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -1,7 +1,7 @@
 -standalone: \
     ../../bom/runtime-index/target/index.xml;name="org.openhab.core.bom.runtime-index",\
     ../../bom/test-index/target/index.xml;name="org.openhab.core.bom.test-index",\
-    ../../bom/openhab-core-index/target/index.xml;name="org.openhab.core.bom.openhab-core-index",\
+    ../../bom/openhab-core-index/target/local-index.xml;name="org.openhab.core.bom.openhab-core-index",\
      target/index.xml;name="self"
 
 -resolve.effective: active


### PR DESCRIPTION
Generates a simple local index that references all the JARs that resides in the bundles target directory.
This way we can trigger that index generation all the time (without building the whole reactor).