### PR TITLE
Revert main part of DS requirements removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,6 @@ Import-Package: \\
   org.eclipse.smarthome.*
 -sources: false
 -contract: *
--dsannotations-options: norequirements
 ]]></bnd>
             <!-- Bundle-SymbolicName: ${project.groupId}.${project.artifactId} -->
           </configuration>


### PR DESCRIPTION
This reverts the DS requirements removal of commit
981a447e9931ae98daaee60c99022a8f97c2441f which has been done on PR #530.

Fixes: https://github.com/openhab/openhab-core/issues/590
Related to: https://github.com/openhab/openhab-distro/pull/882
