### PR TITLE
blacklist API bundle as long as jersey-all is used

### DIFF
--- a/demo/app/app.bndrun
+++ b/demo/app/app.bndrun
@@ -64,6 +64,8 @@ feature.openhab-model-runtime-all: \
 	osgi.console.enable.builtin=false,\
 	logback.configurationFile=file:${.}/logback.xml
 
+-runblacklist: bnd.identity;id='org.apache.aries.javax.jax.rs-api'
+
 #
 # done
 #


### PR DESCRIPTION
As long as jersey-all is used that bundles a dozen of other artifacts,
we have to blacklist the JAX-RS API. Otherwise it will be added on every
new resolve call.

Related to: https://github.com/openhab/openhab-core/issues/576
Related to: https://github.com/openhab/openhab-core/pull/580
