### PR TITLE
add runtime dependency declarations to project

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -21,47 +21,303 @@
   </properties>
 
   <dependencies>
+    <!-- BEG: Slightly modified EnRoute implementation index artifacts -->
+
+    <!-- The OSGi framework RI is Equinox -->
     <dependency>
-      <groupId>org.osgi.enroute</groupId>
-      <artifactId>impl-index</artifactId>
-      <version>7.0.0</version>
-      <type>pom</type>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.osgi</artifactId>
+      <version>3.13.100</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Declarative Services -->
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.scr</artifactId>
+      <version>2.1.10</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>org.apache.felix.http.jetty</artifactId>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>animal-sniffer-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
 
+    <!-- Configuration Admin -->
     <dependency>
-      <groupId>org.osgi.enroute</groupId>
-      <artifactId>debug-bundles</artifactId>
-      <version>7.0.0</version>
-      <type>pom</type>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.configadmin</artifactId>
+      <version>1.9.8</version>
       <scope>compile</scope>
     </dependency>
 
-    <!-- BEG: logging -->
+    <!-- Metatype -->
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.equinox.metatype</artifactId>
+      <version>1.4.500</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype</artifactId>
+      <version>1.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Event Admin -->
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.equinox.event</artifactId>
+      <version>1.4.300</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.event</artifactId>
+      <version>1.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Log Stream Service -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.log</artifactId>
+      <version>1.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.platform</groupId>
+      <artifactId>org.eclipse.equinox.log.stream</artifactId>
+      <version>1.0.100</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Http Servlet 3.1 API with contract -->
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.http.servlet-api</artifactId>
+      <version>1.1.2</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- JAX-RS Whiteboard -->
+    <dependency>
+      <groupId>org.apache.aries.jax.rs</groupId>
+      <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
+      <version>1.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- JAX-RS 2.1 API with contract -->
+    <dependency>
+      <groupId>org.apache.aries.spec</groupId>
+      <artifactId>org.apache.aries.javax.jax.rs-api</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- JAX-B 2.2 API -->
+    <dependency>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Java-Activation 1.1 API -->
+    <dependency>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Stax 1.2 API -->
+    <dependency>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.stax-api-1.2</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- JAX-WS 2.2 API -->
+    <dependency>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.jaxws-api-2.2</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- SAAJ 1.3 API -->
+    <dependency>
+      <groupId>org.apache.servicemix.specs</groupId>
+      <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
+      <version>2.9.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi Function -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.function</artifactId>
+      <version>1.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi Promise -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.promise</artifactId>
+      <version>1.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi PushStream -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.pushstream</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi Converter -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.converter</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi Transaction Control -->
+    <dependency>
+      <groupId>org.apache.aries.tx-control</groupId>
+      <artifactId>tx-control-service-xa</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.aries.tx-control</groupId>
+      <artifactId>tx-control-provider-jdbc-xa</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.aries.tx-control</groupId>
+      <artifactId>tx-control-provider-jpa-xa</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi Configurator -->
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.configurator</artifactId>
+      <version>1.0.6</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- OSGi JPA Service -->
+    <dependency>
+      <groupId>org.apache.aries.jpa</groupId>
+      <artifactId>org.apache.aries.jpa.container</artifactId>
+      <version>2.7.0</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.aries.jpa.javax.persistence</groupId>
+          <artifactId>javax.persistence_2.0</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Used heavily in conjunction with JDBC -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.jdbc</artifactId>
+      <version>1.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Several implementations need to log using SLF4J -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <version>1.7.25</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.3</version>
       <scope>compile</scope>
     </dependency>
+
+    <!-- END: Slightly modified EnRoute implementation index artifacts -->
+
+
+    <!-- BEG: Slightly modified EnRoute debug tools index artifacts -->
+
+    <!-- The Web Console -->
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.webconsole</artifactId>
+      <version>4.3.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.webconsole.plugins.ds</artifactId>
+      <version>2.0.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.inventory</artifactId>
+      <version>1.0.4</version>
+    </dependency>
+
+    <!-- The Gogo Shell -->
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.gogo.shell</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.gogo.runtime</artifactId>
+      <version>1.0.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.gogo.command</artifactId>
+      <version>1.0.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.compendium</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- END: Slightly modified EnRoute debug tools index artifacts -->
+
+    <!-- BEG: logging -->
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.log</artifactId>

--- a/demo/app/app.bndrun
+++ b/demo/app/app.bndrun
@@ -69,8 +69,6 @@ feature.openhab-model-runtime-all: \
 #
 
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
 	com.eclipsesource.jaxrs.publisher;version='[5.3.1,5.3.2)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
@@ -136,7 +134,6 @@ feature.openhab-model-runtime-all: \
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
@@ -177,4 +174,7 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.transform;version='[2.5.0,2.5.1)',\
-	org.openhab.core.voice;version='[2.5.0,2.5.1)'
+	org.openhab.core.voice;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)'

--- a/itests/org.openhab.core.audio.tests/itest.bndrun
+++ b/itests/org.openhab.core.audio.tests/itest.bndrun
@@ -14,8 +14,6 @@ Fragment-Host: org.openhab.core.audio
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -55,6 +53,8 @@ Fragment-Host: org.openhab.core.audio
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
@@ -28,7 +26,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.eclipse.jetty.websocket.common;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
@@ -42,4 +39,8 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.auth.oauth2client;version='[2.5.0,2.5.1)',\
-	org.openhab.core.auth.oauth2client.tests;version='[2.5.0,2.5.1)'
+	org.openhab.core.auth.oauth2client.tests;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -14,8 +14,6 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -40,6 +38,8 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.compat1x.tests/itest.bndrun
+++ b/itests/org.openhab.core.compat1x.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.compat1x
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
@@ -65,7 +63,6 @@ Fragment-Host: org.openhab.core.compat1x
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
@@ -93,4 +90,6 @@ Fragment-Host: org.openhab.core.compat1x
 	org.openhab.core.model.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[2.5.0,2.5.1)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -15,8 +15,6 @@ Fragment-Host: org.openhab.core.config.core
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -40,7 +38,9 @@ Fragment-Host: org.openhab.core.config.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
-	org.openhab.core.config.core.tests;version='[2.5.0,2.5.1)'
+	org.openhab.core.config.core.tests;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -27,7 +25,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
@@ -41,4 +38,7 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.openhab.core.config.discovery.mdns;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.mdns.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.transport.mdns;version='[2.5.0,2.5.1)',\
-	org.openhab.core.test;version='[2.5.0,2.5.1)'
+	org.openhab.core.test;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -11,8 +11,6 @@ Fragment-Host: org.openhab.core.config.discovery
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -45,6 +43,8 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -10,8 +10,6 @@ Fragment-Host: org.openhab.core.io.net
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -39,6 +37,8 @@ Fragment-Host: org.openhab.core.io.net
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -16,8 +16,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
@@ -56,6 +54,8 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -13,8 +13,6 @@ Fragment-Host: org.openhab.core.model.thing
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
@@ -65,7 +63,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
@@ -97,8 +94,11 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
-	org.openhab.core.model.thing.testsupport;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.thing.testsupport;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
+	slf4j.api;version='[1.7.25,1.7.26)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -14,8 +14,6 @@ Fragment-Host: org.openhab.core
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -36,10 +34,12 @@ Fragment-Host: org.openhab.core
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
-	org.openhab.core.tests;version='[2.5.0,2.5.1)'
+	org.openhab.core.tests;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -17,8 +17,6 @@ Fragment-Host: org.openhab.core.thing
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -47,9 +45,11 @@ Fragment-Host: org.openhab.core.thing
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
-	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)'
+	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -11,8 +11,6 @@ Fragment-Host: org.openhab.core.thing.xml
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -39,7 +37,9 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
-	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)'
+	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.transform.tests/itest.bndrun
+++ b/itests/org.openhab.core.transform.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.transform
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -24,7 +22,9 @@ Fragment-Host: org.openhab.core.transform
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.ui.icon.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.icon.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.ui.icon
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
@@ -50,7 +48,9 @@ Fragment-Host: org.openhab.core.ui.icon
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'

--- a/itests/org.openhab.core.ui.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.ui
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
@@ -68,7 +66,6 @@ Fragment-Host: org.openhab.core.ui
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.item;version='[2.5.0,2.5.1)',\
-	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.persistence;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.rule;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.script;version='[2.5.0,2.5.1)',\
@@ -91,6 +88,9 @@ Fragment-Host: org.openhab.core.ui
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
+	slf4j.api;version='[1.7.25,1.7.26)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -9,8 +9,6 @@ Fragment-Host: org.openhab.core.voice
 # done
 #
 -runbundles: \
-	ch.qos.logback.classic;version='[1.2.0,1.2.1)',\
-	ch.qos.logback.core;version='[1.2.0,1.2.1)',\
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -49,6 +47,8 @@ Fragment-Host: org.openhab.core.voice
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	slf4j.api;version='[1.7.21,1.7.22)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)'
+	tec.uom.se;version='[1.0.8,1.0.9)',\
+	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	slf4j.simple;version='[1.7.21,1.7.22)'


### PR DESCRIPTION
For the runtime dependencies a template from the EnRoute project has been used. To allow further customization and usages of different Maven scopes, we migrate the template to this repo.

To be more detailed:
* This is just about the runtime BOM, that is currently used for the demo application and the integration tests.
* I did not add any new dependencies, I just integrated the ones that has been declared by a POM out of our control.