### PR TITLE
Added new parent class for units to fix import problems.

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/CustomUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/CustomUnits.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.library.unit;
+
+import tec.uom.se.AbstractSystemOfUnits;
+
+/**
+ * Base class for all custom unit classes added in openHAB.
+ *
+ * @author Hilbrand Bouwkamp - initial contribution
+ */
+class CustomUnits extends AbstractSystemOfUnits {
+
+    @Override
+    public String getName() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
@@ -23,7 +23,6 @@ import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import tec.uom.se.AbstractSystemOfUnits;
 import tec.uom.se.format.SimpleUnitFormat;
 import tec.uom.se.function.AddConverter;
 import tec.uom.se.function.MultiplyConverter;
@@ -39,7 +38,7 @@ import tec.uom.se.unit.Units;
  *
  */
 @NonNullByDefault
-public final class ImperialUnits extends AbstractSystemOfUnits {
+public final class ImperialUnits extends CustomUnits {
 
     private static final ImperialUnits INSTANCE = new ImperialUnits();
 
@@ -97,11 +96,6 @@ public final class ImperialUnits extends AbstractSystemOfUnits {
 
     private ImperialUnits() {
         // avoid external instantiation
-    }
-
-    @Override
-    public String getName() {
-        return ImperialUnits.class.getSimpleName();
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
@@ -24,7 +24,6 @@ import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import tec.uom.se.AbstractSystemOfUnits;
 import tec.uom.se.format.SimpleUnitFormat;
 import tec.uom.se.unit.Units;
 
@@ -36,7 +35,7 @@ import tec.uom.se.unit.Units;
  *
  */
 @NonNullByDefault
-public final class SIUnits extends AbstractSystemOfUnits {
+public final class SIUnits extends CustomUnits {
 
     private static final SIUnits INSTANCE = new SIUnits();
 
@@ -49,13 +48,13 @@ public final class SIUnits extends AbstractSystemOfUnits {
     public static final Unit<Volume> CUBIC_METRE = addUnit(Units.CUBIC_METRE);
     public static final Unit<Pressure> PASCAL = addUnit(Units.PASCAL);
 
-    private SIUnits() {
-        // avoid external instantiation
+    static {
+        // Override the default unit symbol ℃ to better support TTS and UIs:
+        SimpleUnitFormat.getInstance().label(CELSIUS, "°C");
     }
 
-    @Override
-    public String getName() {
-        return this.getClass().getSimpleName();
+    private SIUnits() {
+        // avoid external instantiation
     }
 
     /**
@@ -76,10 +75,5 @@ public final class SIUnits extends AbstractSystemOfUnits {
     private static <U extends Unit<?>> U addUnit(U unit) {
         INSTANCE.units.add(unit);
         return unit;
-    }
-
-    static {
-        // Override the default unit symbol ℃ to better support TTS and UIs:
-        SimpleUnitFormat.getInstance().label(CELSIUS, "°C");
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -53,7 +53,6 @@ import org.eclipse.smarthome.core.library.dimension.Density;
 import org.eclipse.smarthome.core.library.dimension.Intensity;
 import org.eclipse.smarthome.core.library.dimension.VolumetricFlowRate;
 
-import tec.uom.se.AbstractSystemOfUnits;
 import tec.uom.se.AbstractUnit;
 import tec.uom.se.format.SimpleUnitFormat;
 import tec.uom.se.function.ExpConverter;
@@ -75,7 +74,7 @@ import tec.uom.se.unit.Units;
  *
  */
 @NonNullByDefault
-public final class SmartHomeUnits extends AbstractSystemOfUnits {
+public final class SmartHomeUnits extends CustomUnits {
 
     private static final SmartHomeUnits INSTANCE = new SmartHomeUnits();
 
@@ -196,11 +195,6 @@ public final class SmartHomeUnits extends AbstractSystemOfUnits {
 
     private SmartHomeUnits() {
         // avoid external instantiation
-    }
-
-    @Override
-    public String getName() {
-        return SmartHomeUnits.class.getSimpleName();
     }
 
     /**


### PR DESCRIPTION
The change with unit classes parent (#617) causes it to report missing imports of tec.uom.se when using static import. Before the change this was not a problem because the parent class was SmartHomeUnits. This change adds a new parent class for all units.
