### PR TITLE
[Automation] DayOfWeekCondition

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/DayOfWeekCondition.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/DayOfWeekCondition.json
@@ -4,7 +4,6 @@
          "uid":"timer.DayOfWeekCondition",
          "label":"it is a certain day of the week",
          "description":"checks for the current day of the week",
-         "visibility":"PUBLIC",
          "configDescriptions":[  
             {  
                "name":"days",


### PR DESCRIPTION
Remove inconsistent visibility "PUBLIC". This value is not documented (there is only HIDDEN and VISIBLE) and this is the only module type that uses PUBLIC instead of just not setting this value at all.

Signed-off-by: davidgraeff <david.graeff@web.de>