### PR TITLE
[Automation] GenericCronTrigger

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/GenericCronTrigger.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/ESH-INF/automation/moduletypes/GenericCronTrigger.json
@@ -4,11 +4,11 @@
          "uid":"timer.GenericCronTrigger",
          "label":"Cron Trigger",
          "description":"This triggers a rule based on a cron expression",
-         "visibility":"HIDDEN",
          "configDescriptions":[  
             {  
                "name":"cronExpression",
                "type":"TEXT",
+               "context":"cronexpression",
                "label":"cron expression",
                "description":"the cron expression",
                "required":true


### PR DESCRIPTION
A cron trigger module is actually not that "Generic" and a useful trigger type for a lot of rules.

Therefore I suggest to remove the visibility "HIDDEN" with this PR.
I have also added a context "cronexpression" to the TEXT configuration value, so that UI's can offer a cron expression
selection widget.
(we currently have: 'time','item','script','channel','dayOfWeek','rule')

Signed-off-by: davidgraeff <david.graeff@web.de>