### PR TITLE
Reenable SAT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <bnd.version>4.1.0</bnd.version>
     <karaf.version>4.2.1</karaf.version>
-    <sat.version>0.5.0</sat.version>
+    <sat.version>0.6.1</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
     <xtext.version>2.14.0</xtext.version>
   </properties>
@@ -88,6 +88,18 @@
       <url>http://eclipse.github.io/smarthome/third-party/m2-repo/</url>
     </repository>
     <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>openhab-artifactory-release</id>
+      <name>JFrog Artifactory Repository</name>
+      <url>https://openhab.jfrog.io/openhab/libs-release</url>
+    </repository>
+    <repository>
       <id>bintray-maggu2810-maven</id>
       <url>https://dl.bintray.com/maggu2810/maven/</url>
     </repository>
@@ -97,6 +109,10 @@
     <pluginRepository>
       <id>jcenter</id>
       <url>https://jcenter.bintray.com</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>openhab-artifactory-release</id>
+      <url>https://openhab.jfrog.io/openhab/libs-release</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -564,14 +580,68 @@ Import-Package: \\
                     <ignore></ignore>
                   </action>
                 </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.commonjava.maven.plugins</groupId>
+                    <artifactId>directory-maven-plugin</artifactId>
+                    <versionRange>[0.3.1,)</versionRange>
+                    <goals>
+                      <goal>highest-basedir</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.openhab.tools.sat</groupId>
+          <artifactId>sat-plugin</artifactId>
+          <version>${sat.version}</version>
+          <configuration>
+            <pmdFilter>${basedirRoot}/tools/static-code-analysis/pmd/suppressions.properties</pmdFilter>
+            <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
+            <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
+            <spotbugsExclude>${basedirRoot}/tools/static-code-analysis/spotbugs/suppressions.xml</spotbugsExclude>
+          </configuration>
+          <executions>
+            <execution>
+              <id>sat-all</id>
+              <goals>
+                <goal>checkstyle</goal>
+                <goal>pmd</goal>
+                <goal>spotbugs</goal>
+                <goal>report</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+        <version>0.3.1</version>
+        <executions>
+          <execution>
+            <id>directories</id>
+            <goals>
+              <goal>highest-basedir</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <property>basedirRoot</property>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -595,6 +665,47 @@ Import-Package: \\
   </build>
 
   <profiles>
+    <profile>
+      <id>skip-check</id>
+      <activation>
+        <property>
+          <name>skipChecks</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.openhab.tools.sat</groupId>
+              <artifactId>sat-plugin</artifactId>
+              <version>${sat.version}</version>
+              <executions>
+                <execution>
+                  <id>sat-all</id>
+                  <phase>none</phase>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>check-bundles</id>
+      <activation>
+        <file>
+          <exists>src</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openhab.tools.sat</groupId>
+            <artifactId>sat-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>skip-itest</id>
       <activation>

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,0 +1,7 @@
+checkstyle.beforeExecutionExclusionFileFilter.fileNamePattern=.+org.eclipse.smarthome.core.internal.i18n.I18nProviderImpl\.java$|.+org.eclipse.smarthome.core.i18n.TranslationProvider\.java$
+checkstyle.forbiddenPackageUsageCheck.exceptions=
+checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common
+checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
+checkstyle.headerCheck.values=2010,2019
+checkstyle.pomXmlCheck.currentVersionRegex=^2\.5\.0
+checkstyle.requiredFilesCheck.files=pom.xml

--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- These suppressions define which files to be suppressed for which checks. -->
+    <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
+    <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />
+    <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
+    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationCheck"/>
+
+    <!-- All generated files will skip the author tag check -->
+    <suppress files=".+[\\/]gen[\\/].+\.java" checks="AuthorTagCheck"/>
+    <!-- Some checks will be supressed for test bundles -->
+    <suppress files=".+.test[\\/].+" checks="RequireBundleCheck|OutsideOfLibExternalLibrariesCheck|ManifestExternalLibrariesCheck|BuildPropertiesExternalLibrariesCheck"/>
+
+    <!-- openHAB Core specific suppressions-->
+
+    <!-- These bundles are generated trough XText -->
+    <suppress files=".+org.openhab.core.model.+" checks="RequireBundleCheck|ExportInternalPackageCheck|ManifestPackageVersionCheck|ImportExportedPackagesCheck|PackageExportsNameCheck|PomXmlCheck"/>
+
+    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java|.+org.eclipse.smarthome.io.console.eclipse.internal.ConsoleSupportEclipse.java|.+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java|.+org.eclipse.smarthome.core.library.unit.MetricPrefix.java" checks="MethodNameCheck"/>
+
+	<!-- Add suppression as discussed in https://github.com/openhab/static-code-analysis/issues/265 -->
+	<suppress files=".+org.eclipse.smarthome.core.common.registry.AbstractRegistry.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+	<suppress files=".+org.eclipse.smarthome.core.thing.binding.BaseThingHandler.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+	<suppress files=".+org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+	<suppress files=".+org.eclipse.smarthome.core.transform.AbstractFileTransformationService.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+	<suppress files=".+org.openhab.core.automation.internal.commands.AbstractCommandProvider.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+	<suppress files=".+org.openhab.core.automation.sample.rest.api.internal.Activator.java" checks="DeclarativeServicesDependencyInjectionCheck"/>
+</suppressions>

--- a/tools/static-code-analysis/pmd/suppressions.properties
+++ b/tools/static-code-analysis/pmd/suppressions.properties
@@ -1,0 +1,16 @@
+org.eclipse.smarthome.core.common.registry.AbstractRegistry=AvoidCatchingThrowable
+org.eclipse.smarthome.core.internal.common.SafeCallManagerImpl=CompareObjectsWithEquals
+org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=CompareObjectsWithEquals
+org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=EmptyIfStmt
+org.eclipse.smarthome.core.thing.internal.ChannelItemProvider=CompareObjectsWithEquals
+org.eclipse.smarthome.core.thing.internal.ThingManager=CompareObjectsWithEquals
+org.eclipse.smarthome.io.console.karaf.internal.OSGiConsole=SystemPrintln
+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper=SystemPrintln
+org.eclipse.smarthome.io.console.rfc147.internal.OSGiConsole=SystemPrintln
+org.eclipse.smarthome.io.net.http.internal.SecureHttpClientFactory=AvoidThrowingRawExceptionTypes
+org.eclipse.smarthome.model.core.internal.ModelRepositoryImpl=AvoidCatchingNPE
+org.eclipse.smarthome.model.script.interpreter.ScriptInterpreter=AvoidCatchingThrowable
+org.eclipse.smarthome.ui.internal.proxy.ProxyServletService=AvoidCatchingThrowable
+org.openhab.core.automation.internal.RuleEngineImpl=AvoidCatchingThrowable
+org.openhab.core.automation.internal.RuleRegistryImpl=CompareObjectsWithEquals
+org.openhab.core.automation.internal.provider.AutomationResourceBundlesEventQueue=AvoidCatchingThrowable

--- a/tools/static-code-analysis/spotbugs/suppressions.xml
+++ b/tools/static-code-analysis/spotbugs/suppressions.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!-- Groovy files produce a lot of warnings and will be ignored -->
+  <Match>
+    <Source name="~.*\.groovy" />
+  </Match>
+  <!-- Excludes all bugs with priority higher than 4 -->
+  <Match>
+    <Rank value="4"/>
+    <Not>
+      <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+    </Not>
+  </Match>
+  <!-- This pattern is not wanted as it reports usage of Throwable.getMessage() as argument to SLF4G logger -->
+  <Match>
+    <Bug pattern="SLF4J_MANUALLY_PROVIDED_MESSAGE"/>
+  </Match>
+  <!-- Allow util classes to have static loggers -->
+  <Match>
+    <Class name="~.*Utils"/>
+    <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+  </Match>
+  <Match>
+    <Class name="~.*Util"/>
+    <Bug pattern="SLF4J_LOGGER_SHOULD_BE_NON_STATIC"/>
+  </Match>
+  <!-- The format string is parameter, it can't be constant -->
+  <Match>
+    <Class name="org.eclipse.smarthome.model.script.actions.LogAction"/>
+    <Bug pattern="SLF4J_FORMAT_SHOULD_BE_CONST"/>
+  </Match>
+  <Match>
+    <Bug pattern="SLF4J_UNKNOWN_ARRAY"/>
+  </Match>
+  <Match>
+    <Bug pattern="SLF4J_SIGN_ONLY_FORMAT"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
This PR is based on the original SAT configuration of ESH with the following changes:
* configuration is updated for newer SAT versions
* suppressions have been updated for package changes
* extensions have been removed from suppressions

Most manifest checks will not work because SAT currently doesn't check bnd.bnd files or the generated manifest in the target directory (https://github.com/openhab/static-code-analysis/issues/341). But at least this PR enables SAT with most of the checks again. :smile: 

Because of https://github.com/openhab/static-code-analysis/pull/342 SAT 0.6.0 seems unusable.