### PR TITLE
Automation: [RFC] Add scriptlanguage context

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/ESH-INF/automation/moduletypes/ScriptTypes.json
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/ESH-INF/automation/moduletypes/ScriptTypes.json
@@ -10,6 +10,7 @@
                "type":"TEXT",
                "description":"the scripting language used",
                "required":true,
+               "context":"scriptlanguage",
                "options":[
                     {
                         "label": "Javascript",
@@ -38,6 +39,7 @@
                "type":"TEXT",
                "description":"the scripting language used",
                "required":true,
+               "context":"scriptlanguage",
                "options":[
                     {
                         "label": "Javascript",


### PR DESCRIPTION
We have the "script" context so far to tell a user-interface to render a script editor. The user-interface does not know however which language is going to be edited (-> syntax highlighting modules or even another editor component might be required).

Ideally "context" tells exactly about the content like "script_javascript". That is not possible here for obvious reasons.

I therefore publish this as a RFC, suggesting that we add another "context" value called "scriptlanguage". A "scriptlanguage" config parameter would always accompany a "script" config parameter. 
A user-interface would then have all required information for rendering the correct widget.

Signed-off-by: davidgraeff <david.graeff@web.de>