### PR TITLE
Fix SAT errors

### DIFF
--- a/demo/app/src/main/java/config/package-info.java
+++ b/demo/app/src/main/java/config/package-info.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 //@RequireConfigurator
 package config;
 

--- a/itests/org.openhab.core.audio.tests/src/main/java/org/eclipse/smarthome/core/audio/internal/utils/BundledSoundFileHandler.java
+++ b/itests/org.openhab.core.audio.tests/src/main/java/org/eclipse/smarthome/core/audio/internal/utils/BundledSoundFileHandler.java
@@ -24,6 +24,8 @@ import java.util.Comparator;
 
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.audio.internal.AudioManagerTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to handle bundled resources.
@@ -31,9 +33,9 @@ import org.eclipse.smarthome.core.audio.internal.AudioManagerTest;
  * @author Markus Rathgeb - Initial contribution
  */
 public class BundledSoundFileHandler implements Closeable {
-
     private static final String MP3_FILE_NAME = "mp3AudioFile.mp3";
     private static final String WAV_FILE_NAME = "wavAudioFile.wav";
+    private final Logger logger = LoggerFactory.getLogger(BundledSoundFileHandler.class);
 
     private static void copy(final String resourcePath, final String filePath) throws IOException {
         try (InputStream is = AudioManagerTest.class.getResourceAsStream(resourcePath)) {
@@ -71,7 +73,7 @@ public class BundledSoundFileHandler implements Closeable {
             try {
                 Files.walk(tmpdir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                logger.error("Exception while deleting files", ex);
             }
         }
     }

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/ConnectionValidatorTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/ConnectionValidatorTest.java
@@ -17,6 +17,9 @@ import java.util.regex.Pattern;
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * @author Ana Dimova - Initial contribution
+ */
 public class ConnectionValidatorTest {
 
     @Test

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/ReferenceResolverUtilTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/ReferenceResolverUtilTest.java
@@ -27,6 +27,9 @@ import org.openhab.core.automation.util.ReferenceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @author Vasil Ilchev - Initial contribution
+ */
 public class ReferenceResolverUtilTest {
     private static final String CONTEXT_PROPERTY1 = "contextProperty1";
     private static final String CONTEXT_PROPERTY2 = "contextProperty2";

--- a/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
@@ -29,6 +29,9 @@ import org.junit.Test;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
+/**
+ * @author Dennis Nobel - Initial contribution
+ */
 public class BindingInfoI18nTest extends JavaOSGiTest {
 
     private static final String TEST_BUNDLE_NAME = "yahooweather.bundle";

--- a/itests/org.openhab.core.compat1x.tests/src/main/java/org/openhab/core/compat1x/internal/ItemMapperTest.java
+++ b/itests/org.openhab.core.compat1x.tests/src/main/java/org/openhab/core/compat1x/internal/ItemMapperTest.java
@@ -29,6 +29,9 @@ import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 import org.openhab.core.items.Item;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class ItemMapperTest {
 
     @Test

--- a/itests/org.openhab.core.compat1x.tests/src/main/java/org/openhab/core/compat1x/internal/TypeMapperTest.java
+++ b/itests/org.openhab.core.compat1x.tests/src/main/java/org/openhab/core/compat1x/internal/TypeMapperTest.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.library.tel.types.CallType;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class TypeMapperTest {
 
     @Test

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/InboxOSGITest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/InboxOSGITest.java
@@ -47,8 +47,6 @@ import org.eclipse.smarthome.config.discovery.inbox.InboxListener;
 import org.eclipse.smarthome.config.discovery.inbox.events.InboxAddedEvent;
 import org.eclipse.smarthome.config.discovery.inbox.events.InboxRemovedEvent;
 import org.eclipse.smarthome.config.discovery.inbox.events.InboxUpdatedEvent;
-import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl;
-import org.eclipse.smarthome.config.discovery.internal.PersistentInbox;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFilter;
 import org.eclipse.smarthome.core.events.EventSubscriber;
@@ -71,6 +69,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.osgi.service.component.ComponentContext;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class InboxOSGITest extends JavaOSGiTest {
 
     class DiscoveryService1 extends AbstractDiscoveryService {

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMockOfBridge.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMockOfBridge.java
@@ -18,6 +18,9 @@ import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
+/**
+ * @author Andre Fuechsel - Initial contribution
+ */
 public class DiscoveryServiceMockOfBridge extends DiscoveryServiceMock {
 
     ThingUID bridge;

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryTest.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryTest.java
@@ -46,6 +46,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class WebClientFactoryTest {
 
     private WebClientFactoryImpl webClientFactory;

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/channel/ChannelTypeResourceTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/channel/ChannelTypeResourceTest.java
@@ -39,6 +39,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class ChannelTypeResourceTest {
 
     private ChannelTypeResource channelTypeResource;

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResourceOSGITest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResourceOSGITest.java
@@ -29,6 +29,9 @@ import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Christoph Knauf - Initial contribution
+ */
 public class InboxResourceOSGITest extends JavaOSGiTest {
 
     private InboxResource resource;

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperTest.java
@@ -26,6 +26,9 @@ import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class EnrichedItemDTOMapperTest extends JavaTest {
 
     private CoreItemFactory itemFactory;

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
@@ -32,6 +32,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
 
     private static final String ITEM_NAME = "Item1";

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -51,6 +51,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.jayway.jsonpath.JsonPath;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class ItemResourceOSGiTest extends JavaOSGiTest {
 
     private static final String ITEM_NAME1 = "Item1";

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/thing/EnrichedThingDTOMapperTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/thing/EnrichedThingDTOMapperTest.java
@@ -40,6 +40,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class EnrichedThingDTOMapperTest {
 
     private static final String ITEM_TYPE = "itemType";

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
@@ -33,6 +33,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class GenericItemChannelLinkProviderTest extends JavaOSGiTest {
 
     private final static String THINGS_TESTMODEL_NAME = "test.things";

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericThingProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericThingProviderTest.java
@@ -45,6 +45,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class GenericThingProviderTest extends JavaOSGiTest {
 
     private final static String TESTMODEL_NAME = "testModel.things";

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericThingProviderTest2.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericThingProviderTest2.java
@@ -30,6 +30,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.osgi.service.component.ComponentContext;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class GenericThingProviderTest2 extends JavaOSGiTest {
 
     private final static String TESTMODEL_NAME = "testModelX.things";

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenResponseTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenResponseTest.java
@@ -18,6 +18,9 @@ import java.time.LocalDateTime;
 
 import org.junit.Test;
 
+/**
+ * @author Gary Tse - Initial contribution
+ */
 public class AccessTokenResponseTest {
 
     @Test

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/common/osgi/ResourceBundleClassLoaderTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/common/osgi/ResourceBundleClassLoaderTest.java
@@ -28,6 +28,9 @@ import java.util.Collections;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 
+/**
+ * @author Simon Kaufmann - Initial contribution
+ */
 public class ResourceBundleClassLoaderTest {
 
     static URL createTmpTestPropetiesFile(Path root, String relativeFile) throws Exception {

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 
+/**
+ * @author Stefan Triller - Initial contribution
+ */
 public class TranslationProviderOSGiTest extends JavaOSGiTest {
 
     private static final String KEY_HELLO = "HELLO";

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/GroupItemTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/GroupItemTest.java
@@ -65,6 +65,9 @@ import org.mockito.Mock;
 
 import tec.uom.se.unit.Units;
 
+/**
+ * @author Stefan Triller - Initial contribution
+ */
 public class GroupItemTest extends JavaOSGiTest {
 
     /** Time to sleep when a file is created/modified/deleted, so the event can be handled */
@@ -690,14 +693,14 @@ public class GroupItemTest extends JavaOSGiTest {
         NumberItem kelvin = createNumberItem("K", Temperature.class, new QuantityType<Temperature>("23 K"));
         groupItem.addMember(kelvin);
 
-        QuantityType<?> state = (QuantityType<?>) groupItem.getStateAs(QuantityType.class);
+        QuantityType<?> state = groupItem.getStateAs(QuantityType.class);
 
         assertThat(state.getUnit(), is(Units.CELSIUS));
         assertThat(state.doubleValue(), is(-232.15d));
 
         celsius.setState(new QuantityType<Temperature>("265 °C"));
 
-        state = (QuantityType<?>) groupItem.getStateAs(QuantityType.class);
+        state = groupItem.getStateAs(QuantityType.class);
 
         assertThat(state.getUnit(), is(Units.CELSIUS));
         assertThat(state.doubleValue(), is(9.85d));
@@ -721,7 +724,7 @@ public class GroupItemTest extends JavaOSGiTest {
         NumberItem percent = createNumberItem("K", Dimensionless.class, new QuantityType<Dimensionless>("110 %"));
         groupItem.addMember(percent);
 
-        QuantityType<?> state = (QuantityType<?>) groupItem.getStateAs(QuantityType.class);
+        QuantityType<?> state = groupItem.getStateAs(QuantityType.class);
 
         assertThat(state, is(new QuantityType<Temperature>("23 °C")));
 

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapperTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapperTest.java
@@ -24,6 +24,9 @@ import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.junit.Test;
 
+/**
+ * @author Stefan Triller - Initial contribution
+ */
 public class ItemDTOMapperTest {
 
     @Test

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/library/CoreItemFactoryTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/library/CoreItemFactoryTest.java
@@ -26,6 +26,9 @@ import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 @SuppressWarnings("null")
 public class CoreItemFactoryTest {
 

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtilTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtilTest.java
@@ -26,6 +26,9 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class HttpServiceUtilTest {
 
     private static final String ORG_OSGI_SERVICE_HTTP_SERVICE = "org.osgi.service.http.HttpService";

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtilsTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtilsTest.java
@@ -31,6 +31,9 @@ import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class UnitUtilsTest {
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/ThingUIDTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/ThingUIDTest.java
@@ -16,6 +16,9 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+/**
+ * @author Stefan Triller - Initial contribution
+ */
 public class ThingUIDTest {
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/UIDTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/UIDTest.java
@@ -14,6 +14,9 @@ package org.eclipse.smarthome.core.thing;
 
 import org.junit.Test;
 
+/**
+ * @author Alex Tugarev - Initial contribution
+ */
 public class UIDTest {
 
     @Test(expected = IllegalArgumentException.class)

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/Constants.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/Constants.java
@@ -24,6 +24,9 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
 import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareBuilder;
 
+/**
+ * @author Thomas Höfer - Initial contribution
+ */
 public class Constants {
 
     public static final String UNKNOWN = "unknown";

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/SimpleThingTypeProvider.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/SimpleThingTypeProvider.java
@@ -19,6 +19,9 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 
+/**
+ * @author Markus Rathgeb - Initial contribution
+ */
 public class SimpleThingTypeProvider implements ThingTypeProvider {
     private final Collection<ThingType> thingTypes;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelperTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelperTest.java
@@ -28,6 +28,9 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.internal.ThingImpl;
 import org.junit.Test;
 
+/**
+ * @author Alex Tugarev - Initial contribution
+ */
 public class ThingHelperTest {
 
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.java
@@ -28,6 +28,9 @@ import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class ConfigDescriptionsTest extends JavaOSGiTest {
 
     private LoadedTestBundle loadedTestBundle() throws Exception {

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/LoadedTestBundle.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/LoadedTestBundle.java
@@ -26,6 +26,9 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 
+/**
+ * @author Markus Rathgeb - Initial contribution
+ */
 public class LoadedTestBundle extends JavaTest implements AutoCloseable {
 
     @FunctionalInterface

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypeI18nTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypeI18nTest.java
@@ -31,6 +31,9 @@ import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class ThingTypeI18nTest extends JavaOSGiTest {
 
     private LoadedTestBundle loadedTestBundle() throws Exception {

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
@@ -33,6 +33,9 @@ import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 
+/**
+ * @author Henning Treu - Initial contribution
+ */
 public class ThingTypesTest extends JavaOSGiTest {
 
     private LoadedTestBundle loadedTestBundle() throws Exception {

--- a/itests/org.openhab.core.transform.tests/src/main/java/org/eclipse/smarthome/core/transform/actions/TransformationTest.java
+++ b/itests/org.openhab.core.transform.tests/src/main/java/org/eclipse/smarthome/core/transform/actions/TransformationTest.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.junit.Test;
 
+/**
+ * @author Stefan Triller - Initial contribution
+ */
 public class TransformationTest {
 
     @Test

--- a/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -51,6 +51,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+/**
+ * @author Kai Kreuzer - Initial contribution
+ */
 public class ItemUIRegistryImplTest {
 
     static private ItemUIRegistryImpl uiRegistry;


### PR DESCRIPTION
Fixes the issues resuling in errors found by SAT 0.6.1:
* missing license header on `package-info.java` in Demo App
* `printStackTrace()`
* missing author tags
