### PR TITLE
[gson] bump gson version to 2.4

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.4</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -380,7 +380,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.4</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -31,7 +31,7 @@
     <!--<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>-->
 
     <!-- Gson -->
-    <bundle dependency="true">mvn:com.google.code.gson/gson/2.3.1</bundle>
+    <bundle dependency="true">mvn:com.google.code.gson/gson/2.4</bundle>
 
     <!-- Measurement -->
     <bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>


### PR DESCRIPTION
When I tried to migrate my tplinksmarthome binding to mvn + bnd (because I thought that would be easier to get test running, silly me) I found out it didn't work because the gson version it links to is 2.3.1. Unfortunately my binding uses a feature added in 2.4. Therefor I updated the gson version to the version also uses are runtime version. I looks like I was not the first with this problem #608
