### PR TITLE
Upgrade Mockito to 2.25.0 for Java 11 compatibility

### DIFF
--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.13.0</version>
+      <version>2.25.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/itests/org.openhab.core.audio.tests/itest.bndrun
+++ b/itests/org.openhab.core.audio.tests/itest.bndrun
@@ -16,8 +16,6 @@ Fragment-Host: org.openhab.core.audio
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -33,7 +31,7 @@ Fragment-Host: org.openhab.core.audio
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.commons;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.tree;version='[6.1.1,6.1.2)',\
@@ -57,4 +55,6 @@ Fragment-Host: org.openhab.core.audio
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -34,13 +34,13 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.auth.oauth2client;version='[2.5.0,2.5.1)',\
 	org.openhab.core.auth.oauth2client.tests;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -42,4 +42,4 @@ Fragment-Host: org.openhab.core.automation
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -37,4 +37,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.compat1x.tests/itest.bndrun
+++ b/itests/org.openhab.core.compat1x.tests/itest.bndrun
@@ -89,7 +89,7 @@ Fragment-Host: org.openhab.core.compat1x
 	org.openhab.core.model.rule;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
-	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -17,8 +17,6 @@ Fragment-Host: org.openhab.core.config.core
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -30,7 +28,7 @@ Fragment-Host: org.openhab.core.config.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -43,4 +41,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.openhab.core.config.core.tests;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -41,4 +41,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -13,8 +13,6 @@ Fragment-Host: org.openhab.core.config.discovery
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -29,7 +27,7 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -47,4 +45,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -38,7 +38,7 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.usbserial;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.io.http.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.http.tests/itest.bndrun
@@ -25,6 +25,6 @@ Fragment-Host: org.openhab.core.io.http
 	org.openhab.core.io.http;version='[2.5.0,2.5.1)',\
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.io.http.tests;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -12,8 +12,6 @@ Fragment-Host: org.openhab.core.io.net
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -27,7 +25,7 @@ Fragment-Host: org.openhab.core.io.net
 	org.eclipse.jetty.websocket.client;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -41,4 +39,6 @@ Fragment-Host: org.openhab.core.io.net
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -20,8 +20,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	net.minidev.accessors-smart;version='[1.2.0,1.2.1)',\
 	net.minidev.json-smart;version='[2.3.0,2.3.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
@@ -37,7 +35,7 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[5.0.4,5.0.5)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -58,4 +56,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.io.rest.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.tests/itest.bndrun
@@ -30,7 +30,7 @@ Fragment-Host: org.openhab.core.io.rest
 	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.io.rest;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.rest.tests;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -86,9 +86,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.voice;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.rule;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.thing;version='[2.5.0,2.5.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.model.thing.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
@@ -100,5 +98,8 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.model.thing.testsupport;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.semantics.tests/itest.bndrun
+++ b/itests/org.openhab.core.semantics.tests/itest.bndrun
@@ -18,7 +18,7 @@ Fragment-Host: org.openhab.core.semantics
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -16,8 +16,6 @@ Fragment-Host: org.openhab.core
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -30,7 +28,7 @@ Fragment-Host: org.openhab.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
@@ -42,4 +40,6 @@ Fragment-Host: org.openhab.core
 	org.openhab.core.tests;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -19,8 +19,6 @@ Fragment-Host: org.openhab.core.thing
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -34,7 +32,7 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -52,4 +50,6 @@ Fragment-Host: org.openhab.core.thing
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -42,4 +42,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.ui.icon.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.icon.tests/itest.bndrun
@@ -11,8 +11,6 @@ Fragment-Host: org.openhab.core.ui.icon
 -runbundles: \
 	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -29,7 +27,7 @@ Fragment-Host: org.openhab.core.ui.icon
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.commons;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.tree;version='[6.1.1,6.1.2)',\
@@ -53,4 +51,6 @@ Fragment-Host: org.openhab.core.ui.icon
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'

--- a/itests/org.openhab.core.ui.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.tests/itest.bndrun
@@ -15,8 +15,6 @@ Fragment-Host: org.openhab.core.ui
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	joda-time;version='[2.9.2,2.9.3)',\
 	log4j;version='[1.2.17,1.2.18)',\
-	net.bytebuddy.byte-buddy;version='[1.7.9,1.7.10)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.7.9,1.7.10)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
@@ -53,7 +51,7 @@ Fragment-Host: org.openhab.core.ui
 	org.eclipse.xtext.xbase.lib;version='[2.14.0,2.14.1)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
-	org.mockito.mockito-core;version='[2.13.0,2.13.1)',\
+	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.commons;version='[6.1.1,6.1.2)',\
 	org.objectweb.asm.tree;version='[6.1.1,6.1.2)',\
@@ -92,5 +90,7 @@ Fragment-Host: org.openhab.core.ui
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -51,4 +51,5 @@ Fragment-Host: org.openhab.core.voice
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'


### PR DESCRIPTION
Currently the first exceptions that occur in a Java 11 build are due to Mockito/Byte Buddy being incompatible with Java 11:

```
Mockito cannot mock this class: interface java.lang.Runnable.

Mockito can only mock non-private & non-final classes.
If you're not sure why you're getting this error, please report to the mailing list.


Java               : 11
JVM vendor name    : Oracle Corporation
JVM vendor version : 11.0.1+13
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 11.0.1+13
JVM info           : mixed mode
OS name            : Linux
OS version         : 4.15.0-1026-gcp


Underlying exception : java.lang.UnsupportedOperationException: Cannot define class using reflection
	at org.eclipse.smarthome.test.java.JavaTestTest.waitForAssertShouldRunAfterLastCall_whenAssertionSucceeds(JavaTestTest.java:38)
Caused by: java.lang.UnsupportedOperationException: Cannot define class using reflection
	at org.eclipse.smarthome.test.java.JavaTestTest.waitForAssertShouldRunAfterLastCall_whenAssertionSucceeds(JavaTestTest.java:38)
Caused by: java.lang.IllegalStateException: Could not find sun.misc.Unsafe
	at org.eclipse.smarthome.test.java.JavaTestTest.waitForAssertShouldRunAfterLastCall_whenAssertionSucceeds(JavaTestTest.java:38)
Caused by: java.lang.NoSuchMethodException: sun.misc.Unsafe.defineClass(java.lang.String, [B, int, int, java.lang.ClassLoader, java.security.ProtectionDomain)
	at org.eclipse.smarthome.test.java.JavaTestTest.waitForAssertShouldRunAfterLastCall_whenAssertionSucceeds(JavaTestTest.java:38)
```

After upgrading Mockito these exceptions are resolved. The stacktraces then show that next Xtext needs to be upgraded to 2.17 (#646) to make the Java 11 build more successful.

We'll also need to update the itests dependencies in openhab2-addons.