### PR TITLE
bump Gson to 2.8.2

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -99,9 +99,9 @@
 
     <!-- Gson -->
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <groupId>org.eclipse.orbit.bundles</groupId>
+      <artifactId>com.google.gson</artifactId>
+      <version>2.8.2.v20180104-1110</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -378,15 +378,9 @@
 
     <!-- Gson -->
     <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.3.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.orbit.bundles</groupId>
       <artifactId>com.google.gson</artifactId>
-      <version>2.7.0.v20170129-0911</version>
+      <version>2.8.2.v20180104-1110</version>
       <scope>compile</scope>
     </dependency>
 

--- a/demo/app/app.bndrun
+++ b/demo/app/app.bndrun
@@ -138,7 +138,6 @@ feature.openhab-model-runtime-all: \
 	org.osgi.service.metatype;version='[1.4.0,1.4.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
 	tec.uom.se;version='[1.0.8,1.0.9)',\
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.audio;version='[2.5.0,2.5.1)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
@@ -179,4 +178,5 @@ feature.openhab-model-runtime-all: \
 	org.openhab.core.voice;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -23,6 +23,8 @@
     <requirement>openhab.tp;filter:="(feature=base)"</requirement>
     <feature dependency="true">openhab.tp-base</feature>
 
+    <feature dependency="true">openhab.tp-gson</feature>
+
     <requirement>openhab.tp;filter:="(&amp;(feature=xtext)(version&gt;=2.14.0)(!(version&gt;=2.15.0)))"</requirement>
     <feature dependency="true">openhab.tp-xtext</feature>
 
@@ -515,7 +517,6 @@
   </feature>
 
   <feature name="openhab-runtime-base" description="openHAB Runtime Base" version="${project.version}">
-    <bundle>mvn:p2.osgi.bundle/com.google.gson/2.8.2.v20180104-1110</bundle>
     <bundle>mvn:com.google.guava/guava/18.0</bundle>
     <requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
     <feature dependency="true">openhab.tp-commons-net</feature>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -30,9 +30,6 @@
     <bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>
     <!--<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>-->
 
-    <!-- Gson -->
-    <bundle dependency="true">mvn:com.google.code.gson/gson/2.3.1</bundle>
-
     <!-- Measurement -->
     <bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>
     <bundle dependency="true">mvn:tec.uom/uom-se/1.0.8</bundle>
@@ -53,6 +50,11 @@
   <feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">
     <capability>openhab.tp;feature=commons-net;version=3.3</capability>
     <bundle dependency="true">mvn:commons-net/commons-net/3.3</bundle>
+  </feature>
+
+  <feature name="openhab.tp-gson" description="Gson" version="${project.version}">
+    <capability>openhab.tp;feature=gson;version=2.8.2.v20180104-1110</capability>
+    <bundle>mvn:org.eclipse.orbit.bundles/com.google.gson/2.8.2.v20180104-1110</bundle>
   </feature>
 
   <feature name="openhab.tp-httpclient" version="${project.version}">
@@ -126,8 +128,8 @@
     <bundle>mvn:org.eclipse.lsp4j/org.eclipse.lsp4j/0.4.1</bundle>
     <bundle>mvn:org.eclipse.lsp4j/org.eclipse.lsp4j.jsonrpc/0.4.1</bundle>
 
+    <feature dependency="true">openhab.tp-gson</feature>
     <feature dependency="true">openhab.tp-xtext</feature>
-    <bundle dependency="true">mvn:org.eclipse.orbit.bundles/com.google.gson/2.7.0.v20170129-0911</bundle>
   </feature>
 
   <feature name="openhab.tp-mapdb" description="MapDB" version="${project.version}">

--- a/itests/org.openhab.core.audio.tests/itest.bndrun
+++ b/itests/org.openhab.core.audio.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core.audio
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -57,4 +56,5 @@ Fragment-Host: org.openhab.core.audio
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -43,4 +42,5 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -42,4 +41,5 @@ Fragment-Host: org.openhab.core.automation
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	ch.qos.logback.classic;version='[1.2.3,1.2.4)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.binding.xml
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -38,4 +37,4 @@ Fragment-Host: org.openhab.core.binding.xml
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.compat1x.tests/itest.bndrun
+++ b/itests/org.openhab.core.compat1x.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.compat1x
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
@@ -92,4 +91,5 @@ Fragment-Host: org.openhab.core.compat1x
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.config.core
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -43,4 +42,5 @@ Fragment-Host: org.openhab.core.config.core
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -42,4 +41,4 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -7,11 +7,15 @@ Fragment-Host: org.openhab.core.config.discovery
 	bnd.identity;id='org.openhab.core.config.discovery.tests',\
 	bnd.identity;id='org.openhab.core.thing.xml'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -47,4 +51,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -10,7 +10,6 @@ Fragment-Host: org.openhab.core.io.net
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -41,4 +40,5 @@ Fragment-Host: org.openhab.core.io.net
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 #
 -runbundles: \
 	com.eclipsesource.jaxrs.jersey-all;version='[2.22.2,2.22.3)',\
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.minidev.accessors-smart;version='[1.2.0,1.2.1)',\
@@ -58,4 +57,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -13,7 +13,6 @@ Fragment-Host: org.openhab.core.model.thing
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
@@ -101,5 +100,5 @@ Fragment-Host: org.openhab.core.model.thing
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.storage.json
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -34,4 +33,5 @@ Fragment-Host: org.openhab.core.storage.json
 	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -42,4 +41,5 @@ Fragment-Host: org.openhab.core
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core.thing
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -52,4 +51,5 @@ Fragment-Host: org.openhab.core.thing
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.thing.xml
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -43,4 +42,4 @@ Fragment-Host: org.openhab.core.thing.xml
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.transform.tests/itest.bndrun
+++ b/itests/org.openhab.core.transform.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.transform
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -27,4 +26,5 @@ Fragment-Host: org.openhab.core.transform
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	slf4j.simple;version='[1.7.21,1.7.22)'
+	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.ui.icon.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.icon.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.ui.icon
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -53,4 +52,5 @@ Fragment-Host: org.openhab.core.ui.icon
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)'
+	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
+	com.google.gson;version='[2.8.2,2.8.3)'

--- a/itests/org.openhab.core.ui.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.ui
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	com.google.guava;version='[15.0.0,15.0.1)',\
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
@@ -93,4 +92,5 @@ Fragment-Host: org.openhab.core.ui
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	org.openhab.core.model.persistence.runtime;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -9,7 +9,6 @@ Fragment-Host: org.openhab.core.voice
 # done
 #
 -runbundles: \
-	com.google.gson;version='[2.7.0,2.7.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
@@ -52,4 +51,4 @@ Fragment-Host: org.openhab.core.voice
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	com.google.gson;version='[2.8.2,2.8.3)'


### PR DESCRIPTION
As long as we depend on the internal Gson packages, we need to use the Gson bundle provided by Eclipse Orbit instead of the official one.

Related to: https://github.com/openhab/openhab-core/pull/641
