### PR TITLE
Added i18n feature for dynamic state descriptions

### DIFF
--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
@@ -42,6 +42,8 @@ public class MagicBindingConstants {
     public static final ThingTypeUID THING_TYPE_PLAYER = new ThingTypeUID(BINDING_ID, "player");
     public static final ThingTypeUID THING_TYPE_IMAGE = new ThingTypeUID(BINDING_ID, "image");
     public static final ThingTypeUID THING_TYPE_ACTION_MODULE = new ThingTypeUID(BINDING_ID, "action-module");
+    public static final ThingTypeUID THING_TYPE_DYNAMIC_STATE_DESCRIPTION = new ThingTypeUID(BINDING_ID,
+            "dynamic-state-description");
     public static final ThingTypeUID THING_TYPE_ONLINE_OFFLINE = new ThingTypeUID(BINDING_ID, "online-offline");
 
     // bridged things
@@ -57,6 +59,8 @@ public class MagicBindingConstants {
     public static final String CHANNEL_LOCATION = "location";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_SET_TEMPERATURE = "set-temperature";
+    public static final String CHANNEL_SYSTEM_COMMAND = "systemcommand";
+    public static final String CHANNEL_SIGNAL_STRENGTH = "signal-strength";
 
     // Firmware update needed models
     public static final String UPDATE_MODEL_PROPERTY = "updateModel";

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.binding.handler;
+
+import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.*;
+
+import java.util.Arrays;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.eclipse.smarthome.magic.binding.internal.MagicDynamicStateDescriptionProvider;
+
+/**
+ * ThingHandler which provides channels with dynamic state descriptions.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class MagicDynamicStateDescriptionThingHandler extends BaseThingHandler {
+
+    private static final String SYSTEM_COMMAND_HIBERNATE = "Hibernate";
+    private static final String SYSTEM_COMMAND_REBOOT = "Reboot";
+    private static final String SYSTEM_COMMAND_SHUTDOWN = "Shutdown";
+    private static final String SYSTEM_COMMAND_SUSPEND = "Suspend";
+    private static final String SYSTEM_COMMAND_QUIT = "Quit";
+
+    private final MagicDynamicStateDescriptionProvider stateDescriptionProvider;
+
+    public MagicDynamicStateDescriptionThingHandler(Thing thing,
+            MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
+        super(thing);
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    @Override
+    public void initialize() {
+        ChannelUID systemCommandChannelUID = new ChannelUID(getThing().getUID(), CHANNEL_SYSTEM_COMMAND);
+        stateDescriptionProvider.setStateOptions(systemCommandChannelUID,
+                Arrays.asList(new StateOption(SYSTEM_COMMAND_HIBERNATE, SYSTEM_COMMAND_HIBERNATE),
+                        new StateOption(SYSTEM_COMMAND_REBOOT, SYSTEM_COMMAND_REBOOT),
+                        new StateOption(SYSTEM_COMMAND_SHUTDOWN, SYSTEM_COMMAND_SHUTDOWN),
+                        new StateOption(SYSTEM_COMMAND_SUSPEND, SYSTEM_COMMAND_SUSPEND),
+                        new StateOption(SYSTEM_COMMAND_QUIT, SYSTEM_COMMAND_QUIT)));
+
+        ChannelUID signalStrengthChannelUID = new ChannelUID(getThing().getUID(), CHANNEL_SIGNAL_STRENGTH);
+        stateDescriptionProvider.setStateOptions(signalStrengthChannelUID, Arrays.asList(
+                new StateOption("1", "Unusable"), new StateOption("2", "Okay"), new StateOption("3", "Amazing")));
+
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // doing nothing here
+    }
+}

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicDiscoveryService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicDiscoveryService.java
@@ -12,8 +12,9 @@
  */
 package org.eclipse.smarthome.magic.binding.internal;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.THING_TYPE_CONFIG_THING;
+
+import java.util.Collections;
 import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,28 +24,26 @@ import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
-import org.eclipse.smarthome.magic.binding.MagicBindingConstants;
 import org.osgi.service.component.annotations.Component;
 
 /**
  * The {@link MagicDiscoveryService} magically discovers magic things.
  *
- * @author Henning Treu - initial contribution
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class, immediate = true)
 public class MagicDiscoveryService extends AbstractDiscoveryService {
 
     public MagicDiscoveryService() throws IllegalArgumentException {
-        super(new HashSet<>(Arrays.asList(MagicBindingConstants.THING_TYPE_CONFIG_THING)), 0);
+        super(Collections.singleton(THING_TYPE_CONFIG_THING), 0);
     }
 
     @Override
     protected void startScan() {
         String serialNumber = createRandomSerialNumber();
         DiscoveryResult discoveryResult = DiscoveryResultBuilder
-                .create(new ThingUID(MagicBindingConstants.THING_TYPE_CONFIG_THING, serialNumber))
+                .create(new ThingUID(THING_TYPE_CONFIG_THING, serialNumber))
                 .withRepresentationProperty(Thing.PROPERTY_SERIAL_NUMBER)
                 .withProperty(Thing.PROPERTY_SERIAL_NUMBER, serialNumber).withLabel("Magic Thing").build();
         thingDiscovered(discoveryResult);

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.binding.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Dynamic provider of state options while leaving other state description fields as original.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, MagicDynamicStateDescriptionProvider.class })
+@NonNullByDefault
+public class MagicDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+
+    @Reference
+    protected void setChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+
+    protected void unsetChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = null;
+    }
+}

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
@@ -34,6 +34,7 @@ import org.eclipse.smarthome.magic.binding.handler.MagicConfigurableThingHandler
 import org.eclipse.smarthome.magic.binding.handler.MagicContactHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicDelayedOnlineHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicDimmableLightHandler;
+import org.eclipse.smarthome.magic.binding.handler.MagicDynamicStateDescriptionThingHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicExtensibleThingHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicFirmwareUpdateThingHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicImageHandler;
@@ -44,6 +45,7 @@ import org.eclipse.smarthome.magic.binding.handler.MagicPlayerHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicRolllershutterHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicThermostatThingHandler;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * The {@link MagicHandlerFactory} is responsible for creating things and thing
@@ -54,13 +56,15 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.magic")
 public class MagicHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
-            .of(THING_TYPE_EXTENSIBLE_THING, THING_TYPE_ON_OFF_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_LIGHT,
-                    THING_TYPE_CONTACT_SENSOR, THING_TYPE_CONFIG_THING, THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION,
-                    THING_TYPE_THERMOSTAT, THING_TYPE_FIRMWARE_UPDATE, THING_TYPE_BRIDGE_1, THING_TYPE_BRIDGE_2,
-                    THING_TYPE_BRIDGED_THING, THING_TYPE_CHATTY_THING, THING_TYPE_ROLLERSHUTTER, THING_TYPE_PLAYER,
-                    THING_TYPE_IMAGE, THING_TYPE_ACTION_MODULE, THING_TYPE_ONLINE_OFFLINE)
-            .collect(Collectors.toSet()));
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_EXTENSIBLE_THING, THING_TYPE_ON_OFF_LIGHT, THING_TYPE_DIMMABLE_LIGHT,
+                    THING_TYPE_COLOR_LIGHT, THING_TYPE_CONTACT_SENSOR, THING_TYPE_CONFIG_THING,
+                    THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION, THING_TYPE_THERMOSTAT, THING_TYPE_FIRMWARE_UPDATE,
+                    THING_TYPE_BRIDGE_1, THING_TYPE_BRIDGE_2, THING_TYPE_BRIDGED_THING, THING_TYPE_CHATTY_THING,
+                    THING_TYPE_ROLLERSHUTTER, THING_TYPE_PLAYER, THING_TYPE_IMAGE, THING_TYPE_ACTION_MODULE,
+                    THING_TYPE_DYNAMIC_STATE_DESCRIPTION, THING_TYPE_ONLINE_OFFLINE).collect(Collectors.toSet()));
+
+    private MagicDynamicStateDescriptionProvider stateDescriptionProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -117,8 +121,10 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
             return new MagicImageHandler(thing);
         }
         if (thingTypeUID.equals(THING_TYPE_ACTION_MODULE)) {
-            MagicActionModuleThingHandler handler = new MagicActionModuleThingHandler(thing);
-            return handler;
+            return new MagicActionModuleThingHandler(thing);
+        }
+        if (thingTypeUID.equals(THING_TYPE_DYNAMIC_STATE_DESCRIPTION)) {
+            return new MagicDynamicStateDescriptionThingHandler(thing, stateDescriptionProvider);
         }
         if (thingTypeUID.equals(THING_TYPE_ONLINE_OFFLINE)) {
             return new MagicOnlineOfflineHandler(thing);
@@ -129,5 +135,14 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
         }
 
         return null;
+    }
+
+    @Reference
+    protected void setDynamicStateDescriptionProvider(MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    protected void unsetDynamicStateDescriptionProvider(MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = null;
     }
 }

--- a/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/i18n/magic_de.properties
+++ b/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/i18n/magic_de.properties
@@ -4,4 +4,12 @@ channel-type.magic.alert.state.option.NONE = Kein Blinken
 channel-type.magic.alert.state.option.SELECT = Einmaliges Blinken
 channel-type.magic.alert.state.option.LSELECT = Mehrfaches Blinken
 
+channel-type.magic.systemcommand.label = Systembefehl
+channel-type.magic.systemcommand.description = Ermöglicht das Senden eines Systembefehls um das Kodi Media Center neu zu starten, in den Ruhezustand oder Stromsparmodus zu versetzen oder herunterzufahren.
+channel-type.magic.systemcommand.state.option.Shutdown = Herunterfahren
+channel-type.magic.systemcommand.state.option.Suspend = Bereitschaft
+channel-type.magic.systemcommand.state.option.Hibernate = Ruhezustand
+channel-type.magic.systemcommand.state.option.Reboot = Neustart
+channel-type.magic.systemcommand.state.option.Quit = Verlassen
+
 module.binding.magic.testMethod.label = Test Methode

--- a/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/thing/channel-types.xml
@@ -28,7 +28,8 @@
 		<item-type>Color</item-type>
 		<label>Color</label>
 		<description>The color channel allows to control the color of a light.
-			It is also possible to dim values and switch the light on and off.
+			It is also possible to dim values and switch the
+			light on and off.
 		</description>
 		<category>ColorLight</category>
 		<tags>
@@ -89,6 +90,11 @@
 		<item-type>String</item-type>
 		<label>Text channel</label>
 		<autoUpdatePolicy>recommend</autoUpdatePolicy>
+	</channel-type>
+
+	<channel-type id="systemcommand">
+		<label>Send system command</label>
+		<description>Sends a system command to Kodi. This allows to shutdown/suspend/hibernate/reboot/quit Kodi.</description>
 	</channel-type>
 
 	<channel-type id="temperature">

--- a/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.core.test.magic/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -193,7 +193,22 @@
 				<description>Just a text</description>
 			</parameter>
 		</config-description>
-		</thing-type>
+	</thing-type>
+
+	<thing-type id="dynamic-state-description">
+		<label>Magic DynamicStateDescription Thing</label>
+		<description>A Thing with a DynamicStateDescription</description>
+		<channels>
+			<channel typeId="systemcommand" id="systemcommand" />
+			<channel typeId="system.signal-strength" id="signal-strength" />
+		</channels>
+		<config-description>
+			<parameter name="textParam" type="text" required="true">
+				<label>Text Parameter</label>
+				<description>Just a text</description>
+			</parameter>
+		</config-description>
+	</thing-type>
 
 	<thing-type id="online-offline">
 		<label>Magic Online Offline</label>

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.binding;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * The {@link BaseDynamicStateDescriptionProvider} provides a base implementation for the
+ * {@link DynamicStateDescriptionProvider}.
+ * <p>
+ * It provides localized state patterns and dynamic state options while leaving other state description fields as
+ * original. Therefore the inheriting class has to request the reference for the
+ * {@link ChannelTypeI18nLocalizationService} on its own.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public abstract class BaseDynamicStateDescriptionProvider implements DynamicStateDescriptionProvider {
+
+    private @NonNullByDefault({}) BundleContext bundleContext;
+    protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
+
+    private final Map<ChannelUID, @Nullable String> channelPatternMap = new ConcurrentHashMap<>();
+    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+
+    /**
+     * For a given channel UID, set a pattern that should be used for the channel, instead of the one defined statically
+     * in the {@link ChannelType}.
+     *
+     * @param channelUID the channel UID of the channel
+     * @param pattern a pattern
+     */
+    public void setStatePattern(ChannelUID channelUID, String pattern) {
+        channelPatternMap.put(channelUID, pattern);
+    }
+
+    /**
+     * For a given channel UID, set a {@link List} of {@link StateOption}s that should be used for the channel, instead
+     * of the one defined statically in the {@link ChannelType}.
+     *
+     * @param channelUID the channel UID of the channel
+     * @param options a {@link List} of {@link StateOption}s
+     */
+    public void setStateOptions(ChannelUID channelUID, List<StateOption> options) {
+        channelOptionsMap.put(channelUID, options);
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
+            @Nullable Locale locale) {
+        // can be overridden by subclasses
+        ChannelUID channelUID = channel.getUID();
+        String pattern = channelPatternMap.get(channelUID);
+        List<StateOption> options = channelOptionsMap.get(channelUID);
+        if (pattern == null && options == null) {
+            return null;
+        }
+
+        StateDescriptionFragmentBuilder builder = (original == null) ? StateDescriptionFragmentBuilder.create()
+                : StateDescriptionFragmentBuilder.create(original);
+
+        if (pattern != null) {
+            String localizedPattern = localizeStatePattern(pattern, channel, locale);
+            if (localizedPattern != null) {
+                builder.withPattern(localizedPattern);
+            }
+        }
+
+        if (options != null) {
+            builder.withOptions(localizedStateOptions(options, channel, locale));
+        }
+
+        return builder.build().toStateDescription();
+    }
+
+    /**
+     * Localizes a pattern that should be used for the channel.
+     *
+     * @param pattern a pattern
+     * @param channel the channel
+     * @param locale a locale
+     * @return the localized pattern
+     */
+    protected @Nullable String localizeStatePattern(String pattern, Channel channel, @Nullable Locale locale) {
+        // can be overridden by subclasses
+        ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+        if (channelTypeI18nLocalizationService != null && channelTypeUID != null) {
+            return channelTypeI18nLocalizationService.createLocalizedStatePattern(bundleContext.getBundle(), pattern,
+                    channelTypeUID, locale);
+        }
+        return pattern;
+    }
+
+    /**
+     * Localizes a {@link List} of {@link StateOption}s that should be used for the channel.
+     *
+     * @param options a {@link List} of {@link StateOption}s
+     * @param channel the channel
+     * @param locale a locale
+     * @return the localized {@link List} of {@link StateOption}s
+     */
+    protected List<StateOption> localizedStateOptions(List<StateOption> options, Channel channel,
+            @Nullable Locale locale) {
+        // can be overridden by subclasses
+        ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+        if (channelTypeI18nLocalizationService != null && channelTypeUID != null) {
+            return channelTypeI18nLocalizationService.createLocalizedStateOptions(bundleContext.getBundle(), options,
+                    channelTypeUID, locale);
+        }
+        return options;
+    }
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        bundleContext = componentContext.getBundleContext();
+    }
+
+    @Deactivate
+    public void deactivate() {
+        channelOptionsMap.clear();
+        bundleContext = null;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -24,7 +24,6 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.thing.Bridge;
-import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/DynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/DynamicStateDescriptionProvider.java
@@ -21,10 +21,9 @@ import org.eclipse.smarthome.core.types.StateDescription;
 
 /**
  * The {@link DynamicStateDescriptionProvider} is responsible for providing {@link StateDescription} for a channel
- * dynamically in the runtime.
+ * dynamically in the runtime. Therefore the provider must be registered as OSGi service.
  *
- * @author Pawel Pieczul - initial contribution
- *
+ * @author Pawel Pieczul - Initial contribution
  */
 @NonNullByDefault
 public interface DynamicStateDescriptionProvider {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
@@ -82,7 +82,8 @@ public class ItemStateConverterImpl implements ItemStateConverter {
                 Class<? extends Quantity<?>> dimension = numberItem.getDimension();
                 @SuppressWarnings({ "unchecked", "rawtypes" })
                 // explicit cast to Class<? extends Quantity> as JDK compiler complains
-                Unit<? extends Quantity<?>> conversionUnit = unitProvider.getUnit((Class<? extends Quantity>) dimension);
+                Unit<? extends Quantity<?>> conversionUnit = unitProvider
+                        .getUnit((Class<? extends Quantity>) dimension);
                 if (conversionUnit != null
                         && UnitUtils.isDifferentMeasurementSystem(conversionUnit, quantityState.getUnit())) {
                     return convertOrUndef(quantityState, conversionUnit);
@@ -115,9 +116,12 @@ public class ItemStateConverterImpl implements ItemStateConverter {
         if (stateDescription == null) {
             return null;
         }
-
         String pattern = stateDescription.getPattern();
-        return UnitUtils.parseUnit(pattern);
+        if (pattern == null) {
+            return null;
+        } else {
+            return UnitUtils.parseUnit(pattern);
+        }
     }
 
     private boolean isAccepted(Item item, State state) {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/types/CommandDescriptionImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/types/CommandDescriptionImpl.java
@@ -23,8 +23,7 @@ import org.eclipse.smarthome.core.types.CommandOption;
 /**
  * The {@link CommandDescriptionImpl} groups state command properties.
  *
- * @author Henning Treu - initial contribution
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public class CommandDescriptionImpl implements CommandDescription {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/types/StateDescriptionFragmentImpl.java
@@ -24,8 +24,7 @@ import org.eclipse.smarthome.core.types.StateOption;
 /**
  * Data holder for StateDescriptionFragment creation.
  *
- * @author Henning Treu - initial contribution
- *
+ * @author Henning Treu - Initial contribution
  */
 public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
@@ -167,5 +166,4 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
         return this;
     }
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -450,7 +450,6 @@ public abstract class GenericItem implements ActiveItem {
         CommandDescriptionBuilder builder = CommandDescriptionBuilder.create();
         stateDescription.getOptions()
                 .forEach(so -> builder.withCommandOption(new CommandOption(so.getValue(), so.getLabel())));
-
         return builder.build();
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -204,9 +204,12 @@ public class NumberItem extends GenericItem {
     private @Nullable Unit<? extends Quantity<?>> getUnit(@Nullable Class<? extends Quantity<?>> dimension) {
         StateDescription stateDescription = getStateDescription();
         if (stateDescription != null) {
-            Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(stateDescription.getPattern());
-            if (stateDescriptionUnit != null) {
-                return stateDescriptionUnit;
+            String pattern = stateDescription.getPattern();
+            if (pattern != null) {
+                Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
+                if (stateDescriptionUnit != null) {
+                    return stateDescriptionUnit;
+                }
             }
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescription.java
@@ -19,8 +19,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 /**
  * The {@link CommandDescription} groups state command properties.
  *
- * @author Henning Treu - initial contribution
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public interface CommandDescription {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescriptionBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescriptionBuilder.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.internal.types.CommandDescriptionImpl;
  * Used to build instances of {@link CommandDescription}.
  *
  * @author Henning Treu - Initial contribution
- *
  */
 public class CommandDescriptionBuilder {
 
@@ -35,8 +34,9 @@ public class CommandDescriptionBuilder {
         return new CommandDescriptionBuilder();
     }
 
-    public void withCommandOption(CommandOption commandOption) {
+    public CommandDescriptionBuilder withCommandOption(CommandOption commandOption) {
         this.commandOptions.add(commandOption);
+        return this;
     }
 
     public CommandDescription build() {
@@ -45,5 +45,4 @@ public class CommandDescriptionBuilder {
 
         return commandDescription;
     }
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandOption.java
@@ -13,13 +13,13 @@
 package org.eclipse.smarthome.core.types;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * Represents a command option for "write only" command channels. CommandOptions will be rendered as
- * push-buttons in the UI and will not represent a state.
+ * Represents a command option for "write only" command channels. CommandOptions will be rendered as push-buttons in the
+ * UI and will not represent a state.
  *
  * @author Henning Treu - Initial contribution
- *
  */
 @NonNullByDefault
 public class CommandOption {
@@ -32,9 +32,9 @@ public class CommandOption {
     /**
      * The name of the command which will be displayed in the UI.
      */
-    private final String label;
+    private @Nullable String label;
 
-    public CommandOption(String command, String label) {
+    public CommandOption(String command, @Nullable String label) {
         this.command = command;
         this.label = label;
     }
@@ -43,8 +43,12 @@ public class CommandOption {
         return command;
     }
 
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
+    @Override
+    public String toString() {
+        return "CommandOption [command=" + command + ", label=" + label + "]";
+    }
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescription.java
@@ -13,24 +13,27 @@
 package org.eclipse.smarthome.core.types;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
- * Describes restrictions of an item state and gives information how to interpret
+ * The {@link StateDescription} describes restrictions of an item state and gives information how to interpret
  * it.
  *
  * @author Dennis Nobel - Initial contribution
  */
+@NonNullByDefault
 public class StateDescription {
 
-    private final BigDecimal minimum;
-    private final BigDecimal maximum;
-    private final BigDecimal step;
-    private final String pattern;
-    private final boolean readOnly;
-    private final List<StateOption> options;
+    protected @Nullable final BigDecimal minimum;
+    protected @Nullable final BigDecimal maximum;
+    protected @Nullable final BigDecimal step;
+    protected @Nullable final String pattern;
+    protected final boolean readOnly;
+    protected final List<StateOption> options;
 
     /**
      * Creates a state description object.
@@ -41,19 +44,17 @@ public class StateDescription {
      * @param pattern pattern to render the state
      * @param readOnly if the state can be changed by the system
      * @param options predefined list of options
+     * @deprecated use {@link StateDescriptionFragmentBuilder} instead.
      */
-    public StateDescription(BigDecimal minimum, BigDecimal maximum, BigDecimal step, String pattern, boolean readOnly,
-            List<StateOption> options) {
+    @Deprecated
+    public StateDescription(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
+            @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
         this.pattern = pattern;
         this.readOnly = readOnly;
-        if (options != null) {
-            this.options = Collections.unmodifiableList(new ArrayList<StateOption>(options));
-        } else {
-            this.options = Collections.emptyList();
-        }
+        this.options = options == null ? Collections.emptyList() : Collections.unmodifiableList(options);
     }
 
     /**
@@ -61,7 +62,7 @@ public class StateDescription {
      *
      * @return minimum value of an item state
      */
-    public BigDecimal getMinimum() {
+    public @Nullable BigDecimal getMinimum() {
         return minimum;
     }
 
@@ -70,7 +71,7 @@ public class StateDescription {
      *
      * @return maximum value of an item state
      */
-    public BigDecimal getMaximum() {
+    public @Nullable BigDecimal getMaximum() {
         return maximum;
     }
 
@@ -79,7 +80,7 @@ public class StateDescription {
      *
      * @return step size
      */
-    public BigDecimal getStep() {
+    public @Nullable BigDecimal getStep() {
         return step;
     }
 
@@ -88,7 +89,7 @@ public class StateDescription {
      *
      * @return pattern
      */
-    public String getPattern() {
+    public @Nullable String getPattern() {
         return pattern;
     }
 
@@ -118,5 +119,4 @@ public class StateDescription {
         return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
                 + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
     }
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragment.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragment.java
@@ -22,8 +22,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * A {@link StateDescriptionFragment} will deliver only the parts of a {@link StateDescription} it knows of.
  * All other methods should return {@code null} to indicate an unknown value.
  *
- * @author Henning Treu - initial contribution and API.
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public interface StateDescriptionFragment {
@@ -85,5 +84,4 @@ public interface StateDescriptionFragment {
      */
     @Nullable
     StateDescription toStateDescription();
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentBuilder.java
@@ -21,8 +21,7 @@ import org.eclipse.smarthome.core.internal.types.StateDescriptionFragmentImpl;
 /**
  * Builds a {@link StateDescriptionFragment} with the relevant parts only.
  *
- * @author Henning Treu - initial contribution and API.
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public class StateDescriptionFragmentBuilder {
@@ -131,5 +130,4 @@ public class StateDescriptionFragmentBuilder {
         fragment.setOptions(options);
         return this;
     }
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentProvider.java
@@ -21,8 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * Provide a {@link StateDescriptionFragment} for the current {@link StateDescription}. Use the
  * {@link StateDescriptionFragmentBuilder} to create a {@link StateDescriptionFragment} with only the parts known.
  *
- * @author Henning Treu - initial contribution and API
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public interface StateDescriptionFragmentProvider {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateOption.java
@@ -12,44 +12,44 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Describes one possible value an item might have.
  *
  * @author Dennis Nobel - Initial contribution
  */
+@NonNullByDefault
 public final class StateOption {
 
     private String value;
-    private String label;
+    private @Nullable String label;
 
     /**
      * Creates a {@link StateOption} object.
      *
-     * @param value value of the item
+     * @param value the value of the item
      * @param label label
-     * @throws IllegalArgumentException if value is null
      */
-    public StateOption(String value, String label) {
-        if (value == null) {
-            throw new IllegalArgumentException("Value must not be null.");
-        }
+    public StateOption(String value, @Nullable String label) {
         this.value = value;
         this.label = label;
     }
 
     /**
-     * Returns the label (can be null).
+     * Returns the label.
      *
-     * @return label (can be null)
+     * @return label
      */
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
     /**
-     * Returns the value (can not be null).
+     * Returns the value.
      *
-     * @return value (can not be null)
+     * @return value
      */
     public String getValue() {
         return value;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/SimpleThingTypeProvider.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/SimpleThingTypeProvider.java
@@ -25,7 +25,7 @@ import org.eclipse.smarthome.core.thing.type.ThingType;
 public class SimpleThingTypeProvider implements ThingTypeProvider {
     private final Collection<ThingType> thingTypes;
 
-    SimpleThingTypeProvider(final Collection<ThingType> thingTypes) {
+    public SimpleThingTypeProvider(final Collection<ThingType> thingTypes) {
         this.thingTypes = thingTypes;
     }
 


### PR DESCRIPTION
- Added i18n feature for dynamic state descriptions via a `BaseDynamicStateDescriptionProvider` class
- Added null annotations to `StateOption`, `StateDescription` and `ChannelStateDescriptionProvider`
- Make use of `StateDescriptionFragmentBuilder`
- Changed null annotation of `CommandOption` label as we always allow `Nullable` labels
- Minor improvements

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>