### PR TITLE
improve nullness of events

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
@@ -67,9 +67,6 @@ public class RuleEventFactory extends AbstractEventFactory {
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
         logger.trace("creating ruleEvent of type: {}", eventType);
-        if (eventType == null) {
-            return null;
-        }
         if (eventType.equals(RuleAddedEvent.TYPE)) {
             return createRuleAddedEvent(topic, payload, source);
         } else if (eventType.equals(RuleRemovedEvent.TYPE)) {
@@ -79,7 +76,7 @@ public class RuleEventFactory extends AbstractEventFactory {
         } else if (eventType.equals(RuleUpdatedEvent.TYPE)) {
             return createRuleUpdatedEvent(topic, payload, source);
         }
-        return null;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     private Event createRuleUpdatedEvent(String topic, String payload, String source) {
@@ -116,9 +113,9 @@ public class RuleEventFactory extends AbstractEventFactory {
     /**
      * Creates a rule updated event.
      *
-     * @param rule    the new rule.
+     * @param rule the new rule.
      * @param oldRule the rule that has been updated.
-     * @param source  the source of the event.
+     * @param source the source of the event.
      * @return {@link RuleUpdatedEvent} instance.
      */
     public static RuleUpdatedEvent createRuleUpdatedEvent(Rule rule, Rule oldRule, String source) {
@@ -136,8 +133,8 @@ public class RuleEventFactory extends AbstractEventFactory {
      * Creates a rule status info event.
      *
      * @param statusInfo the status info of the event.
-     * @param ruleUID    the UID of the rule for which the event is created.
-     * @param source     the source of the event.
+     * @param ruleUID the UID of the rule for which the event is created.
+     * @param source the source of the event.
      * @return {@link RuleStatusInfoEvent} instance.
      */
     public static RuleStatusInfoEvent createRuleStatusInfoEvent(RuleStatusInfo statusInfo, String ruleUID,
@@ -150,7 +147,7 @@ public class RuleEventFactory extends AbstractEventFactory {
     /**
      * Creates a rule removed event.
      *
-     * @param rule   the rule for which this event is created.
+     * @param rule the rule for which this event is created.
      * @param source the source of the event.
      * @return {@link RuleRemovedEvent} instance.
      */
@@ -164,7 +161,7 @@ public class RuleEventFactory extends AbstractEventFactory {
     /**
      * Creates a rule added event.
      *
-     * @param rule   the rule for which this event is created.
+     * @param rule the rule for which this event is created.
      * @param source the source of the event.
      * @return {@link RuleAddedEvent} instance.
      */

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactory.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactory.java
@@ -47,15 +47,14 @@ public class InboxEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        Event event = null;
         if (eventType.equals(InboxAddedEvent.TYPE)) {
-            event = createAddedEvent(topic, payload);
+            return createAddedEvent(topic, payload);
         } else if (eventType.equals(InboxRemovedEvent.TYPE)) {
-            event = createRemovedEvent(topic, payload);
+            return createRemovedEvent(topic, payload);
         } else if (eventType.equals(InboxUpdatedEvent.TYPE)) {
-            event = createUpdatedEvent(topic, payload);
+            return createUpdatedEvent(topic, payload);
         }
-        return event;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     private Event createAddedEvent(String topic, String payload) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
@@ -61,22 +61,20 @@ public class ThingEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        Event event = null;
         if (eventType.equals(ThingStatusInfoEvent.TYPE)) {
-            event = createStatusInfoEvent(topic, payload);
+            return createStatusInfoEvent(topic, payload);
         } else if (eventType.equals(ThingStatusInfoChangedEvent.TYPE)) {
-            event = createStatusInfoChangedEvent(topic, payload);
+            return createStatusInfoChangedEvent(topic, payload);
         } else if (eventType.equals(ThingAddedEvent.TYPE)) {
-            event = createAddedEvent(topic, payload);
+            return createAddedEvent(topic, payload);
         } else if (eventType.equals(ThingRemovedEvent.TYPE)) {
-            event = createRemovedEvent(topic, payload);
+            return createRemovedEvent(topic, payload);
         } else if (eventType.equals(ThingUpdatedEvent.TYPE)) {
-            event = createUpdatedEvent(topic, payload);
+            return createUpdatedEvent(topic, payload);
         } else if (eventType.equals(ChannelTriggeredEvent.TYPE)) {
-            event = createTriggerEvent(topic, payload, source);
+            return createTriggerEvent(topic, payload, source);
         }
-
-        return event;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactory.java
@@ -58,7 +58,7 @@ public final class FirmwareEventFactory extends AbstractEventFactory {
         } else if (FirmwareUpdateResultInfoEvent.TYPE.equals(eventType)) {
             return createFirmwareUpdateResultInfoEvent(topic, payload);
         }
-        return null;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
@@ -48,13 +48,12 @@ public class LinkEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        Event event = null;
         if (eventType.equals(ItemChannelLinkAddedEvent.TYPE)) {
-            event = createItemChannelLinkAddedEvent(topic, payload);
+            return createItemChannelLinkAddedEvent(topic, payload);
         } else if (eventType.equals(ItemChannelLinkRemovedEvent.TYPE)) {
-            event = createItemChannelLinkRemovedEvent(topic, payload);
+            return createItemChannelLinkRemovedEvent(topic, payload);
         }
-        return event;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     private Event createItemChannelLinkAddedEvent(String topic, String payload) throws Exception {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
@@ -16,6 +16,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.Gson;
 
 /**
@@ -26,6 +29,7 @@ import com.google.gson.Gson;
  *
  * @author Stefan Bußweiler - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractEventFactory implements EventFactory {
 
     private final Set<String> supportedEventTypes;
@@ -42,7 +46,7 @@ public abstract class AbstractEventFactory implements EventFactory {
     }
 
     @Override
-    public Event createEvent(String eventType, String topic, String payload, String source) throws Exception {
+    public Event createEvent(String eventType, String topic, String payload, @Nullable String source) throws Exception {
         assertValidArguments(eventType, topic, payload);
 
         if (!getSupportedEventTypes().contains(eventType)) {
@@ -73,7 +77,7 @@ public abstract class AbstractEventFactory implements EventFactory {
      * @return the created event instance
      * @throws Exception if the creation of the event fails
      */
-    protected abstract Event createEventByType(String eventType, String topic, String payload, String source)
+    protected abstract Event createEventByType(String eventType, String topic, String payload, @Nullable String source)
             throws Exception;
 
     /**
@@ -108,13 +112,13 @@ public abstract class AbstractEventFactory implements EventFactory {
         return topic.split("/");
     }
 
-    protected static void checkNotNull(Object object, String argumentName) {
+    protected static void checkNotNull(@Nullable Object object, String argumentName) {
         if (object == null) {
             throw new IllegalArgumentException("The argument '" + argumentName + "' must not be null.");
         }
     }
 
-    protected static void checkNotNullOrEmpty(String string, String argumentName) {
+    protected static void checkNotNullOrEmpty(@Nullable String string, String argumentName) {
         if (string == null || string.isEmpty()) {
             throw new IllegalArgumentException("The argument '" + argumentName + "' must not be null or empty.");
         }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/Event.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/Event.java
@@ -12,40 +12,45 @@
  */
 package org.eclipse.smarthome.core.events;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * {@link Event} objects are delivered by the {@link EventPublisher} through the openHAB event bus.
  * The callback interface {@link EventSubscriber} can be implemented in order to receive such events.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
+@NonNullByDefault
 public interface Event {
 
     /**
      * Gets the event type.
-     * 
+     *
      * @return the event type
      */
     String getType();
 
     /**
      * Gets the topic of an event.
-     * 
+     *
      * @return the event topic
      */
     String getTopic();
 
     /**
      * Gets the payload as a serialized string.
-     * 
+     *
      * @return the serialized event
      */
     String getPayload();
 
     /**
      * Gets the name of the source identifying the sender.
-     * 
+     *
      * @return the name of the source
      */
+    @Nullable
     String getSource();
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventFactory.java
@@ -14,19 +14,23 @@ package org.eclipse.smarthome.core.events;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * An {@link EventFactory} is responsible for creating {@link Event} instances of specific event types. The Eclipse
  * SmartHome framework uses Event Factories in order to create new Events (
  * {@link #createEvent(String, String, String, String)}) based on the event type, the topic, the payload and the source
  * if an event type is supported ( {@link #getSupportedEventTypes()}).
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
+@NonNullByDefault
 public interface EventFactory {
 
     /**
      * Create a new event instance of a specific event type.
-     * 
+     *
      * @param eventType the event type
      * @param topic the topic
      * @param payload the payload
@@ -36,11 +40,11 @@ public interface EventFactory {
      * @throws IllegalArgumentException if the eventType is not supported
      * @throws Exception if the creation of the event has failed
      */
-    Event createEvent(String eventType, String topic, String payload, String source) throws Exception;
+    Event createEvent(String eventType, String topic, String payload, @Nullable String source) throws Exception;
 
     /**
      * Returns a list of all supported event types of this factory.
-     * 
+     *
      * @return the supported event types (not null)
      */
     Set<String> getSupportedEventTypes();

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -73,25 +73,24 @@ public class ItemEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        Event event = null;
         if (eventType.equals(ItemCommandEvent.TYPE)) {
-            event = createCommandEvent(topic, payload, source);
+            return createCommandEvent(topic, payload, source);
         } else if (eventType.equals(ItemStateEvent.TYPE)) {
-            event = createStateEvent(topic, payload, source);
+            return createStateEvent(topic, payload, source);
         } else if (eventType.equals(ItemStatePredictedEvent.TYPE)) {
-            event = createStatePredictedEvent(topic, payload, source);
+            return createStatePredictedEvent(topic, payload, source);
         } else if (eventType.equals(ItemStateChangedEvent.TYPE)) {
-            event = createStateChangedEvent(topic, payload);
+            return createStateChangedEvent(topic, payload);
         } else if (eventType.equals(ItemAddedEvent.TYPE)) {
-            event = createAddedEvent(topic, payload);
+            return createAddedEvent(topic, payload);
         } else if (eventType.equals(ItemUpdatedEvent.TYPE)) {
-            event = createUpdatedEvent(topic, payload);
+            return createUpdatedEvent(topic, payload);
         } else if (eventType.equals(ItemRemovedEvent.TYPE)) {
-            event = createRemovedEvent(topic, payload);
+            return createRemovedEvent(topic, payload);
         } else if (eventType.equals(GroupItemStateChangedEvent.TYPE)) {
-            event = createGroupStateChangedEvent(topic, payload);
+            return createGroupStateChangedEvent(topic, payload);
         }
-        return event;
+        throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
     private Event createGroupStateChangedEvent(String topic, String payload) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
@@ -53,10 +53,9 @@ public class FirmwareEventFactoryTest extends JavaTest {
 
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testCreateEventForUnknownType() throws Exception {
-        Event event = eventFactory.createEventByType("unknownType", "topic", "somePayload", "Source");
-        assertThat(event, is(nullValue()));
+        eventFactory.createEventByType("unknownType", "topic", "somePayload", "Source");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The most changes are straight forward.

For `createEventByType` I assume that the current implementations does not fully follow the API.

```
     * @return the created event instance
     * @throws Exception if the creation of the event fails
```

* `null` is not an event instance (`instanceof` will fail)
* if the creation fails (so also by an unknown type) an exception should be thrown