### PR TITLE
Increase DateTimeType parsing and formatting precision

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Kai Kreuzer - Initial contribution
  * @author Erdoan Hadzhiyusein - Refactored to use ZonedDateTime
  * @author Jan N. Klug - add ability to use time or date only
+ * @author Wouter Born - increase parsing and formatting precision
  */
 @NonNullByDefault
 public class DateTimeType implements PrimitiveType, State, Command {
@@ -45,17 +46,23 @@ public class DateTimeType implements PrimitiveType, State, Command {
     public static final String DATE_PATTERN_WITH_TZ_AND_MS_GENERAL = "yyyy-MM-dd'T'HH:mm:ss.SSSz";
     public static final String DATE_PATTERN_WITH_TZ_AND_MS_ISO = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
-    // internal format patterns for parsing
-    private static final String DATE_PARSE_PATTERN_WITHOUT_TZ = "yyyy-MM-dd'T'HH:mm[:ss[.SSS]]";
-    private static final String DATE_PARSE_PATTERN_WITH_TZ = "yyyy-MM-dd'T'HH:mm[:ss[.SSS]]z";
-    private static final String DATE_PARSE_PATTERN_WITH_TZ_RFC = "yyyy-MM-dd'T'HH:mm[:ss[.SSS]]Z";
-    private static final String DATE_PARSE_PATTERN_WITH_TZ_ISO = "yyyy-MM-dd'T'HH:mm[:ss[.SSS]]X";
+    // internal patterns for parsing
+    private static final String DATE_PARSE_PATTERN_WITHOUT_TZ = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS][.SSSSSS][.SSS]]";
+    private static final String DATE_PARSE_PATTERN_WITH_TZ = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS][.SSSSSS][.SSS]]z";
+    private static final String DATE_PARSE_PATTERN_WITH_TZ_RFC = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS][.SSSSSS][.SSS]]Z";
+    private static final String DATE_PARSE_PATTERN_WITH_TZ_ISO = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS][.SSSSSS][.SSS]]X";
+
+    private static final DateTimeFormatter PARSER = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITHOUT_TZ);
+    private static final DateTimeFormatter PARSER_TZ = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ);
+    private static final DateTimeFormatter PARSER_TZ_RFC = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ_RFC);
+    private static final DateTimeFormatter PARSER_TZ_ISO = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ_ISO);
+
+    // internal patterns for formatting
+    private static final String DATE_FORMAT_PATTERN_WITH_TZ_RFC = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS]]Z";
+    private static final DateTimeFormatter FORMATTER_TZ_RFC = DateTimeFormatter
+            .ofPattern(DATE_FORMAT_PATTERN_WITH_TZ_RFC);
 
     private ZonedDateTime zonedDateTime;
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITHOUT_TZ);
-    private final DateTimeFormatter formatterTz = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ);
-    private final DateTimeFormatter formatterTzRFC = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ_RFC);
-    private final DateTimeFormatter formatterTzIso = DateTimeFormatter.ofPattern(DATE_PARSE_PATTERN_WITH_TZ_ISO);
 
     /**
      * @deprecated The constructor uses Calendar object hence it doesn't store time zone. A new constructor is
@@ -140,7 +147,21 @@ public class DateTimeType implements PrimitiveType, State, Command {
 
     @Override
     public String toFullString() {
-        return zonedDateTime.format(formatterTzRFC);
+        String formatted = zonedDateTime.format(FORMATTER_TZ_RFC);
+        if (formatted.contains(".")) {
+            String sign = "";
+            if (formatted.contains("+")) {
+                sign = "+";
+            } else if (formatted.contains("-")) {
+                sign = "-";
+            }
+            if (!sign.isEmpty()) {
+                // the formatted string contains 9 fraction-of-second digits
+                // truncate at most 2 trailing groups of 000s
+                return formatted.replace("000" + sign, sign).replace("000" + sign, sign);
+            }
+        }
+        return formatted;
     }
 
     @Override
@@ -176,15 +197,15 @@ public class DateTimeType implements PrimitiveType, State, Command {
     private ZonedDateTime parse(String value) throws DateTimeParseException {
         ZonedDateTime date = null;
         try {
-            date = ZonedDateTime.parse(value, formatterTzRFC);
+            date = ZonedDateTime.parse(value, PARSER_TZ_RFC);
         } catch (DateTimeParseException tzMsRfcException) {
             try {
-                date = ZonedDateTime.parse(value, formatterTzIso);
+                date = ZonedDateTime.parse(value, PARSER_TZ_ISO);
             } catch (DateTimeParseException tzMsIsoException) {
                 try {
-                    date = ZonedDateTime.parse(value, formatterTz);
+                    date = ZonedDateTime.parse(value, PARSER_TZ);
                 } catch (DateTimeParseException tzException) {
-                    LocalDateTime localDateTime = LocalDateTime.parse(value, formatter);
+                    LocalDateTime localDateTime = LocalDateTime.parse(value, PARSER);
                     date = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
                 }
             }


### PR DESCRIPTION
Since Java 9 ([JDK-8164428](https://bugs.openjdk.java.net/browse/JDK-8164428)) the maximum resolution from the underlying clock is used.
Instead of just milliseconds the resolution can now even be tenth of microseconds.

According to the Type JavaDocs `toFullString()` should return the full string representation of the type to be consumed by `valueOf(String)`.

With the changes in this PR `toFullString()` may return higher resolution date time strings on newer Java versions and `valueOf(value)` is able to parse these.

Code depending on a certain resolution returned by `toFullString()` should use the `format(pattern)` method instead so the resolution will not change.

Fixes #667