### PR TITLE
Print message instead of null on console when specified play volume is invalid

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleCommandExtension.java
@@ -144,7 +144,7 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 try {
                     volume = PercentType.valueOf(args[2]);
                 } catch (Exception e) {
-                    console.println(e.getMessage());
+                    console.println("Specify volume as percentage between 0 and 100");
                     break;
                 }
                 playOnSinks(args[0], args[1], volume, console);

--- a/itests/org.openhab.core.audio.tests/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleTest.java
+++ b/itests/org.openhab.core.audio.tests/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleTest.java
@@ -140,7 +140,8 @@ public class AudioConsoleTest extends AbstractAudioServeltTest {
                 fileHandler.wavFileName(), "invalid" };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
-        waitForAssert(() -> assertThat("The given volume was invalid", consoleOutput, nullValue()));
+        waitForAssert(() -> assertThat("The given volume was invalid", consoleOutput,
+                is("Specify volume as percentage between 0 and 100")));
     }
 
     @Test


### PR DESCRIPTION
This is the next Java 11 related issue causing the build to fail when #668 is merged.
The fix helps users and also ensures the unit test works on both Java 8 and 11.

---

On Java 8 a NFE without a message is thrown when creating a BigDecimal with the invalid value. 

On Java 11 the NFE has a message which causes the assertion to fail:

```
TEST audioConsolePlaysFileForASpecifiedSinkWithAnInvalidVolume(org.eclipse.smarthome.core.audio.internal.AudioConsoleTest) <<< ERROR: The given volume was invalid
Expected: null
     but: was "Character i is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
java.lang.AssertionError: The given volume was invalid
Expected: null
     but: was "Character i is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark."
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.eclipse.smarthome.core.audio.internal.AudioConsoleTest.lambda$0(AudioConsoleTest.java:143)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:152)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:120)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:73)
	at org.eclipse.smarthome.core.audio.internal.AudioConsoleTest.audioConsolePlaysFileForASpecifiedSinkWithAnInvalidVolume(AudioConsoleTest.java:143)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```