### PR TITLE
Handle itests as part of the reactor during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -600,6 +600,17 @@ Import-Package: \\
       </modules>
     </profile>
     <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
+      <modules>
+        <module>itests</module>
+      </modules>
+    </profile>
+    <profile>
       <id>with-bnd-resolver-resolve</id>
       <activation>
         <property>


### PR DESCRIPTION
This fixes a NPE by the unlesh plugin during a version bump. Cause of the NPE: Unit Tests are skipped during release to speed up the process, but itests won't be part of the reactor then even though its part of the POM hierarchy. This breaks some unleash internals.

Signed-off-by: Patrick Fink <mail@pfink.de>