### PR TITLE
Add unleash plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,18 @@ Import-Package: \\
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>com.itemis.maven.plugins</groupId>
+          <artifactId>unleash-maven-plugin</artifactId>
+          <version>2.8.0</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.itemis.maven.plugins</groupId>
+              <artifactId>unleash-scm-provider-git</artifactId>
+              <version>2.1.0</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
Hotfix for "unleash plugin not found" during release as suggested by @kaikreuzer. Clean solution is tackled by https://github.com/openhab/openhab-core/pull/555. 

Signed-off-by: Patrick Fink <mail@pfink.de>