### PR TITLE
Ignore and remove Eclipse project specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/
 .DS_Store
 *.iml
 .idea/
+**/.settings/org.eclipse.*
 
 dependency-reduced-pom.xml
 bundles/antlr-generator-3.2.0-patch.jar

--- a/bom/compile-model/.settings/org.eclipse.core.resources.prefs
+++ b/bom/compile-model/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/compile-model/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/compile-model/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/compile/.settings/org.eclipse.core.resources.prefs
+++ b/bom/compile/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/compile/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/compile/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/openhab-core-index/.settings/org.eclipse.core.resources.prefs
+++ b/bom/openhab-core-index/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/openhab-core-index/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/openhab-core-index/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/openhab-core/.settings/org.eclipse.core.resources.prefs
+++ b/bom/openhab-core/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/openhab-core/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/openhab-core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/runtime-index/.settings/org.eclipse.core.resources.prefs
+++ b/bom/runtime-index/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/runtime-index/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/runtime-index/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bom/runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/test-index/.settings/org.eclipse.core.resources.prefs
+++ b/bom/test-index/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/test-index/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/test-index/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bom/test/.settings/org.eclipse.core.resources.prefs
+++ b/bom/test/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bom/test/.settings/org.eclipse.m2e.core.prefs
+++ b/bom/test/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.audio/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.audio/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.audio/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.audio/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.auth.jaas/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.auth.jaas/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.auth.jaas/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.auth.jaas/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.auth.oauth2client/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.auth.oauth2client/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.auth.oauth2client/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.auth.oauth2client/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.automation.module.media/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.automation.module.media/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.automation.module.media/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.automation.module.media/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.automation.module.script/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.automation.module.script/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.automation.module.script/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.automation.module.script/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.automation.rest/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.automation.rest/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.automation.rest/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.automation.rest/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.automation/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.automation/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.automation/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.automation/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.binding.xml/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.binding.xml/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.binding.xml/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.binding.xml/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.boot/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.boot/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.boot/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.boot/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.compat1x/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.compat1x/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.compat1x/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.compat1x/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.core/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.core/.settings/org.eclipse.core.resources.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.core/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.discovery.mdns/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.discovery.mdns/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.discovery.mdns/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.discovery.mdns/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.discovery.upnp/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.discovery.upnp/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.discovery.upnp/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.discovery.upnp/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.discovery.usbserial/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.discovery.usbserial/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.discovery.usbserial/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.discovery.usbserial/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.discovery/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.discovery/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.discovery/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.discovery/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.dispatch/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.dispatch/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.dispatch/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.dispatch/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.serial/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.serial/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.serial/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.serial/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.config.xml/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.config.xml/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.config.xml/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.config.xml/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.extension.sample/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.extension.sample/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.extension.sample/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.extension.sample/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.id/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.id/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.id/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.id/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.console.eclipse/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.console.eclipse/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.console.eclipse/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.console.eclipse/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.console.karaf/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.console.karaf/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.console.karaf/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.console.karaf/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.console.rfc147/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.console.rfc147/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.console.rfc147/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.console.rfc147/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.console/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.console/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.console/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.console/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.http.auth.basic/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.http.auth.basic/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.http.auth.basic/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.http.auth.basic/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.http.auth/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.http.auth/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.http.auth/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.http.auth/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.http/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.http/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.http/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.http/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.jetty.certificate/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.jetty.certificate/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.io.jetty.certificate/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.jetty.certificate/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.monitor/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.monitor/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.monitor/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.monitor/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.net/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.net/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.net/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.net/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.auth/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.auth/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.auth/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.auth/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.core/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.core/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.core/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.log/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.log/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.log/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.log/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.mdns/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.mdns/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.mdns/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.mdns/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.optimize/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.optimize/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.optimize/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.optimize/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.sitemap/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.sitemap/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.sitemap/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.sitemap/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.sse/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.sse/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.sse/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.sse/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest.voice/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest.voice/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest.voice/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest.voice/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.rest/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.rest/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.rest/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.rest/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.dbus/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.dbus/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.io.transport.dbus/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.dbus/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.mdns/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.mdns/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.mdns/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.mdns/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.mqtt/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.mqtt/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.mqtt/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.mqtt/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.serial/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.serial/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.serial/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.serial/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.io.transport.upnp/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.io.transport.upnp/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.io.transport.upnp/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.io.transport.upnp/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.karaf/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.karaf/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.karaf/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.karaf/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.core/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.core/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.core/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.item.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.item.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.item.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.item.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.item.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.item/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.item/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.item/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.item/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.item/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.item/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.lazygen/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.lazygen/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.lazygen/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.lazygen/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.lsp/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.lsp/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.lsp/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.lsp/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.persistence.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.persistence.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.persistence.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.persistence.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.persistence.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.persistence/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.rule.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.rule.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.rule.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.rule.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.rule.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.rule/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.rule/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.rule/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.rule/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.rule/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.rule/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.script.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.script.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.script.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.script.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.script.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.script/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.script/.settings/org.eclipse.core.resources.prefs
@@ -1,8 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.script/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.script/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.script/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.script/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.sitemap.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.sitemap.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.sitemap.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.sitemap.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.sitemap.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.sitemap/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.thing.ide/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.model.thing.runtime/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.thing.runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.model.thing.runtime/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.thing.runtime/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.thing/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.model.thing/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/notestsources=UTF-8
-encoding/src=UTF-8
-encoding/src-gen=UTF-8

--- a/bundles/org.openhab.core.model.thing/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.model.thing/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.model.thing/.settings/org.eclipse.xtend.core.Xtend.prefs
+++ b/bundles/org.openhab.core.model.thing/.settings/org.eclipse.xtend.core.Xtend.prefs
@@ -1,7 +1,0 @@
-BuilderConfiguration.is_project_specific=true
-eclipse.preferences.version=1
-outlet.DEFAULT_OUTPUT.hideLocalSyntheticVariables=true
-outlet.DEFAULT_OUTPUT.installDslAsPrimarySource=false
-outlet.DEFAULT_OUTPUT.sourceFolder.notestsources.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.sourceFolder.src.directory=xtend-gen
-outlet.DEFAULT_OUTPUT.userOutputPerSourceFolder=true

--- a/bundles/org.openhab.core.persistence/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.persistence/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.persistence/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.persistence/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.scheduler/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.scheduler/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.scheduler/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.scheduler/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.semantics/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.semantics/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/model=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.semantics/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.semantics/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.storage.json/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.storage.json/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.storage.json/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.storage.json/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.storage.mapdb/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.storage.mapdb/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.storage.mapdb/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.storage.mapdb/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.test.magic/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.test.magic/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.test.magic/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.test.magic/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.test/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.test/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/test/java=UTF-8
-encoding/<project>=UTF-8

--- a/bundles/org.openhab.core.test/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.test/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.thing.xml/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.thing.xml/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.thing.xml/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.thing.xml/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.thing/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.thing/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.thing/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.thing/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.transform/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.transform/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.transform/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.transform/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.ui.icon/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.ui.icon/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.ui.icon/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.ui.icon/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.ui/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.ui/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core.voice/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core.voice/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core.voice/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core.voice/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/bundles/org.openhab.core/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.openhab.core/.settings/org.eclipse.core.resources.prefs
@@ -1,6 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8
-encoding/src=UTF-8

--- a/bundles/org.openhab.core/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.openhab.core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/demo/app/.settings/org.eclipse.core.resources.prefs
+++ b/demo/app/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/src=UTF-8

--- a/demo/app/.settings/org.eclipse.m2e.core.prefs
+++ b/demo/app/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/features/karaf/openhab-core/.settings/org.eclipse.core.resources.prefs
+++ b/features/karaf/openhab-core/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/features/karaf/openhab-core/.settings/org.eclipse.m2e.core.prefs
+++ b/features/karaf/openhab-core/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/features/karaf/openhab-tp/.settings/org.eclipse.core.resources.prefs
+++ b/features/karaf/openhab-tp/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/features/karaf/openhab-tp/.settings/org.eclipse.m2e.core.prefs
+++ b/features/karaf/openhab-tp/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.audio.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.audio.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.audio.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.audio.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.auth.oauth2client.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.auth.oauth2client.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.auth.oauth2client.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.auth.oauth2client.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.integration.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.integration.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.integration.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.integration.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.module.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.module.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.module.core.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.module.core.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.module.script.defaultscope.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.module.script.defaultscope.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.module.script.defaultscope.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.module.script.defaultscope.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.module.script.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.module.script.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.module.script.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.module.script.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.module.timer.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.module.timer.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.module.timer.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.module.timer.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.automation.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.automation.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.automation.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.automation.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.binding.xml.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.binding.xml.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.binding.xml.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.binding.xml.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.compat1x.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.compat1x.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.compat1x.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.compat1x.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.core.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.core.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.discovery.mdns.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.discovery.mdns.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.discovery.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.discovery.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.discovery.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.discovery.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.dispatch.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.dispatch.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.dispatch.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.dispatch.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.config.xml.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.config.xml.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.config.xml.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.config.xml.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.http.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.http.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.http.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.http.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.net.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.net.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.net.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.net.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.rest.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.rest.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.rest.core.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.rest.core.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.rest.sse.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.rest.sse.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.rest.sse.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.rest.sse.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.rest.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.rest.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.rest.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.rest.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.transport.mqtt.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.transport.mqtt.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.transport.mqtt.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.transport.mqtt.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.io.transport.upnp.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.io.transport.upnp.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.io.transport.upnp.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.io.transport.upnp.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.magic.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.magic.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.magic.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.magic.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.core.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.core.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.item.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.item.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.item.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.item.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.lsp.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.lsp.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.lsp.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.lsp.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.persistence.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.persistence.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.persistence.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.persistence.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.rule.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.rule.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.rule.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.rule.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.script.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.script.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.script.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.script.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.thing.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.thing.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.thing.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.thing.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.model.thing.testsupport/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.model.thing.testsupport/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.model.thing.testsupport/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.model.thing.testsupport/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.semantics.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.semantics.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.semantics.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.semantics.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.storage.json.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.storage.json.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.storage.json.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.storage.json.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,5 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8
-encoding/ESH-INF=UTF-8

--- a/itests/org.openhab.core.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.thing.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.thing.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.thing.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.thing.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.thing.xml.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.thing.xml.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.thing.xml.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.thing.xml.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.transform.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.transform.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.transform.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.transform.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.ui.icon.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.ui.icon.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.ui.icon.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.ui.icon.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,3 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.ui.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.ui.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1

--- a/itests/org.openhab.core.voice.tests/.settings/org.eclipse.core.resources.prefs
+++ b/itests/org.openhab.core.voice.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-encoding//src/main/java=UTF-8
-encoding//src/main/resources=UTF-8
-encoding/<project>=UTF-8

--- a/itests/org.openhab.core.voice.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/itests/org.openhab.core.voice.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,4 +1,0 @@
-activeProfiles=
-eclipse.preferences.version=1
-resolveWorkspaceProjects=true
-version=1


### PR DESCRIPTION
These are unnecessary and may override defaults. They will be regenerated after updating projects.

It's still possible to force add files ([source](https://stackoverflow.com/questions/24844782/how-to-override-a-rule-set-in-gitignore/24845089)) in case we do want to commit files that are otherwise ignored.