### PR TITLE
bump SAT version to 0.6.1 for Tycho builds

### DIFF
--- a/features/p2/poms/pom.xml
+++ b/features/p2/poms/pom.xml
@@ -48,7 +48,7 @@
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jna.version>4.5.2</jna.version>
     <jackson.version>1.9.13</jackson.version>
-    <sat.version>0.5.0</sat.version>
+    <sat.version>0.6.1</sat.version>
     <nrjavaserial.version>3.15.0.OH2</nrjavaserial.version>
     <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
     <build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>


### PR DESCRIPTION
This should be merged immediately before https://github.com/openhab/openhab2-addons/pull/5026.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>