### PR TITLE
Increase stability of MDNSDiscoveryServiceOSGiTest by increasing timeouts to 5s

### DIFF
--- a/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
@@ -47,10 +47,10 @@ public class MDNSDiscoveryServiceOSGiTest extends JavaOSGiTest {
     @Test
     public void testDynamicConfigurationOfBackgroundDiscovery() throws IOException {
         setBackgroundDiscoveryViaConfigAdmin(true);
-        waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(true)), 2000, 100);
+        waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(true)), 5000, 100);
 
         setBackgroundDiscoveryViaConfigAdmin(false);
-        waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(false)), 2000, 100);
+        waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(false)), 5000, 100);
     }
 
     private void setBackgroundDiscoveryViaConfigAdmin(boolean status) throws IOException {


### PR DESCRIPTION
Split off from #685