### PR TITLE
Require successful Travis CI Java 11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc
 install:
   - |
-    function extra_maven_opts() {
-        if [ "$TRAVIS_JDK_VERSION" != "openjdk8" ]; then echo "-Denforcer.skip=true"; fi;
-    }
     function prevent_timeout() {
         local i=0
         while [ -e /proc/$1 ]; do
@@ -46,9 +43,5 @@ after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
-env: # required for allowing failures
-matrix:
-  allow_failures:
-    - jdk: openjdk11
 script:
-  - mvnp clean verify -B -DskipChecks $(extra_maven_opts)
+  - mvnp clean verify -B -DskipChecks

--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@ Import-Package: \\
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[1.8.0-40,1.9)</version>
+                  <version>[1.8.0-40,1.9),[9.0,12.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
* Update enforcer to allow compilation with Java 8, 9, 10 and 11
* Update Travis CI configuration to require the Java 11 build to succeed

---

Depends on #685