### PR TITLE
Removed apache commons-httpclient, added commons-codec.

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -71,9 +71,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
-      <version>3.1_7</version>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.12</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -358,9 +358,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
-      <version>3.1_7</version>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.12</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
@@ -14,31 +14,13 @@ package org.openhab.io.net.http;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.httpclient.Credentials;
-import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.methods.DeleteMethod;
-import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.PutMethod;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.smarthome.core.auth.Credentials;
+import org.eclipse.smarthome.core.auth.UsernamePasswordCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,32 +90,13 @@ public class HttpUtil {
      */
     public static String executeUrl(String httpMethod, String url, Properties httpHeaders, InputStream content,
             String contentType, int timeout) {
-        String proxySet = System.getProperty("http.proxySet");
-
-        String proxyHost = null;
-        int proxyPort = 80;
-        String proxyUser = null;
-        String proxyPassword = null;
-        String nonProxyHosts = null;
-
-        if ("true".equalsIgnoreCase(proxySet)) {
-            proxyHost = System.getProperty("http.proxyHost");
-            String proxyPortString = System.getProperty("http.proxyPort");
-            if (StringUtils.isNotBlank(proxyPortString)) {
-                try {
-                    proxyPort = Integer.valueOf(proxyPortString);
-                } catch (NumberFormatException e) {
-                    logger.warn("'{}' is not a valid proxy port - using port 80 instead");
-                }
-            }
-            proxyUser = System.getProperty("http.proxyUser");
-            proxyPassword = System.getProperty("http.proxyPassword");
-            nonProxyHosts = System.getProperty("http.nonProxyHosts");
+        try {
+            return org.eclipse.smarthome.io.net.http.HttpUtil.executeUrl(httpMethod, url, content, contentType,
+                    timeout);
+        } catch (IOException ioe) {
+            logger.error("Fatal transport error: {}", ioe.toString());
         }
-
-        return executeUrl(httpMethod, url, httpHeaders, content, contentType, timeout, proxyHost, proxyPort, proxyUser,
-                proxyPassword, nonProxyHosts);
-
+        return null;
     }
 
     /**
@@ -156,112 +119,13 @@ public class HttpUtil {
     public static String executeUrl(String httpMethod, String url, Properties httpHeaders, InputStream content,
             String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
             String proxyPassword, String nonProxyHosts) {
-
-        HttpClient client = new HttpClient();
-
-        // only configure a proxy if a host is provided
-        if (StringUtils.isNotBlank(proxyHost) && proxyPort != null && shouldUseProxy(url, nonProxyHosts)) {
-            client.getHostConfiguration().setProxy(proxyHost, proxyPort);
-            if (StringUtils.isNotBlank(proxyUser)) {
-                client.getState().setProxyCredentials(AuthScope.ANY,
-                        new UsernamePasswordCredentials(proxyUser, proxyPassword));
-            }
-        }
-
-        HttpMethod method = HttpUtil.createHttpMethod(httpMethod, url);
-        method.getParams().setSoTimeout(timeout);
-        method.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, new DefaultHttpMethodRetryHandler(3, false));
-        if (httpHeaders != null) {
-            for (String httpHeaderKey : httpHeaders.stringPropertyNames()) {
-                method.addRequestHeader(new Header(httpHeaderKey, httpHeaders.getProperty(httpHeaderKey)));
-            }
-        }
-        // add content if a valid method is given ...
-        if (method instanceof EntityEnclosingMethod && content != null) {
-            EntityEnclosingMethod eeMethod = (EntityEnclosingMethod) method;
-            eeMethod.setRequestEntity(new InputStreamRequestEntity(content, contentType));
-        }
-
-        Credentials credentials = extractCredentials(url);
-        if (credentials != null) {
-            client.getParams().setAuthenticationPreemptive(true);
-            client.getState().setCredentials(AuthScope.ANY, credentials);
-        }
-
-        if (logger.isDebugEnabled()) {
-            try {
-                logger.debug("About to execute '{}'", method.getURI());
-            } catch (URIException e) {
-                logger.debug("{}", e.getMessage());
-            }
-        }
-
         try {
-
-            int statusCode = client.executeMethod(method);
-            if (statusCode != HttpStatus.SC_OK) {
-                logger.debug("Method failed: {}", method.getStatusLine());
-            }
-
-            String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
-            if (!responseBody.isEmpty()) {
-                logger.debug("{}", responseBody);
-            }
-
-            return responseBody;
-        } catch (HttpException he) {
-            logger.error("Fatal protocol violation: {}", he.toString());
+            return org.eclipse.smarthome.io.net.http.HttpUtil.executeUrl(httpMethod, url, httpHeaders, content,
+                    contentType, timeout, proxyHost, proxyPort, proxyUser, proxyPassword, nonProxyHosts);
         } catch (IOException ioe) {
             logger.error("Fatal transport error: {}", ioe.toString());
-        } finally {
-            method.releaseConnection();
         }
-
         return null;
-    }
-
-    /**
-     * Determines whether the list of <code>nonProxyHosts</code> contains the
-     * host (which is part of the given <code>urlString</code> or not.
-     *
-     * @param urlString
-     * @param nonProxyHosts
-     *
-     * @return <code>false</code> if the host of the given <code>urlString</code>
-     *         is contained in <code>nonProxyHosts</code>-list and <code>true</code>
-     *         otherwise
-     */
-    private static boolean shouldUseProxy(String urlString, String nonProxyHosts) {
-
-        if (StringUtils.isNotBlank(nonProxyHosts)) {
-            String givenHost = urlString;
-
-            try {
-                URL url = new URL(urlString);
-                givenHost = url.getHost();
-            } catch (MalformedURLException e) {
-                logger.error("the given url {} is malformed", urlString);
-            }
-
-            String[] hosts = nonProxyHosts.split("\\|");
-            for (String host : hosts) {
-                if (host.contains("*")) {
-                    // the nonProxyHots-pattern allows wildcards '*' which must
-                    // be masked to be used with regular expressions
-                    String hostRegexp = host.replaceAll("\\.", "\\\\.");
-                    hostRegexp = hostRegexp.replaceAll("\\*", ".*");
-                    if (givenHost.matches(hostRegexp)) {
-                        return false;
-                    }
-                } else {
-                    if (givenHost.equals(host)) {
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
     }
 
     /**
@@ -298,33 +162,6 @@ public class HttpUtil {
         }
 
         return null;
-    }
-
-    /**
-     * Factory method to create a {@link HttpMethod}-object according to the
-     * given String <code>httpMethod</codde>
-     *
-     * &#64;param httpMethodString the name of the {@link HttpMethod} to create
-     * &#64;param url
-     *
-     * &#64;return an object of type {@link GetMethod}, {@link PutMethod},
-     * {@link PostMethod} or {@link DeleteMethod}
-     * @throws IllegalArgumentException if <code>httpMethod</code> is none of
-     *             <code>GET</code>, <code>PUT</code>, <code>POST</POST> or <code>DELETE</code>
-     */
-    public static HttpMethod createHttpMethod(String httpMethodString, String url) {
-
-        if ("GET".equals(httpMethodString)) {
-            return new GetMethod(url);
-        } else if ("PUT".equals(httpMethodString)) {
-            return new PutMethod(url);
-        } else if ("POST".equals(httpMethodString)) {
-            return new PostMethod(url);
-        } else if ("DELETE".equals(httpMethodString)) {
-            return new DeleteMethod(url);
-        } else {
-            throw new IllegalArgumentException("given httpMethod '" + httpMethodString + "' is unknown");
-        }
     }
 
 }


### PR DESCRIPTION
While [migrating the neato binding](https://github.com/openhab/openhab2-addons/pull/5290) I encountered a problem with commons-codec versions.
Turns out the commons-codec version included is from the rather old commons-httpclient. Since all http goes through jetty I guess this library could be removed. SoI've removed the dependency on commons-httpclient and put back an up-to-date version of commons-code.
The only use in core was in the compat1x HttpUtil. This has be replaced by calls to the smarthome HttpUtil methods.

Disclaimer: I don't have a full overview of the impact of this change. This repository did build locally with this change.