### PR TITLE
[core] Improved thing / bridge performance

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Bridge.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Bridge.java
@@ -21,10 +21,20 @@ import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
 /**
  * A {@link Bridge} is a {@link Thing} that connects other {@link Thing}s.
  *
- * @author Dennis Nobel - Initial contribution and API
+ * @author Dennis Nobel - Initial contribution
+ * @author Christoph Weitkamp - Added method `getThing(ThingUID)`
  */
 @NonNullByDefault
 public interface Bridge extends Thing {
+
+    /**
+     * Gets the thing for the given UID or null if no thing with the UID exists.
+     *
+     * @param thingUID thing UID
+     * @return the thing for the given UID or null if no thing with the UID exists
+     */
+    @Nullable
+    Thing getThing(ThingUID thingUID);
 
     /**
      * Returns the children of the bridge.

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
@@ -29,11 +29,12 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
  * A {@link Thing} might be connected through a {@link Bridge}.
  * <p>
  *
- * @author Dennis Nobel - Initial contribution and API
+ * @author Dennis Nobel - Initial contribution
  * @author Thomas Höfer - Added thing and thing type properties
  * @author Simon Kaufmann - Added label, location
  * @author Kai Kreuzer - Removed linked items from Thing
  * @author Yordan Zhelev - Added method for getting the enabled status
+ * @author Christoph Weitkamp - Added method `getChannel(ChannelUID)`
  */
 @NonNullByDefault
 public interface Thing extends Identifiable<ThingUID> {
@@ -87,14 +88,22 @@ public interface Thing extends Identifiable<ThingUID> {
     List<Channel> getChannelsOfGroup(String channelGroupId);
 
     /**
-     * Gets the channel for the given id or null if no channel with the id
-     * exists.
+     * Gets the channel for the given id or null if no channel with the id exists.
      *
      * @param channelId channel ID
      * @return the channel for the given id or null if no channel with the id exists
      */
     @Nullable
     Channel getChannel(String channelId);
+
+    /**
+     * Gets the channel for the given UID or null if no channel with the UID exists.
+     *
+     * @param channelUID channel UID
+     * @return the channel for the given UID or null if no channel with the UID exists
+     */
+    @Nullable
+    Channel getChannel(ChannelUID channelUID);
 
     /**
      * Gets the status of a thing.
@@ -217,7 +226,7 @@ public interface Thing extends Identifiable<ThingUID> {
 
     /**
      * Returns information whether the {@link Thing} is enabled or not.
-     * 
+     *
      * @return Returns {@code true} if the thing is enabled. Return {@code false} otherwise.
      */
     boolean isEnabled();

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
@@ -29,10 +29,9 @@ import org.eclipse.smarthome.core.thing.internal.BridgeImpl;
 /**
  * This class allows the easy construction of a {@link Bridge} instance using the builder pattern.
  *
- * @author Dennis Nobel - Initial contribution and API
+ * @author Dennis Nobel - Initial contribution
  * @author Kai Kreuzer - Refactoring to make BridgeBuilder a subclass of ThingBuilder
  * @author Markus Rathgeb - Override methods to return BridgeBuidler instead of ThingBuidler
- *
  */
 @NonNullByDefault
 public class BridgeBuilder extends ThingBuilder {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
@@ -14,7 +14,6 @@ package org.eclipse.smarthome.core.thing.binding.builder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -34,13 +33,13 @@ import org.eclipse.smarthome.core.thing.util.ThingHelper;
 /**
  * This class allows the easy construction of a {@link Thing} instance using the builder pattern.
  *
- * @author Dennis Nobel - Initial contribution and API
+ * @author Dennis Nobel - Initial contribution
  * @author Kai Kreuzer - Refactoring to make BridgeBuilder a subclass
- *
  */
 @NonNullByDefault
 public class ThingBuilder {
 
+    private final List<Channel> channels = new ArrayList<>();
     private final ThingImpl thing;
 
     protected ThingBuilder(ThingImpl thing) {
@@ -69,10 +68,9 @@ public class ThingBuilder {
     }
 
     public ThingBuilder withChannel(Channel channel) {
-        final Collection<Channel> mutableThingChannels = this.thing.getChannelsMutable();
         validateChannelUIDs(Collections.singletonList(channel));
-        ThingHelper.ensureUniqueChannels(mutableThingChannels, channel);
-        mutableThingChannels.add(channel);
+        ThingHelper.ensureUniqueChannels(channels, channel);
+        channels.add(channel);
         return this;
     }
 
@@ -83,12 +81,13 @@ public class ThingBuilder {
     public ThingBuilder withChannels(List<Channel> channels) {
         validateChannelUIDs(channels);
         ThingHelper.ensureUniqueChannels(channels);
-        this.thing.setChannels(new ArrayList<>(channels));
+        this.channels.clear();
+        this.channels.addAll(channels);
         return this;
     }
 
     public ThingBuilder withoutChannel(ChannelUID channelUID) {
-        Iterator<Channel> iterator = this.thing.getChannelsMutable().iterator();
+        Iterator<Channel> iterator = channels.iterator();
         while (iterator.hasNext()) {
             if (iterator.next().getUID().equals(channelUID)) {
                 iterator.remove();
@@ -132,7 +131,8 @@ public class ThingBuilder {
     }
 
     public Thing build() {
-        return this.thing;
+        thing.setChannels(channels);
+        return thing;
     }
 
     private void validateChannelUIDs(List<Channel> channels) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.iterators.ArrayIterator;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -47,6 +48,7 @@ import org.eclipse.smarthome.core.thing.internal.ThingImpl;
  * @author Dennis Nobel - Removed createAndBindItems method
  * @author Kai Kreuzer - Added merge method
  */
+@NonNullByDefault
 public class ThingHelper {
 
     /**
@@ -98,9 +100,11 @@ public class ThingHelper {
     }
 
     public static void addChannelsToThing(Thing thing, Collection<Channel> channels) {
-        List<Channel> mutableChannels = ((ThingImpl) thing).getChannelsMutable();
+        Collection<Channel> mutableChannels = thing.getChannels();
         ensureUniqueChannels(mutableChannels, channels);
-        mutableChannels.addAll(channels);
+        for (Channel channel : channels) {
+            ((ThingImpl) thing).addChannel(channel);
+        }
     }
 
     public static void ensureUnique(Collection<Channel> channels) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingImplTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.junit.Test;
+
+/**
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class ThingImplTest {
+
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("test", "test");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "test");
+    private static final String FIRST_CHANNEL_ID = "firstgroup#channel1";
+    private static final String SECOND_CHANNEL_ID = "secondgroup#channel1";
+    private static final ChannelUID FIRST_CHANNEL_UID = new ChannelUID(THING_UID, FIRST_CHANNEL_ID);
+    private static final ChannelUID SECOND_CHANNEL_UID = new ChannelUID(THING_UID, SECOND_CHANNEL_ID);
+
+    @Test
+    public void testGetChannelMethods() {
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
+                .withChannel(ChannelBuilder.create(FIRST_CHANNEL_UID, CoreItemFactory.STRING).build()).build();
+        assertEquals(1, thing.getChannels().size());
+
+        assertNull(thing.getChannel("channel1"));
+
+        assertNotNull(thing.getChannel(FIRST_CHANNEL_UID));
+        assertEquals(FIRST_CHANNEL_UID, thing.getChannel(FIRST_CHANNEL_UID).getUID());
+
+        assertNotNull(thing.getChannel(FIRST_CHANNEL_ID));
+        assertEquals(FIRST_CHANNEL_UID, thing.getChannel(FIRST_CHANNEL_ID).getUID());
+    }
+
+    @Test
+    public void testGetGroupChannels() {
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
+                .withChannel(ChannelBuilder.create(FIRST_CHANNEL_UID, CoreItemFactory.STRING).build())
+                .withChannel(ChannelBuilder.create(SECOND_CHANNEL_UID, CoreItemFactory.STRING).build()).build();
+        assertEquals(2, thing.getChannels().size());
+
+        assertNull(thing.getChannel("channel1"));
+
+        assertNotNull(thing.getChannel(FIRST_CHANNEL_UID));
+        assertEquals(FIRST_CHANNEL_UID, thing.getChannel(FIRST_CHANNEL_UID).getUID());
+
+        assertNotNull(thing.getChannel(FIRST_CHANNEL_ID));
+        assertEquals(FIRST_CHANNEL_UID, thing.getChannel(FIRST_CHANNEL_ID).getUID());
+
+        assertNotNull(thing.getChannel(SECOND_CHANNEL_UID));
+        assertEquals(SECOND_CHANNEL_UID, thing.getChannel(SECOND_CHANNEL_UID).getUID());
+
+        assertNotNull(thing.getChannel(SECOND_CHANNEL_ID));
+        assertEquals(SECOND_CHANNEL_UID, thing.getChannel(SECOND_CHANNEL_ID).getUID());
+    }
+
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -273,13 +275,12 @@ public class ThingFactoryTest extends JavaOSGiTest {
 
         Thing thing = ThingFactory.createThing(thingType, new ThingUID(thingType.getUID(), "thingId"), configuration);
 
+        List<String> channelUIDs = Arrays.asList("bindingId:thingType:thingId:group1#ch1",
+                "bindingId:thingType:thingId:group1#ch2", "bindingId:thingType:thingId:group2#ch1");
         assertThat(thing.getChannels().size(), is(3));
-        assertThat(thing.getChannels().get(0).getUID().toString(),
-                is(equalTo("bindingId:thingType:thingId:group1#ch1")));
-        assertThat(thing.getChannels().get(1).getUID().toString(),
-                is(equalTo("bindingId:thingType:thingId:group1#ch2")));
-        assertThat(thing.getChannels().get(2).getUID().toString(),
-                is(equalTo("bindingId:thingType:thingId:group2#ch1")));
+        for (Channel channel : thing.getChannels()) {
+            assertThat(channelUIDs.contains(channel.getUID().toString()), is(true));
+        }
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactoryTest.java
@@ -22,11 +22,12 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.dto.ThingDTOMapper;
 import org.eclipse.smarthome.core.thing.events.ThingEventFactory.TriggerEventPayloadBean;
-import org.eclipse.smarthome.core.thing.internal.ThingImpl;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Test;
 
@@ -44,8 +45,9 @@ public class ThingEventFactoryTest extends JavaOSGiTest {
 
     private final ThingEventFactory factory = new ThingEventFactory();
 
-    private final ThingUID THING_UID = new ThingUID("binding:type:id");
-    private final Thing THING = new ThingImpl(THING_UID);
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
+    private static final Thing THING = ThingBuilder.create(THING_TYPE_UID, THING_UID).build();
 
     private final String THING_STATUS_EVENT_TOPIC = ThingEventFactory.THING_STATUS_INFO_EVENT_TOPIC
             .replace("{thingUID}", THING_UID.getAsString());


### PR DESCRIPTION
- Changed property `channels` from `List<Channel>` to `Map<ChannelUID, Channel>` for faster accessing channels of a thing
- Changed property `things` from `List<Thing>` to `Map<ThingUID, Thing>` for faster accessing things of a bridge
- Added new methods `getChannel(ChannelUID)` and `getThing(ThingUID)`
- Fixed SAT findings (e.g. null annotation on `BridgeImpl`)

I removed the method `getChannelsMutable()` from `ThingImpl` and replaced it by a `addChannel(Channel)` method. Imho the best solution will be to omit this new method too, but unfortunately we need it in the helper class `ThingHelper#addChannelsToThing()`. Any ideas how to get rid of that? It is used only in two places - first one can be refactored completely to make use of the `ThingBuilder`:

https://github.com/openhab/openhab-core/blob/48d873a32ba0901a9b58f04c541f0f858fbfcd51/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java#L221

and

https://github.com/openhab/openhab-core/blob/48d873a32ba0901a9b58f04c541f0f858fbfcd51/bundles/org.openhab.core.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend#L327

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>