### PR TITLE
Add commons-net to bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -375,6 +375,12 @@
       <version>2.6</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>3.3</version>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Gson -->
     <dependency>


### PR DESCRIPTION
The resolver failed to resolve the commons-net bundle used in the Max Cube Binding itests (https://github.com/openhab/openhab2-addons/pull/5376).