### PR TITLE
Channel groups should not require static channels

### DIFF
--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelGroupTypeConverter.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelGroupTypeConverter.java
@@ -56,7 +56,7 @@ public class ChannelGroupTypeConverter extends AbstractDescriptionTypeConverter<
 
     @SuppressWarnings("unchecked")
     protected List<ChannelXmlResult> readChannelTypeDefinitions(NodeIterator nodeIterator) throws ConversionException {
-        return (List<ChannelXmlResult>) nodeIterator.nextList("channels", true);
+        return (List<ChannelXmlResult>) nodeIterator.nextList("channels", false);
     }
 
     @Override

--- a/bundles/org.openhab.core.thing.xml/thing-description-1.0.0.xsd
+++ b/bundles/org.openhab.core.thing.xml/thing-description-1.0.0.xsd
@@ -88,7 +88,7 @@
             <xs:element name="label" type="xs:string"/>
             <xs:element name="description" type="xs:string" minOccurs="0"/>
             <xs:element name="category" type="xs:string" minOccurs="0"/>
-            <xs:element name="channels" type="thing-description:channels" minOccurs="1"/>
+            <xs:element name="channels" type="thing-description:channels" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="id" type="config-description:idRestrictionPattern" use="required"/>
         <xs:attribute name="advanced" type="xs:boolean" default="false" use="optional"/>

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypesTest.java
@@ -24,6 +24,9 @@ import java.util.Set;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
@@ -40,11 +43,12 @@ public class ThingTypesTest extends JavaOSGiTest {
 
     private LoadedTestBundle loadedTestBundle() throws Exception {
         return new LoadedTestBundle("ThingTypesTest.bundle", bundleContext, this::getService,
-                new StuffAddition().thingTypes(3));
+                new StuffAddition().thingTypes(4));
     }
 
     private ThingTypeProvider thingTypeProvider;
     private ChannelTypeRegistry channelTypeRegistry;
+    private ChannelGroupTypeRegistry channelGroupTypeRegistry;
 
     @Before
     public void setUp() {
@@ -53,6 +57,9 @@ public class ThingTypesTest extends JavaOSGiTest {
 
         channelTypeRegistry = getService(ChannelTypeRegistry.class);
         assertThat(channelTypeRegistry, is(notNullValue()));
+
+        channelGroupTypeRegistry = getService(ChannelGroupTypeRegistry.class);
+        assertThat(channelGroupTypeRegistry, is(notNullValue()));
     }
 
     @Test
@@ -60,6 +67,7 @@ public class ThingTypesTest extends JavaOSGiTest {
         try (final AutoCloseable unused = loadedTestBundle()) {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(null);
 
+            // HUE Bridge
             BridgeType bridgeType = (BridgeType) thingTypes.stream().filter(it -> it.toString().equals("hue:bridge"))
                     .findFirst().get();
             assertThat(bridgeType, is(notNullValue()));
@@ -71,6 +79,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(bridgeType.getProperties().get("vendor"), is("Philips"));
             assertThat(bridgeType.getRepresentationProperty(), is("serialNumber"));
 
+            // HUE Lamp
             ThingType thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp")).findFirst().get();
 
             assertThat(thingType, is(notNullValue()));
@@ -163,11 +172,42 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(state.getOptions().get(0).getValue(), is(equalTo("SOUND")));
             assertThat(state.getOptions().get(0).getLabel(), is(equalTo("My great sound.")));
 
+            // HUE Lamp with group
             thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-with-group")).findFirst().get();
+            assertThat(thingType, is(notNullValue()));
             assertThat(thingType.getProperties().size(), is(0));
             assertThat(thingType.getCategory(), is(nullValue()));
             assertThat(thingType.isListed(), is(true));
             assertThat(thingType.getExtensibleChannelTypeIds(), containsInAnyOrder("brightness", "alarm"));
+
+            List<ChannelGroupDefinition> channelGroupDefinitions = thingType.getChannelGroupDefinitions();
+            assertThat(channelGroupDefinitions.size(), is(2));
+
+            // Channel Group
+            ChannelGroupDefinition channelGroupDefinition = channelGroupDefinitions.stream()
+                    .filter(it -> it.getId().equals("lampgroup")).findFirst().get();
+            assertThat(channelGroupDefinition, is(notNullValue()));
+            ChannelGroupType channelGroupType = channelGroupTypeRegistry
+                    .getChannelGroupType(channelGroupDefinition.getTypeUID());
+            assertThat(channelGroupType, is(notNullValue()));
+            channelDefinitions = channelGroupType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(3));
+
+            // Channel Group without channels
+            channelGroupDefinition = channelGroupDefinitions.stream()
+                    .filter(it -> it.getId().equals("lampgroup-without-channels")).findFirst().get();
+            assertThat(channelGroupDefinition, is(notNullValue()));
+            channelGroupType = channelGroupTypeRegistry.getChannelGroupType(channelGroupDefinition.getTypeUID());
+            assertThat(channelGroupType, is(notNullValue()));
+            channelDefinitions = channelGroupType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(0));
+
+            // HUE Lamp without channels
+            thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-without-channels")).findFirst()
+                    .get();
+            assertThat(thingType, is(notNullValue()));
+            channelDefinitions = thingType.getChannelDefinitions();
+            assertThat(channelDefinitions.size(), is(0));
         }
     }
 

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/ESH-INF/thing/thing-types.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="hue"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="hue" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 org.eclipse.smarthome.thing-description.xsd">
 
@@ -63,7 +62,7 @@
 		<representation-property>uniqueId</representation-property>
 	</thing-type>
 
-	<!-- HUE Lamp with Group -->
+	<!-- HUE Lamp with group -->
 	<thing-type id="lamp-with-group" extensible="brightness, alarm">
 
 		<label>HUE Lamp</label>
@@ -71,17 +70,34 @@
 
 		<channel-groups>
 			<channel-group id="lampgroup" typeId="lampgroup" />
+			<channel-group id="lampgroup-without-channels" typeId="lampgroup-without-channels" />
 		</channel-groups>
 	</thing-type>
 
+	<!-- HUE Lamp without channels -->
+	<thing-type id="lamp-without-channels" listed="false" extensible="alarm,brightness">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="bridge" />
+		</supported-bridge-type-refs>
+
+		<label>HUE Lamp</label>
+		<description>My own great HUE Lamp without channels.</description>
+
+		<category>Lightbulb</category>
+
+		<properties>
+			<property name="key1">value1</property>
+			<property name="key2">value2</property>
+		</properties>
+		<representation-property>uniqueId</representation-property>
+	</thing-type>
 
 	<!-- HUE Lamp Color Channel -->
 	<channel-type id="color">
 		<item-type>ColorItem</item-type>
 		<label>HUE Lamp Color</label>
-		<description>The color channel allows to control the color of the hue
-			lamp. It is also possible to dim values and switch the lamp on and
-			off.
+		<description>The color channel allows to control the color of the hue lamp. It is also possible to dim values and
+			switch the lamp on and off.
 		</description>
 		<tags>
 			<tag>Hue</tag>
@@ -116,8 +132,7 @@
 			<tag>Hue</tag>
 			<tag>AlarmSystem</tag>
 		</tags>
-		<state min="0" max="100.0" step="10.0" pattern="%d Peek"
-			readOnly="true">
+		<state min="0" max="100.0" step="10.0" pattern="%d Peek" readOnly="true">
 			<options>
 				<option value="SOUND">My great sound.</option>
 				<option value="LIGHT" />
@@ -134,6 +149,12 @@
 			<channel id="color_temperature" typeId="color_temperature" />
 			<channel id="alarm" typeId="alarm" />
 		</channels>
+	</channel-group-type>
+
+	<!-- Channel Group without channels -->
+	<channel-group-type id="lampgroup-without-channels" advanced="true">
+		<label>Alarm System</label>
+		<description>The alarm system without channels.</description>
 	</channel-group-type>
 
 </thing:thing-descriptions>


### PR DESCRIPTION
The [linuxinput binding](https://github.com/openhab/openhab2-addons/pull/4629) creates a channelgroup for dynamically created channels.
Currently this results in warnings on binding load:

```
2019-04-04 21:35:58.672 [WARN ] [ig.xml.osgi.XmlDocumentBundleTracker] - The XML document '/ESH-INF/thing/thing-types.xml' in module 'org.openhab.binding.linuxinput' could not be parsed: The node 'channels' is missing!
---- Debugging information ----
class               : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
required-type       : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
converter-type      : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter
path                : /thing-descriptions/channel-group-type
line number         : 50
class[1]            : java.util.ArrayList
converter-type[1]   : com.thoughtworks.xstream.converters.collections.CollectionConverter
class[2]            : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionList
converter-type[2]   : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter
version             : 1.4.7
-------------------------------
com.thoughtworks.xstream.converters.ConversionException: The node 'channels' is missing!
---- Debugging information ----
class               : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
required-type       : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeXmlResult
converter-type      : org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter
path                : /thing-descriptions/channel-group-type
line number         : 50
class[1]            : java.util.ArrayList
converter-type[1]   : com.thoughtworks.xstream.converters.collections.CollectionConverter
class[2]            : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionList
converter-type[2]   : org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter
version             : 1.4.7
-------------------------------
	at org.eclipse.smarthome.config.xml.util.NodeIterator.next(NodeIterator.java:117) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.util.NodeIterator.nextList(NodeIterator.java:198) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.readChannelTypeDefinitions(ChannelGroupTypeConverter.java:59) ~[?:?]
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.unmarshalType(ChannelGroupTypeConverter.java:72) ~[?:?]
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelGroupTypeConverter.unmarshalType(ChannelGroupTypeConverter.java:1) ~[?:?]
	at org.eclipse.smarthome.core.thing.xml.internal.AbstractDescriptionTypeConverter.unmarshal(AbstractDescriptionTypeConverter.java:194) ~[?:?]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.converters.collections.AbstractCollectionConverter.readItem(AbstractCollectionConverter.java:71) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.addCurrentElementToCollection(CollectionConverter.java:98) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:91) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.populateCollection(CollectionConverter.java:85) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.converters.collections.CollectionConverter.unmarshal(CollectionConverter.java:80) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.core.thing.xml.internal.ThingDescriptionConverter.unmarshal(ThingDescriptionConverter.java:53) ~[?:?]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:134) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1185) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1169) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1115) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1062) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.util.XmlDocumentReader.readFromXML(XmlDocumentReader.java:85) ~[101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.parseDocuments(XmlDocumentBundleTracker.java:407) [101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:394) [101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.access$6(XmlDocumentBundleTracker.java:389) [101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:359) [101:org.eclipse.smarthome.config.xml:0.11.0.oh250M1]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]

```