### PR TITLE
Added null checks to dividend and divisor to prevent NPEs

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/lib/NumberExtensions.java
@@ -26,8 +26,7 @@ import org.eclipse.smarthome.core.types.Type;
  * This class contains all kinds of extensions to be used by scripts and not
  * provided by Xbase. These include things like number handling and comparisons.
  *
- * @author Kai Kreuzer - Initial contribution and API
- *
+ * @author Kai Kreuzer - Initial contribution
  */
 public class NumberExtensions {
 
@@ -89,7 +88,13 @@ public class NumberExtensions {
     public static BigDecimal operator_divide(Number x, Number y) {
         BigDecimal xValue = numberToBigDecimal(x);
         BigDecimal yValue = numberToBigDecimal(y);
-        return xValue.divide(yValue, 8, RoundingMode.HALF_UP);
+        if (xValue == null) {
+            return NULL_DEFINITION;
+        } else if (yValue == null) {
+            return NULL_DEFINITION;
+        } else {
+            return xValue.divide(yValue, 8, RoundingMode.HALF_UP);
+        }
     }
 
     // Comparison operations between numbers


### PR DESCRIPTION
- Added null checks to dividend and divisor to prevent NPEs

Needed to get `org.eclipse.smarthome.model.script.tests` running properly. Currently failing:

```
TEST testOperator_divideNullLeft(org.eclipse.smarthome.model.script.tests.lib.NumberExtensionsTest) <<< ERROR: null
java.lang.NullPointerException
	at org.eclipse.smarthome.model.script.lib.NumberExtensions.operator_divide(NumberExtensions.java:92)
	at org.eclipse.smarthome.model.script.tests.lib.NumberExtensionsTest.testOperator_divideNullLeft(NumberExtensionsTest.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```

```
TEST testOperator_divideNullRight(org.eclipse.smarthome.model.script.tests.lib.NumberExtensionsTest) <<< ERROR: Unexpected exception, expected<java.lang.ArithmeticException> but was<java.lang.NullPointerException>
java.lang.Exception: Unexpected exception, expected<java.lang.ArithmeticException> but was<java.lang.NullPointerException>
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:28)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
Caused by: java.lang.NullPointerException
	at java.math.BigDecimal.divide(BigDecimal.java:1563)
	at java.math.BigDecimal.divide(BigDecimal.java:1594)
	at org.eclipse.smarthome.model.script.lib.NumberExtensions.operator_divide(NumberExtensions.java:94)
	at org.eclipse.smarthome.model.script.tests.lib.NumberExtensionsTest.testOperator_divideNullRight(NumberExtensionsTest.java:221)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:19)
	... 18 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>