### PR TITLE
Update AbstractManagedProvider.java

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> extends AbstractProvider<E>
         implements ManagedProvider<E, K> {
 
-    private StorageService storageService;
+    protected StorageService storageService;
     private volatile Storage<PE> storage;
 
     protected final Logger logger = LoggerFactory.getLogger(AbstractManagedProvider.class);


### PR DESCRIPTION
The storage service must be set by the parent class at some point,
but the parent class is not able to check later on if a storage service is set.

Make the field protected to access the storage service for null checks and other usage.
The alternative is that the parent class stores the same field another time.

Signed-off-by: David Gräff <david.graeff@web.de>