### PR TITLE
Fix BaseThingHandlerFactory.getServices()

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -188,7 +188,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                         } else {
                             serviceRegs.add(serviceReg);
                         }
-                        ths.activate();
+                        serviceInstance.activate();
                     }
                 }
             } catch (InstantiationException | IllegalAccessException e) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -188,7 +188,8 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                         } else {
                             serviceRegs.add(serviceReg);
                         }
-                        serviceInstance.activate();
+                        Method activateMethod = c.getMethod("activate");
+                        activateMethod.invoke(serviceInstance);
                     }
                 }
             } catch (InstantiationException | IllegalAccessException e) {


### PR DESCRIPTION
If we only call activate() on the `ThingHandlerService` interface, and not on the service instance itself,
we skip super class activation. This breaks thing handler services that extend AbstractDiscoveryService.

@cweitkamp DYT this solves the discovery issue?

See: https://github.com/openhab/openhab2-addons/pull/5013#issuecomment-481470448
And: https://github.com/openhab/openhab2-addons/pull/5351#issuecomment-479118436
And find numerous other cases (Deconz, Yamaha etc)

Signed-off-by: David Gräff <david.graeff@web.de>