### PR TITLE
[automation][WIP] Improve exception logging

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -150,14 +150,15 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     Invocable inv = (Invocable) engine;
                     try {
                         inv.invokeFunction("scriptLoaded", engineIdentifier);
-                    } catch (NoSuchMethodException e) {
-                        logger.trace("scriptLoaded() is not defined in the script: {}", engineIdentifier);
+                    } catch (NoSuchMethodException ex) {
+                        logger.trace("The function 'scriptLoaded()' is not defined in the script: {}.",
+                                engineIdentifier);
                     }
                 } else {
                     logger.trace("ScriptEngine does not support Invocable interface");
                 }
             } catch (Exception ex) {
-                logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
+                logger.error("Error during evaluation of script '{}'", engineIdentifier, ex);
             }
         }
     }
@@ -170,10 +171,10 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                 Invocable inv = (Invocable) container.getScriptEngine();
                 try {
                     inv.invokeFunction("scriptUnloaded");
-                } catch (NoSuchMethodException e) {
-                    logger.trace("scriptUnloaded() is not defined in the script");
+                } catch (NoSuchMethodException ex) {
+                    logger.trace("The function scriptUnloaded() is not defined in the script.");
                 } catch (ScriptException ex) {
-                    logger.error("Error while executing script", ex);
+                    logger.error("Error while executing script '{}':", engineIdentifier, ex);
                 }
             } else {
                 logger.trace("ScriptEngine does not support Invocable interface");
@@ -182,11 +183,11 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
         }
     }
 
-    private void removeScriptExtensions(String pathIdentifier) {
+    private void removeScriptExtensions(String engineIdentifier) {
         try {
-            scriptExtensionManager.dispose(pathIdentifier);
+            scriptExtensionManager.dispose(engineIdentifier);
         } catch (Exception ex) {
-            logger.error("Error removing ScriptEngine", ex);
+            logger.error("Error while removing ScriptExtensions for '{}':", engineIdentifier, ex);
         }
     }
 


### PR DESCRIPTION
There were several places where just ex.getMessage() was being used. It
is much more helpful to see the full stack trace, especially when using
scripted automation. This PR does not cover all areas of the automation code. BTW, I tried fixing some of the existing warnings, but n matter what I tried, I could not get rid of some of them, so I left it as it was.

Signed-off-by: Scott Rushworth <openhab@5iver.com>