### PR TITLE
remove build path entries for non-existent folders

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/.classpath
+++ b/bundles/org.openhab.core.automation.module.script/.classpath
@@ -16,17 +16,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
This makes the projects compile correctly in the IDE again.

Signed-off-by: Kai Kreuzer <kai@openhab.org>