### PR TITLE
[core] Deprecated method 'ensureUnique'

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
@@ -107,6 +107,10 @@ public class ThingHelper {
         }
     }
 
+    /**
+     * @deprecated Use {@link ThingHelper#ensureUniqueChannels(Collection)} instead.
+     */
+    @Deprecated
     public static void ensureUnique(Collection<Channel> channels) {
         HashSet<UID> ids = new HashSet<>();
         for (Channel channel : channels) {


### PR DESCRIPTION
- Deprecate method `ensureUnique` - could be removed because of superfluous code. It is never used in the framework and we have a more powerful method available.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>