### PR TITLE
[core] Removed deprecated methods

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
@@ -46,12 +46,6 @@ public class BridgeBuilder extends ThingBuilder {
         return new BridgeBuilder(bridge);
     }
 
-    @Deprecated
-    public static BridgeBuilder create(ThingUID thingUID) {
-        BridgeImpl bridge = new BridgeImpl(thingUID);
-        return new BridgeBuilder(bridge);
-    }
-
     public static BridgeBuilder create(ThingTypeUID thingTypeUID, ThingUID thingUID) {
         BridgeImpl bridge = new BridgeImpl(thingTypeUID, thingUID);
         return new BridgeBuilder(bridge);

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
@@ -51,12 +51,6 @@ public class ThingBuilder {
         return new ThingBuilder(thing);
     }
 
-    @Deprecated
-    public static ThingBuilder create(ThingUID thingUID) {
-        ThingImpl thing = new ThingImpl(thingUID);
-        return new ThingBuilder(thing);
-    }
-
     public static ThingBuilder create(ThingTypeUID thingTypeUID, ThingUID thingUID) {
         ThingImpl thing = new ThingImpl(thingTypeUID, thingUID);
         return new ThingBuilder(thing);

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/BridgeImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/BridgeImpl.java
@@ -54,16 +54,6 @@ public class BridgeImpl extends ThingImpl implements Bridge {
     }
 
     /**
-     * @param thingUID
-     * @throws IllegalArgumentException
-     * @deprecated use {@link #BridgeImpl(ThingTypeUID, ThingUID)} instead.
-     */
-    @Deprecated
-    public BridgeImpl(ThingUID thingUID) throws IllegalArgumentException {
-        super(thingUID);
-    }
-
-    /**
      * @param thingTypeUID
      * @param thingUID
      * @throws IllegalArgumentException

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
@@ -92,21 +92,6 @@ public class ThingImpl implements Thing {
     }
 
     /**
-     * @param thingUID
-     * @throws IllegalArgumentException
-     * @deprecated use {@link #ThingImpl(ThingTypeUID, ThingUID)} instead.
-     */
-    @Deprecated
-    public ThingImpl(ThingUID thingUID) throws IllegalArgumentException {
-        if ("".equals(thingUID.getThingTypeId())) {
-            throw new IllegalArgumentException(
-                    "The given ThingUID does not specify a ThingType. You might want to use ThingImpl(ThingTypeUID, ThingUID) instead.");
-        }
-        this.uid = thingUID;
-        this.thingTypeUID = new ThingTypeUID(thingUID.getBindingId(), thingUID.getThingTypeId());
-    }
-
-    /**
      * @param thingTypeUID thing type UID
      * @param thingUID
      * @throws IllegalArgumentException


### PR DESCRIPTION
- Removed deprecated methods in `ThingImpl` and `BridgeImpl` and as well in the related builders

Follow-up PR off #693

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>