### PR TITLE
Update Karaf to 4.2.4 in openHAB add-ons Parent POM

### DIFF
--- a/features/p2/poms/pom.xml
+++ b/features/p2/poms/pom.xml
@@ -44,7 +44,7 @@
 
     <ohdr.version>1.0.42</ohdr.version>
     <repo.version>2.5.x</repo.version>
-    <karaf.version>4.2.2</karaf.version>
+    <karaf.version>4.2.4</karaf.version>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jna.version>4.5.2</jna.version>
     <jackson.version>1.9.13</jackson.version>


### PR DESCRIPTION
For Karaf 4.2.3 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12344587

For Karaf 4.2.4 release notes, see:
  https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12344856&projectId=12311140

---

Shoud be merged together with:

* https://github.com/openhab/openhab2-addons/pull/5459
* https://github.com/openhab/openhab-webui/pull/56
* https://github.com/openhab/openhab-distro/pull/900

---

The fix for [KARAF-6077](https://issues.apache.org/jira/browse/KARAF-6077) allows for using the servicemix bundles in openhab2-addons instead of wrapping JARs (see https://github.com/openhab/openhab-core/pull/684#discussion_r270680736).