### PR TITLE
[JSR223] Sort by filename instead of path

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcher.java
@@ -21,6 +21,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
 import java.util.Comparator;
@@ -252,9 +253,17 @@ public class ScriptFileWatcher extends AbstractWatchService {
         SortedSet<URL> reimportUrls = new TreeSet<URL>(new Comparator<URL>() {
             @Override
             public int compare(URL o1, URL o2) {
-                String f1 = o1.getPath();
-                String f2 = o2.getPath();
-                return String.CASE_INSENSITIVE_ORDER.compare(f1, f2);
+                Path path1 = Paths.get(o1.getPath());
+                Path path2 = Paths.get(o2.getPath());
+                String name1 = path1.getFileName().toString();
+                String name2 = path2.getFileName().toString();
+                int nameCompare = name1.compareToIgnoreCase(name2);
+                if (nameCompare != 0) {
+                    return nameCompare;
+                } else {
+                    int pathCompare = path1.getParent().toString().compareToIgnoreCase(path2.getParent().toString());
+                    return pathCompare;
+                }
             }
         });
 


### PR DESCRIPTION
Currently, the scripts are loaded by ScriptFileWatcher based on the lexicographical order of the absolute paths of the scripts. This makes it difficult to control the load order. This change bases the load order solely on the filename, as was originally used before [ESH/#3855](https://github.com/eclipse/smarthome/pull/3855), and preserves the ability to use scripts with the same filename. This PR resolves https://github.com/OH-Jython-Scripters/openhab2-jython/issues/76.

## [Current load order](https://www.openhab.org/docs/configuration/jsr223.html#script-locations)

## After this PR
Scripts will be loaded based on the filename. If more than one script have the same filename, their paths will also be taken into account for the sorting. This is especially helpful with the direcotry structure adopted by the Jython helper libraries. Currently, Community scripts (in a community directory), are being loaded before the Core scripts (in a core directory).

**Directory structure and scripts**
```
├── /automation/sr223
│   ├── 00
│   │   ├── 00
│   │   │   ├── 00_script.py
│   │   │   ├── 01_script.py
│   │   │   └── another.py
│   │   ├── 00_script.py
│   │   ├── 01
│   │   │   ├── 00_script.py
│   │   │   ├── 01_script.py
│   │   │   └── another.py
│   │   ├── 01_script.py
│   │   └── another.py
│   ├── 00_script.py
│   ├── 01
│   │   ├── 00
│   │   │   ├── 00_script.py
│   │   │   ├── 01_script.py
│   │   │   └── another.py
│   │   ├── 00_script.py
│   │   ├── 01
│   │   │   ├── 00_script.py
│   │   │   ├── 01_script.py
│   │   │   └── another.py
│   │   ├── 01_script.py
│   │   └── another.py
│   ├── 01_script.py
│   ├── another.py
```
**Load order**
```
/00_script.py
/00/00_script.py
/00/00/00_script.py
/00/01/00_script.py
/01/00_script.py
/01/00/00_script.py
/01/01/00_script.py
/01_script.py
/00/01_script.py
/00/00/01_script.py
/00/01/01_script.py
/01/01_script.py
/01/00/01_script.py
/01/01/01_script.py
/another.py
/00/another.py
/00/00/another.py
/00/01/another.py
/01/another.py
/01/00/another.py
/01/01/another.py
```
@lewie, I'm curious what your thoughts are about this change.

Signed-off-by: Scott Rushworth <openhab@5iver.com>