### PR TITLE
add default constructor to MetadataKey (Gson deserialization support)

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/MetadataKey.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/MetadataKey.java
@@ -24,6 +24,14 @@ import org.eclipse.smarthome.core.common.AbstractUID;
  */
 @NonNullByDefault
 public final class MetadataKey extends AbstractUID {
+    /**
+     * Package protected default constructor to allow reflective instantiation.
+     *
+     * !!! DO NOT REMOVE - Gson needs it !!!
+     */
+    MetadataKey() {
+        super("", "");
+    }
 
     /**
      * Creates a new instance.


### PR DESCRIPTION
Second part of #704

Signed-off-by: David Gräff <david.graeff@web.de>