### PR TITLE
About REST endpoint

### DIFF
--- a/bom/openhab-core/pom.xml
+++ b/bom/openhab-core/pom.xml
@@ -42,6 +42,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.boot.rest</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.compat1x</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/bundles/org.openhab.core.boot.rest/.classpath
+++ b/bundles/org.openhab.core.boot.rest/.classpath
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.boot.rest/.project
+++ b/bundles/org.openhab.core.boot.rest/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.boot.rest</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.boot.rest/NOTICE
+++ b/bundles/org.openhab.core.boot.rest/NOTICE
@@ -1,0 +1,14 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core
+

--- a/bundles/org.openhab.core.boot.rest/README.md
+++ b/bundles/org.openhab.core.boot.rest/README.md
@@ -1,0 +1,15 @@
+# openHAB About distribution
+
+This Bundle provides a REST resource to query
+the core and distribution name, version, build-date and similar information.
+
+A distribution optionally wants to provide a file in the openHAB
+system directory `{OPENHAB_DIR}/etc/distribution.properties`:
+
+An example could look like:
+
+```
+name=openhabian
+version=1.4.1
+abouturl=https://www.openhab.org/docs/installation/openhabian.html
+```

--- a/bundles/org.openhab.core.boot.rest/pom.xml
+++ b/bundles/org.openhab.core.boot.rest/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>2.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.boot.rest</artifactId>
+
+  <name>openHAB Core :: Bundles :: About distribution REST</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.boot</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.boot.rest/src/main/java/org/openhab/boot/rest/internal/AboutHandler.java
+++ b/bundles/org.openhab.core.boot.rest/src/main/java/org/openhab/boot/rest/internal/AboutHandler.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.boot.rest.internal;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigConstants;
+import org.eclipse.smarthome.io.rest.RESTResource;
+import org.openhab.boot.rest.internal.dto.About;
+import org.openhab.boot.rest.internal.dto.About.Distribution;
+import org.openhab.core.OpenHAB;
+import org.osgi.service.component.annotations.Component;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+/**
+ * Provides the /about rest endpoint
+ * 
+ * @author David Graeff - Initial contribution
+ */
+@Component
+@Path("/about")
+@Api(value = "about")
+@Produces(MediaType.APPLICATION_JSON)
+@NonNullByDefault
+public class AboutHandler implements RESTResource {
+    @GET
+    @ApiOperation(value = "Get name and version information about the running openHAB installation and underlying distribution")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successful retrieval of about detail", response = About.class),
+            @ApiResponse(code = 500, message = "Internal server error") })
+    public Response about() throws IOException, ParseException {
+        InputStream stream = getClass().getResourceAsStream("/META-INF/MANIFEST.MF");
+        Manifest manifest = new Manifest(stream);
+        Attributes attributes = manifest.getMainAttributes();
+        String builtDateStr = attributes.getValue("Built-Date");
+        Date buildDate = Date.from(Instant.now());
+        buildDate = new SimpleDateFormat().parse(builtDateStr);
+        return Response.ok(new About("openHAB", OpenHAB.getVersion(), buildDate, distribution())).build();
+    }
+
+    static public @Nullable Distribution distribution() {
+        Properties prop = new Properties();
+
+        java.nio.file.Path versionFilePath = Paths.get(ConfigConstants.getUserDataFolder(), "etc",
+                "distribution.properties");
+        try (FileInputStream fis = new FileInputStream(versionFilePath.toFile())) {
+            prop.load(fis);
+            String name = prop.getProperty("name", "");
+            String version = prop.getProperty("version", "");
+            String abouturl = prop.getProperty("abouturl", "");
+            return new Distribution(name, version, abouturl);
+        } catch (Exception ignore) {
+            // ignore if the file is not there or not readable
+            return null;
+        }
+    }
+}

--- a/bundles/org.openhab.core.boot.rest/src/main/java/org/openhab/boot/rest/internal/dto/About.java
+++ b/bundles/org.openhab.core.boot.rest/src/main/java/org/openhab/boot/rest/internal/dto/About.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.boot.rest.internal.dto;
+
+import java.time.Instant;
+import java.util.Date;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+/**
+ * @author David Graeff - Initial contribution
+ */
+@ApiModel(description = "Provides information about this openHAB instance")
+public class About {
+    @ApiModelProperty(value = "The product core name, usually \"openHAB\"")
+    public final String name;
+    @ApiModelProperty(value = "The product core version. This does not express any API version guarantees.")
+    public final String version;
+    @ApiModelProperty(value = "The build date in the form of 2017-04-07T18:07:00")
+    public final Date builddate;
+
+    @ApiModel(description = "Optional distribution information")
+    public static class Distribution {
+        @ApiModelProperty(value = "The distribution name")
+        public final String name;
+        @ApiModelProperty(value = "The distribution version")
+        public final String version;
+        @ApiModelProperty(value = "An optional, version independant url for further information about the distribution")
+        public final String abouturl;
+
+        Distribution() {
+            name = "";
+            version = "";
+            abouturl = "";
+        }
+
+        public Distribution(String name, String version, String abouturl) {
+            this.name = name;
+            this.version = version;
+            this.abouturl = abouturl;
+        }
+
+    }
+
+    public final Distribution distribution;
+
+    About() {
+        name = "";
+        version = "";
+        builddate = Date.from(Instant.now());
+        distribution = null;
+    }
+
+    public About(String name, String version, Date builddate, Distribution distribution) {
+        this.name = name;
+        this.version = version;
+        this.builddate = builddate;
+        this.distribution = distribution;
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -46,6 +46,7 @@
     <module>org.openhab.core.transform</module>
     <module>org.openhab.core.voice</module>
     <module>org.openhab.core.boot</module>
+    <module>org.openhab.core.boot.rest</module>
     <module>org.openhab.core.compat1x</module>
     <module>org.openhab.core.karaf</module>
     <module>org.openhab.core.io.console</module>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -543,6 +543,7 @@
     <!-- It is temperarily disabled due to https://github.com/openhab/openhab-core/issues/422 -->
     <!-- <bundle start-level="30">mvn:org.openhab.core.bundles/org.openhab.ui.start/${project.version}</bundle> -->
     <bundle start-level="90">mvn:org.openhab.core.bundles/org.openhab.core.boot/${project.version}</bundle>
+    <bundle start-level="90">mvn:org.openhab.core.bundles/org.openhab.core.boot.rest/${project.version}</bundle>
     <bundle>mvn:org.openhab.core.bundles/org.openhab.core.karaf/${project.version}</bundle>
     <config name="org.eclipse.smarthome.audio">
       defaultSink = enhancedjavasound


### PR DESCRIPTION
Provides core and distribution information via REST for user-interfaces.

As of now user-interfaces do not have the means to query the core for
the solution name, version, and distribution information and that information
was backed in into the deprecated dashboard concept.

This is a first, simple proposal. The rest endpoint is `/rest/about`.

The use case is to present those informational data
like here https://davidgraeff.github.io/paperui-ng/maintenance.html at the top part of the page.

Signed-off-by: David Graeff <david.graeff@web.de>