### PR TITLE
Configure LanguageServer exit behavior

### DIFF
--- a/bundles/org.openhab.core.boot/src/main/java/org/openhab/core/internal/CoreActivator.java
+++ b/bundles/org.openhab.core.boot/src/main/java/org/openhab/core/internal/CoreActivator.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.internal;
 
-import java.security.Permission;
-
 import org.eclipse.smarthome.model.rule.runtime.RuleEngine;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -46,18 +44,6 @@ public class CoreActivator implements BundleActivator {
             tracker.waitForService(10000);
         } catch (NoClassDefFoundError e) {
         }
-
-        // see https://github.com/eclipse/smarthome/issues/6291
-        final SecurityManager securityManager = new SecurityManager() {
-            @Override
-            public void checkPermission(Permission permission) {
-                if (permission.getName().contains("exitVM")) {
-                    throw new SecurityException("Prevented System.exit() call.");
-                }
-            }
-        };
-        System.setSecurityManager(securityManager);
-
     }
 
     /*
@@ -68,7 +54,6 @@ public class CoreActivator implements BundleActivator {
      */
     @Override
     public void stop(BundleContext context) throws Exception {
-        System.setSecurityManager(null);
     }
 
 }

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/RuntimeServerModule.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/RuntimeServerModule.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.model.script.ScriptServiceUtil;
 import org.eclipse.smarthome.model.script.engine.ScriptEngine;
 import org.eclipse.xtext.ide.ExecutorServiceProvider;
 import org.eclipse.xtext.ide.server.DefaultProjectDescriptionFactory;
+import org.eclipse.xtext.ide.server.ILanguageServerShutdownAndExitHandler;
 import org.eclipse.xtext.ide.server.IProjectDescriptionFactory;
 import org.eclipse.xtext.ide.server.IWorkspaceConfigFactory;
 import org.eclipse.xtext.ide.server.LanguageServerImpl;
@@ -57,6 +58,7 @@ public class RuntimeServerModule extends AbstractModule {
         bind(IWorkspaceConfigFactory.class).to(ProjectWorkspaceConfigFactory.class);
         bind(IProjectDescriptionFactory.class).to(DefaultProjectDescriptionFactory.class);
         bind(IContainer.Manager.class).to(ProjectDescriptionBasedContainerManager.class);
+        bind(ILanguageServerShutdownAndExitHandler.class).to(ILanguageServerShutdownAndExitHandler.NullImpl.class);
     }
 
 }


### PR DESCRIPTION
Xtext 2.17 allows for configuring the LanguageServer exit behavior so the SecurityManager workaround can be removed.

Fixes: https://github.com/eclipse/smarthome/issues/6291
Undos: https://github.com/openhab/openhab-core/pull/409

See also: 
* "Configurable Server Exit Behavior" in the Xtext 2.16.0 [release notes](https://www.eclipse.org/Xtext/releasenotes.html#/releasenotes/2018/12/04/version-2-16-0)
* https://github.com/eclipse/xtext-core/issues/885
