### PR TITLE
Import 'SmartHomeUnits' in Script Scope

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.binding.ThingActions;
 import org.eclipse.smarthome.model.persistence.extensions.PersistenceExtensions;
 import org.eclipse.smarthome.model.script.actions.Audio;
@@ -48,11 +49,9 @@ import com.google.inject.Singleton;
  * extensions for specific jvm types, which should only be available in rules,
  * but not in scripts
  *
- * @author Kai Kreuzer - Initial contribution and API
+ * @author Kai Kreuzer - Initial contribution
  * @author Oliver Libutzki - Xtext 2.5.0 migration
- *
  */
-
 @SuppressWarnings("restriction")
 @Singleton
 public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
@@ -104,8 +103,9 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(Things.class);
 
         result.add(ImperialUnits.class);
-        result.add(SIUnits.class);
         result.add(MetricPrefix.class);
+        result.add(SIUnits.class);
+        result.add(SmartHomeUnits.class);
 
         // jodatime static functions
         result.add(DateTime.class);


### PR DESCRIPTION
- Import 'SmartHomeUnits' in Script Scope

We need it to solve integration test failures in #737. It somehow got lost or was missing (see also https://github.com/eclipse/smarthome/pull/5961).

```
TEST testToUnit_QuantityType3(org.eclipse.smarthome.model.script.engine.ScriptEngineOSGiTest) <<< ERROR: new  ___ QuantityType(1,  ___ KELVIN)
   1. The method or field KELVIN is undefined; line 1, column 20, length 6
   2. Bounds mismatch: The type argument <Quantity<?>> is not a valid substitute for the bounded type parameter <T extends Quantity<T>> of the constructor QuantityType<T>(Number, Unit<T>); line 1, column 4, length 12
org.eclipse.smarthome.model.script.engine.ScriptParsingException: new  ___ QuantityType(1,  ___ KELVIN)
   1. The method or field KELVIN is undefined; line 1, column 20, length 6
   2. Bounds mismatch: The type argument <Quantity<?>> is not a valid substitute for the bounded type parameter <T extends Quantity<T>> of the constructor QuantityType<T>(Number, Unit<T>); line 1, column 4, length 12
	at org.eclipse.smarthome.model.script.runtime.internal.engine.ScriptEngineImpl.parseScriptIntoXTextEObject(ScriptEngineImpl.java:151)
	at org.eclipse.smarthome.model.script.runtime.internal.engine.ScriptEngineImpl.newScriptFromString(ScriptEngineImpl.java:111)
	at org.eclipse.smarthome.model.script.engine.ScriptEngineOSGiTest.runScript(ScriptEngineOSGiTest.java:358)
	at org.eclipse.smarthome.model.script.engine.ScriptEngineOSGiTest.testToUnit_QuantityType3(ScriptEngineOSGiTest.java:304)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>