### PR TITLE
Added profiles to control Player Items via default system triggers

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonTogglePlayerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonTogglePlayerProfile.java
@@ -12,10 +12,10 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
-import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_PLAY_PAUSE;
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWBUTTON_TOGGLE_PLAYER;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.core.library.items.PlayerItem;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.PlayPauseType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
@@ -24,36 +24,43 @@ import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * The {@link RawRockerPlayPauseProfile} transforms rocker switch channel events into PLAY and PAUSE commands. Can be
- * used on a {@link PlayerItem}.
+ * This profile allows a channel of the "system:rawbutton" type to be bound to an item.
  *
- * @author Daniel Weber - Initial contribution
+ * It reads the triggered events and uses the item's current state and toggles it once it detects that the
+ * button was pressed.
+ *
+ * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public class RawRockerPlayPauseProfile implements TriggerProfile {
+public class RawButtonTogglePlayerProfile implements TriggerProfile {
 
     private final ProfileCallback callback;
 
-    RawRockerPlayPauseProfile(ProfileCallback callback) {
+    @Nullable
+    private State previousState;
+
+    public RawButtonTogglePlayerProfile(ProfileCallback callback) {
         this.callback = callback;
     }
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return RAWROCKER_PLAY_PAUSE;
-    }
-
-    @Override
-    public void onStateUpdateFromItem(State state) {
+        return RAWBUTTON_TOGGLE_PLAYER;
     }
 
     @Override
     public void onTriggerFromHandler(String event) {
-        if (CommonTriggerEvents.DIR1_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PLAY);
-        } else if (CommonTriggerEvents.DIR2_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PAUSE);
+        if (CommonTriggerEvents.PRESSED.equals(event)) {
+            PlayPauseType newState = PlayPauseType.PLAY.equals(previousState) ? PlayPauseType.PAUSE
+                    : PlayPauseType.PLAY;
+            callback.sendCommand(newState);
+            previousState = newState;
         }
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        previousState = state.as(PlayPauseType.class);
     }
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfile.java
@@ -12,13 +12,14 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWBUTTON_TOGGLE_SWITCH;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
-import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
 import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.State;
 
@@ -28,8 +29,7 @@ import org.eclipse.smarthome.core.types.State;
  * It reads the triggered events and uses the item's current state and toggles it once it detects that the
  * button was pressed.
  *
- * @author Simon Kaufmann - initial contribution and API.
- *
+ * @author Simon Kaufmann - Initial contribution
  */
 @NonNullByDefault
 public class RawButtonToggleSwitchProfile implements TriggerProfile {
@@ -45,7 +45,7 @@ public class RawButtonToggleSwitchProfile implements TriggerProfile {
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return SystemProfiles.RAWBUTTON_TOGGLE_SWITCH;
+        return RAWBUTTON_TOGGLE_SWITCH;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerDimmerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerDimmerProfile.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_DIMMER;
+
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -23,7 +25,6 @@ import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
-import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
 import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -54,7 +55,7 @@ public class RawRockerDimmerProfile implements TriggerProfile {
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return SystemProfiles.RAWROCKER_DIMMER;
+        return RAWROCKER_DIMMER;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerNextPreviousProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerNextPreviousProfile.java
@@ -12,11 +12,11 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
-import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_PLAY_PAUSE;
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_NEXT_PREVIOUS;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.items.PlayerItem;
-import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.NextPreviousType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
@@ -24,23 +24,23 @@ import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * The {@link RawRockerPlayPauseProfile} transforms rocker switch channel events into PLAY and PAUSE commands. Can be
- * used on a {@link PlayerItem}.
+ * The {@link RawRockerNextPreviousProfile} transforms rocker switch channel events into NEXT and PREVIOUS commands. Can
+ * be used on a {@link PlayerItem}.
  *
- * @author Daniel Weber - Initial contribution
+ * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public class RawRockerPlayPauseProfile implements TriggerProfile {
+public class RawRockerNextPreviousProfile implements TriggerProfile {
 
     private final ProfileCallback callback;
 
-    RawRockerPlayPauseProfile(ProfileCallback callback) {
+    RawRockerNextPreviousProfile(ProfileCallback callback) {
         this.callback = callback;
     }
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return RAWROCKER_PLAY_PAUSE;
+        return RAWROCKER_NEXT_PREVIOUS;
     }
 
     @Override
@@ -50,9 +50,9 @@ public class RawRockerPlayPauseProfile implements TriggerProfile {
     @Override
     public void onTriggerFromHandler(String event) {
         if (CommonTriggerEvents.DIR1_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PLAY);
+            callback.sendCommand(NextPreviousType.NEXT);
         } else if (CommonTriggerEvents.DIR2_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PAUSE);
+            callback.sendCommand(NextPreviousType.PREVIOUS);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerOnOffProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerOnOffProfile.java
@@ -12,11 +12,13 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_ON_OFF;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
-import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
 import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.State;
 
@@ -25,6 +27,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Jan Kemmler - Initial contribution
  */
+@NonNullByDefault
 public class RawRockerOnOffProfile implements TriggerProfile {
 
     private final ProfileCallback callback;
@@ -35,14 +38,9 @@ public class RawRockerOnOffProfile implements TriggerProfile {
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return SystemProfiles.RAWROCKER_ON_OFF;
+        return RAWROCKER_ON_OFF;
     }
 
-    /**
-     * Will be called if an item has changed its state and this information should be forwarded to the binding.
-     *
-     * @param state
-     */
     @Override
     public void onStateUpdateFromItem(State state) {
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerRewindFastforwardProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerRewindFastforwardProfile.java
@@ -12,11 +12,11 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
-import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_PLAY_PAUSE;
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWROCKER_REWIND_FASTFORWARD;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.items.PlayerItem;
-import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.RewindFastforwardType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
@@ -24,23 +24,23 @@ import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * The {@link RawRockerPlayPauseProfile} transforms rocker switch channel events into PLAY and PAUSE commands. Can be
- * used on a {@link PlayerItem}.
+ * The {@link RawRockerRewindFastforwardProfile} transforms rocker switch channel events into REWIND and FASTFORWARD
+ * commands. Can be used on a {@link PlayerItem}.
  *
- * @author Daniel Weber - Initial contribution
+ * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public class RawRockerPlayPauseProfile implements TriggerProfile {
+public class RawRockerRewindFastforwardProfile implements TriggerProfile {
 
     private final ProfileCallback callback;
 
-    RawRockerPlayPauseProfile(ProfileCallback callback) {
+    RawRockerRewindFastforwardProfile(ProfileCallback callback) {
         this.callback = callback;
     }
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return RAWROCKER_PLAY_PAUSE;
+        return RAWROCKER_REWIND_FASTFORWARD;
     }
 
     @Override
@@ -50,9 +50,9 @@ public class RawRockerPlayPauseProfile implements TriggerProfile {
     @Override
     public void onTriggerFromHandler(String event) {
         if (CommonTriggerEvents.DIR1_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PLAY);
+            callback.sendCommand(RewindFastforwardType.FASTFORWARD);
         } else if (CommonTriggerEvents.DIR2_PRESSED.equals(event)) {
-            callback.sendCommand(PlayPauseType.PAUSE);
+            callback.sendCommand(RewindFastforwardType.REWIND);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -165,7 +165,6 @@ public class SystemOffsetProfile implements StateProfile {
 
     private @Nullable QuantityType<Temperature> handleTemperature(QuantityType<Temperature> qtState,
             QuantityType<Temperature> offset) {
-
         QuantityType<Temperature> finalOffset;
 
         // do the math in kelvin and afterwards convert it back to the unit of the state

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.*;
+
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Set;
@@ -31,7 +33,6 @@ import org.eclipse.smarthome.core.thing.profiles.ProfileFactory;
 import org.eclipse.smarthome.core.thing.profiles.ProfileType;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeProvider;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
-import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.osgi.service.component.annotations.Component;
@@ -45,8 +46,7 @@ import org.osgi.service.component.annotations.Reference;
  * The same applies to the creation of profile instances: This factory will be used of no other factory supported the
  * required profile type.
  *
- * @author Simon Kaufmann - initial contribution and API.
- *
+ * @author Simon Kaufmann - Initial contribution
  */
 @NonNullByDefault
 @Component(service = { SystemProfileFactory.class, ProfileTypeProvider.class })
@@ -55,39 +55,44 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     @NonNullByDefault({})
     private ChannelTypeRegistry channelTypeRegistry;
 
-    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream
-            .of(SystemProfiles.DEFAULT_TYPE, SystemProfiles.FOLLOW_TYPE, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE,
-                    SystemProfiles.RAWROCKER_ON_OFF_TYPE, SystemProfiles.RAWROCKER_DIMMER_TYPE,
-                    SystemProfiles.OFFSET_TYPE, SystemProfiles.RAWROCKER_PLAY_PAUSE_TYPE,
-                    SystemProfiles.TIMESTAMP_UPDATE_TYPE, SystemProfiles.TIMESTAMP_CHANGE_TYPE)
+    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream.of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE,
+            RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE,
+            RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
+            RAWROCKER_REWIND_FASTFORWARD_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_UPDATE_TYPE)
             .collect(Collectors.toSet());
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of(SystemProfiles.DEFAULT,
-            SystemProfiles.FOLLOW, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH, SystemProfiles.RAWROCKER_ON_OFF,
-            SystemProfiles.RAWROCKER_DIMMER, SystemProfiles.OFFSET, SystemProfiles.RAWROCKER_PLAY_PAUSE,
-            SystemProfiles.TIMESTAMP_UPDATE, SystemProfiles.TIMESTAMP_CHANGE).collect(Collectors.toSet());
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of(DEFAULT, FOLLOW, OFFSET,
+            RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS,
+            RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD, TIMESTAMP_CHANGE, TIMESTAMP_UPDATE)
+            .collect(Collectors.toSet());
 
     @Nullable
     @Override
     public Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext context) {
-        if (SystemProfiles.DEFAULT.equals(profileTypeUID)) {
+        if (DEFAULT.equals(profileTypeUID)) {
             return new SystemDefaultProfile(callback);
-        } else if (SystemProfiles.FOLLOW.equals(profileTypeUID)) {
+        } else if (FOLLOW.equals(profileTypeUID)) {
             return new SystemFollowProfile(callback);
-        } else if (SystemProfiles.RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
-            return new RawButtonToggleSwitchProfile(callback);
-        } else if (SystemProfiles.RAWROCKER_ON_OFF.equals(profileTypeUID)) {
-            return new RawRockerOnOffProfile(callback);
-        } else if (SystemProfiles.RAWROCKER_DIMMER.equals(profileTypeUID)) {
-            return new RawRockerDimmerProfile(callback, context);
-        } else if (SystemProfiles.RAWROCKER_PLAY_PAUSE.equals(profileTypeUID)) {
-            return new RawRockerPlayPauseProfile(callback);
-        } else if (SystemProfiles.OFFSET.equals(profileTypeUID)) {
+        } else if (OFFSET.equals(profileTypeUID)) {
             return new SystemOffsetProfile(callback, context);
-        } else if (SystemProfiles.TIMESTAMP_UPDATE.equals(profileTypeUID)) {
-            return new TimestampUpdateProfile(callback);
-        } else if (SystemProfiles.TIMESTAMP_CHANGE.equals(profileTypeUID)) {
+        } else if (RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
+            return new RawButtonToggleSwitchProfile(callback);
+        } else if (RAWBUTTON_TOGGLE_PLAYER.equals(profileTypeUID)) {
+            return new RawButtonTogglePlayerProfile(callback);
+        } else if (RAWROCKER_DIMMER.equals(profileTypeUID)) {
+            return new RawRockerDimmerProfile(callback, context);
+        } else if (RAWROCKER_NEXT_PREVIOUS.equals(profileTypeUID)) {
+            return new RawRockerNextPreviousProfile(callback);
+        } else if (RAWROCKER_ON_OFF.equals(profileTypeUID)) {
+            return new RawRockerOnOffProfile(callback);
+        } else if (RAWROCKER_PLAY_PAUSE.equals(profileTypeUID)) {
+            return new RawRockerPlayPauseProfile(callback);
+        } else if (RAWROCKER_REWIND_FASTFORWARD.equals(profileTypeUID)) {
+            return new RawRockerRewindFastforwardProfile(callback);
+        } else if (TIMESTAMP_CHANGE.equals(profileTypeUID)) {
             return new TimestampChangeProfile(callback);
+        } else if (TIMESTAMP_UPDATE.equals(profileTypeUID)) {
+            return new TimestampUpdateProfile(callback);
         } else {
             return null;
         }
@@ -101,19 +106,21 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
         }
         switch (channelType.getKind()) {
             case STATE:
-                return SystemProfiles.DEFAULT;
+                return DEFAULT;
             case TRIGGER:
                 if (DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID().equals(channelType.getUID())) {
-                    if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
-                        return SystemProfiles.RAWBUTTON_TOGGLE_SWITCH;
+                    if (CoreItemFactory.PLAYER.equalsIgnoreCase(itemType)) {
+                        return RAWBUTTON_TOGGLE_PLAYER;
+                    } else if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
+                        return RAWBUTTON_TOGGLE_SWITCH;
                     }
                 } else if (DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID().equals(channelType.getUID())) {
-                    if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
-                        return SystemProfiles.RAWROCKER_ON_OFF;
-                    } else if (CoreItemFactory.DIMMER.equalsIgnoreCase(itemType)) {
-                        return SystemProfiles.RAWROCKER_DIMMER;
+                    if (CoreItemFactory.DIMMER.equalsIgnoreCase(itemType)) {
+                        return RAWROCKER_DIMMER;
                     } else if (CoreItemFactory.PLAYER.equalsIgnoreCase(itemType)) {
-                        return SystemProfiles.RAWROCKER_PLAY_PAUSE;
+                        return RAWROCKER_PLAY_PAUSE;
+                    } else if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
+                        return RAWROCKER_ON_OFF;
                     }
                 }
                 break;
@@ -130,7 +137,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
         if (channelType == null) {
             switch (channel.getKind()) {
                 case STATE:
-                    return SystemProfiles.DEFAULT;
+                    return DEFAULT;
                 case TRIGGER:
                     return null;
                 default:

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -19,8 +19,7 @@ import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 /**
  * System profile constants.
  *
- * @author Simon Kaufmann - initial contribution and API.
- *
+ * @author Simon Kaufmann - Initial contribution
  */
 @NonNullByDefault
 public interface SystemProfiles {
@@ -28,12 +27,17 @@ public interface SystemProfiles {
     ProfileTypeUID DEFAULT = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "follow");
     ProfileTypeUID OFFSET = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "offset");
+    ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-player");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-switch");
-    ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-on-off");
     ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-dimmer");
+    ProfileTypeUID RAWROCKER_NEXT_PREVIOUS = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE,
+            "rawrocker-to-next-previous");
+    ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-on-off");
     ProfileTypeUID RAWROCKER_PLAY_PAUSE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-play-pause");
-    ProfileTypeUID TIMESTAMP_UPDATE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "timestamp-update");
+    ProfileTypeUID RAWROCKER_REWIND_FASTFORWARD = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE,
+            "rawrocker-to-rewind-fastforward");
     ProfileTypeUID TIMESTAMP_CHANGE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "timestamp-change");
+    ProfileTypeUID TIMESTAMP_UPDATE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "timestamp-update");
 
     StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
@@ -43,8 +47,13 @@ public interface SystemProfiles {
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
             .build();
 
+    TriggerProfileType RAWBUTTON_TOGGLE_PLAYER_TYPE = ProfileTypeBuilder
+            .newTrigger(RAWBUTTON_TOGGLE_PLAYER, "Raw Button Toggle Player")
+            .withSupportedItemTypes(CoreItemFactory.PLAYER)
+            .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
+
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle")
+            .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle Switch")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
@@ -56,14 +65,24 @@ public interface SystemProfiles {
             .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
+    TriggerProfileType RAWROCKER_NEXT_PREVIOUS_TYPE = ProfileTypeBuilder
+            .newTrigger(RAWROCKER_NEXT_PREVIOUS, "Raw Rocker To Next/Previous")
+            .withSupportedItemTypes(CoreItemFactory.PLAYER)
+            .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
+
     TriggerProfileType RAWROCKER_PLAY_PAUSE_TYPE = ProfileTypeBuilder
             .newTrigger(RAWROCKER_PLAY_PAUSE, "Raw Rocker To Play/Pause").withSupportedItemTypes(CoreItemFactory.PLAYER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
-    StateProfileType TIMESTAMP_UPDATE_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_UPDATE, "Timestamp on update")
-            .withSupportedItemTypesOfChannel(CoreItemFactory.DATETIME).build();
+    TriggerProfileType RAWROCKER_REWIND_FASTFORWARD_TYPE = ProfileTypeBuilder
+            .newTrigger(RAWROCKER_REWIND_FASTFORWARD, "Raw Rocker To Rewind/Fastforward")
+            .withSupportedItemTypes(CoreItemFactory.PLAYER)
+            .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
     StateProfileType TIMESTAMP_CHANGE_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_CHANGE, "Timestamp on change")
-            .withSupportedItemTypesOfChannel(CoreItemFactory.DATETIME).build();
+            .withSupportedItemTypes(CoreItemFactory.DATETIME).build();
+
+    StateProfileType TIMESTAMP_UPDATE_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_UPDATE, "Timestamp on update")
+            .withSupportedItemTypes(CoreItemFactory.DATETIME).build();
 
 }


### PR DESCRIPTION
- Added `RawButtonTogglePlayerProfile`, `RawRockerNextPreviousProfile` and `RawRockerRewindFastforwardProfile`
- Fixed `getProfileTypeUID` for RawRockerPlayPauseProfile
- SAT findings and code clean-up

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>