### PR TITLE
REST SSE: disable compression also if servlet 3 support is present

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/SseResource.java
@@ -111,12 +111,11 @@ public class SseResource {
         // This allows you to not disable proxy buffering in nginx and still have working sse
         response.addHeader(X_ACCEL_BUFFERING_HEADER, "no");
 
-        if (!SseUtil.SERVLET3_SUPPORT) {
-            // if we don't have sevlet 3.0 async support, we want to make sure
-            // that the response is not compressed and buffered so that the
-            // client receives server sent events at the moment of sending them
-            response.addHeader(HttpHeaders.CONTENT_ENCODING, "identity");
+        // We want to make sure that the response is not compressed and buffered so that the client receives server sent
+        // events at the moment of sending them.
+        response.addHeader(HttpHeaders.CONTENT_ENCODING, "identity");
 
+        if (!SseUtil.SERVLET3_SUPPORT) {
             // Response headers are written now, since the thread will be
             // blocked later on.
             response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
We should disable the compression regardless if servlet 3 is used or not. It does not matter which servlet version is used, the client should receive the messages as soon as possible without compression or
buffering.

You can identify the lost SSE feature as soon as you enable the usage of Jetty's GzipHandler.
