### PR TITLE
[WIP] Add profile to control Dimmer Items via rawbutton channel

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonDimmerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonDimmerProfile.java
@@ -77,7 +77,7 @@ public class RawButtonDimmerProfile implements TriggerProfile {
                     IncreaseDecreaseType.INCREASE;
             buttonPressed(command);
         } else if (CommonTriggerEvents.RELEASED.equals(event)) {
-            OnOffType newState = previousState.equals(PercentType.HUNDRED) ? OnOffType.OFF : OnOffType.ON;
+            OnOffType newState = previousState.equals(PercentType.ZERO) ? OnOffType.ON : OnOffType.OFF;
             buttonReleased(newState);
         }
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonDimmerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonDimmerProfile.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.RAWBUTTON_DIMMER;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * This profile allows a channel of the "system:rawbutton" type to be bound to a Dimmer item.
+ *
+ * If the dimmer is fully ON, the profile will send 'decrease' commands while the button is pressed. Otherwise,
+ * the profile will send 'increase' commands to the item. A short press will toggle the state of the item.
+ *
+ * @author Aitor Iturrioz - initial contribution.
+ *
+ */
+@NonNullByDefault
+public class RawButtonDimmerProfile implements TriggerProfile {
+
+    private final ProfileCallback callback;
+
+    private final ProfileContext context;
+
+    @Nullable
+    private State previousState;
+    @Nullable
+    private ScheduledFuture<?> dimmFuture;
+    @Nullable
+    private ScheduledFuture<?> timeoutFuture;
+
+    private long pressedTime = 0;
+
+    public RawButtonDimmerProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+        this.context = context;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return RAWBUTTON_DIMMER;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        previousState = state.as(PercentType.class);
+    }
+
+    @Override
+    public void onTriggerFromHandler(String event) {
+        if (CommonTriggerEvents.PRESSED.equals(event)) {
+            IncreaseDecreaseType command = previousState.equals(PercentType.HUNDRED) ? IncreaseDecreaseType.DECREASE : 
+                    IncreaseDecreaseType.INCREASE;
+            buttonPressed(command);
+        } else if (CommonTriggerEvents.RELEASED.equals(event)) {
+            OnOffType newState = previousState.equals(PercentType.HUNDRED) ? OnOffType.OFF : OnOffType.ON;
+            buttonReleased(newState);
+        }
+    }
+
+    private synchronized void buttonPressed(Command commandToSend) {
+        if (null != timeoutFuture) {
+            timeoutFuture.cancel(false);
+        }
+
+        this.cancelDimmFuture();
+
+        dimmFuture = context.getExecutorService().scheduleWithFixedDelay(() -> callback.sendCommand(commandToSend), 550,
+                200, TimeUnit.MILLISECONDS);
+        timeoutFuture = context.getExecutorService().schedule(() -> this.cancelDimmFuture(), 10, TimeUnit.SECONDS);
+        pressedTime = System.currentTimeMillis();
+    }
+
+    private synchronized void buttonReleased(Command commandToSend) {
+        if (null != timeoutFuture) {
+            timeoutFuture.cancel(false);
+        }
+
+        this.cancelDimmFuture();
+
+        if (System.currentTimeMillis() - pressedTime <= 500) {
+            callback.sendCommand(commandToSend);
+        }
+    }
+
+    private synchronized void cancelDimmFuture() {
+        if (null != dimmFuture) {
+            dimmFuture.cancel(false);
+        }
+    }
+
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -67,13 +67,13 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream
             .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
-                    RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE,
+                    RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWBUTTON_DIMMER_TYPE, RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE,
                     RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE, RAWROCKER_REWIND_FASTFORWARD_TYPE,
                     RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_UPDATE_TYPE)
             .collect(Collectors.toSet());
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of(DEFAULT, FOLLOW, OFFSET,
-            RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER,
+            RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWBUTTON_DIMMER, RAWROCKER_DIMMER,
             RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD,
             RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_UPDATE).collect(Collectors.toSet());
 
@@ -106,6 +106,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new RawButtonToggleRollershutterProfile(callback);
         } else if (RAWBUTTON_TOGGLE_PLAYER.equals(profileTypeUID)) {
             return new RawButtonTogglePlayerProfile(callback);
+        } else if (RAWBUTTON_DIMMER.equals(profileTypeUID)) {
+            return new RawButtonDimmerProfile(callback, context);
         } else if (RAWROCKER_DIMMER.equals(profileTypeUID)) {
             return new RawRockerDimmerProfile(callback, context);
         } else if (RAWROCKER_NEXT_PREVIOUS.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -32,6 +32,7 @@ public interface SystemProfiles {
     ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
     ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-rollershutter");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-switch");
+    ProfileTypeUID RAWBUTTON_DIMMER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-to-dimmer");
     ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-dimmer");
     ProfileTypeUID RAWROCKER_NEXT_PREVIOUS = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-next-previous");
     ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-on-off");
@@ -63,6 +64,11 @@ public interface SystemProfiles {
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle Switch")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
+            .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
+
+    TriggerProfileType RAWBUTTON_DIMMER_TYPE = ProfileTypeBuilder
+            .newTrigger(RAWBUTTON_DIMMER, "Raw Button to Dimmer")
+            .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
     TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")


### PR DESCRIPTION
Hi guys!

I have implemented a new profile to control Dimmer Items via a rawbutton trigger channel.

- "Short" press event (PRESSED and RELEASED in less than 550 milliseconds): send ON/OFF command.
- "Long" press event: after 550 milliseconds, start sending INCREASE/DECREASE commands every 200 milliseconds. If the dimmer is fully ON (100%), it will send DECREASE commands, otherwise, INCREASE. Perhaps I could make this a user configuration parameter, since I am not sure if it makes sense to start sending INCREASE commands if the dimmer is at 90%. The parameter would be a number, between 0 and 100, and it will establish the dimmer state above which the profile will start sending the increase commands (100 by default).

What do you think?

Many thanks and best regards,

Aitor

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>