### PR TITLE
use upstream nrjavaserial 3.15.0 on runtime

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -446,7 +446,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.14.0</version>
+      <version>3.15.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-core/pom.xml
+++ b/features/karaf/openhab-core/pom.xml
@@ -17,7 +17,6 @@
   <properties>
     <jetty.version>9.4.12.v20180830</jetty.version>
     <jna.version>4.5.2</jna.version>
-    <nrjavaserial.version>3.15.0.OH2</nrjavaserial.version>
   </properties>
 
   <build>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -609,6 +609,7 @@
   </feature>
 
   <feature name="openhab-transport-serial" description="Serial Transport" version="${project.version}">
+    <feature>openhab.tp-serial-rxtx-noliblockdev</feature>
     <feature>openhab-core-io-transport-serial-rfc2217</feature>
     <feature>openhab-core-config-serial</feature>
     <feature>openhab-core-config-discovery-usbserial</feature>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -609,7 +609,6 @@
   </feature>
 
   <feature name="openhab-transport-serial" description="Serial Transport" version="${project.version}">
-    <bundle>mvn:org.openhab/nrjavaserial/${nrjavaserial.version}</bundle>
     <feature>openhab-core-io-transport-serial-rfc2217</feature>
     <feature>openhab-core-config-serial</feature>
     <feature>openhab-core-config-discovery-usbserial</feature>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -345,7 +345,6 @@
     <requirement>openhab.tp;filter:="(&amp;(feature=serial)(impl=rxtx))"</requirement>
     <feature dependency="true">openhab-core-io-transport-serial-rxtx</feature>
 
-
     <requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
     <feature dependency="true">openhab.tp-commons-net</feature>
 
@@ -609,7 +608,6 @@
   </feature>
 
   <feature name="openhab-transport-serial" description="Serial Transport" version="${project.version}">
-    <feature>openhab.tp-serial-rxtx-noliblockdev</feature>
     <feature>openhab-core-io-transport-serial-rfc2217</feature>
     <feature>openhab-core-config-serial</feature>
     <feature>openhab-core-config-discovery-usbserial</feature>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -157,6 +157,11 @@
     <bundle>mvn:com.neuronrobotics/nrjavaserial/3.15.0</bundle>
   </feature>
 
+  <feature name="openhab.tp-serial-rxtx-noliblockdev" version="${project.version}">
+    <capability>openhab.tp;feature=serial;impl=rxtx</capability>
+    <bundle>mvn:org.openhab/nrjavaserial/3.15.0.OH2</bundle>
+  </feature>
+
   <feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">
     <capability>openhab.tp;feature=xtext;version=2.17.0</capability>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -154,7 +154,7 @@
 
   <feature name="openhab.tp-serial-rxtx" version="${project.version}">
     <capability>openhab.tp;feature=serial;impl=rxtx</capability>
-    <bundle>mvn:com.neuronrobotics/nrjavaserial/3.14.0</bundle>
+    <bundle>mvn:com.neuronrobotics/nrjavaserial/3.15.0</bundle>
   </feature>
 
   <feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -154,11 +154,11 @@
 
   <feature name="openhab.tp-serial-rxtx" version="${project.version}">
     <capability>openhab.tp;feature=serial;impl=rxtx</capability>
-    <bundle>mvn:com.neuronrobotics/nrjavaserial/3.15.0</bundle>
-  </feature>
-
-  <feature name="openhab.tp-serial-rxtx-noliblockdev" version="${project.version}">
-    <capability>openhab.tp;feature=serial;impl=rxtx</capability>
+    
+    <!-- Use "no liblockdev" version -->
+    <!-- See: https://github.com/openhab/openhab-core/pull/761 -->
+    <!-- See: https://github.com/openhab/openhab-core/issues/750 -->
+    <!-- <bundle>mvn:com.neuronrobotics/nrjavaserial/3.15.0</bundle> -->
     <bundle>mvn:org.openhab/nrjavaserial/3.15.0.OH2</bundle>
   </feature>
 


### PR DESCRIPTION
Fixes: https://github.com/openhab/openhab-core/issues/750

I see two possible fixes for #750:
* use the upstream library all the time and drop the OH specific release of nrjavaserial
* state that the OH nrjavaserial provides the specific capability (`openhab.tp;feature=serial;impl=rxtx`)

I don't know what's the difference between 3.15.0.OH2 of openHAB's nrjavaserial and 3.15.0 of the upstream one.
The nrjavaserial repository of openHAB does not contain any tag or commit that tells me anything about that.

So, let's wait for a reply to https://github.com/openhab/openhab-core/issues/750#issuecomment-487284749

At the moment I switch to the upstream one in this PR, but we can also remain at the OH spefic one, if working with upstream of nrjavaserial is not possible.