### PR TITLE
automation: remove specific handling for CompositeModuleHandlerFactory

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -463,10 +463,6 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param moduleHandlerFactory a {@link ModuleHandlerFactory} service.
      */
     protected void removeModuleHandlerFactory(ModuleHandlerFactory moduleHandlerFactory) {
-        if (moduleHandlerFactory instanceof CompositeModuleHandlerFactory) {
-            compositeFactory.deactivate();
-            compositeFactory = null;
-        }
         allModuleHandlerFactories.remove(moduleHandlerFactory);
         Collection<String> moduleTypes = moduleHandlerFactory.getTypes();
         removeMissingModuleTypes(moduleTypes);


### PR DESCRIPTION
The member variable "compositeFactory" that holds the
"CompositeModuleHandlerFactory" instance is set in the activation method
by calling the constructor of of "CompositeModuleHandlerFactory".
This reference is destroyed and unset in the deactivate method.

There exists DS managed multiple optional references to
"ModuleHandlerFactory".
The "add" logic does not touch the "compositeFactory" variable.
The "remove" logic checks if the given service reference is a
"CompositeModuleHandlerFactory" and unsets the "compositeFactory" member
variable.

If e.g. a module handler factory is injected that also implements the
CompositeModuleHandlerFactory the CompositeModuleHandlerFactory created
by the activate method is still be used. If that specific module handler
factory is removed again, the variable "compositeFactory" is unset and
there is NO CompositeModuleHandlerFactory present anymore.

There are two options:
* The instance created in the activate method should be used as long as
  no other one is injected.
* The instance created in the activate method should be used all the
  time.

The whole code base does not contain another specific implementation for
CompositeModuleHandlerFactory, so there is no (at least in openHAB Core)
change that a CompositeModuleHandlerFactory is injected.

So instead of adding a non deterministic usage of "some" composite
module handler factory (which will require a fix of the "set module
handler factory method" and some others), let's drop the buggy code in
the "remove module handler factory" and use the manually created
composite module handler factory all the time.
