### PR TITLE
Allow to use Declarative Services 1.4

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
-      <version>6.0.0</version>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>


### PR DESCRIPTION
Change compile dependency for compendium specification to R7.
This allows us to use the version 1.4 of the components and we can use the Constructor Injection.