### PR TITLE
Changed visibility of maps in 'BaseDynamicStateDescriptionProvider' to allow subclasses to access and use them

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -49,8 +49,8 @@ public abstract class BaseDynamicStateDescriptionProvider implements DynamicStat
     private @NonNullByDefault({}) BundleContext bundleContext;
     protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
 
-    private final Map<ChannelUID, @Nullable String> channelPatternMap = new ConcurrentHashMap<>();
-    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+    protected final Map<ChannelUID, @Nullable String> channelPatternMap = new ConcurrentHashMap<>();
+    protected final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
 
     /**
      * For a given channel UID, set a pattern that should be used for the channel, instead of the one defined statically


### PR DESCRIPTION
- Changed visibility of maps in `BaseDynamicStateDescriptionProvider` to allow subclasses to access and use them

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>