### PR TITLE
Added i18n feature for dynamic command descriptions

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.binding;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.thing.type.DynamicCommandDescriptionProvider;
+import org.eclipse.smarthome.core.types.CommandDescription;
+import org.eclipse.smarthome.core.types.CommandDescriptionBuilder;
+import org.eclipse.smarthome.core.types.CommandOption;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * The {@link BaseDynamicCommandDescriptionProvider} provides a base implementation for the
+ * {@link DynamicCommandDescriptionProvider}.
+ * <p>
+ * It provides localized command options. Therefore the inheriting class has to request the reference for the
+ * {@link ChannelTypeI18nLocalizationService} on its own.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public abstract class BaseDynamicCommandDescriptionProvider implements DynamicCommandDescriptionProvider {
+
+    private @NonNullByDefault({}) BundleContext bundleContext;
+    protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
+
+    protected final Map<ChannelUID, @Nullable List<CommandOption>> channelOptionsMap = new ConcurrentHashMap<>();
+
+    /**
+     * For a given channel UID, set a {@link List} of {@link CommandOption}s that should be used for the channel,
+     * instead of the one defined statically in the {@link ChannelType}.
+     *
+     * @param channelUID the channel UID of the channel
+     * @param options a {@link List} of {@link CommandOption}s
+     */
+    public void setCommandOptions(ChannelUID channelUID, List<CommandOption> options) {
+        channelOptionsMap.put(channelUID, options);
+    }
+
+    @Override
+    public @Nullable CommandDescription getCommandDescription(Channel channel,
+            @Nullable CommandDescription originalCommandDescription, @Nullable Locale locale) {
+        List<CommandOption> options = channelOptionsMap.get(channel.getUID());
+        if (options == null) {
+            return null;
+        }
+
+        return CommandDescriptionBuilder.create().withCommandOptions(localizedCommandOptions(options, channel, locale)).build();
+    }
+
+    /**
+     * Localizes a {@link List} of {@link CommandOption}s that should be used for the channel.
+     *
+     * @param options a {@link List} of {@link CommandOption}s
+     * @param channel the channel
+     * @param locale a locale
+     * @return the localized {@link List} of {@link CommandOption}s
+     */
+    protected List<CommandOption> localizedCommandOptions(List<CommandOption> options, Channel channel,
+            @Nullable Locale locale) {
+        // can be overridden by subclasses
+        ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+        if (channelTypeI18nLocalizationService != null && channelTypeUID != null) {
+            return channelTypeI18nLocalizationService.createLocalizedCommandOptions(bundleContext.getBundle(), options,
+                    channelTypeUID, locale);
+        }
+        return options;
+    }
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        bundleContext = componentContext.getBundleContext();
+    }
+
+    @Deactivate
+    public void deactivate() {
+        channelOptionsMap.clear();
+        bundleContext = null;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -98,6 +98,20 @@ public class ChannelTypeI18nLocalizationService {
         return builder.withOptions(localizedOptions).build().toStateDescription();
     }
 
+    public List<CommandOption> createLocalizedCommandOptions(final Bundle bundle, List<CommandOption> commandOptions,
+            final ChannelTypeUID channelTypeUID, final @Nullable Locale locale) {
+        List<CommandOption> localizedOptions = new ArrayList<>();
+        for (final CommandOption commandOption : commandOptions) {
+            String optionLabel = commandOption.getLabel();
+            if (optionLabel != null) {
+                optionLabel = thingTypeI18nUtil.getChannelCommandOption(bundle, channelTypeUID,
+                        commandOption.getCommand(), optionLabel, locale);
+            }
+            localizedOptions.add(new CommandOption(commandOption.getCommand(), optionLabel));
+        }
+        return localizedOptions;
+    }
+
     public @Nullable CommandDescription createLocalizedCommandDescription(final Bundle bundle,
             final @Nullable CommandDescription command, final ChannelTypeUID channelTypeUID,
             final @Nullable Locale locale) {
@@ -105,17 +119,11 @@ public class ChannelTypeI18nLocalizationService {
             return null;
         }
 
-        CommandDescriptionBuilder commandDescriptionBuilder = CommandDescriptionBuilder.create();
-        for (final CommandOption options : command.getCommandOptions()) {
-            String optionLabel = options.getLabel();
-            if (optionLabel != null) {
-                optionLabel = thingTypeI18nUtil.getChannelCommandOption(bundle, channelTypeUID, options.getCommand(),
-                        optionLabel, locale);
-            }
-            commandDescriptionBuilder.withCommandOption(new CommandOption(options.getCommand(), optionLabel));
-        }
+        List<CommandOption> localizedOptions = createLocalizedCommandOptions(bundle, command.getCommandOptions(),
+                channelTypeUID, locale);
 
-        return commandDescriptionBuilder.build();
+        CommandDescriptionBuilder commandDescriptionBuilder = CommandDescriptionBuilder.create();
+        return commandDescriptionBuilder.withCommandOptions(localizedOptions).build();
     }
 
     public ChannelType createLocalizedChannelType(Bundle bundle, ChannelType channelType, @Nullable Locale locale) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/DynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/DynamicCommandDescriptionProvider.java
@@ -20,14 +20,13 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.types.CommandDescription;
 
 /**
- * Implementations may provide channel specific {@link CommandDescription}s.
+ * Implementations may provide channel specific {@link CommandDescription}s. Therefore the provider must be registered
+ * as OSGi service.
  *
  * @author Henning Treu - Initial contribution
- *
  */
 @NonNullByDefault
 public interface DynamicCommandDescriptionProvider {
-
     /**
      * For a given channel UID, return a {@link CommandDescription} that should be used for the channel, instead of the
      * one defined statically in the {@link ChannelType}.

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescriptionBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandDescriptionBuilder.java
@@ -30,19 +30,45 @@ public class CommandDescriptionBuilder {
         // prevent public instantiation
     }
 
+    /**
+     * Create and return a fresh builder instance.
+     *
+     * @return a fresh {@link CommandDescriptionBuilder} instance.
+     */
     public static CommandDescriptionBuilder create() {
         return new CommandDescriptionBuilder();
     }
 
+    /**
+     * Build a {@link CommandDescription} from the values of this builder.
+     *
+     * @return a {@link CommandDescription} from the values of this builder.
+     */
+    public CommandDescription build() {
+        CommandDescriptionImpl commandDescription = new CommandDescriptionImpl();
+        commandOptions.forEach(co -> commandDescription.addCommandOption(co));
+        return commandDescription;
+    }
+
+    /**
+     * Add a {@link CommandOption} for the resulting {@link CommandDescription}.
+     *
+     * @param commandOption a {@link CommandOption} for the resulting {@link CommandDescription}.
+     * @return this builder.
+     */
     public CommandDescriptionBuilder withCommandOption(CommandOption commandOption) {
         this.commandOptions.add(commandOption);
         return this;
     }
 
-    public CommandDescription build() {
-        CommandDescriptionImpl commandDescription = new CommandDescriptionImpl();
-        commandOptions.forEach(co -> commandDescription.addCommandOption(co));
-
-        return commandDescription;
+    /**
+     * Set the {@link CommandOption}s for the resulting {@link CommandDescription}.
+     *
+     * @param commandOptions the {@link CommandOption}s for the resulting {@link CommandDescription}.
+     * @return this builder.
+     */
+    public CommandDescriptionBuilder withCommandOptions(List<CommandOption> commandOptions) {
+        commandOptions.forEach(co -> this.commandOptions.add(co));
+        return this;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/CommandOption.java
@@ -34,15 +34,31 @@ public class CommandOption {
      */
     private @Nullable String label;
 
+    /**
+     * Creates a {@link CommandOption} object.
+     *
+     * @param command the command of the item
+     * @param label label
+     */
     public CommandOption(String command, @Nullable String label) {
         this.command = command;
         this.label = label;
     }
 
+    /**
+     * Returns the command.
+     *
+     * @return command
+     */
     public String getCommand() {
         return command;
     }
 
+    /**
+     * Returns the label.
+     *
+     * @return label
+     */
     public @Nullable String getLabel() {
         return label;
     }


### PR DESCRIPTION
- Added i18n feature for dynamic command descriptions via `BaseDynamicCommandDescriptionProvider` class
- Added method `withCommandOptions(List<CommandOption>)` to `CommandDescriptionBuilder`
- Improved JavaDoc on related classes

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>