### PR TITLE
automation: some cleanup

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -279,15 +279,6 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         for (Rule rule : ruleRegistry.getAll()) {
             addRule(rule);
         }
-
-        // enable the rules that are not persisted as Disabled;
-        for (Rule rule : ruleRegistry.getAll()) {
-            String uid = rule.getUID();
-            final Storage<Boolean> disabledRulesStorage = this.disabledRulesStorage;
-            if (disabledRulesStorage == null || disabledRulesStorage.get(uid) == null) {
-                setEnabled(uid, true);
-            }
-        }
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -113,7 +113,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     /**
      * Delay between rule's re-initialization tries.
      */
-    private long scheduleReinitializationDelay;
+    private final long scheduleReinitializationDelay;
 
     private final @NonNullByDefault({}) Map<String, WrappedRule> managedRules = new ConcurrentHashMap<>();
 
@@ -134,7 +134,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * {@link Map} holding all available {@link ModuleHandlerFactory}s linked with {@link ModuleType}s that they
      * supporting. The relation is {@link ModuleType}'s UID to {@link ModuleHandlerFactory} instance.
      */
-    private final @NonNullByDefault({}) Map<String, ModuleHandlerFactory> moduleHandlerFactories;
+    private final Map<String, ModuleHandlerFactory> moduleHandlerFactories;
 
     /**
      * {@link Set} holding all available {@link ModuleHandlerFactory}s.
@@ -151,12 +151,12 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      */
     private boolean isDisposed = false;
 
-    protected Logger logger = LoggerFactory.getLogger(RuleEngineImpl.class.getName());
+    protected final Logger logger = LoggerFactory.getLogger(RuleEngineImpl.class);
 
     /**
      * A callback that is notified when the status of a {@link Rule} changes.
      */
-    private @NonNullByDefault({}) RuleRegistryImpl ruleRegistry;
+    private final RuleRegistry ruleRegistry;
 
     /**
      * {@link Map} holding all Rule context maps. Rule context maps contain dynamic parameters used by the
@@ -164,25 +164,25 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * The context map of a {@link Rule} is cleaned when the execution is completed. The relation is
      * {@link Rule}'s UID to Rule context map.
      */
-    private @NonNullByDefault({}) final Map<String, Map<String, Object>> contextMap;
+    private final Map<String, Map<String, Object>> contextMap;
 
     /**
      * This field holds reference to {@link ModuleTypeRegistry}. The {@link RuleEngineImpl} needs it to auto-map
      * connection between rule's modules and to determine module handlers.
      */
-    private @NonNullByDefault({}) ModuleTypeRegistry mtRegistry;
+    private final ModuleTypeRegistry mtRegistry;
 
     /**
      * Provides all composite {@link ModuleHandler}s.
      */
-    private @NonNullByDefault({}) CompositeModuleHandlerFactory compositeFactory;
+    private final CompositeModuleHandlerFactory compositeFactory;
 
     /**
      * {@link Map} holding all scheduled {@link Rule} re-initialization tasks. The relation is {@link Rule}'s
      * UID to
      * re-initialization task as a {@link Future} instance.
      */
-    private final @NonNullByDefault({}) Map<String, Future<?>> scheduleTasks = new HashMap<>(31);
+    private final Map<String, Future<?>> scheduleTasks = new HashMap<>(31);
 
     /**
      * Performs the {@link Rule} re-initialization tasks.
@@ -193,7 +193,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * This field holds {@link RegistryChangeListener} that listen for changes in the rule registry.
      * We cannot implement the interface ourselves as we are already a RegistryChangeListener for module types.
      */
-    private @NonNullByDefault({}) RegistryChangeListener<Rule> listener;
+    private final RegistryChangeListener<Rule> listener;
 
     /**
      * Posts an event through the event bus in an asynchronous way. {@link RuleEngineImpl} use it for posting the
@@ -237,21 +237,48 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     };
 
     /**
-     * Constructor of {@link RuleEngineImpl}. It initializes the logger and starts tracker for
-     * {@link ModuleHandlerFactory} services.
-     */
-    public RuleEngineImpl() {
-        this.contextMap = new HashMap<String, Map<String, Object>>();
-        this.moduleHandlerFactories = new HashMap<String, ModuleHandlerFactory>(20);
-    }
-
-    /**
-     * This method is used to create a {@link CompositeModuleHandlerFactory} that handles all composite
-     * {@link ModuleType}s. Called from DS to activate the rule engine component.
+     * Constructor of {@link RuleEngineImpl}.
      */
     @Activate
-    protected void activate() {
+    public RuleEngineImpl(final @Reference ModuleTypeRegistry moduleTypeRegistry,
+            final @Reference RuleRegistry ruleRegistry) {
+        this.contextMap = new HashMap<String, Map<String, Object>>();
+        this.moduleHandlerFactories = new HashMap<String, ModuleHandlerFactory>(20);
+
+        mtRegistry = moduleTypeRegistry;
+        mtRegistry.addRegistryChangeListener(this);
+
         compositeFactory = new CompositeModuleHandlerFactory(mtRegistry, this);
+
+        this.ruleRegistry = ruleRegistry;
+
+        if (ruleRegistry instanceof RuleRegistryImpl) {
+            scheduleReinitializationDelay = ((RuleRegistryImpl) this.ruleRegistry).getScheduleReinitializationDelay();
+        } else {
+            scheduleReinitializationDelay = RuleRegistryImpl.DEFAULT_REINITIALIZATION_DELAY;
+        }
+
+        listener = new RegistryChangeListener<Rule>() {
+            @Override
+            public void added(Rule rule) {
+                RuleEngineImpl.this.addRule(rule);
+            }
+
+            @Override
+            public void removed(Rule rule) {
+                RuleEngineImpl.this.removeRule(rule.getUID());
+            }
+
+            @Override
+            public void updated(Rule oldRule, Rule rule) {
+                removed(oldRule);
+                added(rule);
+            }
+        };
+        ruleRegistry.addRegistryChangeListener(listener);
+        for (Rule rule : ruleRegistry.getAll()) {
+            addRule(rule);
+        }
 
         // enable the rules that are not persisted as Disabled;
         for (Rule rule : ruleRegistry.getAll()) {
@@ -264,73 +291,32 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     /**
-     * Bind the {@link ModuleTypeRegistry} service - called from DS.
-     *
-     * @param moduleTypeRegistry a {@link ModuleTypeRegistry} service.
+     * The method cleans used resources by rule engine when it is deactivated.
      */
-    @Reference
-    protected void setModuleTypeRegistry(ModuleTypeRegistry moduleTypeRegistry) {
-        mtRegistry = moduleTypeRegistry;
-        mtRegistry.addRegistryChangeListener(this);
-    }
-
-    /**
-     * Unbind the {@link ModuleTypeRegistry} service - called from DS.
-     *
-     * @param moduleTypeRegistry a {@link ModuleTypeRegistry} service.
-     */
-    protected void unsetModuleTypeRegistry(ModuleTypeRegistry moduleTypeRegistry) {
-        mtRegistry.removeRegistryChangeListener(this);
-        mtRegistry = null;
-    }
-
-    /**
-     * Bind the {@link RuleRegistry} service - called from DS.
-     *
-     * @param ruleRegistry a {@link RuleRegistry} service.
-     */
-    @Reference
-    protected void setRuleRegistry(RuleRegistry ruleRegistry) {
-        if (ruleRegistry instanceof RuleRegistryImpl) {
-            this.ruleRegistry = (RuleRegistryImpl) ruleRegistry;
-            scheduleReinitializationDelay = this.ruleRegistry.getScheduleReinitializationDelay();
-            listener = new RegistryChangeListener<Rule>() {
-                @Override
-                public void added(Rule rule) {
-                    RuleEngineImpl.this.addRule(rule);
-                }
-
-                @Override
-                public void removed(Rule rule) {
-                    RuleEngineImpl.this.removeRule(rule.getUID());
-                }
-
-                @Override
-                public void updated(Rule oldRule, Rule rule) {
-                    removed(oldRule);
-                    added(rule);
-                }
-            };
-            ruleRegistry.addRegistryChangeListener(listener);
-            for (Rule rule : ruleRegistry.getAll()) {
-                addRule(rule);
+    @Deactivate
+    protected void deactivate() {
+        synchronized (this) {
+            if (isDisposed) {
+                return;
             }
-        } else {
-            logger.error("Unexpected RuleRegistry service: {}", ruleRegistry);
+            isDisposed = true;
         }
-    }
 
-    /**
-     * Unbind the {@link RuleRegistry} service - called from DS.
-     *
-     * @param ruleRegistry a {@link RuleRegistry} service.
-     */
-    protected void unsetRuleRegistry(RuleRegistry ruleRegistry) {
-        if (this.ruleRegistry == ruleRegistry) {
-            ruleRegistry.removeRegistryChangeListener(listener);
-            listener = null;
-            this.ruleRegistry = null;
+        compositeFactory.deactivate();
+
+        for (Future<?> f : scheduleTasks.values()) {
+            f.cancel(true);
         }
+        if (scheduleTasks.isEmpty() && executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
+        scheduleTasks.clear();
+        contextMap.clear();
+
+        mtRegistry.removeRegistryChangeListener(this);
+
+        ruleRegistry.removeRegistryChangeListener(listener);
     }
 
     /**
@@ -907,18 +893,13 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     protected void scheduleRuleInitialization(final String rUID) {
         Future<?> f = scheduleTasks.get(rUID);
         if (f == null || f.isDone()) {
-            ScheduledExecutorService ex = getScheduledExecutor();
-            f = ex.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    final WrappedRule managedRule = getManagedRule(rUID);
-                    if (managedRule == null) {
-                        return;
-                    }
-                    setRule(managedRule);
+            scheduleTasks.put(rUID, getScheduledExecutor().schedule(() -> {
+                final WrappedRule managedRule = getManagedRule(rUID);
+                if (managedRule == null) {
+                    return;
                 }
-            }, scheduleReinitializationDelay, TimeUnit.MILLISECONDS);
-            scheduleTasks.put(rUID, f);
+                setRule(managedRule);
+            }, scheduleReinitializationDelay, TimeUnit.MILLISECONDS));
         }
     }
 
@@ -1208,33 +1189,6 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                 }
             }
         }
-    }
-
-    /**
-     * The method cleans used resources by rule engine when it is deactivated.
-     */
-    @Deactivate
-    protected void deactivate() {
-        synchronized (this) {
-            if (isDisposed) {
-                return;
-            }
-            isDisposed = true;
-        }
-        if (compositeFactory != null) {
-            compositeFactory.deactivate();
-            compositeFactory = null;
-        }
-        for (Future<?> f : scheduleTasks.values()) {
-            f.cancel(true);
-        }
-        if (scheduleTasks.isEmpty() && executor != null) {
-            executor.shutdown();
-            executor = null;
-        }
-        scheduleTasks.clear();
-        contextMap.clear();
-        unsetRuleRegistry(ruleRegistry);
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -107,7 +107,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
     /**
      * Default value of delay between rule's re-initialization tries.
      */
-    private static final long DEFAULT_REINITIALIZATION_DELAY = 500;
+    static final long DEFAULT_REINITIALIZATION_DELAY = 500;
 
     /**
      * Delay between rule's re-initialization tries.
@@ -243,12 +243,12 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      * @param rule a {@link Rule} instance which have to be added into the {@link RuleEngineImpl}.
      * @return a copy of the added {@link Rule}
      * @throws RuntimeException
-     *                                  when passed module has a required configuration property and it is not specified
-     *                                  in rule definition
-     *                                  nor
-     *                                  in the module's module type definition.
+     *             when passed module has a required configuration property and it is not specified
+     *             in rule definition
+     *             nor
+     *             in the module's module type definition.
      * @throws IllegalArgumentException
-     *                                  when a module id contains dot or when the rule with the same UID already exists.
+     *             when a module id contains dot or when the rule with the same UID already exists.
      */
     @Override
     public Rule add(Rule rule) {
@@ -298,7 +298,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      * This method can be used in order to post events through the openHAB events bus. A common
      * use case is to notify event subscribers about the {@link Rule}'s status change.
      *
-     * @param ruleUID    the UID of the {@link Rule}, whose status is changed.
+     * @param ruleUID the UID of the {@link Rule}, whose status is changed.
      * @param statusInfo the new {@link Rule}s status.
      */
     protected void postRuleStatusInfoEvent(String ruleUID, RuleStatusInfo statusInfo) {
@@ -386,9 +386,9 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      * Updates the content of the {@link Map} that maps the template to rules, using it to complete their definitions.
      *
      * @param templateUID the {@link RuleTemplate}'s UID specifying the template.
-     * @param ruleUID     the {@link Rule}'s UID specifying a rule created by the specified template.
-     * @param resolved    specifies if the {@link Map} should be updated by adding or removing the specified rule
-     *                    accordingly if the rule is resolved or not.
+     * @param ruleUID the {@link Rule}'s UID specifying a rule created by the specified template.
+     * @param resolved specifies if the {@link Map} should be updated by adding or removing the specified rule
+     *            accordingly if the rule is resolved or not.
      */
     private void updateRuleTemplateMapping(String templateUID, String ruleUID, boolean resolved) {
         synchronized (this) {
@@ -484,7 +484,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      * This method serves to resolve and normalize the {@link Rule}s configuration values and its module configurations.
      *
      * @param rule the {@link Rule}, whose configuration values and module configuration values should be resolved and
-     *             normalized.
+     *            normalized.
      */
     private void resolveConfigurations(Rule rule) {
         List<ConfigDescriptionParameter> configDescriptions = rule.getConfigurationDescriptions();
@@ -565,7 +565,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
     /**
      * Utility method for {@link Rule}s configuration validation. Validates the value of a configuration property.
      *
-     * @param configValue     the value for {@link Rule}s configuration property, that should be validated.
+     * @param configValue the value for {@link Rule}s configuration property, that should be validated.
      * @param configParameter the meta-data for {@link Rule}s configuration value, used for validation.
      */
     private void processValue(Object configValue, ConfigDescriptionParameter configParameter) {
@@ -599,7 +599,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
     /**
      * Avoid code duplication in {@link #processValue(Object, ConfigDescriptionParameter)} method.
      *
-     * @param type        the {@link Type} of a parameter that should be checked.
+     * @param type the {@link Type} of a parameter that should be checked.
      * @param configValue the value of a parameter that should be checked.
      * @return <code>true</code> if the type and value matching or <code>false</code> in the opposite.
      */
@@ -621,9 +621,9 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
     /**
      * This method serves to replace module configuration references with the {@link Rule}s configuration values.
      *
-     * @param modules           the {@link Rule}'s modules, whose configuration values should be resolved.
+     * @param modules the {@link Rule}'s modules, whose configuration values should be resolved.
      * @param ruleConfiguration the {@link Rule}'s configuration values that should be resolve module configuration
-     *                          values.
+     *            values.
      */
     private void resolveModuleConfigReferences(List<? extends Module> modules, Map<String, ?> ruleConfiguration) {
         if (modules != null) {


### PR DESCRIPTION
Cleanup the rule engine implementation by using constructor injection. This allows us to use more final members. Also make some code "nicer looking"

If a rule is added, the status is set dependent on the "disabled storage" (see `addRule) to initializing or uninitialized-disabled.
The old code calls "set enabled" after adding all rules.
This is not necessary at all.

After removing the code my rules are working after an update, so perhaps this is also the root cause for #636 and #746. Sure, this could also just be timing dependent -- we will see.