### PR TITLE
Initial contribution of 'Round' profile

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.OFFSET;
+
 import java.math.BigDecimal;
 
 import javax.measure.UnconvertibleException;
@@ -29,7 +31,6 @@ import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.StateProfile;
-import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
@@ -40,8 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Applies the given parameter "offset" to a QuantityType or DecimalType state
  *
- * @author Stefan Triller - initial contribution
- *
+ * @author Stefan Triller - Initial contribution
  */
 @NonNullByDefault
 public class SystemOffsetProfile implements StateProfile {
@@ -83,7 +83,7 @@ public class SystemOffsetProfile implements StateProfile {
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return SystemProfiles.OFFSET;
+        return OFFSET;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.core.thing.internal.profiles;
 import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.*;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,17 +55,17 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
 
-    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream
-            .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
-                    RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE,
-                    RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE, RAWROCKER_REWIND_FASTFORWARD_TYPE,
-                    RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_UPDATE_TYPE)
-            .collect(Collectors.toSet());
+    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Collections.unmodifiableSet(Stream.of(DEFAULT_TYPE,
+            FOLLOW_TYPE, OFFSET_TYPE, ROUND_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
+            RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE,
+            RAWROCKER_PLAY_PAUSE_TYPE, RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE,
+            RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_UPDATE_TYPE).collect(Collectors.toSet()));
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of(DEFAULT, FOLLOW, OFFSET,
-            RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER,
-            RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD,
-            RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_UPDATE).collect(Collectors.toSet());
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Collections
+            .unmodifiableSet(Stream.of(DEFAULT, FOLLOW, OFFSET, ROUND, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_PLAYER,
+                    RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF,
+                    RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN,
+                    TIMESTAMP_CHANGE, TIMESTAMP_UPDATE).collect(Collectors.toSet()));
 
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
@@ -75,6 +76,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemFollowProfile(callback);
         } else if (OFFSET.equals(profileTypeUID)) {
             return new SystemOffsetProfile(callback, context);
+        } else if (ROUND.equals(profileTypeUID)) {
+            return new SystemRoundProfile(callback, context);
         } else if (RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
             return new RawButtonToggleSwitchProfile(callback);
         } else if (RAWBUTTON_TOGGLE_PLAYER.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfile.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import static org.eclipse.smarthome.core.thing.profiles.SystemProfiles.ROUND;
+
+import java.math.RoundingMode;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfile;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies rounding with the specified scale and the rounding mode to a {@link QuantityType} or {@link DecimalType}
+ * state. Default rounding mode is {@link RoundingMode#HALF_UP}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class SystemRoundProfile implements StateProfile {
+
+    private static final String PARAM_SCALE = "scale";
+    private static final String PARAM_ROUNDING_MODE = "mode";
+
+    private static final Map<String, RoundingMode> SUPPORTED_ROUNDING_MODES = Collections.unmodifiableMap(Stream
+            .of(new SimpleEntry<>("UP", RoundingMode.UP), new SimpleEntry<>("DOWN", RoundingMode.DOWN),
+                    new SimpleEntry<>("CEILING", RoundingMode.CEILING), new SimpleEntry<>("FLOOR", RoundingMode.FLOOR),
+                    new SimpleEntry<>("HALF_UP", RoundingMode.HALF_UP),
+                    new SimpleEntry<>("HALF_DOWN", RoundingMode.HALF_DOWN))
+            .collect(Collectors.toMap(SimpleEntry::getKey, SimpleEntry::getValue)));
+
+    private final Logger logger = LoggerFactory.getLogger(SystemRoundProfile.class);
+
+    private final ProfileCallback callback;
+    private final ProfileContext context;
+
+    private final int scale;
+    private final RoundingMode roundingMode;
+
+    public SystemRoundProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+        this.context = context;
+
+        Object paramScale = this.context.getConfiguration().get(PARAM_SCALE);
+        Object paramRoundingMode = this.context.getConfiguration().get(PARAM_ROUNDING_MODE);
+        logger.debug("Configuring profile with parameters: [{scale='{}', mode='{}']", paramScale, paramRoundingMode);
+
+        int scale = 0;
+        if (paramScale instanceof String) {
+            try {
+                scale = Integer.valueOf((String) paramScale);
+            } catch (NumberFormatException e) {
+                logger.error("Cannot convert value '{}' of parameter 'scale' into a valid integer.", paramScale);
+            }
+        } else if (paramScale instanceof Number) {
+            scale = ((Number) paramScale).intValue();
+        } else {
+            logger.error("Parameter 'scale' is not of type String or Number.");
+        }
+
+        if (scale < 0) {
+            logger.error("Parameter 'scale' has to be a non-negative integer. Ignoring it.");
+            scale = 0;
+        }
+
+        RoundingMode roundingMode = RoundingMode.HALF_UP;
+        if (paramRoundingMode instanceof String) {
+            if (SUPPORTED_ROUNDING_MODES.containsKey(paramRoundingMode)) {
+                roundingMode = SUPPORTED_ROUNDING_MODES.get(paramRoundingMode);
+            } else {
+                logger.error("Parameter 'mode' is not a supported rounding mode: '{}'", paramRoundingMode);
+            }
+        } else {
+            logger.error("Parameter 'mode' is not of type String.");
+        }
+
+        this.scale = scale;
+        this.roundingMode = roundingMode;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return ROUND;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        callback.handleUpdate((State) applyRound(state));
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand((Command) applyRound(command));
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        callback.sendCommand((Command) applyRound(command));
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        callback.sendUpdate((State) applyRound(state));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Type applyRound(Type state) {
+        if (state instanceof UnDefType) {
+            // we cannot round UNDEF or NULL values, thus we simply return them without reporting an error or warning
+            return state;
+        }
+
+        Type result = UnDefType.UNDEF;
+        if (state instanceof QuantityType) {
+            QuantityType qtState = (QuantityType) state;
+            result = new QuantityType<>(qtState.toBigDecimal().setScale(scale, roundingMode), qtState.getUnit());
+        } else if (state instanceof DecimalType) {
+            DecimalType dtState = (DecimalType) state;
+            result = new DecimalType(dtState.toBigDecimal().setScale(scale, roundingMode));
+        } else {
+            logger.warn(
+                    "Round cannot be applied to the incompatible state '{}' sent from the binding. Returning original state.",
+                    state);
+            result = state;
+        }
+        return result;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -29,6 +29,7 @@ public interface SystemProfiles {
     ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
     ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
+    ProfileTypeUID ROUND = new ProfileTypeUID(SYSTEM_SCOPE, "round");
     ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
     ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-rollershutter");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-switch");
@@ -47,6 +48,10 @@ public interface SystemProfiles {
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
     StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
+            .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
+            .build();
+
+    StateProfileType ROUND_TYPE = ProfileTypeBuilder.newState(ROUND, "Round")
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
             .build();
 

--- a/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/config/roundProfile.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/config/roundProfile.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:system:round">
+		<parameter name="scale" type="integer" min="0" max="16" required="true">
+			<label>Scale</label>
+			<description>Scale (non-negative number) to be applied on the state.</description>
+		</parameter>
+		<parameter name="mode" type="text">
+			<label>Rounding Mode</label>
+			<description>Rounding mode to be used (UP, DOWN, CEILING, FLOOR, HALF_UP or HALF_DOWN). Default: HALF_UP.</description>
+			<default>HALF_UP</default>
+			<options>
+				<option value="UP">UP</option>
+				<option value="DOWN">DOWN</option>
+				<option value="CEILING">CEILING</option>
+				<option value="FLOOR">FLOOR</option>
+				<option value="HALF_UP">HALF_UP</option>
+				<option value="HALF_DOWN">HALF_DOWN</option>
+			</options>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfileTest.java
@@ -36,8 +36,7 @@ import org.mockito.ArgumentCaptor;
 /**
  * Tests for the system:offset profile
  *
- * @author Stefan Triller - initial contribution
- *
+ * @author Stefan Triller - Initial contribution
  */
 public class SystemOffsetProfileTest {
 

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfileTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+import javax.measure.Unit;
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests for the system:round profile
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class SystemRoundProfileTest {
+
+    @Before
+    public void setup() {
+        // initialize parser with ImperialUnits, otherwise units like °F are unknown
+        @SuppressWarnings("unused")
+        Unit<Temperature> fahrenheit = ImperialUnits.FAHRENHEIT;
+    }
+
+    @Test
+    public void testDecimalTypeOnCommandFromItem() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 2, "HALF_UP");
+
+        Command cmd = new DecimalType(23.333);
+        roundProfile.onCommandFromItem(cmd);
+
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        verify(callback, times(1)).handleCommand(capture.capture());
+
+        Command result = capture.getValue();
+        DecimalType dtResult = (DecimalType) result;
+        assertThat(dtResult.doubleValue(), is(23.33));
+    }
+
+    @Test
+    public void testDecimalTypeOnCommandFromItemWithCeiling() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 0, "CEILING");
+
+        Command cmd = new DecimalType(23.3);
+        roundProfile.onCommandFromItem(cmd);
+
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        verify(callback, times(1)).handleCommand(capture.capture());
+
+        Command result = capture.getValue();
+        DecimalType dtResult = (DecimalType) result;
+        assertThat(dtResult.doubleValue(), is(24.0));
+    }
+
+    @Test
+    public void testDecimalTypeOnCommandFromItemWithFloor() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 0, "FLOOR");
+
+        Command cmd = new DecimalType(23.6);
+        roundProfile.onCommandFromItem(cmd);
+
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        verify(callback, times(1)).handleCommand(capture.capture());
+
+        Command result = capture.getValue();
+        DecimalType dtResult = (DecimalType) result;
+        assertThat(dtResult.doubleValue(), is(23.0));
+    }
+
+    @Test
+    public void testDecimalTypeOnStateUpdateFromItem() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 2, "HALF_UP");
+
+        State state = new DecimalType(23.666);
+        roundProfile.onStateUpdateFromItem(state);
+
+        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
+        verify(callback, times(1)).handleUpdate(capture.capture());
+
+        State result = capture.getValue();
+        DecimalType dtResult = (DecimalType) result;
+        assertThat(dtResult.doubleValue(), is(23.67));
+    }
+
+    @Test
+    public void testQuantityTypeOnCommandFromItem() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 1, "HALF_UP");
+
+        Command cmd = new QuantityType<Temperature>("23.333 °C");
+        roundProfile.onCommandFromItem(cmd);
+
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        verify(callback, times(1)).handleCommand(capture.capture());
+
+        Command result = capture.getValue();
+        @SuppressWarnings("unchecked")
+        QuantityType<Temperature> qtResult = (QuantityType<Temperature>) result;
+        assertThat(qtResult.doubleValue(), is(23.3));
+        assertThat(qtResult.getUnit(), is(SIUnits.CELSIUS));
+    }
+
+    @Test
+    public void testQuantityTypeOnStateUpdateFromItem() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile roundProfile = createProfile(callback, 1, "HALF_UP");
+
+        State state = new QuantityType<Temperature>("23.666 °C");
+        roundProfile.onStateUpdateFromItem(state);
+
+        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
+        verify(callback, times(1)).handleUpdate(capture.capture());
+
+        State result = capture.getValue();
+        @SuppressWarnings("unchecked")
+        QuantityType<Temperature> qtResult = (QuantityType<Temperature>) result;
+        assertThat(qtResult.doubleValue(), is(23.7));
+        assertThat(qtResult.getUnit(), is(SIUnits.CELSIUS));
+    }
+
+    private SystemRoundProfile createProfile(ProfileCallback callback, Integer scale, String mode) {
+        ProfileContext context = mock(ProfileContext.class);
+        Configuration config = new Configuration();
+        config.put("scale", scale);
+        config.put("mode", mode);
+        when(context.getConfiguration()).thenReturn(config);
+
+        return new SystemRoundProfile(callback, context);
+    }
+}

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/TimestampProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/TimestampProfileTest.java
@@ -28,8 +28,7 @@ import org.mockito.ArgumentCaptor;
 /**
  * Tests for the system:timestamp-update profile
  *
- * @author Gaël L'hopital - initial contribution
- *
+ * @author Gaël L'hopital - Initial contribution
  */
 public class TimestampProfileTest {
 
@@ -75,5 +74,4 @@ public class TimestampProfileTest {
         DateTimeType updatedResult = (DateTimeType) result;
         assertTrue(updatedResult.getZonedDateTime().isAfter(newChangeResult.getZonedDateTime()));
     }
-
 }


### PR DESCRIPTION
- Initial contribution of 'Round' profile

In general bindings are meant to deliver precise data. If you like to have only one decimal for "visual purpose" you can archive it easily by applying a pattern / format on the state of your item linked to a channel. If a target device or entity requires a fixed decimal number the binding for it should take care of that on its own. We denied fixes in bindings for this purpose (see https://github.com/openhab/openhab2-addons/pull/4108).

But it often occurs that people are asking for rounded values e.g. to expose them via `say()` commands (see https://github.com/openhab/openhab2-addons/issues/4054). This profile can be used - if necessary - to round the states to a specific scale without using rules and introducing dummy items. It additionally provides the feature to choose a rounding mode.

Wdyt?

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>