### PR TITLE
Travis CI: check POM convention

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,24 +39,9 @@ install:
         prevent_timeout $pid &
         wait $pid
     }
-    function check_pom_convention() {
-        mvnp com.github.ekryd.sortpom:sortpom-maven-plugin:sort -Dsort.keepBlankLines=true -Dsort.createBackupFile=false -Dsort.predefinedSortOrder=recommended_2008_06
-        if [ $? != 0 ]; then
-            echo "sortpom failed"
-            exit 1
-        fi
-        if [ $(git diff | wc -l) != 0 ]; then
-            echo "At least one POM file breaks the convention, please use sortpom to fix the POM file(s)."
-            git status | grep 'modified:'
-            echo "You should run the following command in the root directory of your working copy:"
-            echo "    $(grep 'sortpom-maven-plugin:sort' .travis.yml | grep -v grep | sed 's: *mvnp:mvn:g')"
-            exit 1
-        fi
-    }
 after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
 script:
-  - check_pom_convention
   - mvnp clean verify -B -DskipChecks

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,24 @@ install:
         prevent_timeout $pid &
         wait $pid
     }
+    function check_pom_convention() {
+        mvnp com.github.ekryd.sortpom:sortpom-maven-plugin:sort -Dsort.keepBlankLines=true -Dsort.createBackupFile=false -Dsort.predefinedSortOrder=recommended_2008_06
+        if [ $? != 0 ]; then
+            echo "sortpom failed"
+            exit 1
+        fi
+        if [ $(git diff | wc -l) != 0 ]; then
+            echo "At least one POM file breaks the convention, please use sortpom to fix the POM file(s)."
+            git status | grep 'modified:'
+            echo "You should run the following command in the root directory of your working copy:"
+            echo "    $(grep 'sortpom-maven-plugin:sort' .travis.yml | grep -v grep | sed 's: *mvnp:mvn:g')"
+            exit 1
+        fi
+    }
 after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
 script:
+  - check_pom_convention
   - mvnp clean verify -B -DskipChecks

--- a/bundles/org.openhab.core.io.jetty.certificate/pom.xml
+++ b/bundles/org.openhab.core.io.jetty.certificate/pom.xml
@@ -17,6 +17,7 @@
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.52</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -33,6 +34,7 @@
             </goals>
             <phase>package</phase>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <artifactSet>
                 <includes>
                   <include>org.bouncycastle:*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,30 @@ Import-Package: \\
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>com.github.ekryd.sortpom</groupId>
+          <artifactId>sortpom-maven-plugin</artifactId>
+          <version>2.10.0</version>
+          <configuration>
+            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
+            <createBackupFile>false</createBackupFile>
+            <keepBlankLines>true</keepBlankLines>
+          </configuration>
+          <executions>
+            <execution>
+              <id>sortpom-verify</id>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+              <phase>verify</phase>
+              <configuration>
+                <verifyFail>Stop</verifyFail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <groupId>com.itemis.maven.plugins</groupId>
           <artifactId>unleash-maven-plugin</artifactId>
@@ -675,6 +699,10 @@ Import-Package: \\
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
We could use Travis CI to execute some checks in front of the normal build.

This change adds a check if the POM files follow our POM conventions.

If something fails, it show which files violates the convention and the command that should be executed to fix the situation.

For example if the base POM file breaks the convention:

    At least one POM file breaks the convention, please use sortpom to fix the POM file(s).
    	modified:   pom.xml
    You should run the following command in the root directory of your working copy:
        mvn com.github.ekryd.sortpom:sortpom-maven-plugin:sort -Dsort.keepBlankLines=true -Dsort.createBackupFile=false -Dsort.predefinedSortOrder=recommended_2008_06
