### PR TITLE
allow to use "Pure Annotation-Driven Bundle Development"

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.annotation</artifactId>
-      <version>6.0.0</version>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump the OSGi annotation to allow a pure annotation-driven bundle development.

Related to: https://virtual.osgiusers.org/2018/10/pure-annotation-driven-dev