### PR TITLE
 Separate i18n infrastructure for 'ChannelGroup'

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -31,9 +31,10 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * This OSGi service could be used to localize a {@link ChannelGroupType} type using the I18N mechanism of the Eclipse
- * SmartHome framework.
+ * This OSGi service could be used to localize a {@link ChannelGroupType} type using the I18N mechanism of the openHAB
+ * framework.
  *
+ * @author Markus Rathgeb - Initial contribution
  * @author Markus Rathgeb - Move code from XML thing type provider to separate service
  * @author Laurent Garnier - fix localized label and description for channel group definition
  * @author Christoph Weitkamp - factored out from {@link XmlChannelTypeProvider} and {@link XmlChannelGroupTypeProvider}
@@ -44,10 +45,10 @@ import org.osgi.service.component.annotations.Reference;
 public class ChannelGroupTypeI18nLocalizationService {
 
     @NonNullByDefault({})
-    private ChannelI18nUtil channelI18nUtil;
+    private ThingTypeI18nUtil thingTypeI18nUtil;
 
     @NonNullByDefault({})
-    private ThingTypeI18nUtil thingTypeI18nUtil;
+    private ChannelI18nUtil channelI18nUtil;
 
     @NonNullByDefault({})
     private ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -27,7 +27,6 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -44,55 +43,15 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class ChannelGroupTypeI18nLocalizationService {
 
-    @NonNullByDefault({})
-    private ThingTypeI18nUtil thingTypeI18nUtil;
-
-    @NonNullByDefault({})
-    private ChannelI18nUtil channelI18nUtil;
-
-    @NonNullByDefault({})
-    private ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
-
-    @NonNullByDefault({})
-    private ChannelTypeRegistry channelTypeRegistry;
-
-    @Reference
-    protected void setChannelTypeI18nLocalizationService(
-            ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
-    }
-
-    protected void unsetChannelTypeI18nLocalizationService(
-            ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = null;
-    }
-
-    @Reference
-    protected void setChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = channelTypeRegistry;
-    }
-
-    protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = null;
-    }
-
-    @Reference
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.thingTypeI18nUtil = null;
-    }
+    private final ThingTypeI18nUtil thingTypeI18nUtil;
+    private final ChannelI18nUtil channelI18nUtil;
 
     @Activate
-    protected void activate() {
-        channelI18nUtil = new ChannelI18nUtil(channelTypeI18nLocalizationService, channelTypeRegistry);
-    }
-
-    @Deactivate
-    protected void deactivate() {
-        channelI18nUtil = null;
+    public ChannelGroupTypeI18nLocalizationService(final @Reference TranslationProvider i18nProvider,
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService,
+            final @Reference ChannelTypeRegistry channelTypeRegistry) {
+        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
+        this.channelI18nUtil = new ChannelI18nUtil(channelTypeI18nLocalizationService, channelTypeRegistry);
     }
 
     public ChannelGroupType createLocalizedChannelGroupType(Bundle bundle, ChannelGroupType channelGroupType,

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.osgi.framework.Bundle;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -48,15 +49,11 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class ChannelTypeI18nLocalizationService {
 
-    private @NonNullByDefault({}) ThingTypeI18nUtil thingTypeI18nUtil;
+    private final ThingTypeI18nUtil thingTypeI18nUtil;
 
-    @Reference
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
+    @Activate
+    public ChannelTypeI18nLocalizationService(final @Reference TranslationProvider i18nProvider) {
         this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.thingTypeI18nUtil = null;
     }
 
     public @Nullable String createLocalizedStatePattern(final Bundle bundle, String pattern,

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -38,6 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  * This OSGi service could be used to localize a {@link ChannelType} using the I18N mechanism of the openHAB
  * framework.
  *
+ * @author Markus Rathgeb - Initial contribution
  * @author Markus Rathgeb - Move code from XML thing type provider to separate service
  * @author Laurent Garnier - fix localized label and description for channel group definition
  * @author Christoph Weitkamp - factored out from {@link XmlChannelTypeProvider} and {@link XmlChannelGroupTypeProvider}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -47,87 +46,20 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class ThingTypeI18nLocalizationService {
 
-    @NonNullByDefault({})
-    private ThingTypeI18nUtil thingTypeI18nUtil;
-
-    @NonNullByDefault({})
-    private ChannelI18nUtil channelI18nUtil;
-
-    @NonNullByDefault({})
-    private ChannelGroupI18nUtil channelGroupI18nUtil;
-
-    @NonNullByDefault({})
-    private ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
-
-    @NonNullByDefault({})
-    private ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService;
-
-    @NonNullByDefault({})
-    private ChannelTypeRegistry channelTypeRegistry;
-
-    @NonNullByDefault({})
-    private ChannelGroupTypeRegistry channelGroupTypeRegistry;
-
-    @Reference
-    protected void setChannelTypeI18nLocalizationService(
-            ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
-    }
-
-    protected void unsetChannelTypeI18nLocalizationService(
-            ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = null;
-    }
-
-    @Reference
-    protected void setChannelGroupTypeI18nLocalizationService(
-            ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService) {
-        this.channelGroupTypeI18nLocalizationService = channelGroupTypeI18nLocalizationService;
-    }
-
-    protected void unsetChannelGroupTypeI18nLocalizationService(
-            ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService) {
-        this.channelGroupTypeI18nLocalizationService = null;
-    }
-
-    @Reference
-    protected void setChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = channelTypeRegistry;
-    }
-
-    protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = null;
-    }
-
-    @Reference
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.thingTypeI18nUtil = null;
-    }
-
-    @Reference
-    protected void setChannelGroupTypeRegistry(ChannelGroupTypeRegistry channelGroupTypeRegistry) {
-        this.channelGroupTypeRegistry = channelGroupTypeRegistry;
-    }
-
-    protected void unsetChannelGroupTypeRegistry(ChannelGroupTypeRegistry channelGroupTypeRegistry) {
-        this.channelGroupTypeRegistry = null;
-    }
+    private final ThingTypeI18nUtil thingTypeI18nUtil;
+    private final ChannelGroupI18nUtil channelGroupI18nUtil;
+    private final ChannelI18nUtil channelI18nUtil;
 
     @Activate
-    protected void activate() {
-        channelI18nUtil = new ChannelI18nUtil(channelTypeI18nLocalizationService, channelTypeRegistry);
-        channelGroupI18nUtil = new ChannelGroupI18nUtil(channelGroupTypeI18nLocalizationService,
+    public ThingTypeI18nLocalizationService(final @Reference TranslationProvider i18nProvider,
+            final @Reference ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService,
+            final @Reference ChannelGroupTypeRegistry channelGroupTypeRegistry,
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService,
+            final @Reference ChannelTypeRegistry channelTypeRegistry) {
+        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
+        this.channelGroupI18nUtil = new ChannelGroupI18nUtil(channelGroupTypeI18nLocalizationService,
                 channelGroupTypeRegistry);
-    }
-
-    @Deactivate
-    protected void deactivate() {
-        channelI18nUtil = null;
-        channelGroupI18nUtil = null;
+        this.channelI18nUtil = new ChannelI18nUtil(channelTypeI18nLocalizationService, channelTypeRegistry);
     }
 
     public ThingType createLocalizedThingType(Bundle bundle, ThingType thingType, @Nullable Locale locale) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelGroupI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelGroupI18nUtil.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.i18n;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.i18n.ChannelGroupTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeRegistry;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
+import org.osgi.framework.Bundle;
+
+/**
+ * A utility service which localizes {@link ChannelGroupDefinition}.
+ * Falls back to a localized {@link ChannelGroupType} for label and description when not given otherwise.
+ *
+ * @see {@link ThingTypeI18nLocalizationService}
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ChannelGroupI18nUtil {
+
+    private final ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService;
+
+    private final ChannelGroupTypeRegistry channelGroupTypeRegistry;
+
+    /**
+     * Create a new util instance and pass the appropriate dependencies.
+     *
+     * @param channelGroupTypeI18nLocalizationService an instance of {@link ChannelGroupTypeI18nLocalizationService}.
+     * @param channelGroupTypeRegistry the {@link ChannelGroupTypeRegistry}.
+     */
+    public ChannelGroupI18nUtil(ChannelGroupTypeI18nLocalizationService channelGroupTypeI18nLocalizationService,
+            ChannelGroupTypeRegistry channelGroupTypeRegistry) {
+        this.channelGroupTypeI18nLocalizationService = channelGroupTypeI18nLocalizationService;
+        this.channelGroupTypeRegistry = channelGroupTypeRegistry;
+    }
+
+    public List<ChannelGroupDefinition> createLocalizedChannelGroupDefinitions(final Bundle bundle,
+            final List<ChannelGroupDefinition> channelGroupDefinitions,
+            final Function<ChannelGroupDefinition, @Nullable String> channelGroupLabelResolver,
+            final Function<ChannelGroupDefinition, @Nullable String> channelGroupDescriptionResolver,
+            final @Nullable Locale locale) {
+        List<ChannelGroupDefinition> localizedChannelGroupDefinitions = new ArrayList<>(channelGroupDefinitions.size());
+        for (final ChannelGroupDefinition channelGroupDefinition : channelGroupDefinitions) {
+            String channelGroupLabel = channelGroupLabelResolver.apply(channelGroupDefinition);
+            String channelGroupDescription = channelGroupDescriptionResolver.apply(channelGroupDefinition);
+            if (channelGroupLabel == null || channelGroupDescription == null) {
+                ChannelGroupTypeUID channelGroupTypeUID = channelGroupDefinition.getTypeUID();
+                ChannelGroupType channelGroupType = channelGroupTypeRegistry.getChannelGroupType(channelGroupTypeUID,
+                        locale);
+                if (channelGroupType != null) {
+                    ChannelGroupType localizedChannelGroupType = channelGroupTypeI18nLocalizationService
+                            .createLocalizedChannelGroupType(bundle, channelGroupType, locale);
+                    if (channelGroupLabel == null) {
+                        channelGroupLabel = localizedChannelGroupType.getLabel();
+                    }
+                    if (channelGroupDescription == null) {
+                        channelGroupDescription = localizedChannelGroupType.getDescription();
+                    }
+                }
+            }
+            localizedChannelGroupDefinitions.add(new ChannelGroupDefinition(channelGroupDefinition.getId(),
+                    channelGroupDefinition.getTypeUID(), channelGroupLabel, channelGroupDescription));
+        }
+        return localizedChannelGroupDefinitions;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
@@ -55,7 +55,6 @@ public class ChannelI18nUtil {
             ChannelTypeRegistry channelTypeRegistry) {
         this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
         this.channelTypeRegistry = channelTypeRegistry;
-
     }
 
     public List<ChannelDefinition> createLocalizedChannelDefinitions(final Bundle bundle,

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
@@ -36,8 +36,7 @@ import org.osgi.framework.Bundle;
  * @see {@link ThingTypeI18nLocalizationService}
  * @see {@link ChannelGroupTypeI18nLocalizationService}
  *
- * @author Henning Treu - initial contribution
- *
+ * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public class ChannelI18nUtil {


### PR DESCRIPTION
- Separate i18n infrastructure for `ChannelGroup`
- Use constructor dependency injection

Follow-Up on https://github.com/eclipse/smarthome/pull/6072#discussion_r210986246

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>