### PR TITLE
[archetype] Fixed generation of binding skeletons

### DIFF
--- a/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -75,33 +75,6 @@ def addBundleToBom(bundleAfter, newBundle) {
      println 'Added bundle to bom pom'
 }
 
-/**
- * Add the new bundle to the feature.xml
- */
-def addBundleToFeature(bundleAfter, newBundle, bundleName) {
-    def feature = '''
-    <feature name="##1" description="##2 Binding" version="${project.version}">
-        <feature>openhab-runtime-base</feature>
-        <bundle start-level="80">mvn:org.openhab.addons.bundles/##3/${project.version}</bundle>
-    </feature>
-'''.replace('##1', newBundle.replace('org.', '').replace('.', '-')).replace('##2', bundleName).replace('##3', newBundle)
-    def bomFile = new File(outputDirectory, '../features/openhab-addons/src/main/feature/feature.xml')
-    def newContent = ''
-    def insertIndex = 0;
-    def lines = bomFile.eachLine { line, index ->
-        newContent += line + nl
-        if (line.contains(bundleAfter) && line.contains('<bundle')) {
-            insertIndex = index + 1
-        }
-        if (insertIndex > 0 && index == insertIndex) {
-            newContent += feature
-            insertIndex = 0
-        }
-    }
-     bomFile.write(newContent)
-     println 'Added bundle to feature.xml'
-}
-
 //
 /**
  * Fix the bundle parent pom. The maven archytype adds the bundle, but add the end of the module list.
@@ -139,7 +112,6 @@ if (codeownersFile.exists()) {
     println 'Add new bundle after: ' + bundleAfter
     addUserToCodewoners(githubUser, codeownersFile, bundleAfter, newBundle)
     addBundleToBom(bundleAfter, newBundle)
-    addBundleToFeature(bundleAfter, newBundle, bundleName)
     fixBundlePom(bundleAfter, newBundle)
 
     println ''

--- a/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -35,6 +35,12 @@
 			</includes>
 		</fileSet>
 		<fileSet filtered="true" packaged="false" encoding="UTF-8">
+			<directory>src/main/feature</directory>
+			<includes>
+				<include>feature.xml</include>
+			</includes>
+		</fileSet>
+		<fileSet filtered="true" packaged="false" encoding="UTF-8">
 			<directory>src/main/resources/ESH-INF</directory>
 			<includes>
 				<include>**/*.*</include>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features name="${rootArtifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+    <repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+
+    <feature name="openhab-binding-${bindingId}" description="${bindingIdCamelCase} Binding" version="${project.version}">
+        <feature>openhab-runtime-base</feature>
+        <bundle start-level="80">mvn:org.openhab.addons.bundles/${rootArtifactId}/${project.version}</bundle>
+    </feature>
+</features>


### PR DESCRIPTION
- Fixed generation of binding skeletons

After https://github.com/openhab/openhab2-addons/pull/5555 which splitted the feature file into separate files we need some adjustments in the skeleton script

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.1.0:generate (default-cli) on project org.openhab.addons.reactor.bundles: java.io.FileNotFoundException: /home/christoph/Downloads/openhab-master/git/openhab2-addons/bundles/../features/karaf/openhab-addons/src/main/feature/feature.xml (Datei oder Verzeichnis nicht gefunden) -> [Help 1]
```

@J-N-K @Hilbrand May I ask you for validation? Thanks.

Also-by: Hilbrand Bouwkamp <hilbrand@h72.nl>
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>