### PR TITLE
set http context ID for smarthome HTTP context

### DIFF
--- a/bundles/org.openhab.core.io.http/src/main/java/org/eclipse/smarthome/io/http/internal/SmartHomeHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/eclipse/smarthome/io/http/internal/SmartHomeHttpContext.java
@@ -42,7 +42,8 @@ import org.osgi.service.http.HttpContext;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
-@Component(service = { HttpContext.class, WrappingHttpContext.class })
+@Component(service = { HttpContext.class, WrappingHttpContext.class }, property = {
+        "httpContext.id:String=oh-dfl-http-ctx" })
 public class SmartHomeHttpContext implements WrappingHttpContext {
 
     /**


### PR DESCRIPTION
The Pax Web Extender is much more happy if this property is present.
Let's make it happy...

Fixes: https://github.com/openhab/openhab-distro/issues/891