### PR TITLE
MQTT: disable https hostname verification

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -206,7 +206,7 @@
     <dependency>
       <groupId>org.eclipse.paho</groupId>
       <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -632,6 +632,7 @@ public class MqttBrokerConnection {
         }
 
         options.setKeepAliveInterval(keepAliveInterval);
+        options.setHttpsHostnameVerificationEnabled(false);
         return options;
     }
 


### PR DESCRIPTION
After the bump of Paho from 1.2.0 to 1.2.1 the library enables the https hostname verification.
This breaks compatibility with current consumers.
Connections cannot be established anymore.

We disable the https hostname verification to keep the old behaviour.
We should add an API so the hostname verification can be enabled if desired.

This also makes the version 1.2.1 the lower version limit as we need to use the API to disable the verification internally.

Related to: https://github.com/openhab/openhab-core/issues/815