### PR TITLE
Use correct profile builder

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/i18n/ProfileTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/i18n/ProfileTypeI18nLocalizationService.java
@@ -50,7 +50,7 @@ public class ProfileTypeI18nLocalizationService {
         String label = profileI18nUtil.getProfileLabel(bundle, profileTypeUID, defaultLabel, locale);
 
         if (profileType instanceof StateProfileType) {
-            return ProfileTypeBuilder.newTrigger(profileTypeUID, label != null ? label : defaultLabel)
+            return ProfileTypeBuilder.newState(profileTypeUID, label != null ? label : defaultLabel)
                     .withSupportedItemTypes(profileType.getSupportedItemTypes())
                     .withSupportedItemTypesOfChannel(((StateProfileType) profileType).getSupportedItemTypesOfChannel())
                     .build();


### PR DESCRIPTION
- Use `newState` profile builder for `StateProfileType`s

Fixes #830

Shall I add an assertion to the unit tests to count the number of available `StateProfileTypes` and `TriggerProfileTypes`?

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>