### PR TITLE
Use nrjavaserial 3.15.0.OH2 in BOMs

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -232,14 +232,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.openhab</groupId>
+      <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <!-- Use "no liblockdev" version -->
-      <!-- See: https://github.com/openhab/openhab-core/pull/761 -->
-      <!-- See: https://github.com/openhab/openhab-core/issues/750 -->
-      <!-- <groupId>com.neuronrobotics</groupId> -->
-      <!-- <version>3.15.0</version> -->
-      <version>3.15.0.OH2</version>
+      <version>3.14.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -232,9 +232,14 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>com.neuronrobotics</groupId>
+      <groupId>org.openhab</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.14.0</version>
+      <!-- Use "no liblockdev" version -->
+      <!-- See: https://github.com/openhab/openhab-core/pull/761 -->
+      <!-- See: https://github.com/openhab/openhab-core/issues/750 -->
+      <!-- <groupId>com.neuronrobotics</groupId> -->
+      <!-- <version>3.15.0</version> -->
+      <version>3.15.0.OH2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -442,9 +442,14 @@
 
     <!-- All serial transports -->
     <dependency>
-      <groupId>com.neuronrobotics</groupId>
+      <groupId>org.openhab</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.15.0</version>
+      <!-- Use "no liblockdev" version -->
+      <!-- See: https://github.com/openhab/openhab-core/pull/761 -->
+      <!-- See: https://github.com/openhab/openhab-core/issues/750 -->
+      <!-- <groupId>com.neuronrobotics</groupId> -->
+      <!-- <version>3.15.0</version> -->
+      <version>3.15.0.OH2</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
When debugging openHAB in Eclipse I ran into serial port locking issues again on Ubuntu 18.04.2.
We resolved these in the distro by using 3.15.0.OH2 which doesn't use liblockdev.

Errors similar to the one below may show after stopping/restarting openHAB when using serial ports on certain distros:

```
RXTX fhs_lock() Error: opening lock file: /var/lock/LCK..ttyUSB0: File exists. It is mine

testRead() Lock file failed
````

See also: https://github.com/openhab/openhab-core/pull/761