### PR TITLE
split activation logic

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -109,10 +109,10 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         this.thingTypeRegistry = thingTypeRegistry;
         this.thingRegistry = thingRegistry;
         this.inbox = inbox;
+    }
 
-        // This should be the last step (to be more precise: providing the "this" reference to other ones as long as
-        // the constructor is not finished is a bad idea at all) as "this" will be used by another thread and so we need
-        // an already fully instantiated object.
+    @Activate
+    protected void activate() {
         this.thingRegistry.addRegistryChangeListener(this);
         this.inbox.addInboxListener(this);
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -138,7 +138,7 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
     private final ConfigDescriptionRegistry configDescRegistry;
     private final Storage<DiscoveryResult> discoveryResultStorage;
     private final Map<DiscoveryResult, Class<?>> resultDiscovererMap = new ConcurrentHashMap<>();
-    private ScheduledFuture<?> timeToLiveChecker;
+    private @NonNullByDefault({}) ScheduledFuture<?> timeToLiveChecker;
     private @Nullable EventPublisher eventPublisher;
     private final List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<>();
 
@@ -156,10 +156,10 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
         this.managedThingProvider = thingProvider;
         this.thingTypeRegistry = thingTypeRegistry;
         this.configDescRegistry = configDescriptionRegistry;
+    }
 
-        // This should be the last steps (to be more precise: providing the "this" reference to other ones as long as
-        // the constructor is not finished is a bad idea at all) as "this" will be used by another thread and so we need
-        // already fully instantiated object.
+    @Activate
+    protected void activate() {
         this.discoveryServiceRegistry.addDiscoveryListener(this);
         this.thingRegistry.addRegistryChangeListener(this);
         this.timeToLiveChecker = ThreadPoolManager.getScheduledPool("discovery")

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -157,8 +157,10 @@ public class AutomaticInboxProcessorTest {
         inbox = new PersistentInbox(new VolatileStorageService(), mock(DiscoveryServiceRegistry.class), thingRegistry,
                 thingProvider, thingTypeRegistry, configDescriptionRegistry);
         inbox.addThingHandlerFactory(thingHandlerFactory);
+        inbox.activate();
 
         automaticInboxProcessor = new AutomaticInboxProcessor(thingTypeRegistry, thingRegistry, inbox);
+        automaticInboxProcessor.activate();
     }
 
     @After

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInboxTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInboxTest.java
@@ -100,6 +100,7 @@ public class PersistentInboxTest {
         inbox = new PersistentInbox(storageService, mock(DiscoveryServiceRegistry.class), thingRegistry, thingProvider,
                 thingTypeRegistry, configDescriptionRegistry);
         inbox.addThingHandlerFactory(thingHandlerFactory);
+        inbox.activate();
     }
 
     @Test


### PR DESCRIPTION
If a component should be activated an instance is constructed and that object is activated.
Let's split the construction and activation logic also if constructor injection is used.
