### PR TITLE
Use bnd for including resources to workaround infinite Eclipse builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,18 +139,6 @@
   </pluginRepositories>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>.</directory>
-        <includes>
-          <include>NOTICE</include>
-          <include>*.xsd</include>
-        </includes>
-      </resource>
-    </resources>
     <pluginManagement>
       <plugins>
 
@@ -177,7 +165,8 @@ Import-Package: \\
   org.openhab.*,\\
   org.eclipse.smarthome.*
 -sources: false
--contract: *]]></bnd>
+-contract: *
+-includeresource: -${.}/NOTICE, -${.}/*.xsd]]></bnd>
             <!-- Bundle-SymbolicName: ${project.groupId}.${project.artifactId} -->
           </configuration>
           <executions>


### PR DESCRIPTION
When "Build Automatically" is enabled in Eclipse, the build never ends.
It seems there is a bnd issue with the way resources are defined in the reactor POM.
The workaround seems to be to include all resources using bnd.

See also:

* https://github.com/bndtools/bnd/issues/3220
* https://github.com/openhab/openhab2-addons/issues/5554