### PR TITLE
UIDs: Allow percent character

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/AbstractUID.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public abstract class AbstractUID {
 
-    public static final String SEGMENT_PATTERN = "[A-Za-z0-9_-]*";
+    public static final String SEGMENT_PATTERN = "[\\w-%]*";
     public static final String SEPARATOR = ":";
     private final List<String> segments;
 


### PR DESCRIPTION
Extend the current regex expression to allow UID segments to contain percent characters.

This helps a lot if you need to map arbitrary utf8 strings (like in MQTT where I need to map topics to channel IDs),
because you can use URI percentage encoding.

See also: https://github.com/openhab/openhab2-addons/issues/5632#issuecomment-498185568

Signed-off-by: David Graeff <david.graeff@web.de>