### PR TITLE
Update ChannelUID.java

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ChannelUID extends UID {
 
-    private static final String CHANNEL_SEGMENT_PATTERN = "[\\w-]*|[\\w-]*#[\\w-]*";
+    private static final String CHANNEL_SEGMENT_PATTERN = "[\\w-%]*|[\\w-%]*#[\\w-]*";
     private static final String CHANNEL_GROUP_SEPARATOR = "#";
 
     /**


### PR DESCRIPTION
Extend the current regex expression to allow UID segments to contain percent characters.

This helps a lot if you need to map arbitrary utf8 strings (like in MQTT where I need to map topics to channel IDs),
because you can use URI percentage encoding.

Signed-off-by: David Graeff <david.graeff@web.de>