### PR TITLE
move event logging for better analyze options

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -130,6 +130,7 @@ public class EventHandler {
         for (final EventSubscriber eventSubscriber : eventSubscribers) {
             EventFilter filter = eventSubscriber.getEventFilter();
             if (filter == null || filter.apply(event)) {
+                logger.trace("Delegate event to subscriber ({}).", eventSubscriber.getClass());
                 safeCaller.create(eventSubscriber, EventSubscriber.class).withAsync().onTimeout(() -> {
                     logger.warn("Dispatching event to subscriber '{}' takes more than {}ms.",
                             eventSubscriber.toString(), SafeCaller.DEFAULT_TIMEOUT);
@@ -137,6 +138,8 @@ public class EventHandler {
                     logger.error("Dispatching/filtering event for subscriber '{}' failed: {}",
                             EventSubscriber.class.getName(), e.getMessage(), e);
                 }).build().receive(event);
+            } else {
+                logger.trace("Skip event subscriber ({}) because of its filter.", eventSubscriber.getClass());
             }
         }
     }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -56,8 +56,6 @@ public class EventHandler {
     }
 
     public void handleEvent(org.osgi.service.event.Event osgiEvent) {
-        logger.trace("Handle OSGi event (event: {})", osgiEvent);
-
         Object typeObj = osgiEvent.getProperty("type");
         Object payloadObj = osgiEvent.getProperty("payload");
         Object topicObj = osgiEvent.getProperty("topic");

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -58,7 +58,9 @@ public class ThreadedEventHandler implements Closeable {
             final EventHandler worker = new EventHandler(typedEventSubscribers, typedEventFactories, safeCaller);
             while (running.get()) {
                 try {
+                    logger.trace("wait for event");
                     final Event event = queue.poll(1, TimeUnit.HOURS);
+                    logger.trace("inspect event: {}", event);
                     if (event == null) {
                         logger.debug("Hey, you have really very few events.");
                     } else if (event == notifyEvent) {


### PR DESCRIPTION
Move the event logging to the place the event is taken from queue and add a message to signal that we wait for an event.

This just move the trace logging to another place to allow a better log of the time consumed for event handling and waiting.