### PR TITLE
Fix Jetty warnings by excluding weak cipher suites

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
@@ -386,8 +386,11 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
             }
         }
 
-        String excludeCipherSuites[] = { "^.*_(MD5)$" };
-        sslContextFactory.setExcludeCipherSuites(excludeCipherSuites);
+        // Exclude weak / insecure ciphers
+        sslContextFactory.addExcludeCipherSuites("^.*_(MD5|SHA|SHA1)$");
+        // Exclude ciphers that don't support forward secrecy
+        sslContextFactory.addExcludeCipherSuites("^TLS_RSA_.*$");
+
         return sslContextFactory;
     }
 


### PR DESCRIPTION
Newer Jetty versions log warnings when weak cipher suites are configured.
This occurs when using Karaf 4.2.6 with Jetty 9.4.18.v20190429.

See also:
* https://github.com/eclipse/jetty.project/pull/3050
* https://github.com/openhab/openhab-distro/pull/900#issuecomment-495381858

Fixes the following warnings:

```
22:25:04.336 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA256 enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.338 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.339 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.340 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.340 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.340 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.341 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.347 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.351 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_DSS_WITH_AES_256_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.352 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA256 enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.352 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.354 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.355 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.356 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.359 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.359 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.360 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.361 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_DSS_WITH_AES_128_CBC_SHA enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.361 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_GCM_SHA384 enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.362 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_GCM_SHA256 enabled for SslContextFactory@12d643d6[provider=null,keyStore=null,trustStore=null]
22:25:04.379 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA256 enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.379 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.380 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.380 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.381 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.381 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.382 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.383 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_RSA_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.384 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_DSS_WITH_AES_256_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.384 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA256 enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.385 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.386 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.386 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.387 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.388 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.389 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_ECDH_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.389 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_RSA_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.390 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_DHE_DSS_WITH_AES_128_CBC_SHA enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.391 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_256_GCM_SHA384 enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
22:25:04.391 [WARN ] [tty.util.ssl.SslContextFactory.config] - Weak cipher suite TLS_RSA_WITH_AES_128_GCM_SHA256 enabled for SslContextFactory@39765aa[provider=null,keyStore=null,trustStore=null]
```