### PR TITLE
don't use safe caller for event delegation to subscribers

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
 import org.eclipse.smarthome.core.events.EventSubscriber;
@@ -51,11 +50,9 @@ public class OSGiEventManager implements EventHandler {
 
     private ThreadedEventHandler eventHandler;
 
-    private SafeCaller safeCaller;
-
     @Activate
     protected void activate(ComponentContext componentContext) {
-        eventHandler = new ThreadedEventHandler(typedEventSubscribers, typedEventFactories, safeCaller);
+        eventHandler = new ThreadedEventHandler(typedEventSubscribers, typedEventFactories);
         eventHandler.open();
     }
 
@@ -114,15 +111,6 @@ public class OSGiEventManager implements EventHandler {
         for (String supportedEventType : supportedEventTypes) {
             typedEventFactories.remove(supportedEventType);
         }
-    }
-
-    @Reference
-    protected void setSafeCaller(SafeCaller safeCaller) {
-        this.safeCaller = safeCaller;
-    }
-
-    protected void unsetSafeCaller(SafeCaller safeCaller) {
-        this.safeCaller = null;
     }
 
     @Override


### PR DESCRIPTION
This changes should address #829 

At the moment we warn if an event subscriber exceeds the limit of expected max. runtime.
This has been done before, too.
It would also be possible (which another implementation I played around today, too) to interrupt the event subscriber if it exceeds the limit. I don't think we should do this. This could perhaps lead into a very confusion behaviour on very high load. The warning should be enough to detect a really bad working event subscriber.