### PR TITLE
Fix serial ports missing when ports are added to system property

### DIFF
--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortUtil.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortUtil.java
@@ -13,6 +13,8 @@
 package org.eclipse.smarthome.io.transport.serial.internal;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -21,28 +23,84 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
+import gnu.io.CommPortIdentifier;
+import gnu.io.NoSuchPortException;
+
 /**
  *
  * @author Matthias Steigenberger - Initial Contribution
- *
+ * @author Wouter Born - Fix serial ports missing when ports are added to system property
  */
 @NonNullByDefault
 public class SerialPortUtil {
 
     private static final String GNU_IO_RXTX_SERIAL_PORTS = "gnu.io.rxtx.SerialPorts";
 
+    private synchronized static boolean isSerialPortsKeySet() {
+        return System.getProperties().containsKey(GNU_IO_RXTX_SERIAL_PORTS);
+    }
+
+    public synchronized static CommPortIdentifier getPortIdentifier(String port) throws NoSuchPortException {
+        if ((System.getProperty("os.name").toLowerCase().indexOf("linux") != -1)) {
+            appendSerialPortProperty(port);
+        }
+
+        return CommPortIdentifier.getPortIdentifier(port);
+    }
+
     /**
-     * Registers the given port as system property {@value #GNU_IO_RXTX_SERIAL_PORTS}. The method is capable of
-     * extending the system property, if any other ports are already registered.
+     * Registers the given port as system property {@value #GNU_IO_RXTX_SERIAL_PORTS}.
+     * The method is capable of extending the system property, if any other ports are already registered.
      *
      * @param port the port to be registered
      */
-    public synchronized static void appendSerialPortProperty(String port) {
+    private synchronized static void appendSerialPortProperty(String port) {
         String serialPortsProperty = System.getProperty(GNU_IO_RXTX_SERIAL_PORTS);
         String newValue = initSerialPort(port, serialPortsProperty);
         if (newValue != null) {
             System.setProperty(GNU_IO_RXTX_SERIAL_PORTS, newValue);
         }
+    }
+
+    /**
+     * Scans for available port identifiers by calling RXTX without using the ({@value #GNU_IO_RXTX_SERIAL_PORTS}
+     * property. Finds port identifiers based on operating system and distribution.
+     *
+     * @return the scanned port identifiers
+     */
+    @SuppressWarnings("unchecked")
+    public synchronized static Stream<CommPortIdentifier> getPortIdentifiersUsingScan() {
+        Enumeration<CommPortIdentifier> identifiers;
+        if (isSerialPortsKeySet()) {
+            // Save the existing serial ports property
+            String value = System.getProperty(GNU_IO_RXTX_SERIAL_PORTS);
+            // Clear the property so library scans the ports
+            System.clearProperty(GNU_IO_RXTX_SERIAL_PORTS);
+            identifiers = CommPortIdentifier.getPortIdentifiers();
+            // Restore the existing serial ports property
+            System.setProperty(GNU_IO_RXTX_SERIAL_PORTS, value);
+        } else {
+            identifiers = CommPortIdentifier.getPortIdentifiers();
+        }
+
+        // Save the Enumeration to a new list so the result is thread safe
+        return Collections.list(identifiers).stream();
+    }
+
+    /**
+     * Get the port identifiers for the ports in the system property by calling RXTX while using the
+     * ({@value #GNU_IO_RXTX_SERIAL_PORTS} property.
+     *
+     * @return the port identifiers for the ports defined in the {@value #GNU_IO_RXTX_SERIAL_PORTS} property
+     */
+    @SuppressWarnings("unchecked")
+    public synchronized static Stream<CommPortIdentifier> getPortIdentifiersUsingProperty() {
+        if (isSerialPortsKeySet()) {
+            // Save the Enumeration to a new list so the result is thread safe
+            return Collections.list(CommPortIdentifier.getPortIdentifiers()).stream();
+        }
+
+        return Stream.empty();
     }
 
     static @Nullable String initSerialPort(String port, @Nullable String serialPortsProperty) {


### PR DESCRIPTION
* Get all serial port identifiers by calling RXTX with and without using the `gnu.io.rxtx.SerialPorts` property
* Filter `getSerialPortIdentifiers()` stream on distinct port names
* Fix thread safety issues by saving `getPortIdentifiers()` Enumeration result to new list

Fixes #805