### PR TITLE
don't drop the itests projects from reactor on skipTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>bundles</module>
     <module>features</module>
     <module>tools</module>
+    <module>itests</module>
   </modules>
 
   <scm>
@@ -699,28 +700,6 @@ Import-Package: \\
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>skip-itest</id>
-      <activation>
-        <property>
-          <name>!skipTests</name>
-        </property>
-      </activation>
-      <modules>
-        <module>itests</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>release</id>
-      <activation>
-        <property>
-          <name>release</name>
-        </property>
-      </activation>
-      <modules>
-        <module>itests</module>
-      </modules>
     </profile>
     <profile>
       <id>with-bnd-resolver-resolve</id>


### PR DESCRIPTION
The bnd-testing-maven-plugin that is used to run the tests already checks for the skipTests property and do not execute any tests if defined.
We should keep the integration tests part of the reactor also if the tests are not executed.
