### PR TITLE
compine filter and map for tooling

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/ExtensibleTrustManagerImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/ExtensibleTrustManagerImpl.java
@@ -161,8 +161,7 @@ public class ExtensibleTrustManagerImpl extends X509ExtendedTrustManager impleme
                     .map(e -> e.get(1))
                     .map(Object::toString)
                     .map(linkedTrustManager::get)
-                    .filter(Objects::nonNull)
-                    .map(Queue::peek)
+                    .map(queue -> queue == null ? null : queue.peek())
                     .filter(Objects::nonNull)
                     .findFirst()
                     .orElse(null);


### PR DESCRIPTION
It should not matter if the instructions are split or not.
But if it is split the nullness tooling don't know that the stream
after the filter contains only non null elements.
As it should not matter and to make the tooling happy...
