### PR TITLE
Reduce polling frequency of usb serial scanner

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -54,7 +54,7 @@ public class PollingUsbSerialScanner implements UsbSerialDiscovery {
     private static final String THREAD_NAME = "usb-serial-discovery-linux-sysfs";
 
     public static final String PAUSE_BETWEEN_SCANS_IN_SECONDS_ATTRIBUTE = "pauseBetweenScansInSeconds";
-    private static final Duration DEFAULT_PAUSE_BETWEEN_SCANS = Duration.ofSeconds(5);
+    private static final Duration DEFAULT_PAUSE_BETWEEN_SCANS = Duration.ofSeconds(60);
     private Duration pauseBetweenScans = DEFAULT_PAUSE_BETWEEN_SCANS;
 
     private @NonNullByDefault({}) DeltaUsbSerialScanner deltaUsbSerialScanner;

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -54,7 +54,7 @@ public class PollingUsbSerialScanner implements UsbSerialDiscovery {
     private static final String THREAD_NAME = "usb-serial-discovery-linux-sysfs";
 
     public static final String PAUSE_BETWEEN_SCANS_IN_SECONDS_ATTRIBUTE = "pauseBetweenScansInSeconds";
-    private static final Duration DEFAULT_PAUSE_BETWEEN_SCANS = Duration.ofSeconds(60);
+    private static final Duration DEFAULT_PAUSE_BETWEEN_SCANS = Duration.ofSeconds(15);
     private Duration pauseBetweenScans = DEFAULT_PAUSE_BETWEEN_SCANS;
 
     private @NonNullByDefault({}) DeltaUsbSerialScanner deltaUsbSerialScanner;


### PR DESCRIPTION
As discussed in a side discussion in issue #829 the most CPU consumption (after #763 and #861 have been implemented) is the USB polling.
I'd propose to reduce the polling frequency from 5 to 60 sec.

Signed-off-by: Björn Brings <bjoernbrings@web.de>