### PR TITLE
add launch configuration to generate the model sources

### DIFF
--- a/tools/oomph/ModelGen.launch
+++ b/tools/oomph/ModelGen.launch
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="-DskipChecks -DskipTests clean install -am -pl bundles/org.openhab.core.model.core -pl bundles/org.openhab.core.model.item -pl bundles/org.openhab.core.model.item.ide -pl bundles/org.openhab.core.model.lazygen -pl bundles/org.openhab.core.model.persistence -pl bundles/org.openhab.core.model.persistence.ide -pl bundles/org.openhab.core.model.rule -pl bundles/org.openhab.core.model.rule.ide -pl bundles/org.openhab.core.model.script -pl bundles/org.openhab.core.model.script.ide -pl bundles/org.openhab.core.model.sitemap -pl bundles/org.openhab.core.model.sitemap.ide -pl bundles/org.openhab.core.model.thing -pl bundles/org.openhab.core.model.thing.ide"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="QT_QPA_PLATFORM" value=""/>
+</mapAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.openhab.core.tools.oomph}/../.."/>
+</launchConfiguration>


### PR DESCRIPTION
This launch configuration should be executed in the distros Oomph setup
as a one time job on first installation (I assume something like
`excludedTriggers="STARTUP MANUAL"`).

If it is executed by as setup instsructions no parallel auto build will
be triggered. If (for testing) executed inside a running IDE manually,
the automatic build should be disabled and a refresh should be triggered
in front of enabling it again.

If you integrate that in the Oomph Distro setup, I assume you can use
the core setup file (not used by others then me I assume) as a template
(and remove it now).

I assume it can be placed after the import task of core and beore a
build task of all projects.

```xml
    <setupTask
        xsi:type="projects:ProjectsImportTask">
      <sourceLocator
          rootFolder="${git.clone.openhabcore.location}"
          locateNestedProjects="true"/>
    </setupTask>
    <setupTask
        xsi:type="launching:LaunchTask"
        id="launch.model.gen"
        excludedTriggers="STARTUP"
        launcher="ModelGen"/>
    <setupTask
        xsi:type="projects:ProjectsBuildTask"
        excludedTriggers="STARTUP"
        refresh="true"
        clean="true"/>
    <setupTask
        xsi:type="setup:ResourceCreationTask"
        id="lifecycle-mapping"
```

Related to: https://github.com/openhab/openhab-distro/issues/927