### PR TITLE
Do not create a second instance of the StateDescriptionFragment on build

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionFragmentBuilder.java
@@ -62,7 +62,7 @@ public class StateDescriptionFragmentBuilder {
      * @return a {@link StateDescriptionFragment} from the values of this builder.
      */
     public StateDescriptionFragment build() {
-        return new StateDescriptionFragmentImpl(fragment);
+        return fragment;
     }
 
     /**


### PR DESCRIPTION
- Do not create a second instance of the `StateDescriptionFragment` on build but return the internal instance like we do it in other builders too

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>