### PR TITLE
[automation] Added nullness annotations

### DIFF
--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
@@ -17,18 +17,16 @@ import java.util.Map;
 import org.eclipse.smarthome.core.audio.AudioException;
 import org.eclipse.smarthome.core.audio.AudioManager;
 import org.openhab.core.automation.Action;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This is an ModuleHandler implementation for Actions that play a sound file from the file system.
  *
- * @author Kai Kreuzer - Initial contribution and API
- *
+ * @author Kai Kreuzer - Initial contribution
  */
-public class PlayActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class PlayActionHandler extends BaseActionModuleHandler {
 
     public static final String TYPE_ID = "media.PlayAction";
     public static final String PARAM_SOUND = "sound";

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
@@ -16,16 +16,14 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.voice.VoiceManager;
 import org.openhab.core.automation.Action;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 
 /**
  * This is an ModuleHandler implementation for Actions that trigger a TTS output through "say".
  *
- * @author Kai Kreuzer - Initial contribution and API
- *
+ * @author Kai Kreuzer - Initial contribution
  */
-public class SayActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class SayActionHandler extends BaseActionModuleHandler {
 
     public static final String TYPE_ID = "media.SayAction";
     public static final String PARAM_TEXT = "text";

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
@@ -18,16 +18,15 @@ import java.util.Map;
 import java.util.Set;
 
 import org.openhab.core.automation.Action;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.openhab.core.automation.module.script.rulesupport.shared.simple.SimpleActionHandler;
 
 /**
  * The SimpleActionHandlerDelegate allows the registration of {@link SimpleActionHandler}s to the RuleManager.
  *
- * @author Simon Merschjohann
+ * @author Simon Merschjohann - Initial contribution
  */
-public class SimpleActionHandlerDelegate extends BaseModuleHandler<Action> implements ActionHandler {
+public class SimpleActionHandlerDelegate extends BaseActionModuleHandler {
 
     private org.openhab.core.automation.module.script.rulesupport.shared.simple.SimpleActionHandler actionHandler;
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleConditionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleConditionHandlerDelegate.java
@@ -15,17 +15,15 @@ package org.openhab.core.automation.module.script.rulesupport.internal.delegates
 import java.util.Map;
 
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.openhab.core.automation.module.script.rulesupport.shared.simple.SimpleConditionHandler;
 
 /**
  * The SimpleConditionHandlerDelegate allows the registration of {@link SimpleConditionHandler}s to the RuleManager.
  *
- * @author Simon Merschjohann
- *
+ * @author Simon Merschjohann - Initial contribution
  */
-public class SimpleConditionHandlerDelegate extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class SimpleConditionHandlerDelegate extends BaseConditionModuleHandler {
 
     private SimpleConditionHandler conditionHandler;
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerDelegate.java
@@ -14,16 +14,16 @@ package org.openhab.core.automation.module.script.rulesupport.internal.delegates
 
 import org.openhab.core.automation.ModuleHandlerCallback;
 import org.openhab.core.automation.Trigger;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.TriggerHandler;
+import org.openhab.core.automation.handler.BaseTriggerModuleHandler;
 import org.openhab.core.automation.handler.TriggerHandlerCallback;
 
 /**
  * The {@link SimpleTriggerHandlerDelegate} allows to define triggers in a script language in different ways.
  *
- * @author Simon Merschjohann
+ * @author Simon Merschjohann - Initial contribution
  */
-public class SimpleTriggerHandlerDelegate extends BaseModuleHandler<Trigger> implements TriggerHandler {
+public class SimpleTriggerHandlerDelegate extends BaseTriggerModuleHandler {
+
     private final org.openhab.core.automation.module.script.rulesupport.shared.simple.SimpleTriggerHandler triggerHandler;
 
     public SimpleTriggerHandlerDelegate(Trigger module,

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.handler.BaseModuleHandler;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
@@ -36,7 +38,9 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> the type of module the concrete handler can handle
  */
+@NonNullByDefault
 public abstract class AbstractScriptModuleHandler<T extends Module> extends BaseModuleHandler<T> {
+
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /** Constant defining the configuration parameter of modules that specifies the mime type of a script */
@@ -45,13 +49,13 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     /** Constant defining the configuration parameter of modules that specifies the script itself */
     protected static final String SCRIPT = "script";
 
-    protected ScriptEngineManager scriptEngineManager;
+    protected final ScriptEngineManager scriptEngineManager;
 
     private final String engineIdentifier;
 
     private Optional<ScriptEngine> scriptEngine = Optional.empty();
-    private String type;
-    protected String script;
+    private @NonNullByDefault({}) String type;
+    protected @NonNullByDefault({}) String script;
 
     private final String ruleUID;
 
@@ -59,16 +63,14 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         super(module);
         this.scriptEngineManager = scriptEngineManager;
         this.ruleUID = ruleUID;
-        engineIdentifier = UUID.randomUUID().toString();
+        this.engineIdentifier = UUID.randomUUID().toString();
 
         loadConfig();
     }
 
     @Override
     public void dispose() {
-        if (scriptEngine != null) {
-            scriptEngineManager.removeEngine(engineIdentifier);
-        }
+        scriptEngineManager.removeEngine(engineIdentifier);
     }
 
     protected Optional<ScriptEngine> getScriptEngine() {
@@ -91,16 +93,18 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         Object type = module.getConfiguration().get(SCRIPT_TYPE);
         Object script = module.getConfiguration().get(SCRIPT);
         if (!isValid(type)) {
-            throw new IllegalStateException(String.format("Type is missing in the configuration of module '%s'.", module.getId()));
+            throw new IllegalStateException(
+                    String.format("Type is missing in the configuration of module '%s'.", module.getId()));
         } else if (!isValid(script)) {
-            throw new IllegalStateException(String.format("Script is missing in the configuration of module '%s'.", module.getId()));
+            throw new IllegalStateException(
+                    String.format("Script is missing in the configuration of module '%s'.", module.getId()));
         } else {
             this.type = (String) type;
             this.script = (String) script;
         }
     }
-    
-    private boolean isValid(Object parameter) {
+
+    private boolean isValid(@Nullable Object parameter) {
         return parameter != null && parameter instanceof String && !((String) parameter).trim().isEmpty();
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -22,6 +22,7 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.handler.BaseModuleHandler;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
@@ -64,18 +65,17 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         this.ruleUID = ruleUID;
         this.engineIdentifier = UUID.randomUUID().toString();
 
-        this.type = getValidConfigParameter(SCRIPT_TYPE);
-        this.script = getValidConfigParameter(SCRIPT);
+        this.type = getValidConfigParameter(SCRIPT_TYPE, module.getConfiguration(), module.getId());
+        this.script = getValidConfigParameter(SCRIPT, module.getConfiguration(), module.getId());
     }
 
-    private String getValidConfigParameter(String parameter) {
-        Object value = module.getConfiguration().get(parameter);
+    private static String getValidConfigParameter(String parameter, Configuration config, String moduleId) {
+        Object value = config.get(parameter);
         if (value != null && value instanceof String && !((String) value).trim().isEmpty()) {
             return (String) value;
         } else {
-            throw new IllegalStateException(
-                    String.format("Config parameter '{}' is missing in the configuration of module '%s'.", parameter,
-                            module.getId()));
+            throw new IllegalStateException(String.format(
+                    "Config parameter '%s' is missing in the configuration of module '%s'.", parameter, moduleId));
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -17,6 +17,8 @@ import java.util.Map;
 
 import javax.script.ScriptException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.handler.ActionHandler;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
@@ -28,8 +30,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Simon Merschjohann
- *
  */
+@NonNullByDefault
 public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> implements ActionHandler {
 
     public static final String TYPE_ID = "script.ScriptAction";
@@ -51,8 +53,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
     }
 
     @Override
-    public Map<String, Object> execute(final Map<String, Object> context) {
-        HashMap<String, Object> resultMap = new HashMap<String, Object>();
+    public @Nullable Map<String, Object> execute(final Map<String, Object> context) {
+        HashMap<String, Object> resultMap = new HashMap<>();
 
         getScriptEngine().ifPresent(scriptEngine -> {
             setExecutionContext(scriptEngine, context);

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.handler.ConditionHandler;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
@@ -29,8 +30,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Simon Merschjohann
- *
  */
+@NonNullByDefault
 public class ScriptConditionHandler extends AbstractScriptModuleHandler<Condition> implements ConditionHandler {
 
     public static final String TYPE_ID = "script.ScriptCondition";
@@ -63,5 +64,4 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
 
         return result;
     }
-
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Trigger.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Trigger.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.automation;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.openhab.core.automation.type.Input;
 import org.openhab.core.automation.type.Output;
@@ -34,8 +35,9 @@ import org.openhab.core.automation.type.TriggerType;
  * Trigger modules are placed in <b>triggers</b> section of the {@link Rule} definition.
  *
  * @see Module
- * @author Yordan Mihaylov - Initial Contribution
+ * @author Yordan Mihaylov - Initial contribution
  */
+@NonNullByDefault
 public interface Trigger extends Module {
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
@@ -24,9 +24,10 @@ import org.openhab.core.automation.Trigger;
  * This interface should be implemented by external modules which provide functionality for processing {@link Action}
  * modules. This functionality is called to execute the {@link Action}s of the {@link Rule} when it is needed.
  *
- * @author Yordan Mihaylov - Initial Contribution
- * @author Ana Dimova - Initial Contribution
- * @author Vasil Ilchev - Initial Contribution
+ * @author Yordan Mihaylov - Initial contribution
+ * @author Ana Dimova - Initial contribution
+ * @author Vasil Ilchev - Initial ontribution
+ * @see ModuleHandler
  */
 @NonNullByDefault
 public interface ActionHandler extends ModuleHandler {
@@ -35,7 +36,7 @@ public interface ActionHandler extends ModuleHandler {
      * Called to execute an {@link Action} of the {@link Rule} when it is needed.
      *
      * @param context an unmodifiable map containing the outputs of the {@link Trigger} that triggered the {@link Rule},
-     *                the outputs of all preceding {@link Action}s, and the inputs for this {@link Action}.
+     *            the outputs of all preceding {@link Action}s, and the inputs for this {@link Action}.
      *
      * @return a map with the {@code outputs} which are the result of the {@link Action}'s execution (may be null).
      */

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseActionModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseActionModuleHandler.java
@@ -13,18 +13,18 @@
 package org.openhab.core.automation.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.Action;
 
 /**
- * This Handler interface is used by the RuleManager to set a callback interface to
- * itself. The callback has to implemented {@link TriggerHandlerCallback} interface
- * and it is used to notify the RuleManager when {@link TriggerHandler} was triggered
+ * This is a base class that can be used by ActionModuleHandler implementations
  *
- * @author Yordan Mihaylov - Initial contribution
- * @author Ana Dimova - Initial contribution
- * @author Vasil Ilchev - Initial contribution
- * @see ModuleHandler
+ * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public interface TriggerHandler extends ModuleHandler {
+public abstract class BaseActionModuleHandler extends BaseModuleHandler<Action> implements ActionHandler {
+
+    public BaseActionModuleHandler(Action module) {
+        super(module);
+    }
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseConditionModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseConditionModuleHandler.java
@@ -13,18 +13,18 @@
 package org.openhab.core.automation.handler;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.Condition;
 
 /**
- * This Handler interface is used by the RuleManager to set a callback interface to
- * itself. The callback has to implemented {@link TriggerHandlerCallback} interface
- * and it is used to notify the RuleManager when {@link TriggerHandler} was triggered
+ * This is a base class that can be used by ConditionModuleHandler implementations
  *
- * @author Yordan Mihaylov - Initial contribution
- * @author Ana Dimova - Initial contribution
- * @author Vasil Ilchev - Initial contribution
- * @see ModuleHandler
+ * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
-public interface TriggerHandler extends ModuleHandler {
+public abstract class BaseConditionModuleHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+
+    public BaseConditionModuleHandler(Condition module) {
+        super(module);
+    }
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandler.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.automation.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.ModuleHandlerCallback;
 
@@ -20,10 +22,11 @@ import org.openhab.core.automation.ModuleHandlerCallback;
  *
  * @author Kai Kreuzer - Initial Contribution
  */
+@NonNullByDefault
 public class BaseModuleHandler<T extends Module> implements ModuleHandler {
 
     protected T module;
-    protected ModuleHandlerCallback callback;
+    protected @Nullable ModuleHandlerCallback callback;
 
     public BaseModuleHandler(T module) {
         this.module = module;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseTriggerModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseTriggerModuleHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.automation.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Trigger;
 
 /**
@@ -19,6 +20,7 @@ import org.openhab.core.automation.Trigger;
  *
  * @author Vasil Ilchev - Initial contribution
  */
+@NonNullByDefault
 public class BaseTriggerModuleHandler extends BaseModuleHandler<Trigger> implements TriggerHandler {
 
     public BaseTriggerModuleHandler(Trigger module) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.handler;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.Trigger;
@@ -21,18 +22,19 @@ import org.openhab.core.automation.Trigger;
 /**
  * This interface provides common functionality for processing {@link Condition} modules.
  *
+ * @author Yordan Mihaylov - Initial contribution
+ * @author Ana Dimova - Initial contribution
+ * @author Vasil Ilchev - Initial contribution
  * @see ModuleHandler
- * @author Yordan Mihaylov - Initial Contribution
- * @author Ana Dimova - Initial Contribution
- * @author Vasil Ilchev - Initial Contribution
  */
+@NonNullByDefault
 public interface ConditionHandler extends ModuleHandler {
 
     /**
      * Checks if the Condition is satisfied in the given {@code context}.
      *
      * @param context an unmodifiable map containing the outputs of the {@link Trigger} that triggered the {@link Rule}
-     *                and the inputs of the {@link Condition}.
+     *            and the inputs of the {@link Condition}.
      * @return {@code true} if {@link Condition} is satisfied, {@code false} otherwise.
      */
     public boolean isSatisfied(Map<String, Object> context);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
@@ -19,7 +19,7 @@ import org.openhab.core.automation.ModuleHandlerCallback;
  * A common interface for all module Handler interfaces. The Handler interfaces are
  * bridge between RuleManager and external modules used by the RuleManager.
  *
- * @author Yordan Mihaylov - Initial Contribution
+ * @author Yordan Mihaylov - Initial contribution
  * @see ModuleHandlerFactory
  */
 @NonNullByDefault

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
@@ -23,8 +23,7 @@ import java.util.Map.Entry;
 
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.annotation.ActionInput;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.openhab.core.automation.type.ActionType;
 import org.openhab.core.automation.type.Input;
 import org.openhab.core.automation.type.Output;
@@ -34,10 +33,9 @@ import org.slf4j.LoggerFactory;
 /**
  * ActionHandler which is dynamically created upon annotation on services
  *
- * @author Stefan Triller - initial contribution
- *
+ * @author Stefan Triller - Initial contribution
  */
-public class AnnotationActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class AnnotationActionHandler extends BaseActionModuleHandler {
 
     private static final String MODULE_RESULT = "result";
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
@@ -21,8 +21,7 @@ import java.util.Map;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.openhab.core.automation.internal.module.exception.UncomparableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * @author Benedikt Niehues - Initial contribution and API
  *
  */
-public class CompareConditionHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class CompareConditionHandler extends BaseConditionModuleHandler {
 
     public final Logger logger = LoggerFactory.getLogger(CompareConditionHandler.class);
 
@@ -56,7 +55,8 @@ public class CompareConditionHandler extends BaseModuleHandler<Condition> implem
         String rightOperandString = (rightObj != null && rightObj instanceof String) ? (String) rightObj : null;
         Object leftObjFieldNameObj = this.module.getConfiguration().get(INPUT_LEFT_FIELD);
         String leftObjectFieldName = (leftObjFieldNameObj != null && leftObjFieldNameObj instanceof String)
-                ? (String) leftObjFieldNameObj : null;
+                ? (String) leftObjFieldNameObj
+                : null;
         if (rightOperandString == null || operator == null) {
             return false;
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DayOfWeekConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DayOfWeekConditionHandler.java
@@ -18,18 +18,16 @@ import java.util.Map;
 import java.util.Set;
 
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This is a ConditionHandler implementation, which checks the current day of the week against a specified list.
  *
- * @author Kai Kreuzer - Initial Contribution
- *
+ * @author Kai Kreuzer - Initial contribution
  */
-public class DayOfWeekConditionHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class DayOfWeekConditionHandler extends BaseConditionModuleHandler {
 
     private final Logger logger = LoggerFactory.getLogger(DayOfWeekConditionHandler.class);
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
@@ -16,19 +16,18 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.events.Event;
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This is the implementation of a event condition which checks if inputs matches configured values.
  *
- * @author Benedikt Niehues - Initial contribution and API
+ * @author Benedikt Niehues - Initial contribution
  * @author Kai Kreuzer - refactored and simplified customized module handling
- *
  */
-public class GenericEventConditionHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class GenericEventConditionHandler extends BaseConditionModuleHandler {
+
     public final Logger logger = LoggerFactory.getLogger(GenericEventConditionHandler.class);
 
     public static final String MODULETYPE_ID = "core.GenericEventCondition";

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
@@ -23,20 +23,18 @@ import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.openhab.core.automation.Action;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This is an implementation of an ActionHandler. It sends commands for items.
  *
- * @author Benedikt Niehues - Initial contribution and API
+ * @author Benedikt Niehues - Initial contribution
  * @author Kai Kreuzer - refactored and simplified customized module handling
  * @author Stefan Triller - use command from input first and if not set, use command from configuration
- *
  */
-public class ItemCommandActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class ItemCommandActionHandler extends BaseActionModuleHandler {
 
     private final Logger logger = LoggerFactory.getLogger(ItemCommandActionHandler.class);
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -21,19 +21,17 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * ConditionHandler implementation to check item state
  *
- * @author Benedikt Niehues - Initial contribution and API
+ * @author Benedikt Niehues - Initial contribution
  * @author Kai Kreuzer - refactored and simplified customized module handling
- *
  */
-public class ItemStateConditionHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class ItemStateConditionHandler extends BaseConditionModuleHandler {
 
     private final Logger logger = LoggerFactory.getLogger(ItemStateConditionHandler.class);
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
@@ -18,8 +18,7 @@ import java.util.Map;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.RuleRegistry;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,11 +38,10 @@ import org.slf4j.LoggerFactory;
  * }
  * </pre>
  *
- * @author Plamen Peev - Initial contribution and API
+ * @author Plamen Peev - Initial contribution
  * @author Kai Kreuzer - use rule engine instead of registry
- *
  */
-public class RuleEnablementActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class RuleEnablementActionHandler extends BaseActionModuleHandler {
 
     /**
      * This filed contains the type of this handler so it can be recognized from the factory.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
@@ -17,8 +17,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.openhab.core.automation.Action;
-import org.openhab.core.automation.handler.ActionHandler;
-import org.openhab.core.automation.handler.BaseModuleHandler;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +38,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Benedikt Niehues - Initial contribution
  * @author Kai Kreuzer - use rule engine instead of registry
- *
  */
-public class RunRuleActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
+public class RunRuleActionHandler extends BaseActionModuleHandler {
 
     /**
      * The UID for this handler for identification in the factory.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayConditionHandler.java
@@ -18,18 +18,16 @@ import java.util.Map;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.openhab.core.automation.Condition;
-import org.openhab.core.automation.handler.BaseModuleHandler;
-import org.openhab.core.automation.handler.ConditionHandler;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * ConditionHandler implementation for time based conditions.
  *
- * @author Dominik Schlierf - initial contribution
- *
+ * @author Dominik Schlierf - Initial contribution
  */
-public class TimeOfDayConditionHandler extends BaseModuleHandler<Condition> implements ConditionHandler {
+public class TimeOfDayConditionHandler extends BaseConditionModuleHandler {
 
     private final Logger logger = LoggerFactory.getLogger(TimeOfDayConditionHandler.class);
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/events/EventFilter.java
@@ -12,19 +12,24 @@
  */
 package org.eclipse.smarthome.core.events;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * An {@link EventFilter} can be provided by an {@link EventSubscriber} in order
  * to receive specific {@link Event}s by an {@link EventPublisher} if the filter applies.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
+@NonNullByDefault
 public interface EventFilter {
 
     /**
-     * Apply the filter on an event. <p> This method is called for each subscribed {@link Event} of an
+     * Apply the filter on an event.
+     * <p>
+     * This method is called for each subscribed {@link Event} of an
      * {@link EventSubscriber}. If the filter applies, the event will be dispatched to the
      * {@link EventSubscriber#receive(Event)} method.
-     * 
+     *
      * @param event the event (not null)
      * @return true if the filter criterion applies
      */


### PR DESCRIPTION
- Added nullness annotations

Therefore introduced two new classes `BaseActionModuleHandler` and `BaseConditionModuleHandler`. A [BaseTriggerModuleHandler](https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseTriggerModuleHandler.java) is already present.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>