### PR TITLE
fix nullness handling in itests

### DIFF
--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
@@ -53,20 +53,20 @@ public class DayOfWeekConditionHandlerTest extends BasicConditionHandlerTest {
                 .build();
         DayOfWeekConditionHandler handler = new DayOfWeekConditionHandler(condition);
 
-        assertThat(handler.isSatisfied(null), is(true));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(true));
 
         condition = ModuleBuilder.createCondition(condition)
                 .withConfiguration(new Configuration(Collections.singletonMap("days", Collections.emptyList())))
                 .build();
         handler = new DayOfWeekConditionHandler(condition);
-        assertThat(handler.isSatisfied(null), is(false));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(false));
 
         condition = ModuleBuilder.createCondition(condition)
                 .withConfiguration(
                         new Configuration(Collections.singletonMap("days", Collections.singletonList(dayOfWeek))))
                 .build();
         handler = new DayOfWeekConditionHandler(condition);
-        assertThat(handler.isSatisfied(null), is(true));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(true));
     }
 
     @Test

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThat;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -52,26 +53,26 @@ public class TimeOfDayConditionHandlerTest extends BasicConditionHandlerTest {
         // Time is between start and end time -> should return true.
         TimeOfDayConditionHandler handler = getTimeOfDayConditionHandler(beforeCurrentTime.toString(),
                 afterCurrentTime.toString());
-        assertThat(handler.isSatisfied(null), is(true));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(true));
 
         // Time is equal to start time -> should return true
         handler = getTimeOfDayConditionHandler(currentTime.toString(), afterCurrentTime.toString());
-        assertThat(handler.isSatisfied(null), is(true));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(true));
 
         // Time is equal to end time -> should return false
         handler = getTimeOfDayConditionHandler(beforeCurrentTime.toString(), currentTime.toString());
-        assertThat(handler.isSatisfied(null), is(false));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(false));
 
         // Start value is in the future & end value is in the past
         // -> should return false
         handler = getTimeOfDayConditionHandler(afterCurrentTime.toString(), beforeCurrentTime.toString());
-        assertThat(handler.isSatisfied(null), is(false));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(false));
 
         // Start & end time are in the future & start time is after the end time
         // -> should return true
         handler = getTimeOfDayConditionHandler(afterCurrentTime.plus(Duration.ofMinutes(2)).toString(),
                 afterCurrentTime.toString());
-        assertThat(handler.isSatisfied(null), is(true));
+        assertThat(handler.isSatisfied(Collections.emptyMap()), is(true));
     }
 
     private TimeOfDayConditionHandler getTimeOfDayConditionHandler(String startTime, String endTime) {


### PR DESCRIPTION
After adding the nullness annotations to the automation stuff, we need
to fix the usage to use a correct nullness handling.

Related to: https://github.com/openhab/openhab-core/pull/910
