### PR TITLE
RFC: add a much simpler "safe" caller

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/Caller.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/Caller.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.caller;
+
+import java.io.Closeable;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Definition of a simple caller.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+public interface Caller extends Closeable {
+
+    // Need some special casting to provide a void that succeed the nullness checks
+    static Void VOID = (@NonNull Void) null;
+
+    @Override
+    void close();
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use the calling thread for execution of the function (the constraints can be
+     * handled by another thread).
+     *
+     * This method returns after the function has been finished.
+     * So, the completion stage has already been completed (regardless if successful or by an exception).
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    default CompletionStage<Void> exec(Runnable func, final ExecutionConstraints constraints) {
+        return exec(() -> {
+            func.run();
+            return Caller.VOID;
+        }, constraints);
+    }
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use the calling thread for execution of the function (the constraints can be
+     * handled by another thread).
+     *
+     * This method returns after the function has been finished.
+     * So, the completion stage has already been completed (regardless if successful or by an exception).
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    <R> CompletionStage<R> exec(Supplier<R> func, final ExecutionConstraints constraints);
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use an executor, so you should prepared that the function is executed in a
+     * different thread.
+     * This method returns after the function has been finished.
+     * So, the completion stage has already been completed (regardless if successful or by an exception).
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    default CompletionStage<Void> execSync(Runnable func, final ExecutionConstraints constraints) {
+        return execSync(() -> {
+            func.run();
+            return Caller.VOID;
+        }, constraints);
+    }
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use an executor, so you should prepared that the function is executed in a
+     * different thread.
+     * This method returns after the function has been finished.
+     * So, the completion stage has already been completed (regardless if successful or by an exception).
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    <R> CompletionStage<R> execSync(Supplier<R> func, final ExecutionConstraints constraints);
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use an executor, so you should prepared that the function is executed in a
+     * different thread.
+     * This method returns regardless if the function is already been executed completely (or at all).
+     * You can use the return value to further act on the special execution.
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    default CompletionStage<Void> execAsync(Runnable func, final ExecutionConstraints constraints) {
+        return execAsync(() -> {
+            func.run();
+            return Caller.VOID;
+        }, constraints);
+    }
+
+    /**
+     * Runs a function.
+     *
+     * <p>
+     * The caller implementations should use an executor, so you should prepared that the function is executed in a
+     * different thread.
+     * This method returns regardless if the function is already been executed completely (or at all).
+     * You can use the return value to further act on the special execution.
+     *
+     * @param <R> the type of the return value
+     * @param func the function to execute
+     * @param constraints the execution constraints
+     * @return a completion stage of the execution
+     */
+    <R> CompletionStage<R> execAsync(Supplier<R> func, final ExecutionConstraints constraints);
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/CallerFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/CallerFactory.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.caller;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Factory for a caller
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+public interface CallerFactory {
+
+    /**
+     * Creates a new caller.
+     *
+     * @param id the identifier
+     * @param fixedThreadPoolSize the number of threads
+     * @return a newly created caller
+     */
+    Caller create(final String id, int fixedThreadPoolSize);
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/ExecutionConstraints.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/caller/ExecutionConstraints.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.caller;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Constraints for an execution.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+public class ExecutionConstraints {
+
+    public static final ExecutionConstraints NONE = new ExecutionConstraints(-1, null);
+
+    private final long timeout;
+    private final @Nullable Runnable onTimeout;
+
+    /**
+     * Constructor.
+     *
+     * @param timeout the timeout (use a negative number if no timeout is used)
+     * @param onTimeout the function that should be called if the timeout has been exceeded (must be non null if timeout
+     *            is non negative, ignored if timeout is negative)
+     */
+    public ExecutionConstraints(long timeout, @Nullable Runnable onTimeout) {
+        if (timeout >= 0) {
+            if (onTimeout != null) {
+                this.onTimeout = onTimeout;
+            } else {
+                throw new IllegalArgumentException("If a timeout is used, a timeout function is mandatory.");
+            }
+        } else {
+            this.onTimeout = null;
+        }
+        this.timeout = timeout;
+    }
+
+    /**
+     * Indicates if a timeout is used.
+     *
+     * @return {@code true} if a timeout is used, {@code false} if not
+     */
+    public boolean useTimeout() {
+        return timeout >= 0;
+    }
+
+    /**
+     * Gets the timeout.
+     *
+     * <p>
+     * This method should be called if {@link #useTimeout()} returns {@code true} only.
+     *
+     * @return the timeout
+     * @throws IllegalStateException if timeout is not used
+     */
+    public long getTimeout() {
+        if (!useTimeout()) {
+            throw new IllegalStateException("timeout is not used");
+        }
+        return timeout;
+    }
+
+    /**
+     * Gets the function that should be called on timeout.
+     *
+     * <p>
+     * This method should be called if {@link #useTimeout()} returns {@code true} only.
+     *
+     * @return the timeout function
+     * @throws IllegalStateException if timeout is not used
+     */
+    public Runnable onTimeout() {
+        if (!useTimeout()) {
+            throw new IllegalStateException("timeout is not used");
+        }
+        final Runnable onTimeout = this.onTimeout;
+        if (onTimeout == null) {
+            throw new IllegalStateException("if timeout if set, a function is mandatory");
+        }
+        return onTimeout;
+    }
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerFactoryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerFactoryImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.caller;
+
+import java.util.concurrent.Executors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.caller.Caller;
+import org.eclipse.smarthome.core.caller.CallerFactory;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Factory for a caller
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { CallerFactory.class })
+public class CallerFactoryImpl implements CallerFactory {
+
+    @Override
+    public Caller create(String id, int fixedThreadPoolSize) {
+        return new CallerImpl(id,
+                Executors.newFixedThreadPool(fixedThreadPoolSize, CallerImpl.newExecutorThreadFactory(id)), true);
+    }
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerImpl.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.caller;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.caller.Caller;
+import org.eclipse.smarthome.core.caller.ExecutionConstraints;
+import org.eclipse.smarthome.core.common.NamedThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of the {@link Caller} interface.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+public class CallerImpl implements Caller {
+
+    private final Logger logger = LoggerFactory.getLogger(CallerImpl.class);
+
+    private final String id;
+    private final ScheduledExecutorService watcher;
+    private final ExecutorService executor;
+    private final boolean ownExecutor;
+
+    public static NamedThreadFactory newExecutorThreadFactory(final String id) {
+        return new NamedThreadFactory(String.format("Caller-%s-Executor", id));
+    }
+
+    private static NamedThreadFactory newWatcherThreadFactory(final String id) {
+        return new NamedThreadFactory(String.format("Caller-%s-Watcher", id));
+    }
+
+    CallerImpl(final String id, final ExecutorService executor, final boolean takeOwnershipOfExecutor) {
+        this.id = id;
+        this.watcher = Executors.newSingleThreadScheduledExecutor(newWatcherThreadFactory(id));
+        this.executor = executor;
+        this.ownExecutor = takeOwnershipOfExecutor;
+    }
+
+    @Override
+    public void close() {
+        if (ownExecutor) {
+            executor.shutdownNow();
+        }
+        watcher.shutdownNow();
+    }
+
+    private <R> R execute(Supplier<R> func, final ExecutionConstraints constraint) throws Exception {
+        final ScheduledFuture<?> timeoutFuture;
+        if (constraint.useTimeout()) {
+            timeoutFuture = watcher.schedule(constraint.onTimeout(), constraint.getTimeout(), TimeUnit.MILLISECONDS);
+        } else {
+            timeoutFuture = null;
+        }
+        try {
+            final R rv = func.get();
+            logger.trace("Caller \"{}\" succeeded (description: {}, rv: {})", id, rv);
+            return rv;
+        } catch (final Throwable ex) {
+            logger.trace("Caller \"{}\" received exception (description: {})", id, ex);
+            throw ex;
+        } finally {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+        }
+    }
+
+    private <R> void execAndStore(final CompletableFuture<R> cf, final Supplier<R> func,
+            final ExecutionConstraints constraint) {
+        try {
+            cf.complete(execute(func, constraint));
+        } catch (final Throwable ex) {
+            if (ex instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            cf.completeExceptionally(ex);
+        }
+    }
+
+    private <R> CompletableFuture<R> execByExecutor(Supplier<R> func, final ExecutionConstraints constraint) {
+        final CompletableFuture<R> cf = new CompletableFuture<>();
+        executor.submit(() -> {
+            execAndStore(cf, func, constraint);
+        });
+        return cf;
+    }
+
+    @Override
+    public <R> CompletionStage<R> exec(Supplier<R> func, final ExecutionConstraints constraint) {
+        final CompletableFuture<R> cf = new CompletableFuture<>();
+        execAndStore(cf, func, constraint);
+        return cf;
+    }
+
+    @Override
+    public <R> CompletionStage<R> execAsync(Supplier<R> func, final ExecutionConstraints constraint) {
+        return execByExecutor(func, constraint);
+    }
+
+    @Override
+    public <R> CompletionStage<R> execSync(Supplier<R> func, final ExecutionConstraints constraint) {
+        final CompletableFuture<R> cf = execByExecutor(func, constraint);
+        try {
+            cf.join();
+        } catch (CompletionException | CancellationException ex) {
+            logger.trace("Caller \"{}\" failed (description: {})", id, ex);
+        }
+        return cf;
+    }
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerService.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/caller/CallerService.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.caller;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.caller.Caller;
+import org.eclipse.smarthome.core.caller.CallerFactory;
+import org.eclipse.smarthome.core.caller.ExecutionConstraints;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * An OSGi component providing the {@link Caller} interface.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+@NonNullByDefault
+@Component(name = "openhab.callerservice")
+public class CallerService implements Caller {
+
+    public @interface Config {
+        int threads() default 4;
+    }
+
+    private final Caller caller;
+
+    @Activate
+    public CallerService(final @Reference CallerFactory callerFactory, Config config) {
+        this.caller = callerFactory.create("service", config.threads());
+    }
+
+    @Override
+    @Deactivate
+    public void close() {
+        caller.close();
+    }
+
+    @Override
+    public <R> CompletionStage<R> exec(Supplier<R> func, ExecutionConstraints constraints) {
+        return caller.exec(func, constraints);
+    }
+
+    @Override
+    public <R> CompletionStage<R> execSync(Supplier<R> func, ExecutionConstraints constraints) {
+        return caller.execSync(func, constraints);
+    }
+
+    @Override
+    public <R> CompletionStage<R> execAsync(Supplier<R> func, ExecutionConstraints constraints) {
+        return caller.execAsync(func, constraints);
+    }
+
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -51,13 +51,14 @@ public class EventHandler implements AutoCloseable {
      * Create a new event handler.
      *
      * @param callerFactory the callerFactory
+     * @param numOfThreads the number of threads to use to inform subscribers
      * @param typedEventSubscribers the event subscribers indexed by the event type
      * @param typedEventFactories the event factories indexed by the event type
      */
-    public EventHandler(final CallerFactory callerFactory,
+    public EventHandler(final CallerFactory callerFactory, final int numOfThreads,
             final Map<String, Set<EventSubscriber>> typedEventSubscribers,
             final Map<String, EventFactory> typedEventFactories) {
-        this.caller = callerFactory.create("EventHandler", 1);
+        this.caller = callerFactory.create("EventHandler", numOfThreads);
         this.typedEventSubscribers = typedEventSubscribers;
         this.typedEventFactories = typedEventFactories;
     }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.eclipse.smarthome.core.caller.CallerFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
 import org.eclipse.smarthome.core.events.EventSubscriber;
@@ -51,8 +52,8 @@ public class OSGiEventManager implements EventHandler {
     private ThreadedEventHandler eventHandler;
 
     @Activate
-    protected void activate(ComponentContext componentContext) {
-        eventHandler = new ThreadedEventHandler(typedEventSubscribers, typedEventFactories);
+    public OSGiEventManager(final @Reference CallerFactory callerFactory, ComponentContext componentContext) {
+        eventHandler = new ThreadedEventHandler(callerFactory, typedEventSubscribers, typedEventFactories);
         eventHandler.open();
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -41,8 +41,12 @@ import org.osgi.service.event.EventHandler;
  * @author Stefan Bußweiler - Initial contribution
  * @author Markus Rathgeb - Return on received events as fast as possible (handle event in another thread)
  */
-@Component(immediate = true, property = { "event.topics:String=smarthome" })
+@Component(immediate = true, name = "openhab.eventmanager", property = { "event.topics:String=smarthome" })
 public class OSGiEventManager implements EventHandler {
+
+    public @interface Config {
+        int subscriber_threads() default 1;
+    }
 
     /** The event subscribers indexed by the event type. */
     // Use a concurrent hash map because the map is written and read by different threads!
@@ -52,8 +56,10 @@ public class OSGiEventManager implements EventHandler {
     private ThreadedEventHandler eventHandler;
 
     @Activate
-    public OSGiEventManager(final @Reference CallerFactory callerFactory, ComponentContext componentContext) {
-        eventHandler = new ThreadedEventHandler(callerFactory, typedEventSubscribers, typedEventFactories);
+    public OSGiEventManager(final @Reference CallerFactory callerFactory, ComponentContext componentContext,
+            final Config config) {
+        eventHandler = new ThreadedEventHandler(callerFactory, config.subscriber_threads(), typedEventSubscribers,
+                typedEventFactories);
         eventHandler.open();
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.caller.CallerFactory;
 import org.eclipse.smarthome.core.events.EventFactory;
 import org.eclipse.smarthome.core.events.EventSubscriber;
 import org.osgi.service.event.Event;
@@ -47,13 +48,15 @@ public class ThreadedEventHandler implements Closeable {
     /**
      * Create a new threaded event handler.
      *
+     * @param callerFactory the caller factory
      * @param typedEventSubscribers the event subscribers
      * @param typedEventFactories the event factories indexed by the event type
      */
-    ThreadedEventHandler(Map<String, Set<EventSubscriber>> typedEventSubscribers,
+    ThreadedEventHandler(final CallerFactory callerFactory,
+            final Map<String, Set<EventSubscriber>> typedEventSubscribers,
             final Map<String, EventFactory> typedEventFactories) {
         thread = new Thread(() -> {
-            try (EventHandler worker = new EventHandler(typedEventSubscribers, typedEventFactories)) {
+            try (EventHandler worker = new EventHandler(callerFactory, typedEventSubscribers, typedEventFactories)) {
                 while (running.get()) {
                     try {
                         logger.trace("wait for event");

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -49,14 +49,16 @@ public class ThreadedEventHandler implements Closeable {
      * Create a new threaded event handler.
      *
      * @param callerFactory the caller factory
+     * @param numOfThreads the number of threads to use to inform subscribers
      * @param typedEventSubscribers the event subscribers
      * @param typedEventFactories the event factories indexed by the event type
      */
-    ThreadedEventHandler(final CallerFactory callerFactory,
+    ThreadedEventHandler(final CallerFactory callerFactory, final int numOfThreads,
             final Map<String, Set<EventSubscriber>> typedEventSubscribers,
             final Map<String, EventFactory> typedEventFactories) {
         thread = new Thread(() -> {
-            try (EventHandler worker = new EventHandler(callerFactory, typedEventSubscribers, typedEventFactories)) {
+            try (EventHandler worker = new EventHandler(callerFactory, numOfThreads, typedEventSubscribers,
+                    typedEventFactories)) {
                 while (running.get()) {
                     try {
                         logger.trace("wait for event");

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
@@ -13,15 +13,11 @@
 package org.eclipse.smarthome.core.thing.internal;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import org.eclipse.smarthome.core.caller.Caller;
 import org.eclipse.smarthome.core.service.ReadyService;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.eclipse.smarthome.core.storage.StorageService;
@@ -29,6 +25,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.util.BundleResolver;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -40,7 +37,7 @@ import org.osgi.service.component.ComponentContext;
  * @author Simon Kaufmann - Initial contribution and API
  *
  */
-public class ThingManagerTest {
+public class ThingManagerTest extends JavaOSGiTest {
 
     private @Mock BundleResolver mockBundleResolver;
     private @Mock Bundle mockBundle;
@@ -52,6 +49,10 @@ public class ThingManagerTest {
     private @Mock Storage<Object> mockStorage;
 
     private final ThingRegistryImpl thingRegistry = new ThingRegistryImpl();
+
+    private Caller getCaller() {
+        return getService(Caller.class);
+    }
 
     @Before
     public void setup() {
@@ -66,7 +67,7 @@ public class ThingManagerTest {
         ThingHandlerFactory mockFactory1 = mock(ThingHandlerFactory.class);
         ThingHandlerFactory mockFactory2 = mock(ThingHandlerFactory.class);
 
-        ThingManagerImpl thingManager = new ThingManagerImpl();
+        ThingManagerImpl thingManager = new ThingManagerImpl(getCaller());
         thingManager.setBundleResolver(mockBundleResolver);
         thingManager.setThingRegistry(thingRegistry);
         thingManager.setReadyService(mockReadyService);
@@ -86,7 +87,7 @@ public class ThingManagerTest {
     @Test
     public void testCallSetEnabledWithUnknownThingUID() throws Exception {
         ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
-        ThingManagerImpl thingManager = new ThingManagerImpl();
+        ThingManagerImpl thingManager = new ThingManagerImpl(getCaller());
 
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(mockStorage);
         thingManager.setStorageService(mockStorageService);
@@ -100,18 +101,17 @@ public class ThingManagerTest {
     @Test
     public void testCallIsEnabledWithUnknownThingUIDAndNullStorage() throws Exception {
         ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
-        ThingManagerImpl thingManager = new ThingManagerImpl();
+        ThingManagerImpl thingManager = new ThingManagerImpl(getCaller());
 
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(null);
         thingManager.setStorageService(mockStorageService);
         assertEquals(thingManager.isEnabled(unknownUID), true);
-
     }
 
     @Test
     public void testCallIsEnabledWithUnknownThingUIDAndNonNullStorage() throws Exception {
         ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
-        ThingManagerImpl thingManager = new ThingManagerImpl();
+        ThingManagerImpl thingManager = new ThingManagerImpl(getCaller());
 
         when(mockStorage.containsKey(unknownUID.getAsString())).thenReturn(false);
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(mockStorage);


### PR DESCRIPTION
~This is just a proof of concept.~

Added a much more lightweight caller implementation that does not create any proxy.

For me it seems that at most places the safe caller is used we want to accomplish two things:

* track if a special time limit has been exceeded while execution of some logic
* ensure all (runtime) exceptions are catched

I am pretty sure the dropped usage of proxies and classloaders will improve the runtime behaviour, reduce the CPU load, and allow handling the same logic in less time!

# ExecutionContraints

The "execution constraints" can be used to define a max. execution time and a method that should be called if the max. execution time has been exceeded.
There is a static "execution constraints" `ExecutionConstraints.NONE` that can be used if no constraint should be used.

# Caller

There is a `Caller` interface that declares the following methods:

* execute the function in the current thread:
  * `CompletionStage<Void> execCallerRunnable func, final ExecutionConstraints constraints)`
  * ` <R> CompletionStage<R> exec(CallerSupplier<R> func, final ExecutionConstraints constraints)`
* execute the function by an executor / in a different thread and wait until its finished
  * `CompletionStage<Void> execSync(CallerRunnable func, final ExecutionConstraints constraints)`
  * ` <R> CompletionStage<R> execSync(CallerSupplier<R> func, final ExecutionConstraints constraints)`
* execute the function by an executor / in a different thread and do not wait
  * `CompletionStage<Void> execAsync(CallerRunnable func, final ExecutionConstraints constraints)`
  * `<R> CompletionStage<R> execAsync(CallerSupplier<R> func, final ExecutionConstraints constraints)`

All execution methods return a `CompletionStage`
* on `exec` and `execSync` you can rely that the completion stage has already been finished
* on `execAsync` the completion stage can still be running

Using the completion stage you could handle exceptions and the return value using the standard API.

# OSGi services

There is an OSGi service that provides a global caller service.
This should be similar to the safe caller and used as the places as it has been.

There is another OSGi service, the caller factory.
The caller factory can be used if you need your own caller e.g. because you want to use your separate thread pool / thread pool configuration.

# Other changes

## Thing Manager

I Changed the thing manager implementation to use the simple caller instead of the safe caller with expensive proxy.

## Event Handler

The event handler already uses the now more generalized logic.
It has been changed to use the caller factory.
