### PR TITLE
[automation] Fixed topic for `ThingStatusTriggerHandler`

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusTriggerHandler.java
@@ -144,7 +144,7 @@ public class ThingStatusTriggerHandler extends BaseTriggerModuleHandler implemen
     @Override
     public boolean apply(Event event) {
         logger.trace("->FILTER: {}: {}", event.getTopic(), thingUID);
-        return event.getTopic().contains("smarthome/thing/" + thingUID + "/");
+        return event.getTopic().contains("smarthome/things/" + thingUID + "/");
     }
 
 }


### PR DESCRIPTION
- Fixed topic for `ThingStatusTriggerHandler`. It is called "things", not "thing".

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>