### PR TITLE
[uom] Bump `tec.uom` libraries

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -192,13 +192,13 @@
     <dependency>
       <groupId>tec.uom</groupId>
       <artifactId>uom-se</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>tec.uom.lib</groupId>
       <artifactId>uom-lib-common</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -422,13 +422,13 @@
     <dependency>
       <groupId>tec.uom</groupId>
       <artifactId>uom-se</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.10</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>tec.uom.lib</groupId>
       <artifactId>uom-lib-common</artifactId>
-      <version>1.0.2</version>
+      <version>1.0.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -32,8 +32,8 @@
 
     <!-- Measurement -->
     <bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>
-    <bundle dependency="true">mvn:tec.uom/uom-se/1.0.8</bundle>
-    <bundle dependency="true">mvn:tec.uom.lib/uom-lib-common/1.0.2</bundle>
+    <bundle dependency="true">mvn:tec.uom/uom-se/1.0.10</bundle>
+    <bundle dependency="true">mvn:tec.uom.lib/uom-lib-common/1.0.3</bundle>
 
     <!-- TODO: Unbundled libraries -->
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>

--- a/itests/org.openhab.core.audio.tests/itest.bndrun
+++ b/itests/org.openhab.core.audio.tests/itest.bndrun
@@ -45,8 +45,6 @@ Fragment-Host: org.openhab.core.audio
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -61,4 +59,6 @@ Fragment-Host: org.openhab.core.audio
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -25,8 +25,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.eclipse.jetty.websocket.common;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -47,4 +45,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -37,8 +37,6 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -46,4 +44,6 @@ Fragment-Host: org.openhab.core.automation
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -23,8 +23,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -42,4 +40,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.compat1x.tests/itest.bndrun
+++ b/itests/org.openhab.core.compat1x.tests/itest.bndrun
@@ -41,8 +41,6 @@ Fragment-Host: org.openhab.core.compat1x
 	org.openhab.core.compat1x;version='[2.5.0,2.5.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -99,4 +97,6 @@ Fragment-Host: org.openhab.core.compat1x
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -35,8 +35,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.openhab.core.config.core.tests;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -47,4 +45,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -24,8 +24,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -46,4 +44,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -45,8 +45,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -56,4 +54,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -34,8 +34,6 @@ Fragment-Host: org.openhab.core.io.net
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -45,4 +43,6 @@ Fragment-Host: org.openhab.core.io.net
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -50,8 +50,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -62,4 +60,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.magic.tests/itest.bndrun
+++ b/itests/org.openhab.core.magic.tests/itest.bndrun
@@ -27,8 +27,6 @@ Fragment-Host: org.openhab.core.test.magic
 	org.eclipse.jetty.xml;version='[9.4.11,9.4.12)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -65,4 +63,6 @@ Fragment-Host: org.openhab.core.test.magic
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.2,1.8.3)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -30,8 +30,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -98,5 +96,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.model.lsp.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.lsp.tests/itest.bndrun
@@ -36,8 +36,6 @@ Fragment-Host: org.openhab.core.model.lsp
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -105,4 +103,6 @@ Fragment-Host: org.openhab.core.model.lsp
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.model.persistence.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.persistence.tests/itest.bndrun
@@ -26,8 +26,6 @@ Fragment-Host: org.openhab.core.model.persistence
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -97,4 +95,6 @@ Fragment-Host: org.openhab.core.model.persistence
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -48,8 +48,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -108,5 +106,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'
 

--- a/itests/org.openhab.core.semantics.tests/itest.bndrun
+++ b/itests/org.openhab.core.semantics.tests/itest.bndrun
@@ -22,8 +22,6 @@ Fragment-Host: org.openhab.core.semantics
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
@@ -34,4 +32,6 @@ Fragment-Host: org.openhab.core.semantics
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
-	slf4j.api;version='[1.7.25,1.7.26)'
+	slf4j.api;version='[1.7.25,1.7.26)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -29,8 +29,6 @@ Fragment-Host: org.openhab.core.storage.json
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -38,4 +36,6 @@ Fragment-Host: org.openhab.core.storage.json
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -31,8 +31,6 @@ Fragment-Host: org.openhab.core
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
@@ -46,4 +44,6 @@ Fragment-Host: org.openhab.core
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -42,8 +42,6 @@ Fragment-Host: org.openhab.core.thing
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing.xml;version='[2.5.0,2.5.1)',\
@@ -56,4 +54,6 @@ Fragment-Host: org.openhab.core.thing
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -36,8 +36,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.openhab.core.binding.xml;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -47,4 +45,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.transform.tests/itest.bndrun
+++ b/itests/org.openhab.core.transform.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.core.transform
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -31,4 +29,6 @@ Fragment-Host: org.openhab.core.transform
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.ui.icon.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.icon.tests/itest.bndrun
@@ -40,8 +40,6 @@ Fragment-Host: org.openhab.core.ui.icon
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -57,4 +55,6 @@ Fragment-Host: org.openhab.core.ui.icon
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)'
+	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.ui.tests/itest.bndrun
+++ b/itests/org.openhab.core.ui.tests/itest.bndrun
@@ -70,8 +70,6 @@ Fragment-Host: org.openhab.core.ui
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -100,4 +98,6 @@ Fragment-Host: org.openhab.core.ui
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)'
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -41,8 +41,6 @@ Fragment-Host: org.openhab.core.voice
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.2,1.0.3)',\
-	tec.uom.se;version='[1.0.8,1.0.9)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -56,4 +54,5 @@ Fragment-Host: org.openhab.core.voice
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)'
+	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
+	tec.uom.se;version='[1.0.10,1.0.11)'


### PR DESCRIPTION
- Bump `tec.uom` libraries to latest version

See [changelog](https://github.com/unitsofmeasurement/uom-se/compare/1.0.9...master). Addresses #644.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>