### PR TITLE
Sync Jetty version with version used by Karaf 4.2.6

### DIFF
--- a/features/karaf/openhab-core/pom.xml
+++ b/features/karaf/openhab-core/pom.xml
@@ -15,7 +15,7 @@
   <description>openHAB Core Features</description>
 
   <properties>
-    <jetty.version>9.4.12.v20180830</jetty.version>
+    <jetty.version>9.4.18.v20190429</jetty.version>
     <jna.version>4.5.2</jna.version>
   </properties>
 

--- a/features/karaf/openhab-tp/pom.xml
+++ b/features/karaf/openhab-tp/pom.xml
@@ -14,7 +14,7 @@
   <name>openHAB Core :: Features :: Karaf :: Target Platform</name>
 
   <properties>
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>9.4.18.v20190429</jetty.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Resolves the Jetty bundle duplicates as reported in #892 

---

I still had these changes on my local checkout. :smile: 