### PR TITLE
[archetype] Fix for double modules in bundle pom

### DIFF
--- a/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -82,7 +82,7 @@ def addBundleToBom(bundleAfter, newBundle) {
  */
 def fixBundlePom(bundleAfter, newBundle) {
     def bomFile = new File(outputDirectory, 'pom.xml')
-    def module = '    <module>' + newBundle + '</module>' 
+    def module = '<module>' + newBundle + '</module>'
     def newContent = ''
     def insertIndex = 0;
     def lines = bomFile.eachLine { line, index ->
@@ -94,7 +94,7 @@ def fixBundlePom(bundleAfter, newBundle) {
             insertIndex = index
         }
         if (insertIndex > 0 && index == insertIndex) {
-            newContent += module + nl
+            newContent += '    ' + module + nl
             insertIndex = 0
         }
     }


### PR DESCRIPTION
Due to changes in the archetype maven it generated multi module name with tabs prefixed. This caused the module name to be inserted twice because the added module by maven plugin was not removed when the module is moved by the groovy script.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>