### PR TITLE
Fix "No SerialPortProvider found" on startup

### DIFF
--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortRegistry.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortRegistry.java
@@ -50,7 +50,7 @@ public class SerialPortRegistry {
      *
      * @param creator
      */
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
     protected void registerSerialPortCreator(SerialPortProvider creator) {
         synchronized (this.portCreators) {
             this.portCreators.add(creator);


### PR DESCRIPTION
Change reference cardinality from `MULTIPLE` to `AT_LEAST_ONE` so the serial port provider can be used immediately when `ThingHandler`s are initialized.

Fixes #937

This would always result in the following logging on startup:

`[WARN ] [serial.internal.SerialPortManagerImpl] - No SerialPortProvider found for: /dev/ttyUSB0`

Bindings without serial port reconnection logic would need to be manually restarted (Z-Wave Binding).
