### PR TITLE
ItemUIRegistry: getLabel returning DateTime item formatted in local time zone

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.ui.internal.items;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
@@ -537,15 +538,22 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     private String fillFormatPattern(String formatPattern, Type state) throws IllegalArgumentException {
         String ret = formatPattern;
-        if (ret != null && state != null) {
+        Type itemState = state;
+        if (state instanceof DateTimeType) {
+            try {
+                itemState = ((DateTimeType) state).toLocaleZone();
+            } catch (DateTimeException e) {
+            }
+        }
+        if (ret != null && itemState != null) {
             Matcher matcher = EXTRACT_TRANSFORMFUNCTION_PATTERN_WITHOUT_SQUARE_BRACKETS.matcher(ret);
             if (matcher.find()) {
                 String type = matcher.group(1);
                 String pattern = matcher.group(2);
                 String value = matcher.group(3);
-                ret = type + "(" + pattern + "):" + state.format(value);
+                ret = type + "(" + pattern + "):" + itemState.format(value);
             } else {
-                ret = state.format(formatPattern);
+                ret = itemState.format(formatPattern);
             }
         }
         return ret;

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -404,6 +404,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         // The widget may define its own unit in the widget label. Convert to this unit:
                         quantityState = convertStateToWidgetUnit(quantityState, w);
                         state = quantityState;
+                    } else if (state instanceof DateTimeType) {
+                        // Translate a DateTimeType state to the local time zone
+                        try {
+                            state = ((DateTimeType) state).toLocaleZone();
+                        } catch (DateTimeException e) {
+                        }
                     }
 
                     // The following exception handling has been added to work around a Java bug with formatting
@@ -538,22 +544,15 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     private String fillFormatPattern(String formatPattern, Type state) throws IllegalArgumentException {
         String ret = formatPattern;
-        Type itemState = state;
-        if (state instanceof DateTimeType) {
-            try {
-                itemState = ((DateTimeType) state).toLocaleZone();
-            } catch (DateTimeException e) {
-            }
-        }
-        if (ret != null && itemState != null) {
+        if (ret != null && state != null) {
             Matcher matcher = EXTRACT_TRANSFORMFUNCTION_PATTERN_WITHOUT_SQUARE_BRACKETS.matcher(ret);
             if (matcher.find()) {
                 String type = matcher.group(1);
                 String pattern = matcher.group(2);
                 String value = matcher.group(3);
-                ret = type + "(" + pattern + "):" + itemState.format(value);
+                ret = type + "(" + pattern + "):" + state.format(value);
             } else {
-                ret = itemState.format(formatPattern);
+                ret = state.format(formatPattern);
             }
         }
         return ret;

--- a/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.smarthome.core.i18n.UnitProvider;
@@ -56,12 +57,12 @@ import org.mockito.Mock;
  */
 public class ItemUIRegistryImplTest {
 
-    static private ItemUIRegistryImpl uiRegistry;
+    private static ItemUIRegistryImpl uiRegistry;
     // we need to get the decimal separator of the default locale for our tests
-    static private final char sep = (new DecimalFormatSymbols().getDecimalSeparator());
+    private static final char SEP = (new DecimalFormatSymbols().getDecimalSeparator());
 
     @Mock
-    static private ItemRegistry registry;
+    private static ItemRegistry registry;
 
     @Mock
     private Widget widget;
@@ -80,6 +81,9 @@ public class ItemUIRegistryImplTest {
 
         when(widget.getItem()).thenReturn("Item");
         when(registry.getItem("Item")).thenReturn(item);
+
+        // Set default time zone to GMT-6
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-6"));
     }
 
     @Test
@@ -151,7 +155,7 @@ public class ItemUIRegistryImplTest {
         when(item.getState()).thenReturn(new DecimalType(10f / 3f));
         when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(10f / 3f));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3" + sep + "333]", label);
+        assertEquals("Label [3" + SEP + "333]", label);
     }
 
     @Test
@@ -161,7 +165,7 @@ public class ItemUIRegistryImplTest {
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new QuantityType<>("" + 10f / 3f + " °C"));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3" + sep + "333 °C]", label);
+        assertEquals("Label [3" + SEP + "333 °C]", label);
     }
 
     @Test
@@ -231,7 +235,7 @@ public class ItemUIRegistryImplTest {
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new QuantityType<>("22 °C"));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [71" + sep + "60 °F]", label);
+        assertEquals("Label [71" + SEP + "60 °F]", label);
     }
 
     @Test
@@ -242,7 +246,7 @@ public class ItemUIRegistryImplTest {
         when(item.getState()).thenReturn(new DecimalType(10f / 3f));
         when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(10f / 3f));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3" + sep + "3 %]", label);
+        assertEquals("Label [3" + SEP + "3 %]", label);
     }
 
     @Test
@@ -263,18 +267,43 @@ public class ItemUIRegistryImplTest {
         when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00"));
         String label = uiRegistry.getLabel(widget);
         assertEquals("Label [01.06.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00Z"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [31.05.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00+02"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [31.05.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00-06"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [01.06.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00-07"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [01.06.2011]", label);
     }
 
     @Test
     public void getLabel_labelWithZonedDate() throws ItemNotFoundException {
         String testLabel = "Label [%1$td.%1$tm.%1$tY]";
+
         Widget w = mock(Widget.class);
         Item item = mock(Item.class);
         when(w.getLabel()).thenReturn(testLabel);
         when(w.getItem()).thenReturn("Item");
         when(registry.getItem("Item")).thenReturn(item);
-        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00Z"));
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00"));
         String label = uiRegistry.getLabel(w);
+        assertEquals("Label [01.06.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00Z"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [31.05.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00+02"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [31.05.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00-06"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [01.06.2011]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T00:00:00-07"));
+        label = uiRegistry.getLabel(w);
         assertEquals("Label [01.06.2011]", label);
     }
 
@@ -286,20 +315,44 @@ public class ItemUIRegistryImplTest {
         when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59"));
         String label = uiRegistry.getLabel(widget);
         assertEquals("Label [15:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59Z"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [09:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59+02"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [07:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59-06"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [15:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59-07"));
+        label = uiRegistry.getLabel(widget);
+        assertEquals("Label [16:30:59]", label);
     }
 
     @Test
     public void getLabel_labelWithZonedTime() throws ItemNotFoundException {
         String testLabel = "Label [%1$tT]";
+
         Widget w = mock(Widget.class);
         Item item = mock(Item.class);
         when(w.getLabel()).thenReturn(testLabel);
         when(w.getItem()).thenReturn("Item");
         when(registry.getItem("Item")).thenReturn(item);
-        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59Z"));
-
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59"));
         String label = uiRegistry.getLabel(w);
         assertEquals("Label [15:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59Z"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [09:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59+02"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [07:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59-06"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [15:30:59]", label);
+        when(item.getState()).thenReturn(new DateTimeType("2011-06-01T15:30:59-07"));
+        label = uiRegistry.getLabel(w);
+        assertEquals("Label [16:30:59]", label);
     }
 
     @Test
@@ -317,7 +370,6 @@ public class ItemUIRegistryImplTest {
 
     @Test
     public void getLabel_labelFromUIProvider() {
-
         ItemUIProvider provider = mock(ItemUIProvider.class);
         uiRegistry.addItemUIProvider(provider);
         when(provider.getLabel(anyString())).thenReturn("ProviderLabel");

--- a/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/itests/org.openhab.core.ui.tests/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -57,12 +57,13 @@ import org.mockito.Mock;
  */
 public class ItemUIRegistryImplTest {
 
-    private static ItemUIRegistryImpl uiRegistry;
     // we need to get the decimal separator of the default locale for our tests
     private static final char SEP = (new DecimalFormatSymbols().getDecimalSeparator());
 
+    private ItemUIRegistryImpl uiRegistry;
+
     @Mock
-    private static ItemRegistry registry;
+    private ItemRegistry registry;
 
     @Mock
     private Widget widget;


### PR DESCRIPTION
Fixes #832

Signed-off-by: Laurent Garnier <lg.hc@free.fr>

This change will impact the REST sitemap API and as a consequence all UIs using this API (Basic UI, Android App, ...). All text widgets in sitemap linked to a DateTime item will now be provided to the UI with a date/time formatted in the local time zone in the label field of the widget (field item.state is unchanged).
Before this change,  the label field of the widget was containing the date/time forrmatted in the zone set by the item state. 