### PR TITLE
Fix null annotations order and cleanup

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
@@ -27,7 +27,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * @author Harald Kuhn - Initial API
  * @author Kelly Davis - Modified to match discussion in #584
  * @author Christoph Weitkamp - Added getSupportedStreams() and UnsupportedAudioStreamException
- * 
+ *
  */
 @NonNullByDefault
 public interface AudioSink {
@@ -37,7 +37,7 @@ public interface AudioSink {
      *
      * @return an id that identifies this service
      */
-    public String getId();
+    String getId();
 
     /**
      * Returns a localized human readable label that can be used within UIs.
@@ -46,7 +46,7 @@ public interface AudioSink {
      * @return a localized string to be used in UIs
      */
     @Nullable
-    public String getLabel(Locale locale);
+    String getLabel(Locale locale);
 
     /**
      * Processes the passed {@link AudioStream}
@@ -71,14 +71,14 @@ public interface AudioSink {
      *
      * @return A Set containing all supported audio formats
      */
-    public Set<AudioFormat> getSupportedFormats();
+    Set<AudioFormat> getSupportedFormats();
 
     /**
      * Gets a set containing all supported audio stream formats
-     * 
+     *
      * @return A Set containing all supported audio stream formats
      */
-    public Set<Class<? extends AudioStream>> getSupportedStreams();
+    Set<Class<? extends AudioStream>> getSupportedStreams();
 
     /**
      * Gets the volume
@@ -86,7 +86,7 @@ public interface AudioSink {
      * @return a PercentType value between 0 and 100 representing the actual volume
      * @throws IOException if the volume can not be determined
      */
-    public PercentType getVolume() throws IOException;
+    PercentType getVolume() throws IOException;
 
     /**
      * Sets the volume
@@ -94,5 +94,5 @@ public interface AudioSink {
      * @param volume a PercentType value between 0 and 100 representing the desired volume
      * @throws IOException if the volume can not be set
      */
-    public void setVolume(PercentType volume) throws IOException;
+    void setVolume(PercentType volume) throws IOException;
 }

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthFactoryImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthFactoryImpl.java
@@ -40,10 +40,8 @@ public class OAuthFactoryImpl implements OAuthFactory {
 
     private final Logger logger = LoggerFactory.getLogger(OAuthFactoryImpl.class);
 
-    @NonNullByDefault({})
-    private OAuthStoreHandler oAuthStoreHandler;
-    @NonNullByDefault({})
-    private HttpClientFactory httpClientFactory;
+    private @NonNullByDefault({}) OAuthStoreHandler oAuthStoreHandler;
+    private @NonNullByDefault({}) HttpClientFactory httpClientFactory;
 
     private int tokenExpiresInBuffer = OAuthClientServiceImpl.DEFAULT_TOKEN_EXPIRES_IN_BUFFER_SECOND;
 
@@ -82,8 +80,7 @@ public class OAuthFactoryImpl implements OAuthFactory {
     }
 
     @Override
-    @Nullable
-    public OAuthClientService getOAuthClientService(String handle) {
+    public @Nullable OAuthClientService getOAuthClientService(String handle) {
         OAuthClientService clientImpl = oauthClientServiceCache.get(handle);
 
         if (clientImpl == null || clientImpl.isClosed()) {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/cipher/SymmetricKeyCipher.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/cipher/SymmetricKeyCipher.java
@@ -58,10 +58,8 @@ public class SymmetricKeyCipher implements StorageCipher {
     private static final int ENCRYPTION_KEY_SIZE_BITS = 128; // do not use high grade encryption due to export limit
     private static final int IV_BYTE_SIZE = 16;
 
-    @NonNullByDefault({})
-    private ConfigurationAdmin configurationAdmin;
-    @NonNullByDefault({})
-    private SecretKey encryptionKey;
+    private @NonNullByDefault({}) ConfigurationAdmin configurationAdmin;
+    private @NonNullByDefault({}) SecretKey encryptionKey;
 
     private final SecureRandom random = new SecureRandom();
 
@@ -83,9 +81,8 @@ public class SymmetricKeyCipher implements StorageCipher {
         return CIPHER_ID;
     }
 
-    @Nullable
     @Override
-    public String encrypt(@Nullable String plainText) throws GeneralSecurityException {
+    public @Nullable String encrypt(@Nullable String plainText) throws GeneralSecurityException {
         if (plainText == null) {
             return null;
         }
@@ -107,9 +104,8 @@ public class SymmetricKeyCipher implements StorageCipher {
         return encryptedBase64String;
     }
 
-    @Nullable
     @Override
-    public String decrypt(@Nullable String base64CipherText) throws GeneralSecurityException {
+    public @Nullable String decrypt(@Nullable String base64CipherText) throws GeneralSecurityException {
         if (base64CipherText == null) {
             return null;
         }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
@@ -44,28 +44,17 @@ import org.openhab.core.automation.template.RuleTemplate;
 @NonNullByDefault
 public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
 
-    @NonNullByDefault({})
-    protected List<Trigger> triggers;
-    @NonNullByDefault({})
-    protected List<Condition> conditions;
-    @NonNullByDefault({})
-    protected List<Action> actions;
-    @NonNullByDefault({})
-    protected Configuration configuration;
-    @NonNullByDefault({})
-    protected List<ConfigDescriptionParameter> configDescriptions;
-    @Nullable
-    protected String templateUID;
-    @NonNullByDefault({})
-    protected String uid;
-    @Nullable
-    protected String name;
-    @NonNullByDefault({})
-    protected Set<String> tags;
-    @NonNullByDefault({})
-    protected Visibility visibility;
-    @Nullable
-    protected String description;
+    protected @NonNullByDefault({}) List<Trigger> triggers;
+    protected @NonNullByDefault({}) List<Condition> conditions;
+    protected @NonNullByDefault({}) List<Action> actions;
+    protected @NonNullByDefault({}) Configuration configuration;
+    protected @NonNullByDefault({}) List<ConfigDescriptionParameter> configDescriptions;
+    protected @Nullable String templateUID;
+    protected @NonNullByDefault({}) String uid;
+    protected @Nullable String name;
+    protected @NonNullByDefault({}) Set<String> tags;
+    protected @NonNullByDefault({}) Visibility visibility;
+    protected @Nullable String description;
 
     protected transient volatile RuleStatusInfo status = new RuleStatusInfo(RuleStatus.UNINITIALIZED,
             RuleStatusDetail.NONE);
@@ -79,8 +68,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
     }
 
     @Override
-    @Nullable
-    public String getTemplateUID() {
+    public @Nullable String getTemplateUID() {
         return templateUID;
     }
 
@@ -94,8 +82,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
     }
 
     @Override
-    @Nullable
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
@@ -123,8 +110,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
     }
 
     @Override
-    @Nullable
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
@@ -116,8 +116,7 @@ public class RuleImpl implements Rule {
     }
 
     @Override
-    @Nullable
-    public String getTemplateUID() {
+    public @Nullable String getTemplateUID() {
         return templateUID;
     }
 
@@ -131,8 +130,7 @@ public class RuleImpl implements Rule {
     }
 
     @Override
-    @Nullable
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
@@ -160,8 +158,7 @@ public class RuleImpl implements Rule {
     }
 
     @Override
-    @Nullable
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
@@ -73,14 +73,12 @@ public class RuleTemplate implements Template {
     /**
      * Holds the short, human-readable label of the {@link RuleTemplate}.
      */
-    @Nullable
-    private final String label;
+    private final @Nullable String label;
 
     /**
      * Describes the usage of the {@link RuleTemplate} and its benefits.
      */
-    @Nullable
-    private final String description;
+    private final @Nullable String description;
 
     /**
      * Determines {@link Visibility} of the {@link RuleTemplate}.
@@ -97,19 +95,19 @@ public class RuleTemplate implements Template {
      * belong to the template. When {@code null} is passed for the {@code uid} parameter, the {@link RuleTemplate}'s
      * identifier will be randomly generated.
      *
-     * @param uid                the {@link RuleTemplate}'s identifier, or {@code null} if a random identifier should be
-     *                           generated.
-     * @param label              the short human-readable {@link RuleTemplate}'s label.
-     * @param description        a detailed human-readable {@link RuleTemplate}'s description.
-     * @param tags               the {@link RuleTemplate}'s assigned tags.
-     * @param triggers           the {@link RuleTemplate}'s triggers list, or {@code null} if the {@link RuleTemplate}
-     *                           should have no triggers.
-     * @param conditions         the {@link RuleTemplate}'s conditions list, or {@code null} if the {@link RuleTemplate}
-     *                           should have no conditions.
-     * @param actions            the {@link RuleTemplate}'s actions list, or {@code null} if the {@link RuleTemplate}
-     *                           should have no actions.
+     * @param uid the {@link RuleTemplate}'s identifier, or {@code null} if a random identifier should be
+     *            generated.
+     * @param label the short human-readable {@link RuleTemplate}'s label.
+     * @param description a detailed human-readable {@link RuleTemplate}'s description.
+     * @param tags the {@link RuleTemplate}'s assigned tags.
+     * @param triggers the {@link RuleTemplate}'s triggers list, or {@code null} if the {@link RuleTemplate}
+     *            should have no triggers.
+     * @param conditions the {@link RuleTemplate}'s conditions list, or {@code null} if the {@link RuleTemplate}
+     *            should have no conditions.
+     * @param actions the {@link RuleTemplate}'s actions list, or {@code null} if the {@link RuleTemplate}
+     *            should have no actions.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Rule} instances.
-     * @param visibility         the {@link RuleTemplate}'s visibility.
+     * @param visibility the {@link RuleTemplate}'s visibility.
      */
     public RuleTemplate(@Nullable String UID, @Nullable String label, @Nullable String description,
             @Nullable Set<String> tags, @Nullable List<Trigger> triggers, @Nullable List<Condition> conditions,
@@ -207,7 +205,7 @@ public class RuleTemplate implements Template {
      * Gets the modules of the {@link RuleTemplate}, corresponding to the specified class.
      *
      * @param moduleClazz defines the class of the looking modules. It can be {@link Module}, {@link Trigger},
-     *                    {@link Condition} or {@link Action}.
+     *            {@link Condition} or {@link Action}.
      * @return the modules of defined type or empty list if the {@link RuleTemplate} has no modules that belong to the
      *         specified type.
      */

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleType.java
@@ -63,14 +63,12 @@ public abstract class ModuleType implements Identifiable<String> {
     /**
      * Defines short and accurate, human-readable label of the {@link ModuleType}.
      */
-    @Nullable
-    private final String label;
+    private final @Nullable String label;
 
     /**
      * Defines detailed, human-readable description of usage of {@link ModuleType} and its benefits.
      */
-    @Nullable
-    private final String description;
+    private final @Nullable String description;
 
     /**
      * Describes meta-data for the configuration of the future {@link Module} instances.
@@ -81,8 +79,8 @@ public abstract class ModuleType implements Identifiable<String> {
      * Creates a {@link ModuleType} instance. This constructor is responsible to initialize common base properties of
      * the {@link ModuleType}s.
      *
-     * @param UID                the {@link ModuleType}'s identifier, or {@code null} if a random identifier should be
-     *                           generated.
+     * @param UID the {@link ModuleType}'s identifier, or {@code null} if a random identifier should be
+     *            generated.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Module} instances
      */
     public ModuleType(@Nullable String UID, @Nullable List<ConfigDescriptionParameter> configDescriptions) {
@@ -93,17 +91,17 @@ public abstract class ModuleType implements Identifiable<String> {
      * Creates a {@link ModuleType} instance. This constructor is responsible to initialize all common properties of
      * the {@link ModuleType}s.
      *
-     * @param UID                the {@link ModuleType}'s identifier, or {@code null} if a random identifier should be
-     *                           generated.
+     * @param UID the {@link ModuleType}'s identifier, or {@code null} if a random identifier should be
+     *            generated.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Module} instances.
-     * @param label              a short and accurate, human-readable label of the {@link ModuleType}.
-     * @param description        a detailed, human-readable description of usage of {@link ModuleType} and its benefits.
-     * @param tags               defines categories that fit the {@link ModuleType} and which can serve as criteria for
-     *                           searching or filtering it.
-     * @param visibility         determines whether the {@link ModuleType} can be used by anyone if it is
-     *                           {@link Visibility#VISIBLE} or only by its creator if it is {@link Visibility#HIDDEN}.
-     *                           If {@code null} is provided the default visibility {@link Visibility#VISIBLE} will be
-     *                           used.
+     * @param label a short and accurate, human-readable label of the {@link ModuleType}.
+     * @param description a detailed, human-readable description of usage of {@link ModuleType} and its benefits.
+     * @param tags defines categories that fit the {@link ModuleType} and which can serve as criteria for
+     *            searching or filtering it.
+     * @param visibility determines whether the {@link ModuleType} can be used by anyone if it is
+     *            {@link Visibility#VISIBLE} or only by its creator if it is {@link Visibility#HIDDEN}.
+     *            If {@code null} is provided the default visibility {@link Visibility#VISIBLE} will be
+     *            used.
      */
     public ModuleType(@Nullable String UID, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable String label, @Nullable String description, @Nullable Set<String> tags,

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -39,14 +39,14 @@ public interface MDNSDiscoveryParticipant {
      *
      * @return a set of thing type UIDs for which results can be created
      */
-    public Set<ThingTypeUID> getSupportedThingTypeUIDs();
+    Set<ThingTypeUID> getSupportedThingTypeUIDs();
 
     /**
      * Defines the mDNS service type this participant listens to
      *
      * @return a valid mDNS service type (see: http://www.dns-sd.org/ServiceTypes.html)
      */
-    public String getServiceType();
+    String getServiceType();
 
     /**
      * Creates a discovery result for a mDNS service
@@ -56,7 +56,7 @@ public interface MDNSDiscoveryParticipant {
      *         supported by this participant
      */
     @Nullable
-    public DiscoveryResult createResult(ServiceInfo service);
+    DiscoveryResult createResult(ServiceInfo service);
 
     /**
      * Returns the thing UID for a mDNS service
@@ -66,5 +66,5 @@ public interface MDNSDiscoveryParticipant {
      *         by this participant
      */
     @Nullable
-    public ThingUID getThingUID(ServiceInfo service);
+    ThingUID getThingUID(ServiceInfo service);
 }

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/UpnpDiscoveryParticipant.java
@@ -42,7 +42,7 @@ public interface UpnpDiscoveryParticipant {
      *
      * @return a set of thing type UIDs for which results can be created
      */
-    public Set<ThingTypeUID> getSupportedThingTypeUIDs();
+    Set<ThingTypeUID> getSupportedThingTypeUIDs();
 
     /**
      * Creates a discovery result for a upnp device
@@ -52,7 +52,7 @@ public interface UpnpDiscoveryParticipant {
      *         supported by this participant
      */
     @Nullable
-    public DiscoveryResult createResult(RemoteDevice device);
+    DiscoveryResult createResult(RemoteDevice device);
 
     /**
      * Returns the thing UID for a upnp device
@@ -62,5 +62,5 @@ public interface UpnpDiscoveryParticipant {
      *         by this participant
      */
     @Nullable
-    public ThingUID getThingUID(RemoteDevice device);
+    ThingUID getThingUID(RemoteDevice device);
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -74,10 +74,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     private @Nullable ScheduledFuture<?> scheduledStop;
 
-    @NonNullByDefault({})
-    protected TranslationProvider i18nProvider;
-    @NonNullByDefault({})
-    protected LocaleProvider localeProvider;
+    protected @NonNullByDefault({}) TranslationProvider i18nProvider;
+    protected @NonNullByDefault({}) LocaleProvider localeProvider;
 
     /**
      * Creates a new instance of this class with the specified parameters.

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryListener.java
@@ -72,8 +72,7 @@ public interface DiscoveryListener {
      * @deprecated use {@link #removeOlderResults(DiscoveryService, long, Collection, ThingUID)} instead
      */
     @Deprecated
-    @Nullable
-    default Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
+    default @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
             @Nullable Collection<ThingTypeUID> thingTypeUIDs) {
         return removeOlderResults(source, timestamp, thingTypeUIDs, null);
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/UpnpDiscoveryParticipant.java
@@ -43,7 +43,7 @@ public interface UpnpDiscoveryParticipant {
      *
      * @return a set of thing type UIDs for which results can be created
      */
-    public Set<ThingTypeUID> getSupportedThingTypeUIDs();
+    Set<ThingTypeUID> getSupportedThingTypeUIDs();
 
     /**
      * Creates a discovery result for a upnp device
@@ -52,7 +52,8 @@ public interface UpnpDiscoveryParticipant {
      * @return the according discovery result or <code>null</code>, if device is not
      *         supported by this participant
      */
-    public @Nullable DiscoveryResult createResult(RemoteDevice device);
+    @Nullable
+    DiscoveryResult createResult(RemoteDevice device);
 
     /**
      * Returns the thing UID for a upnp device
@@ -61,5 +62,6 @@ public interface UpnpDiscoveryParticipant {
      * @return a thing UID or <code>null</code>, if device is not supported
      *         by this participant
      */
-    public @Nullable ThingUID getThingUID(RemoteDevice device);
+    @Nullable
+    ThingUID getThingUID(RemoteDevice device);
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -68,7 +69,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegistry, DiscoveryListener {
 
-    private final HashMap<DiscoveryService, Set<DiscoveryResult>> cachedResults = new HashMap<>();
+    private final Map<DiscoveryService, Set<DiscoveryResult>> cachedResults = new HashMap<>();
 
     private final class AggregatingScanListener implements ScanListener {
 
@@ -137,8 +138,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
 
     private final Logger logger = LoggerFactory.getLogger(DiscoveryServiceRegistryImpl.class);
 
-    @NonNullByDefault({})
-    private SafeCaller safeCaller;
+    private @NonNullByDefault({}) SafeCaller safeCaller;
 
     @Activate
     protected void activate() {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -123,27 +123,19 @@ public class ItemResource implements RESTResource {
     /** The URI path to this resource */
     public static final String PATH_ITEMS = "items";
 
-    @NonNullByDefault({})
     @Context
+    @NonNullByDefault({})
     UriInfo uriInfo;
 
-    @NonNullByDefault({})
-    private ItemRegistry itemRegistry;
-    @NonNullByDefault({})
-    private MetadataRegistry metadataRegistry;
-    @NonNullByDefault({})
-    private EventPublisher eventPublisher;
-    @NonNullByDefault({})
-    private ManagedItemProvider managedItemProvider;
-    @NonNullByDefault({})
-    private DTOMapper dtoMapper;
-    @NonNullByDefault({})
-    private MetadataSelectorMatcher metadataSelectorMatcher;
-    @NonNullByDefault({})
-    private ItemBuilderFactory itemBuilderFactory;
+    private @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private @NonNullByDefault({}) MetadataRegistry metadataRegistry;
+    private @NonNullByDefault({}) EventPublisher eventPublisher;
+    private @NonNullByDefault({}) ManagedItemProvider managedItemProvider;
+    private @NonNullByDefault({}) DTOMapper dtoMapper;
+    private @NonNullByDefault({}) MetadataSelectorMatcher metadataSelectorMatcher;
+    private @NonNullByDefault({}) ItemBuilderFactory itemBuilderFactory;
 
-    @NonNullByDefault({})
-    private LocaleService localeService;
+    private @NonNullByDefault({}) LocaleService localeService;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setItemRegistry(ItemRegistry itemRegistry) {

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/discovery/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/discovery/MDNSDiscoveryParticipant.java
@@ -37,14 +37,14 @@ public interface MDNSDiscoveryParticipant {
      *
      * @return a set of thing type UIDs for which results can be created
      */
-    public Set<ThingTypeUID> getSupportedThingTypeUIDs();
+    Set<ThingTypeUID> getSupportedThingTypeUIDs();
 
     /**
      * Defines the mDNS service type this participant listens to
      *
      * @return a valid mDNS service type (see: http://www.dns-sd.org/ServiceTypes.html)
      */
-    public String getServiceType();
+    String getServiceType();
 
     /**
      * Creates a discovery result for a mDNS service
@@ -53,7 +53,7 @@ public interface MDNSDiscoveryParticipant {
      * @return the according discovery result or <code>null</code>, if device is not
      *         supported by this participant
      */
-    public DiscoveryResult createResult(ServiceInfo service);
+    DiscoveryResult createResult(ServiceInfo service);
 
     /**
      * Returns the thing UID for a mDNS service
@@ -62,5 +62,5 @@ public interface MDNSDiscoveryParticipant {
      * @return a thing UID or <code>null</code>, if device is not supported
      *         by this participant
      */
-    public ThingUID getThingUID(ServiceInfo service);
+    ThingUID getThingUID(ServiceInfo service);
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceItemInfo.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceItemInfo.java
@@ -14,7 +14,7 @@ package org.eclipse.smarthome.core.persistence;
 
 import java.util.Date;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -24,6 +24,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Chris Jackson - Initial contribution
  *
  */
+@NonNullByDefault
 public interface PersistenceItemInfo {
     /**
      * Returns the item name.
@@ -33,7 +34,6 @@ public interface PersistenceItemInfo {
      *
      * @return Item name
      */
-    @NonNull
     String getName();
 
     /**

--- a/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTags.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTags.java
@@ -65,13 +65,11 @@ public class SemanticTags {
      *            (e.g. "Bedroom").
      * @return the class for the id or null, if non exists.
      */
-    @Nullable
-    public static Class<? extends Tag> getById(String tagId) {
+    public static @Nullable Class<? extends Tag> getById(String tagId) {
         return TAGS.get(tagId);
     }
 
-    @Nullable
-    public static Class<? extends Tag> getByLabel(String tagLabel, Locale locale) {
+    public static @Nullable Class<? extends Tag> getByLabel(String tagLabel, Locale locale) {
         return TAGS.values().stream().distinct().filter(t -> getLabel(t, locale).equalsIgnoreCase(tagLabel)).findFirst()
                 .orElse(null);
     }
@@ -112,8 +110,7 @@ public class SemanticTags {
      * @param item the item to get the semantic type for
      * @return a sub-type of Location, Equipment or Point
      */
-    @Nullable
-    public static Class<? extends Tag> getSemanticType(Item item) {
+    public static @Nullable Class<? extends Tag> getSemanticType(Item item) {
         Set<String> tags = item.getTags();
         for (String tag : tags) {
             Class<? extends Tag> type = getById(tag);
@@ -141,8 +138,7 @@ public class SemanticTags {
      * @return a sub-type of Property if the item represents a Point, otherwise null
      */
     @SuppressWarnings("unchecked")
-    @Nullable
-    public static Class<? extends Property> getProperty(Item item) {
+    public static @Nullable Class<? extends Property> getProperty(Item item) {
         Set<String> tags = item.getTags();
         for (String tag : tags) {
             Class<? extends Tag> type = getById(tag);

--- a/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImpl.java
@@ -51,11 +51,8 @@ public class SemanticsServiceImpl implements SemanticsService {
 
     private static final String SYNONYMS_NAMESPACE = "synonyms";
 
-    @NonNullByDefault({})
-    private ItemRegistry itemRegistry;
-
-    @NonNullByDefault({})
-    private MetadataRegistry metadataRegistry;
+    private @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private @NonNullByDefault({}) MetadataRegistry metadataRegistry;
 
     void activate(BundleContext context) {
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -47,8 +47,8 @@ public class Channel {
 
     private final ChannelKind kind;
 
-    @NonNullByDefault({}) // uid might not have been initialized by the default constructor.
-    private ChannelUID uid;
+    // uid might not have been initialized by the default constructor.
+    private @NonNullByDefault({}) ChannelUID uid;
 
     private @Nullable ChannelTypeUID channelTypeUID;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -71,18 +71,15 @@ public abstract class BaseThingHandler implements ThingHandler {
             .getScheduledPool(THING_HANDLER_THREADPOOL_NAME);
 
     @Deprecated // this must not be used by bindings!
-    @NonNullByDefault({})
-    protected ThingRegistry thingRegistry;
+    protected @NonNullByDefault({}) ThingRegistry thingRegistry;
 
     @Deprecated // this must not be used by bindings!
-    @NonNullByDefault({})
-    protected BundleContext bundleContext;
+    protected @NonNullByDefault({}) BundleContext bundleContext;
 
     protected Thing thing;
 
     @SuppressWarnings("rawtypes")
-    @NonNullByDefault({})
-    private ServiceTracker thingRegistryServiceTracker;
+    private @NonNullByDefault({}) ServiceTracker thingRegistryServiceTracker;
 
     private @Nullable ThingHandlerCallback callback;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -53,8 +53,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
-    @NonNullByDefault({})
-    protected BundleContext bundleContext;
+    protected @NonNullByDefault({}) BundleContext bundleContext;
 
     private final Logger logger = LoggerFactory.getLogger(BaseThingHandlerFactory.class);
 
@@ -63,10 +62,8 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private final Map<ThingUID, Set<ServiceRegistration<?>>> thingHandlerServices = new ConcurrentHashMap<>();
 
-    @NonNullByDefault({})
-    private ServiceTracker<ThingTypeRegistry, ThingTypeRegistry> thingTypeRegistryServiceTracker;
-    @NonNullByDefault({})
-    private ServiceTracker<ConfigDescriptionRegistry, ConfigDescriptionRegistry> configDescriptionRegistryServiceTracker;
+    private @NonNullByDefault({}) ServiceTracker<ThingTypeRegistry, ThingTypeRegistry> thingTypeRegistryServiceTracker;
+    private @NonNullByDefault({}) ServiceTracker<ConfigDescriptionRegistry, ConfigDescriptionRegistry> configDescriptionRegistryServiceTracker;
 
     /**
      * Initializes the {@link BaseThingHandlerFactory}. If this method is overridden by a sub class, the implementing

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
@@ -72,7 +72,7 @@ public interface Firmware extends Comparable<Firmware> {
      *
      * @return the thing type UID (not null)
      */
-    public ThingTypeUID getThingTypeUID();
+    ThingTypeUID getThingTypeUID();
 
     /**
      * Returns the vendor of the firmware.
@@ -80,7 +80,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the vendor of the firmware (can be null)
      */
     @Nullable
-    public String getVendor();
+    String getVendor();
 
     /**
      * Returns the model of the firmware.
@@ -88,14 +88,14 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the model of the firmware (can be null)
      */
     @Nullable
-    public String getModel();
+    String getModel();
 
     /**
      * Returns whether this firmware is restricted to things with the model provided by the {@link #getModel()} method.
      *
      * @return whether the firmware is restricted to a particular model
      */
-    public boolean isModelRestricted();
+    boolean isModelRestricted();
 
     /**
      * Returns the description of the firmware.
@@ -103,14 +103,14 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the description of the firmware (can be null)
      */
     @Nullable
-    public String getDescription();
+    String getDescription();
 
     /**
      * Returns the version of the firmware.
      *
      * @return the version of the firmware (not null)
      */
-    public String getVersion();
+    String getVersion();
 
     /**
      * Returns the prerequisite version of the firmware.
@@ -121,14 +121,14 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the prerequisite version of the firmware (can be null)
      */
     @Nullable
-    public String getPrerequisiteVersion();
+    String getPrerequisiteVersion();
 
     /**
      * Provides the restriction of the firmware as {@link FirmwareRestriction} function.
      *
      * @return the restriction of the firmware as {@link FirmwareRestriction} function (not null)
      */
-    public FirmwareRestriction getFirmwareRestriction();
+    FirmwareRestriction getFirmwareRestriction();
 
     /**
      * Returns the changelog of the firmware.
@@ -136,7 +136,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the changelog of the firmware (can be null)
      */
     @Nullable
-    public String getChangelog();
+    String getChangelog();
 
     /**
      * Returns the URL to the online changelog of the firmware.
@@ -144,7 +144,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the URL the an online changelog of the firmware (can be null)
      */
     @Nullable
-    public URL getOnlineChangelog();
+    URL getOnlineChangelog();
 
     /**
      * Returns the input stream for the binary content of the firmware.
@@ -152,7 +152,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the input stream for the binary content of the firmware (can be null)
      */
     @Nullable
-    public InputStream getInputStream();
+    InputStream getInputStream();
 
     /**
      * Returns the MD5 hash value of the firmware.
@@ -160,7 +160,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the MD5 hash value of the firmware (can be null)
      */
     @Nullable
-    public String getMd5Hash();
+    String getMd5Hash();
 
     /**
      * Returns the binary content of the firmware using the firmware´s input stream. If the firmware provides a MD5 hash
@@ -169,14 +169,14 @@ public interface Firmware extends Comparable<Firmware> {
      * @return the binary content of the firmware (can be null)
      * @throws IllegalStateException if the MD5 hash value of the firmware is invalid
      */
-    public byte @Nullable [] getBytes();
+    byte @Nullable [] getBytes();
 
     /**
      * Returns the immutable properties of the firmware.
      *
      * @return the immutable properties of the firmware (not null)
      */
-    public Map<String, String> getProperties();
+    Map<String, String> getProperties();
 
     /**
      * Returns true, if this firmware is a successor version of the given firmware version, otherwise false. If the
@@ -185,7 +185,7 @@ public interface Firmware extends Comparable<Firmware> {
      * @param firmwareVersion the firmware version to be compared
      * @return true, if this firmware is a successor version for the given firmware version, otherwise false
      */
-    public boolean isSuccessorVersion(@Nullable String firmwareVersion);
+    boolean isSuccessorVersion(@Nullable String firmwareVersion);
 
     /**
      * Checks whether this firmware is suitable for the given thing.
@@ -194,5 +194,5 @@ public interface Firmware extends Comparable<Firmware> {
      * @return <code>true</code> if the current firmware is suitable for the given thing and <code>false</code>
      *         otherwise.
      */
-    public boolean isSuitableFor(Thing thing);
+    boolean isSuitableFor(Thing thing);
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareRegistry.java
@@ -46,7 +46,7 @@ public interface FirmwareRegistry {
      * @throws IllegalArgumentException if the thing is null; if the firmware version is null or empty
      */
     @Nullable
-    public Firmware getFirmware(Thing thing, String firmwareVersion);
+    Firmware getFirmware(Thing thing, String firmwareVersion);
 
     /**
      * Returns the firmware for the given thing, firmware version and locale.
@@ -58,7 +58,7 @@ public interface FirmwareRegistry {
      * @throws IllegalArgumentException if the thing is null; if the firmware version is null or empty
      */
     @Nullable
-    public Firmware getFirmware(Thing thing, String firmwareVersion, Locale locale);
+    Firmware getFirmware(Thing thing, String firmwareVersion, Locale locale);
 
     /**
      * Returns the latest firmware for the given thing, using the locale provided by the {@link LocaleProvider}.
@@ -68,7 +68,7 @@ public interface FirmwareRegistry {
      * @throws IllegalArgumentException if the thing is null
      */
     @Nullable
-    public Firmware getLatestFirmware(Thing thing);
+    Firmware getLatestFirmware(Thing thing);
 
     /**
      * Returns the latest firmware for the given thing and locale.
@@ -79,7 +79,7 @@ public interface FirmwareRegistry {
      * @throws IllegalArgumentException if the thing is null
      */
     @Nullable
-    public Firmware getLatestFirmware(Thing thing, @Nullable Locale locale);
+    Firmware getLatestFirmware(Thing thing, @Nullable Locale locale);
 
     /**
      * Returns the collection of available firmwares for the given thing using the locale provided by the
@@ -90,7 +90,7 @@ public interface FirmwareRegistry {
      * @return the collection of available firmwares for the given thing (not null)
      * @throws IllegalArgumentException if the thing is null
      */
-    public Collection<Firmware> getFirmwares(Thing thing);
+    Collection<Firmware> getFirmwares(Thing thing);
 
     /**
      * Returns the collection of available firmwares for the given thing and locale. The collection is
@@ -101,5 +101,5 @@ public interface FirmwareRegistry {
      * @return the collection of available firmwares for the given thing (not null)
      * @throws IllegalArgumentException if the thing is null
      */
-    public Collection<Firmware> getFirmwares(Thing thing, @Nullable Locale locale);
+    Collection<Firmware> getFirmwares(Thing thing, @Nullable Locale locale);
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareStatusInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareStatusInfo.java
@@ -34,8 +34,7 @@ public final class FirmwareStatusInfo {
 
     private final FirmwareStatus firmwareStatus;
 
-    @Nullable
-    private final String firmwareVersion;
+    private final @Nullable String firmwareVersion;
 
     /**
      * Package protected default constructor to allow reflective instantiation.
@@ -110,8 +109,7 @@ public final class FirmwareStatusInfo {
      *
      * @return the firmware version (only set if firmware status is {@link FirmwareStatus#UPDATE_EXECUTABLE})
      */
-    @Nullable
-    public String getUpdatableFirmwareVersion() {
+    public @Nullable String getUpdatableFirmwareVersion() {
         return this.firmwareVersion;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -124,7 +123,6 @@ public final class FirmwareUpdateProgressInfo {
      * @return FirmwareUpdateProgressInfo object (not null)
      * @throws IllegalArgumentException if sequence is null or empty
      */
-    @NonNull
     public static FirmwareUpdateProgressInfo createFirmwareUpdateProgressInfo(ThingUID thingUID,
             ThingTypeUID thingTypeUID, String firmwareVersion, ProgressStep progressStep,
             Collection<ProgressStep> sequence, boolean pending) {
@@ -172,8 +170,7 @@ public final class FirmwareUpdateProgressInfo {
      *
      * @return the progress between 0 and 100 or null if no progress was set
      */
-    @Nullable
-    public Integer getProgress() {
+    public @Nullable Integer getProgress() {
         return progress;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResultInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResultInfo.java
@@ -98,8 +98,7 @@ public final class FirmwareUpdateResultInfo {
      *
      * @return the error message in case of erroneous firmware updates (is null for successful firmware updates)
      */
-    @Nullable
-    public String getErrorMessage() {
+    public @Nullable String getErrorMessage() {
         return errorMessage;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -41,7 +41,7 @@ public interface FirmwareUpdateService {
      *         available)
      */
     @Nullable
-    public FirmwareStatusInfo getFirmwareStatusInfo(ThingUID thingUID);
+    FirmwareStatusInfo getFirmwareStatusInfo(ThingUID thingUID);
 
     /**
      * Updates the firmware of the thing having the given thing UID by invoking the operation
@@ -66,7 +66,7 @@ public interface FirmwareUpdateService {
      *             <li>the firmware requires another prerequisite firmware version</li>
      *             </ul>
      */
-    public void updateFirmware(final ThingUID thingUID, final String firmwareVersion, @Nullable final Locale locale);
+    void updateFirmware(final ThingUID thingUID, final String firmwareVersion, @Nullable final Locale locale);
 
     /**
      * Cancels the firmware update of the thing having the given thing UID by invoking the operation
@@ -74,5 +74,5 @@ public interface FirmwareUpdateService {
      *
      * @param thingUID the thing UID (must not be null)
      */
-    public void cancelFirmwareUpdate(final ThingUID thingUID);
+    void cancelFirmwareUpdate(final ThingUID thingUID);
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -100,24 +100,15 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     private final Logger logger = LoggerFactory.getLogger(CommunicationManager.class);
 
-    @NonNullByDefault({})
-    private SystemProfileFactory defaultProfileFactory;
-    @NonNullByDefault({})
-    private ItemChannelLinkRegistry itemChannelLinkRegistry;
-    @NonNullByDefault({})
-    private ThingRegistry thingRegistry;
-    @NonNullByDefault({})
-    private ItemRegistry itemRegistry;
-    @NonNullByDefault({})
-    private EventPublisher eventPublisher;
-    @NonNullByDefault({})
-    private SafeCaller safeCaller;
-    @NonNullByDefault({})
-    private AutoUpdateManager autoUpdateManager;
-    @NonNullByDefault({})
-    private ItemStateConverter itemStateConverter;
-    @NonNullByDefault({})
-    private ChannelTypeRegistry channelTypeRegistry;
+    private @NonNullByDefault({}) SystemProfileFactory defaultProfileFactory;
+    private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private @NonNullByDefault({}) ThingRegistry thingRegistry;
+    private @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private @NonNullByDefault({}) EventPublisher eventPublisher;
+    private @NonNullByDefault({}) SafeCaller safeCaller;
+    private @NonNullByDefault({}) AutoUpdateManager autoUpdateManager;
+    private @NonNullByDefault({}) ItemStateConverter itemStateConverter;
+    private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
 
     private final Set<ItemFactory> itemFactories = new CopyOnWriteArraySet<>();
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
@@ -64,11 +64,9 @@ public class ThingImpl implements Thing {
 
     private Map<String, String> properties = new HashMap<>();
 
-    @NonNullByDefault({})
-    private ThingUID uid;
+    private @NonNullByDefault({}) ThingUID uid;
 
-    @NonNullByDefault({})
-    private ThingTypeUID thingTypeUID;
+    private @NonNullByDefault({}) ThingTypeUID thingTypeUID;
 
     private @Nullable String location;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareImpl.java
@@ -12,8 +12,7 @@
  */
 package org.eclipse.smarthome.core.thing.internal.firmware;
 
-import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
-import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_MODEL_ID;
+import static org.eclipse.smarthome.core.thing.Thing.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -112,14 +111,12 @@ public final class FirmwareImpl implements Firmware {
     }
 
     @Override
-    @Nullable
-    public String getVendor() {
+    public @Nullable String getVendor() {
         return vendor;
     }
 
     @Override
-    @Nullable
-    public String getModel() {
+    public @Nullable String getModel() {
         return model;
     }
 
@@ -129,8 +126,7 @@ public final class FirmwareImpl implements Firmware {
     }
 
     @Override
-    @Nullable
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 
@@ -140,8 +136,7 @@ public final class FirmwareImpl implements Firmware {
     }
 
     @Override
-    @Nullable
-    public String getPrerequisiteVersion() {
+    public @Nullable String getPrerequisiteVersion() {
         return (prerequisiteVersion != null) ? prerequisiteVersion.toString() : null;
     }
 
@@ -151,26 +146,22 @@ public final class FirmwareImpl implements Firmware {
     }
 
     @Override
-    @Nullable
-    public String getChangelog() {
+    public @Nullable String getChangelog() {
         return changelog;
     }
 
     @Override
-    @Nullable
-    public URL getOnlineChangelog() {
+    public @Nullable URL getOnlineChangelog() {
         return onlineChangelog;
     }
 
     @Override
-    @Nullable
-    public InputStream getInputStream() {
+    public @Nullable InputStream getInputStream() {
         return inputStream;
     }
 
     @Override
-    @Nullable
-    public String getMd5Hash() {
+    public @Nullable String getMd5Hash() {
         return md5Hash;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareRegistryImpl.java
@@ -53,14 +53,12 @@ public final class FirmwareRegistryImpl implements FirmwareRegistry {
     private @NonNullByDefault({}) LocaleProvider localeProvider;
 
     @Override
-    @Nullable
-    public Firmware getFirmware(Thing thing, String firmwareVersion) {
+    public @Nullable Firmware getFirmware(Thing thing, String firmwareVersion) {
         return getFirmware(thing, firmwareVersion, localeProvider.getLocale());
     }
 
     @Override
-    @Nullable
-    public Firmware getFirmware(Thing thing, String firmwareVersion, @Nullable Locale locale) {
+    public @Nullable Firmware getFirmware(Thing thing, String firmwareVersion, @Nullable Locale locale) {
         ParameterChecks.checkNotNull(thing, "Thing");
         ParameterChecks.checkNotNullOrEmpty(firmwareVersion, "Firmware version");
 
@@ -83,14 +81,12 @@ public final class FirmwareRegistryImpl implements FirmwareRegistry {
     }
 
     @Override
-    @Nullable
-    public Firmware getLatestFirmware(Thing thing) {
+    public @Nullable Firmware getLatestFirmware(Thing thing) {
         return getLatestFirmware(thing, localeProvider.getLocale());
     }
 
     @Override
-    @Nullable
-    public Firmware getLatestFirmware(Thing thing, @Nullable Locale locale) {
+    public @Nullable Firmware getLatestFirmware(Thing thing, @Nullable Locale locale) {
         Locale loc = locale != null ? locale : localeProvider.getLocale();
         Collection<Firmware> firmwares = getFirmwares(thing, loc);
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -167,8 +167,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
     }
 
     @Override
-    @Nullable
-    public FirmwareStatusInfo getFirmwareStatusInfo(ThingUID thingUID) {
+    public @Nullable FirmwareStatusInfo getFirmwareStatusInfo(ThingUID thingUID) {
         ParameterChecks.checkNotNull(thingUID, "Thing UID");
         FirmwareUpdateHandler firmwareUpdateHandler = getFirmwareUpdateHandler(thingUID);
 
@@ -252,8 +251,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
     }
 
     @Override
-    @Nullable
-    public EventFilter getEventFilter() {
+    public @Nullable EventFilter getEventFilter() {
         return null;
     }
 
@@ -282,8 +280,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
         return entry;
     }
 
-    @Nullable
-    private Firmware getLatestSuitableFirmware(Thing thing) {
+    private @Nullable Firmware getLatestSuitableFirmware(Thing thing) {
         Collection<Firmware> firmwares = firmwareRegistry.getFirmwares(thing);
         if (firmwares != null) {
             Optional<Firmware> first = firmwares.stream().findFirst();
@@ -380,8 +377,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
         return firmware;
     }
 
-    @Nullable
-    private FirmwareUpdateHandler getFirmwareUpdateHandler(ThingUID thingUID) {
+    private @Nullable FirmwareUpdateHandler getFirmwareUpdateHandler(ThingUID thingUID) {
         for (FirmwareUpdateHandler firmwareUpdateHandler : firmwareUpdateHandlers) {
             if (thingUID.equals(firmwareUpdateHandler.getThing().getUID())) {
                 return firmwareUpdateHandler;
@@ -390,8 +386,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
         return null;
     }
 
-    @Nullable
-    private String getThingFirmwareVersion(FirmwareUpdateHandler firmwareUpdateHandler) {
+    private @Nullable String getThingFirmwareVersion(FirmwareUpdateHandler firmwareUpdateHandler) {
         return firmwareUpdateHandler.getThing().getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION);
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerDimmerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawRockerDimmerProfile.java
@@ -41,10 +41,8 @@ public class RawRockerDimmerProfile implements TriggerProfile {
 
     private final ProfileContext context;
 
-    @Nullable
-    private ScheduledFuture<?> dimmFuture;
-    @Nullable
-    private ScheduledFuture<?> timeoutFuture;
+    private @Nullable ScheduledFuture<?> dimmFuture;
+    private @Nullable ScheduledFuture<?> timeoutFuture;
 
     private long pressedTime = 0;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -57,8 +57,7 @@ public class SystemOffsetProfile implements StateProfile {
     private final ProfileCallback callback;
     private final ProfileContext context;
 
-    @Nullable
-    private QuantityType<?> offset;
+    private @Nullable QuantityType<?> offset;
 
     public SystemOffsetProfile(ProfileCallback callback, ProfileContext context) {
         this.callback = callback;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelGroupTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelGroupTypeRegistry.java
@@ -66,8 +66,7 @@ public class ChannelGroupTypeRegistry {
      *
      * @return channel group type or null if no channel group type for the given UID exists
      */
-    @Nullable
-    public ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID) {
+    public @Nullable ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID) {
         return getChannelGroupType(channelGroupTypeUID, null);
     }
 
@@ -77,8 +76,7 @@ public class ChannelGroupTypeRegistry {
      * @param locale (can be null)
      * @return channel group type or null if no channel group type for the given UID exists
      */
-    @Nullable
-    public ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID,
+    public @Nullable ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID,
             @Nullable Locale locale) {
         if (channelGroupTypeUID == null) {
             return null;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeProvider.java
@@ -45,8 +45,8 @@ public interface ChannelTypeProvider {
      * @deprecated The {@link ChannelGroupTypeProvider} is now to be implemented/used instead.
      */
     @Deprecated
-    @Nullable
-    default ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID, @Nullable Locale locale) {
+    default @Nullable ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID,
+            @Nullable Locale locale) {
         return null;
     }
 
@@ -54,8 +54,7 @@ public interface ChannelTypeProvider {
      * @deprecated The {@link ChannelGroupTypeProvider} is now to be implemented/used instead.
      */
     @Deprecated
-    @Nullable
-    default Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
+    default @Nullable Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
         return Collections.emptyList();
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
@@ -65,8 +65,7 @@ public class ChannelTypeRegistry {
      *
      * @return channel type or null if no channel type for the given UID exists
      */
-    @Nullable
-    public ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID) {
+    public @Nullable ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID) {
         return getChannelType(channelTypeUID, null);
     }
 
@@ -76,8 +75,7 @@ public class ChannelTypeRegistry {
      * @param locale (can be null)
      * @return channel type or null if no channel type for the given UID exists
      */
-    @Nullable
-    public ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+    public @Nullable ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
         if (channelTypeUID == null) {
             return null;
         }

--- a/bundles/org.openhab.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -54,18 +54,15 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class AbstractFileTransformationService<T> implements TransformationService {
 
-    @Nullable
-    private WatchService watchService = null;
+    private @Nullable WatchService watchService = null;
 
     protected final Map<String, T> cachedFiles = new ConcurrentHashMap<>();
     protected final List<String> watchedDirectories = new ArrayList<String>();
 
     private final Logger logger = LoggerFactory.getLogger(AbstractFileTransformationService.class);
 
-    @NonNullByDefault({})
-    private LocaleProvider localeProvider;
-    @NonNullByDefault({})
-    private ServiceTracker<LocaleProvider, LocaleProvider> localeProviderTracker;
+    private @NonNullByDefault({}) LocaleProvider localeProvider;
+    private @NonNullByDefault({}) ServiceTracker<LocaleProvider, LocaleProvider> localeProviderTracker;
 
     private class LocaleProviderServiceTrackerCustomizer
             implements ServiceTrackerCustomizer<LocaleProvider, LocaleProvider> {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/AbstractInvocationHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/AbstractInvocationHandler.java
@@ -48,10 +48,9 @@ abstract class AbstractInvocationHandler<T> {
     private final T target;
     private final Object identifier;
     private final long timeout;
-    @Nullable
-    private final Consumer<Throwable> exceptionHandler;
-    @Nullable
-    private final Runnable timeoutHandler;
+
+    private final @Nullable Consumer<Throwable> exceptionHandler;
+    private final @Nullable Runnable timeoutHandler;
 
     AbstractInvocationHandler(SafeCallManager manager, T target, Object identifier, long timeout,
             @Nullable Consumer<Throwable> exceptionHandler, @Nullable Runnable timeoutHandler) {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/InvocationHandlerAsync.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/InvocationHandlerAsync.java
@@ -38,8 +38,8 @@ class InvocationHandlerAsync<T> extends AbstractInvocationHandler<T> implements 
     }
 
     @Override
-    @Nullable
-    public Object invoke(@Nullable Object proxy, @Nullable Method method, Object @Nullable [] args) throws Throwable {
+    public @Nullable Object invoke(@Nullable Object proxy, @Nullable Method method, Object @Nullable [] args)
+            throws Throwable {
         if (method != null) {
             try {
                 getManager().enqueue(new Invocation(this, method, args));

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/InvocationHandlerSync.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/InvocationHandlerSync.java
@@ -45,8 +45,8 @@ public class InvocationHandlerSync<T> extends AbstractInvocationHandler<T> imple
     }
 
     @Override
-    @Nullable
-    public Object invoke(@Nullable Object proxy, @Nullable Method method, Object @Nullable [] args) throws Throwable {
+    public @Nullable Object invoke(@Nullable Object proxy, @Nullable Method method, Object @Nullable [] args)
+            throws Throwable {
         if (method != null) {
             Invocation invocation = new Invocation(this, method, args);
             Invocation activeInvocation = getManager().getActiveInvocation();

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallManagerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallManagerImpl.java
@@ -131,8 +131,7 @@ public class SafeCallManagerImpl implements SafeCallManager {
         }
     }
 
-    @Nullable
-    public Invocation dequeue(Object identifier) {
+    public @Nullable Invocation dequeue(Object identifier) {
         synchronized (queues) {
             Queue<Invocation> queue = queues.get(identifier);
             if (queue != null) {
@@ -143,8 +142,7 @@ public class SafeCallManagerImpl implements SafeCallManager {
     }
 
     @Override
-    @Nullable
-    public Invocation getActiveInvocation() {
+    public @Nullable Invocation getActiveInvocation() {
         synchronized (activeIdentifiers) {
             for (Invocation invocation : activeIdentifiers.values()) {
                 if (invocation.getThread() == Thread.currentThread()) {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerBuilderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerBuilderImpl.java
@@ -39,10 +39,8 @@ public class SafeCallerBuilderImpl<T> implements SafeCallerBuilder<T> {
     private final Class<?>[] interfaceTypes;
     private long timeout;
     private Object identifier;
-    @Nullable
-    private Consumer<Throwable> exceptionHandler;
-    @Nullable
-    private Runnable timeoutHandler;
+    private @Nullable Consumer<Throwable> exceptionHandler;
+    private @Nullable Runnable timeoutHandler;
     private boolean async;
     private final SafeCallManager manager;
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
@@ -39,11 +39,8 @@ public class SafeCallerImpl implements SafeCaller {
 
     private static final String SAFE_CALL_POOL_NAME = "safeCall";
 
-    @NonNullByDefault({})
-    private ScheduledExecutorService watcher;
-
-    @NonNullByDefault({})
-    private SafeCallManagerImpl manager;
+    private @NonNullByDefault({}) ScheduledExecutorService watcher;
+    private @NonNullByDefault({}) SafeCallManagerImpl manager;
 
     @Activate
     public void activate(@Nullable Map<String, Object> properties) {

--- a/bundles/org.openhab.core/src/test/java/org/eclipse/smarthome/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/eclipse/smarthome/core/library/types/DateTimeTypeTest.java
@@ -62,23 +62,20 @@ public class DateTimeTypeTest {
          * input time.
          * used to call the {@link Calendar#set(int, int, int, int, int, int)} method to set the time.
          */
-        @Nullable
-        public final Map<String, Integer> inputTimeMap;
+        public final @Nullable Map<String, Integer> inputTimeMap;
         /**
          * input time zone.
          * used to call the {@link Calendar#setTimeZone(TimeZone)} to set the time zone.
          * the time zone offset has direct impact on the result.
          */
-        @Nullable
-        public final TimeZone inputTimeZone;
+        public final @Nullable TimeZone inputTimeZone;
         /**
          * direct input of a time string (with or without time zone).
          *
          * @see {@link DateTimeType#valueOf(String)}
          *      if this is set, the {@link ParameterSet#inputTimeMap} and {@link ParameterSet#inputTimeZone} are ignored
          */
-        @Nullable
-        public final String inputTimeString;
+        public final @Nullable String inputTimeString;
         /**
          * the expected result of the test without any additional translation to the time zone specified in the
          * {@link ParameterSet#defaultTimeZone}.
@@ -101,14 +98,12 @@ public class DateTimeTypeTest {
         /**
          * the locale parameter to be used to test the method {@link DateTimeType#format(Locale, String)}.
          */
-        @Nullable
-        public final Locale locale;
+        public final @Nullable Locale locale;
         /**
          * the pattern parameter to be used to test the method {@link DateTimeType#format(Locale, String)}
          * or {@link DateTimeType#format(String)}.
          */
-        @Nullable
-        public final String pattern;
+        public final @Nullable String pattern;
         /**
          * the expected result when testing the method {@link DateTimeType#format(Locale, String)}
          * or {@link DateTimeType#format(String)}.


### PR DESCRIPTION
* Move null annotations between modifiers and variable type
* Remove redundant public modifiers from interfaces where applicable
* Remove redundant `@NonNull` annotations
