### PR TITLE
increase paho inflight message limit

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -717,7 +717,9 @@ public class MqttBrokerConnection {
         // Connect
         _client.setCallback(clientCallback);
         try {
-            _client.connect(createMqttOptions(), null, connectionCallback);
+            MqttConnectOptions mqttConnectOptions = createMqttOptions();
+            mqttConnectOptions.setMaxInflight(16384); // 1/4 of available message ids
+            _client.connect(mqttConnectOptions, null, connectionCallback);
             logger.info("Starting MQTT broker connection to '{}' with clientid {} and file store '{}'", host,
                     getClientId(), persistencePath);
         } catch (org.eclipse.paho.client.mqttv3.MqttException | ConfigurationException e) {


### PR DESCRIPTION
When a lot of messages are published with QoS>0 Paho complains about "too many publishes in progress". This is due to a very low limit of 10 for inflight messages (see https://mvmn.wordpress.com/2016/07/23/paho-mqtt-client-max-in-flight-messages-for-qos-0/) 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>