### PR TITLE
[semantics] Use constructor injection to simplify lifecycle

### DIFF
--- a/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTags.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTags.java
@@ -18,12 +18,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.semantics.model.Property;
@@ -42,11 +43,11 @@ import org.eclipse.smarthome.core.types.StateDescription;
  * For everything that is not static, the {@link SemanticsService} should be used instead.
  *
  * @author Kai Kreuzer - Initial contribution
- *
  */
+@NonNullByDefault
 public class SemanticTags {
 
-    private static String TAGS_BUNDLE_NAME = "tags";
+    private static final String TAGS_BUNDLE_NAME = "tags";
 
     private static final Map<String, Class<? extends Tag>> TAGS = new TreeMap<>();
 
@@ -70,11 +71,12 @@ public class SemanticTags {
     }
 
     public static @Nullable Class<? extends Tag> getByLabel(String tagLabel, Locale locale) {
-        return TAGS.values().stream().distinct().filter(t -> getLabel(t, locale).equalsIgnoreCase(tagLabel)).findFirst()
-                .orElse(null);
+        Optional<Class<? extends Tag>> tag = TAGS.values().stream().distinct()
+                .filter(t -> getLabel(t, locale).equalsIgnoreCase(tagLabel)).findFirst();
+        return tag.isPresent() ? tag.get() : null;
     }
 
-    public static List<Class<? extends @NonNull Tag>> getByLabelOrSynonym(String tagLabelOrSynonym, Locale locale) {
+    public static List<Class<? extends Tag>> getByLabelOrSynonym(String tagLabelOrSynonym, Locale locale) {
         return TAGS.values().stream().distinct()
                 .filter(t -> getLabelAndSynonyms(t, locale).contains(tagLabelOrSynonym.toLowerCase(locale)))
                 .collect(Collectors.toList());

--- a/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsMetadataProvider.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.core.semantics.model.Tag;
 import org.eclipse.smarthome.core.semantics.model.TagInfo;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -50,7 +51,6 @@ import org.osgi.service.component.annotations.Reference;
  * (e.g. "hasLocation") and the value being the id of the referenced entity (e.g. its item name).
  *
  * @author Kai Kreuzer - Initial contribution
- *
  */
 @NonNullByDefault
 @Component(immediate = true)
@@ -73,7 +73,12 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
         }
     });
 
-    private @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private final ItemRegistry itemRegistry;
+
+    @Activate
+    public SemanticsMetadataProvider(final @Reference ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
 
     @Activate
     protected void activate() {
@@ -84,19 +89,10 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
         itemRegistry.addRegistryChangeListener(this);
     }
 
+    @Deactivate
     protected void deactivate() {
         itemRegistry.removeRegistryChangeListener(this);
         semantics.clear();
-
-    }
-
-    @Reference
-    protected void setItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = itemRegistry;
-    }
-
-    protected void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
     }
 
     @Override

--- a/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImpl.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
@@ -35,7 +34,7 @@ import org.eclipse.smarthome.core.semantics.model.Equipment;
 import org.eclipse.smarthome.core.semantics.model.Location;
 import org.eclipse.smarthome.core.semantics.model.Point;
 import org.eclipse.smarthome.core.semantics.model.Tag;
-import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -43,7 +42,6 @@ import org.osgi.service.component.annotations.Reference;
  * The internal implementation of the {@link SemanticsService} interface, which is registered as an OSGi service.
  *
  * @author Kai Kreuzer - Initial contribution
- *
  */
 @NonNullByDefault
 @Component
@@ -51,28 +49,14 @@ public class SemanticsServiceImpl implements SemanticsService {
 
     private static final String SYNONYMS_NAMESPACE = "synonyms";
 
-    private @NonNullByDefault({}) ItemRegistry itemRegistry;
-    private @NonNullByDefault({}) MetadataRegistry metadataRegistry;
+    private final ItemRegistry itemRegistry;
+    private final MetadataRegistry metadataRegistry;
 
-    void activate(BundleContext context) {
-    }
-
-    @Reference
-    void setItemRegistry(ItemRegistry itemRegistry) {
+    @Activate
+    public SemanticsServiceImpl(final @Reference ItemRegistry itemRegistry,
+            final @Reference MetadataRegistry metadataRegistry) {
         this.itemRegistry = itemRegistry;
-    }
-
-    void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
-    }
-
-    @Reference
-    void setMetadataRegistry(MetadataRegistry metadataRegistry) {
         this.metadataRegistry = metadataRegistry;
-    }
-
-    void unsetMetadataRegistry(MetadataRegistry metadataRegistry) {
-        this.metadataRegistry = null;
     }
 
     @Override
@@ -92,7 +76,7 @@ public class SemanticsServiceImpl implements SemanticsService {
 
     @SuppressWarnings({ "unchecked" })
     @Override
-    public @NonNull Set<Item> getItemsInLocation(@NonNull String labelOrSynonym, Locale locale) {
+    public Set<Item> getItemsInLocation(String labelOrSynonym, Locale locale) {
         Set<Item> items = new HashSet<>();
         List<Class<? extends Tag>> tagList = SemanticTags.getByLabelOrSynonym(labelOrSynonym, locale);
         if (!tagList.isEmpty()) {

--- a/itests/org.openhab.core.semantics.tests/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTagsTest.java
+++ b/itests/org.openhab.core.semantics.tests/src/main/java/org/eclipse/smarthome/core/semantics/SemanticTagsTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * @author Kai Kreuzer - Initial contribution and API
+ * @author Kai Kreuzer - Initial contribution
  */
 public class SemanticTagsTest {
 

--- a/itests/org.openhab.core.semantics.tests/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImplTest.java
+++ b/itests/org.openhab.core.semantics.tests/src/main/java/org/eclipse/smarthome/core/semantics/internal/SemanticsServiceImplTest.java
@@ -21,7 +21,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
@@ -33,14 +32,12 @@ import org.eclipse.smarthome.core.semantics.model.location.LivingRoom;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.osgi.framework.BundleContext;
 
 /**
  * @author Kai Kreuzer - Initial contribution
  */
 public class SemanticsServiceImplTest {
 
-    private @Mock BundleContext bundleContext;
     private @Mock ItemRegistry itemRegistry;
     private @Mock MetadataRegistry metadataRegistry;
 
@@ -74,15 +71,12 @@ public class SemanticsServiceImplTest {
                 .thenReturn(Stream.of(locationItem, equipmentItem, pointItem))
                 .thenReturn(Stream.of(locationItem, equipmentItem, pointItem));
 
-        service = new SemanticsServiceImpl();
-        service.setItemRegistry(itemRegistry);
-        service.setMetadataRegistry(metadataRegistry);
-        service.activate(bundleContext);
+        service = new SemanticsServiceImpl(itemRegistry, metadataRegistry);
     }
 
     @Test
     public void testGetItemsInLocation() throws Exception {
-        Set<@NonNull Item> items = service.getItemsInLocation(Bathroom.class);
+        Set<Item> items = service.getItemsInLocation(Bathroom.class);
         assertTrue(items.contains(pointItem));
 
         items = service.getItemsInLocation("Room", Locale.ENGLISH);
@@ -91,7 +85,7 @@ public class SemanticsServiceImplTest {
 
     @Test
     public void testGetItemsInLocationByString() throws Exception {
-        Set<@NonNull Item> items = service.getItemsInLocation("joe's room", Locale.ENGLISH);
+        Set<Item> items = service.getItemsInLocation("joe's room", Locale.ENGLISH);
         assertTrue(items.contains(pointItem));
 
         items = service.getItemsInLocation(LivingRoom.class);


### PR DESCRIPTION
- Use constructor injection to simplify lifecycle
- Minor code clean-up (omit use of `@NonNull` annotation)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>