### PR TITLE
[IconServlet] New optional parameter anyFormat

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class RootBean {
 
-    public final String version = "2";
+    public final String version = "3";
 
     public final List<Links> links = new ArrayList<Links>();
 


### PR DESCRIPTION
Fix #824

If this new parameter is not used by the caller (UI), the behavior is unchanged. So this change will break no existing UI.

When this new parameter is provided and set to true by the caller (UI), the server will search the icon as SVG and PNG formats. If the icon provider is the same in the two cases, it will return the icon with the requested format. In case the 2 icon providers are different for SVG and PNG, the server will return the icon in the format corresponding to the provider with higer priority.

This new parameter allows an UI to select a preferred format for icons without loosing the customized user icons that can be defined  in a different format. Of course, in this case, the UI must handle possible different icon formats returned by the servlet.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>