### PR TITLE
[WIP][money] Initial contribution of 'MonetaryType' and Money API

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -202,6 +202,26 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- Money -->
+    <dependency>
+      <groupId>javax.money</groupId>
+      <artifactId>money-api</artifactId>
+      <version>1.0.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javamoney.moneta</groupId>
+      <artifactId>moneta-core</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javamoney.moneta</groupId>
+      <artifactId>moneta-convert</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Paho MQTT -->
     <dependency>
       <groupId>org.eclipse.paho</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -432,6 +432,26 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- Money -->
+    <dependency>
+      <groupId>javax.money</groupId>
+      <artifactId>money-api</artifactId>
+      <version>1.0.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javamoney.moneta</groupId>
+      <artifactId>moneta-core</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javamoney.moneta</groupId>
+      <artifactId>moneta-convert</artifactId>
+      <version>1.3</version>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Paho MQTT -->
     <dependency>
       <groupId>org.eclipse.paho</groupId>

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/MonetaryType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/MonetaryType.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.library.types;
+
+import java.util.Locale;
+
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+import javax.money.MonetaryAmount;
+import javax.money.MonetaryContext;
+import javax.money.UnknownCurrencyException;
+import javax.money.convert.CurrencyConversion;
+import javax.money.convert.MonetaryConversions;
+import javax.money.format.MonetaryAmountFormat;
+import javax.money.format.MonetaryFormats;
+import javax.money.format.MonetaryParseException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.PrimitiveType;
+import org.eclipse.smarthome.core.types.State;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link MonetaryType} extends {@link Number} to handle monetary amounts
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault()
+public class MonetaryType extends Number implements PrimitiveType, State, Command, Comparable<MonetaryType> {
+
+    private final Logger logger = LoggerFactory.getLogger(MonetaryType.class);
+
+    private static final long serialVersionUID = 8828949721938234633L;
+
+    private final MonetaryAmount amount;
+
+    /**
+     *
+     */
+    public MonetaryType() {
+        this.amount = Monetary.getDefaultAmountFactory().setCurrency(Monetary.getCurrency("EUR")).setNumber(0).create();
+    }
+
+    /**
+     *
+     */
+    public MonetaryType(String value) throws MonetaryParseException {
+        MonetaryAmountFormat format = MonetaryFormats.getAmountFormat(Locale.getDefault());
+        this.amount = format.parse(value);
+    }
+
+    /**
+     *
+     */
+    public MonetaryType(Number value, CurrencyUnit currency) {
+        this.amount = Monetary.getDefaultAmountFactory().setCurrency(currency).setNumber(value).create();
+    }
+
+    /**
+     *
+     */
+    public MonetaryType(Number value, String currency) throws UnknownCurrencyException {
+        this(value, Monetary.getCurrency(currency));
+    }
+
+    /**
+     * Private constructor for arithmetic operations.
+     */
+    private MonetaryType(MonetaryAmount amount) {
+        this.amount = amount;
+    }
+
+    /**
+     *
+     */
+    public static MonetaryType valueOf(double value, CurrencyUnit currency) {
+        return new MonetaryType(value, currency);
+    }
+
+    public static MonetaryType valueOf(double value, String currency) {
+        return new MonetaryType(value, currency);
+    }
+
+    public static MonetaryType valueOf(String value) throws MonetaryParseException {
+        return new MonetaryType(value);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null) {
+            return false;
+        }
+        if (!(object instanceof MonetaryType)) {
+            return false;
+        }
+        return amount.equals(((MonetaryType) object).amount);
+    }
+
+    @Override
+    public int compareTo(MonetaryType object) {
+        return amount.compareTo(object.amount);
+    }
+
+    /**
+     * Returns the {@link CurrencyUnit} of this {@link MonetaryType}.
+     *
+     * @return the {@link CurrencyUnit}
+     */
+    public CurrencyUnit getCurrency() {
+        return amount.getCurrency();
+    }
+
+    /**
+     * Convert this {@link MonetaryType} to a new {@link MonetaryType} using the given target {@link CurrencyUnit}.
+     *
+     * @param targetCurrency the {@link CurrencyUnit} to which this {@link MonetaryType} will be converted to.
+     * @return the new {@link MonetaryType} in the given {@link CurrencyUnit} or {@code null}.
+     */
+    public @Nullable MonetaryType toCurrency(CurrencyUnit targetCurrency) {
+        CurrencyConversion conversion = MonetaryConversions.getConversion(targetCurrency);
+        return new MonetaryType(amount.with(conversion));
+    }
+
+    /**
+     * Converts this {@link MonetaryType} to a new {@link MonetaryType} using the given target currency.
+     *
+     * @param targetCurrency the currency to which this {@link MonetaryType} will be converted to.
+     * @return the new {@link MonetaryType} in the given currency or {@code null}.
+     * @throws UnknownCurrencyException
+     */
+    public @Nullable MonetaryType toCurrency(String targetCurrency) throws UnknownCurrencyException {
+        return toCurrency(Monetary.getCurrency(targetCurrency));
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hash = prime * getCurrency().hashCode();
+        hash += prime * amount.getNumber().hashCode();
+        return hash;
+    }
+
+    @Override
+    public String format(String pattern) {
+        // TODO
+        return "";
+    }
+
+    @Override
+    public int intValue() {
+        return amount.getNumber().intValue();
+    }
+
+    @Override
+    public long longValue() {
+        return amount.getNumber().longValue();
+    }
+
+    @Override
+    public float floatValue() {
+        return amount.getNumber().floatValue();
+    }
+
+    @Override
+    public double doubleValue() {
+        return amount.getNumber().doubleValue();
+    }
+
+    @Override
+    public String toString() {
+        return toFullString();
+    }
+
+    @Override
+    public String toFullString() {
+        return amount.toString();
+    }
+
+    // @Override
+    // public @Nullable State as(@Nullable Class<U> target) {
+    // return UnDefType.UNDEF;
+    // }
+
+    /**
+     * Returns a {@code MonetaryType} whose value is <code>this + other</code>.
+     *
+     * @param other value to be added to this {@code MonetaryType}.
+     * @return {@code this + other}
+     * @throws ArithmeticException if the result exceeds the numeric capabilities of this implementation class, i.e. the
+     *             {@link MonetaryContext} cannot be adapted as required.
+     */
+    public MonetaryType add(MonetaryType other) {
+        return new MonetaryType(amount.add(other.amount));
+    }
+
+    /**
+     * Returns a {@code MonetaryType} whose value is <code>this - other</code>.
+     *
+     * @param other value to be subtracted from this {@code MonetaryType}.
+     * @return {@code this - other}
+     * @throws ArithmeticException if the result exceeds the numeric capabilities of this implementation class, i.e. the
+     *             {@link MonetaryContext} cannot be adapted as required.
+     */
+    public MonetaryType subtract(MonetaryType other) {
+        return new MonetaryType(amount.subtract(other.amount));
+    }
+
+    /**
+     * Returns a {@code MonetaryType} whose value is <code>(this &times; multiplicand)</code>.
+     *
+     * @param multiplicand value to be multiplied by this {@code MonetaryType}. If the multiplicand's scale exceeds
+     *            the capabilities of the implementation, it may be rounded implicitly.
+     * @return {@code this * multiplicand}
+     * @throws ArithmeticException if the result exceeds the numeric capabilities of this implementation class, i.e. the
+     *             {@link MonetaryContext} cannot be adapted as required.
+     */
+    public MonetaryType multiply(Number multiplicand) {
+        return new MonetaryType(amount.multiply(multiplicand));
+    }
+
+    /**
+     * Returns a {@code MonetaryType} whose value is <code>this / divisor</code>; if the exact quotient cannot be
+     * represented an {@code ArithmeticException} is thrown.
+     *
+     * @param divisor value by which this {@code MonetaryType} is to be divided.
+     * @return {@code this / divisor}
+     * @throws ArithmeticException if the exact quotient does not have a terminating decimal expansion, or if the
+     *             result exceeds the numeric capabilities of this implementation class, i.e. the
+     *             {@link MonetaryContext} cannot be adapted as required.
+     */
+    public MonetaryType divide(Number divisor) {
+        return new MonetaryType(amount.divide(divisor));
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/eclipse/smarthome/core/library/types/MonetaryTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/eclipse/smarthome/core/library/types/MonetaryTypeTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.library.types;
+
+import org.junit.Test;
+
+/**
+ * Test for the framework defined {@link MonetaryType}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class MonetaryTypeTest {
+
+    @Test
+    public void testMonetaryType() {
+        new MonetaryType();
+    }
+}

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -35,6 +35,11 @@
     <bundle dependency="true">mvn:tec.uom/uom-se/1.0.10</bundle>
     <bundle dependency="true">mvn:tec.uom.lib/uom-lib-common/1.0.3</bundle>
 
+    <!-- Money -->
+    <bundle dependency="true">mvn:javax.money/money-api/1.0.3</bundle>
+    <bundle dependency="true">mvn:org.javamoney.moneta/moneta-core/1.3</bundle>
+    <bundle dependency="true">mvn:org.javamoney.moneta/moneta-convert/1.3</bundle>
+
     <!-- TODO: Unbundled libraries -->
     <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>
     <bundle dependency="true">mvn:joda-time/joda-time/2.9.2</bundle>


### PR DESCRIPTION
- Initial contribution of `MonetaryType` and Money API

Beside Units of Measurement for representing sensor data and a lot more features I have a need to do some calculations with money. After UoM has been introduced I always got the feeling I had to extend it to support different currencies. After some initial coding sessions I realized that this is the wrong path. Then I found JSR 354 via Google search, get in touch with it and gave it an try.

Based on [Money & Currency API (JSR 354)](https://javamoney.github.io/api.html) using [Moneta implementation](https://javamoney.github.io/ri.html).

@openhab/core-maintainers Is this an option for us? This PR is far away from being useful. Just want to have a hint if I should continue or not. Thanks.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>