### PR TITLE
[thing] Use constructor injection to simplify lifecycle

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelCommandDescriptionProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.type.DynamicCommandDescriptionProvider;
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.CommandDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -39,19 +40,25 @@ import org.slf4j.LoggerFactory;
  * Provides the {@link ChannelType} specific {@link CommandDescription} for the given item name and locale.
  *
  * @author Henning Treu - Initial contribution
- *
  */
-@NonNullByDefault
 @Component
+@NonNullByDefault
 public class ChannelCommandDescriptionProvider implements CommandDescriptionProvider {
 
     private final Logger logger = LoggerFactory.getLogger(ChannelCommandDescriptionProvider.class);
 
-    private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
-    private @NonNullByDefault({}) ThingTypeRegistry thingTypeRegistry;
-    private @NonNullByDefault({}) ThingRegistry thingRegistry;
-
     private final List<DynamicCommandDescriptionProvider> dynamicCommandDescriptionProviders = new CopyOnWriteArrayList<>();
+    private final ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private final ThingTypeRegistry thingTypeRegistry;
+    private final ThingRegistry thingRegistry;
+
+    @Activate
+    public ChannelCommandDescriptionProvider(final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry,
+            final @Reference ThingTypeRegistry thingTypeRegistry, final @Reference ThingRegistry thingRegistry) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.thingTypeRegistry = thingTypeRegistry;
+        this.thingRegistry = thingRegistry;
+    }
 
     @Override
     public @Nullable CommandDescription getCommandDescription(String itemName, @Nullable Locale locale) {
@@ -73,7 +80,6 @@ public class ChannelCommandDescriptionProvider implements CommandDescriptionProv
                 return commandDescription;
             }
         }
-
         return null;
     }
 
@@ -91,35 +97,7 @@ public class ChannelCommandDescriptionProvider implements CommandDescriptionProv
                         dynamicCommandDescriptionProvider.getClass(), e.getLocalizedMessage(), e);
             }
         }
-
         return null;
-    }
-
-    @Reference
-    protected void setThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
-        this.thingTypeRegistry = thingTypeRegistry;
-    }
-
-    protected void unsetThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
-        this.thingTypeRegistry = null;
-    }
-
-    @Reference
-    protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
-        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
-    }
-
-    protected void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
-        this.itemChannelLinkRegistry = null;
-    }
-
-    @Reference
-    protected void setThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = thingRegistry;
-    }
-
-    protected void unsetThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = null;
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -55,10 +55,18 @@ public class ChannelStateDescriptionProvider implements StateDescriptionFragment
     private final Logger logger = LoggerFactory.getLogger(ChannelStateDescriptionProvider.class);
 
     private final List<DynamicStateDescriptionProvider> dynamicStateDescriptionProviders = new CopyOnWriteArrayList<>();
-    private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
-    private @NonNullByDefault({}) ThingTypeRegistry thingTypeRegistry;
-    private @NonNullByDefault({}) ThingRegistry thingRegistry;
+    private final ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private final ThingTypeRegistry thingTypeRegistry;
+    private final ThingRegistry thingRegistry;
     private Integer rank = 0;
+
+    @Activate
+    public ChannelStateDescriptionProvider(final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry,
+            final @Reference ThingTypeRegistry thingTypeRegistry, final @Reference ThingRegistry thingRegistry) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.thingTypeRegistry = thingTypeRegistry;
+        this.thingRegistry = thingRegistry;
+    }
 
     @Activate
     protected void activate(Map<String, Object> properties) {
@@ -129,33 +137,6 @@ public class ChannelStateDescriptionProvider implements StateDescriptionFragment
             }
         }
         return null;
-    }
-
-    @Reference
-    protected void setThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
-        this.thingTypeRegistry = thingTypeRegistry;
-    }
-
-    protected void unsetThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
-        this.thingTypeRegistry = null;
-    }
-
-    @Reference
-    protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
-        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
-    }
-
-    protected void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
-        this.itemChannelLinkRegistry = null;
-    }
-
-    @Reference
-    protected void setThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = thingRegistry;
-    }
-
-    protected void unsetThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = null;
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.UID;
 import org.eclipse.smarthome.core.thing.link.events.LinkEventFactory;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -37,16 +38,19 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Dennis Nobel - Initial contribution
  * @author Markus Rathgeb - Linked items returns only existing items
  * @author Markus Rathgeb - Rewrite collection handling to improve performance
- *
  */
 @Component(immediate = true, service = ItemChannelLinkRegistry.class)
 public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLink, ItemChannelLinkProvider> {
 
-    private ThingRegistry thingRegistry;
-    private ItemRegistry itemRegistry;
+    private final ThingRegistry thingRegistry;
+    private final ItemRegistry itemRegistry;
 
-    public ItemChannelLinkRegistry() {
+    @Activate
+    public ItemChannelLinkRegistry(final @Reference ThingRegistry thingRegistry,
+            final @Reference ItemRegistry itemRegistry) {
         super(ItemChannelLinkProvider.class);
+        this.thingRegistry = thingRegistry;
+        this.itemRegistry = itemRegistry;
     }
 
     /**
@@ -80,24 +84,6 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
         return getBoundChannels(itemName).parallelStream()
                 .map(channelUID -> thingRegistry.get(channelUID.getThingUID())).filter(Objects::nonNull)
                 .collect(Collectors.toSet());
-    }
-
-    @Reference
-    protected void setThingRegistry(final ThingRegistry thingRegistry) {
-        this.thingRegistry = thingRegistry;
-    }
-
-    protected void unsetThingRegistry(final ThingRegistry thingRegistry) {
-        this.thingRegistry = null;
-    }
-
-    @Reference
-    protected void setItemRegistry(final ItemRegistry itemRegistry) {
-        this.itemRegistry = itemRegistry;
-    }
-
-    protected void unsetItemRegistry(final ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
     }
 
     @Reference

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -85,6 +85,10 @@ import org.mockito.Mock;
 public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
     private class ItemChannelLinkRegistryAdvanced extends ItemChannelLinkRegistry {
+        public ItemChannelLinkRegistryAdvanced(ThingRegistry thingRegistry, ItemRegistry itemRegistry) {
+            super(thingRegistry, itemRegistry);
+        }
+
         @Override
         protected void addProvider(Provider<ItemChannelLink> provider) {
             super.addProvider(provider);
@@ -201,7 +205,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         manager.addProfileFactory(mockProfileFactory);
         manager.addProfileAdvisor(mockProfileAdvisor);
 
-        ItemChannelLinkRegistryAdvanced iclRegistry = new ItemChannelLinkRegistryAdvanced();
+        ItemChannelLinkRegistryAdvanced iclRegistry = new ItemChannelLinkRegistryAdvanced(thingRegistry, itemRegistry);
         iclRegistry.addProvider(new ItemChannelLinkProvider() {
             @Override
             public void addProviderChangeListener(ProviderChangeListener<ItemChannelLink> listener) {


### PR DESCRIPTION
- Use constructor injection to simplify lifecycle
- Added nullness annotations to `ThingTypeRegistry`

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>