### PR TITLE
[config dispatch] Use constructor injection to simplify lifecycle

### DIFF
--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -76,7 +76,7 @@ import com.google.gson.JsonSyntaxException;
  * Last but not least, a pid can be defined in the first line of a cfg file by prefixing it with "pid:", e.g.
  * "pid: com.acme.smarthome.security".
  *
- * @author Kai Kreuzer - Initial contribution and API
+ * @author Kai Kreuzer - Initial contribution
  * @author Petar Valchev - Added sort by modification time, when configuration files are read
  * @author Ana Dimova - Reduce to a single watch thread for all class instances
  * @author Henning Treu - Delete orphan exclusive configuration from configAdmin
@@ -116,9 +116,14 @@ public class ConfigDispatcher {
 
     private ExclusivePIDMap exclusivePIDMap;
 
-    private ConfigurationAdmin configAdmin;
+    private final ConfigurationAdmin configAdmin;
 
     private File exclusivePIDStore;
+
+    @Activate
+    public ConfigDispatcher(final @Reference ConfigurationAdmin configAdmin) {
+        this.configAdmin = configAdmin;
+    }
 
     @Activate
     public void activate(BundleContext bundleContext) {
@@ -429,15 +434,6 @@ public class ConfigDispatcher {
             logger.warn("Could not parse line '{}'", line);
             return new ParseLineResult();
         }
-    }
-
-    @Reference
-    public void setConfigurationAdmin(ConfigurationAdmin configAdmin) {
-        this.configAdmin = configAdmin;
-    }
-
-    public void unsetConfigurationAdmin(ConfigurationAdmin configAdmin) {
-        this.configAdmin = null;
     }
 
     /**

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -29,9 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * Watches file-system events and passes them to our {@link ConfigDispatcher}
  *
- * @author Kai Kreuzer - Initial contribution and API
+ * @author Kai Kreuzer - Initial contribution
  * @author Stefan Triller - factored out this code from {@link ConfigDispatcher}
- *
  */
 @Component(immediate = true)
 public class ConfigDispatcherFileWatcher extends AbstractWatchService {
@@ -42,10 +41,12 @@ public class ConfigDispatcherFileWatcher extends AbstractWatchService {
     /** The default folder name of the configuration folder of services */
     public static final String SERVICES_FOLDER = "services";
 
-    private ConfigDispatcher configDispatcher;
+    private final ConfigDispatcher configDispatcher;
 
-    public ConfigDispatcherFileWatcher() {
+    @Activate
+    public ConfigDispatcherFileWatcher(final @Reference ConfigDispatcher configDispatcher) {
         super(getPathToWatch());
+        this.configDispatcher = configDispatcher;
     }
 
     private static String getPathToWatch() {
@@ -57,8 +58,8 @@ public class ConfigDispatcherFileWatcher extends AbstractWatchService {
         }
     }
 
-    @Override
     @Activate
+    @Override
     public void activate() {
         super.activate();
         configDispatcher.processConfigFile(getSourcePath().toFile());
@@ -96,15 +97,6 @@ public class ConfigDispatcherFileWatcher extends AbstractWatchService {
             }
             configDispatcher.fileRemoved(configFile.getAbsolutePath());
         }
-    }
-
-    @Reference
-    public void setConfigDispatcher(ConfigDispatcher configDispatcher) {
-        this.configDispatcher = configDispatcher;
-    }
-
-    public void unsetConfigDispatcher(ConfigDispatcher configDispatcher) {
-        this.configDispatcher = null;
     }
 
 }

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherFileWatcherTest.java
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherFileWatcherTest.java
@@ -38,8 +38,7 @@ public class ConfigDispatcherFileWatcherTest {
     public void setUp() throws Exception {
         initMocks(this);
 
-        configDispatcherFileWatcher = new TestConfigDispatcherFileWatcher();
-        configDispatcherFileWatcher.setConfigDispatcher(configDispatcher);
+        configDispatcherFileWatcher = new TestConfigDispatcherFileWatcher(configDispatcher);
     }
 
     @Test
@@ -97,6 +96,9 @@ public class ConfigDispatcherFileWatcherTest {
     }
 
     public class TestConfigDispatcherFileWatcher extends ConfigDispatcherFileWatcher {
+        public TestConfigDispatcherFileWatcher(ConfigDispatcher configDispatcher) {
+            super(configDispatcher);
+        }
 
         @Override
         protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherOSGiTest.java
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherOSGiTest.java
@@ -69,8 +69,7 @@ public class ConfigDispatcherOSGiTest extends JavaOSGiTest {
         configAdmin = getService(ConfigurationAdmin.class);
         assertThat(configAdmin, is(notNullValue()));
 
-        cd = new ConfigDispatcher();
-        cd.setConfigurationAdmin(configAdmin);
+        cd = new ConfigDispatcher(configAdmin);
     }
 
     @After


### PR DESCRIPTION
- Use constructor injection to simplify lifecycle

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>