### PR TITLE
Fix gamma correction in HSBType for color conversion from sRGB to CIE XYZ and back

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -335,7 +335,7 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
             c = 1.0f;
         }
 
-        return c <= 0.0031308f ? 19.92f * c : (1.0f + 0.055f) * (float) Math.pow(c, 1.0f / 2.4f) - 0.055f;
+        return c <= 0.0031308f ? 12.92f * c : (1.0f + 0.055f) * (float) Math.pow(c, 1.0f / 2.4f) - 0.055f;
     }
 
     // Gamma decompression (sRGB) for a single component, in the 0.0 - 1.0 range
@@ -346,7 +346,7 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
             c = 1.0f;
         }
 
-        return c <= 0.04045f ? c / 19.92f : (float) Math.pow((c + 0.055f) / (1.0f + 0.055f), 2.4f);
+        return c <= 0.04045f ? c / 12.92f : (float) Math.pow((c + 0.055f) / (1.0f + 0.055f), 2.4f);
     }
 
     /**


### PR DESCRIPTION
- Fix gamma correction in HSBType for color conversion from sRGB to CIE XYZ and back

See https://en.m.wikipedia.org/wiki/SRGB#The_forward_transformation_(CIE_XYZ_to_sRGB) or https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>