### PR TITLE
[config dispatch] Added support for values containing a list of configuration options

### DIFF
--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -31,6 +31,8 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -76,11 +78,17 @@ import com.google.gson.JsonSyntaxException;
  * Last but not least, a pid can be defined in the first line of a cfg file by prefixing it with "pid:", e.g.
  * "pid: com.acme.smarthome.security".
  *
+ * <p>
+ * The value can contain value delimiters and will then be interpreted as a list of tokens. Default value delimiter is
+ * the comma ','. So the following property definition "property = This property, has multiple, values" will result in a
+ * list with three values.
+ *
  * @author Kai Kreuzer - Initial contribution
  * @author Petar Valchev - Added sort by modification time, when configuration files are read
  * @author Ana Dimova - Reduce to a single watch thread for all class instances
  * @author Henning Treu - Delete orphan exclusive configuration from configAdmin
  * @author Stefan Triller - Add support for service contexts
+ * @author Christoph Weitkamp - Added support for value containing a list of configuration options
  */
 @Component(immediate = true, service = ConfigDispatcher.class)
 public class ConfigDispatcher {
@@ -113,6 +121,10 @@ public class ConfigDispatcher {
     private static final String PID_MARKER = "pid:";
 
     private static final String EXCLUSIVE_PID_STORE_FILE = "configdispatcher_pid_list.json";
+
+    private static final String DEFAULT_PID_DELIMITER = ":";
+    private static final String DEFAULT_VALUE_DELIMITER = "=";
+    private static final String DEFAULT_LIST_DELIMITER = ",";
 
     private ExclusivePIDMap exclusivePIDMap;
 
@@ -382,7 +394,7 @@ public class ConfigDispatcher {
                         : new Properties();
                 configMap.put(configuration, configProperties);
             }
-            if (!parsedLine.value.equals(configProperties.get(parsedLine.property))) {
+            if (parsedLine.value != null && !parsedLine.value.equals(configProperties.get(parsedLine.property))) {
                 configProperties.put(parsedLine.property, parsedLine.value);
                 configsToUpdate.put(configuration, configProperties);
             }
@@ -416,9 +428,9 @@ public class ConfigDispatcher {
         }
 
         String pid = null; // no override of the pid is default
-        String key = StringUtils.substringBefore(trimmedLine, "=");
-        if (key.contains(":")) {
-            pid = StringUtils.substringBefore(key, ":");
+        String key = StringUtils.substringBefore(trimmedLine, DEFAULT_VALUE_DELIMITER);
+        if (key.contains(DEFAULT_PID_DELIMITER)) {
+            pid = StringUtils.substringBefore(key, DEFAULT_PID_DELIMITER);
             trimmedLine = trimmedLine.substring(pid.length() + 1);
             pid = pid.trim();
             // PID is not fully qualified, so prefix with namespace
@@ -426,10 +438,17 @@ public class ConfigDispatcher {
                 pid = getServicePidNamespace() + "." + pid;
             }
         }
-        if (!trimmedLine.isEmpty() && trimmedLine.substring(1).contains("=")) {
-            String property = StringUtils.substringBefore(trimmedLine, "=");
-            String value = trimmedLine.substring(property.length() + 1);
-            return new ParseLineResult(pid, property.trim(), value.trim());
+        if (!trimmedLine.isEmpty() && trimmedLine.substring(1).contains(DEFAULT_VALUE_DELIMITER)) {
+            String property = StringUtils.substringBefore(trimmedLine, DEFAULT_VALUE_DELIMITER).trim();
+            String value = trimmedLine.substring(property.length() + 1).trim();
+            if (value.contains(DEFAULT_LIST_DELIMITER)) {
+                logger.debug("Found list in value '{}'", value);
+                List<String> values = Arrays.asList(value.split(DEFAULT_LIST_DELIMITER)).stream().map(v -> v.trim())
+                        .filter(v -> !v.isEmpty()).collect(Collectors.toList());
+                return new ParseLineResult(pid, property, values);
+            } else {
+                return new ParseLineResult(pid, property, value);
+            }
         } else {
             logger.warn("Could not parse line '{}'", line);
             return new ParseLineResult();
@@ -439,16 +458,17 @@ public class ConfigDispatcher {
     /**
      * Represents a result of parseLine().
      */
+    @NonNullByDefault
     private class ParseLineResult {
-        public String pid;
-        public String property;
-        public String value;
+        public @Nullable String pid;
+        public @Nullable String property;
+        public @Nullable Object value;
 
         public ParseLineResult() {
             this(null, null, null);
         }
 
-        public ParseLineResult(String pid, String property, String value) {
+        public ParseLineResult(@Nullable String pid, @Nullable String property, @Nullable Object value) {
             this.pid = pid;
             this.property = property;
             this.value = value;

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local.pid.list.default.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local.pid.list.default.file.cfg
@@ -1,0 +1,1 @@
+local.default.pid:default.property=[default.value]

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.fifth.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.fifth.file.cfg
@@ -1,0 +1,1 @@
+local.service.fifth.pid:service.property=[service.value

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.first.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.first.file.cfg
@@ -1,0 +1,1 @@
+local.service.first.pid:service.property=[service.value]

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.fourth.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.fourth.file.cfg
@@ -1,0 +1,1 @@
+local.service.fourth.pid:service.property=[]

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.second.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.second.file.cfg
@@ -1,0 +1,1 @@
+local.service.second.pid:service.property=[first value,second value,third value]

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.seventh.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.seventh.file.cfg
@@ -1,0 +1,1 @@
+local.service.seventh.pid:service.property=first value,second value,third value

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.sixth.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.sixth.file.cfg
@@ -1,0 +1,1 @@
+local.service.sixth.pid:service.property=service.value]

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.third.file.cfg
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/resources/configurations/local_pid_list_conf/local_pid_list_services/local.pid.list.service.third.file.cfg
@@ -1,0 +1,1 @@
+local.service.third.pid:service.property=[first value,  second value  ,third value,,,]


### PR DESCRIPTION
- Added support for values containing a list of configuration options (comma-separated list)

Related to #998

Syntax will be:
```
<service-pid>:<property>=<value_1>,<value_2>,...,<value_n>
```

Is this syntax okay? Or do we risk to break something existent because a comma (`,`) is a common used character in configurations. Should we maybe surround the value list by square brackets?
```
<service-pid>:<property>=[<value_1>,<value_2>,...,<value_n>]
```

I would like to add some unit tests. Before that we have to get #995 running.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>