### PR TITLE
Travis Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.p2
+  - $HOME/.bnd/cache/
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc


### PR DESCRIPTION
We do not use p2 anymore in this repo. Remove the cache directory. Add the bnd cache directory instead.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>