### PR TITLE
Selection widget as default widget for Number or String items with options

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -67,6 +67,7 @@ import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationHelper;
 import org.eclipse.smarthome.core.transform.TransformationService;
+import org.eclipse.smarthome.core.types.CommandDescription;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
@@ -240,6 +241,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         if (itemType == null) {
             return null;
         }
+        int nbOptions = getNbOptions(itemName);
 
         if (itemType.equals(SwitchItem.class)) {
             return SitemapFactory.eINSTANCE.createSwitch();
@@ -248,7 +250,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return SitemapFactory.eINSTANCE.createGroup();
         }
         if (NumberItem.class.isAssignableFrom(itemType)) {
-            return SitemapFactory.eINSTANCE.createText();
+            return nbOptions > 0 ? SitemapFactory.eINSTANCE.createSelection() : SitemapFactory.eINSTANCE.createText();
         }
         if (itemType.equals(ContactItem.class)) {
             return SitemapFactory.eINSTANCE.createText();
@@ -260,7 +262,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return SitemapFactory.eINSTANCE.createSwitch();
         }
         if (itemType.equals(StringItem.class)) {
-            return SitemapFactory.eINSTANCE.createText();
+            return nbOptions > 0 ? SitemapFactory.eINSTANCE.createSelection() : SitemapFactory.eINSTANCE.createText();
         }
         if (itemType.equals(LocationItem.class)) {
             return SitemapFactory.eINSTANCE.createText();
@@ -767,6 +769,23 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     group.getLabel(), itemName);
         }
         return children;
+    }
+
+    private int getNbOptions(String itemName) {
+        try {
+            Item item = itemRegistry.getItem(itemName);
+            CommandDescription commandDescription = item.getCommandDescription();
+            int nbCommandOptions = (commandDescription != null && commandDescription.getCommandOptions() != null)
+                    ? commandDescription.getCommandOptions().size()
+                    : 0;
+            StateDescription stateDescription = item.getStateDescription();
+            int nbStateOptions = (stateDescription != null && stateDescription.getOptions() != null)
+                    ? stateDescription.getOptions().size()
+                    : 0;
+            return nbCommandOptions > nbStateOptions ? nbCommandOptions : nbStateOptions;
+        } catch (ItemNotFoundException e) {
+        }
+        return 0;
     }
 
     private Class<? extends Item> getItemType(@NonNull String itemName) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -241,6 +241,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         if (itemType == null) {
             return null;
         }
+        boolean readOnly = isReadOnly(itemName);
         int nbOptions = getNbOptions(itemName);
 
         if (itemType.equals(SwitchItem.class)) {
@@ -250,7 +251,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return SitemapFactory.eINSTANCE.createGroup();
         }
         if (NumberItem.class.isAssignableFrom(itemType)) {
-            return nbOptions > 0 ? SitemapFactory.eINSTANCE.createSelection() : SitemapFactory.eINSTANCE.createText();
+            return (!readOnly && nbOptions > 0) ? SitemapFactory.eINSTANCE.createSelection()
+                    : SitemapFactory.eINSTANCE.createText();
         }
         if (itemType.equals(ContactItem.class)) {
             return SitemapFactory.eINSTANCE.createText();
@@ -262,7 +264,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return SitemapFactory.eINSTANCE.createSwitch();
         }
         if (itemType.equals(StringItem.class)) {
-            return nbOptions > 0 ? SitemapFactory.eINSTANCE.createSelection() : SitemapFactory.eINSTANCE.createText();
+            return (!readOnly && nbOptions > 0) ? SitemapFactory.eINSTANCE.createSelection()
+                    : SitemapFactory.eINSTANCE.createText();
         }
         if (itemType.equals(LocationItem.class)) {
             return SitemapFactory.eINSTANCE.createText();
@@ -769,6 +772,16 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     group.getLabel(), itemName);
         }
         return children;
+    }
+
+    private boolean isReadOnly(String itemName) {
+        try {
+            Item item = itemRegistry.getItem(itemName);
+            StateDescription stateDescription = item.getStateDescription();
+            return stateDescription != null ? stateDescription.isReadOnly() : false;
+        } catch (ItemNotFoundException e) {
+        }
+        return false;
     }
 
     private int getNbOptions(String itemName) {


### PR DESCRIPTION
Fixes #984

Signed-off-by: Laurent Garnier <lg.hc@free.fr>

Before the change (display from a group so with the default rendering):
![image](https://user-images.githubusercontent.com/10186704/63929227-5b092b00-ca51-11e9-957b-0e101fb1e7fd.png)

And now with this change in Basic UI:
![image](https://user-images.githubusercontent.com/10186704/63929314-812ecb00-ca51-11e9-9f42-fec51e354d03.png)

And in Classic UI:
![image](https://user-images.githubusercontent.com/10186704/63931454-96a5f400-ca55-11e9-814a-3f5be1382dae.png)