### PR TITLE
[rest] Changed property type to Boolean to allow null values

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTO.java
@@ -34,7 +34,7 @@ public class EnrichedItemDTO extends ItemDTO {
     public StateDescription stateDescription;
     public CommandDescription commandDescription;
     public Map<String, Object> metadata;
-    public boolean editable;
+    public Boolean editable;
 
     public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String transformedState,
             StateDescription stateDescription, CommandDescription commandDescription) {

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -165,7 +165,7 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
         Response response = itemResource.getItems(null, null, "MyTag", null, false, "type,name");
 
         JsonElement result = parser.parse(IOUtils.toString((InputStream) response.getEntity()));
-        JsonElement expected = parser.parse("[{editable: true, type: \"Switch\", name: \"Switch\"}]");
+        JsonElement expected = parser.parse("[{type: \"Switch\", name: \"Switch\"}]");
         assertEquals(expected, result);
     }
 


### PR DESCRIPTION
- Changed property type to `Boolean` to allow `null` values

Fixes #985 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>