### PR TITLE
Removed duplicate dependencies

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -131,6 +131,11 @@
       <version>2.9.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
+      <version>2.2.11_1</version>
+    </dependency>
 
     <!-- Java-Activation 1.1 API -->
     <dependency>
@@ -162,6 +167,11 @@
       <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
       <version>2.9.0</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.servicemix.bundles</groupId>
+      <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
+      <version>1.3.23_2</version>
     </dependency>
 
     <!-- OSGi Function -->
@@ -865,35 +875,6 @@
       <groupId>de.jollyday</groupId>
       <artifactId>jollyday</artifactId>
       <version>0.5.8</version>
-    </dependency>
-
-    <!-- JAXB -->
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
-      <version>2.2.11_1</version>
-    </dependency>
-
-    <!-- JAX-WS -->
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
-      <version>1.3.23_2</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
- Removed duplicate dependencies

Fixes the following warnings:
```
13:50:18 [WARNING] Some problems were encountered while building the effective model for org.openhab.core.bom:org.openhab.core.bom.runtime:pom:2.5.0-SNAPSHOT
13:50:18 [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.servicemix.specs:org.apache.servicemix.specs.activation-api-1.1:jar -> duplicate declaration of version 2.9.0 @ line 871, column 17
13:50:18 [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.servicemix.specs:org.apache.servicemix.specs.jaxb-api-2.2:jar -> duplicate declaration of version 2.9.0 @ line 876, column 17
13:50:18 [WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.servicemix.specs:org.apache.servicemix.specs.saaj-api-1.3:jar -> duplicate declaration of version 2.9.0 @ line 888, column 17
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>