### PR TITLE
[WIP] Fix thing creation for updated XML

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseBridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseBridgeHandler.java
@@ -74,10 +74,11 @@ public abstract class BaseBridgeHandler extends BaseThingHandler implements Brid
      */
     @Override
     protected BridgeBuilder editThing() {
-        return BridgeBuilder.create(this.thing.getThingTypeUID(), this.thing.getUID())
-                .withBridge(this.thing.getBridgeUID()).withChannels(this.thing.getChannels())
-                .withConfiguration(this.thing.getConfiguration()).withLabel(this.thing.getLabel())
-                .withLocation(this.thing.getLocation()).withProperties(this.thing.getProperties());
+        Bridge bridge = (Bridge) this.thing;
+        return BridgeBuilder.create(bridge.getThingTypeUID(), bridge.getUID()).withBridge(bridge.getBridgeUID())
+                .withChannels(bridge.getChannels()).withThings(bridge.getThings())
+                .withConfiguration(bridge.getConfiguration()).withLabel(bridge.getLabel())
+                .withLocation(bridge.getLocation()).withProperties(bridge.getProperties());
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.core.thing.binding;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -20,10 +21,12 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
@@ -34,6 +37,8 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
+import org.eclipse.smarthome.core.thing.internal.ThingFactoryHelper;
+import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -633,6 +638,18 @@ public abstract class BaseThingHandler implements ThingHandler {
             logger.warn("Handler {} tried migrating the thing type although the handler was already disposed.",
                     this.getClass().getSimpleName());
         }
+    }
+
+    public void setChannelsFromThingTypeDefinition(ThingType thingType,
+            ConfigDescriptionRegistry configDescriptionRegistry) {
+        logger.info("Synchronizing channels for thing {}", getThing().getUID());
+        List<Channel> channels = ThingFactoryHelper.createChannels(thingType, getThing().getUID(),
+                configDescriptionRegistry);
+
+        ThingBuilder thingBuilder = editThing();
+        thingBuilder.withChannels(channels);
+        Thing editedThing = thingBuilder.build();
+        updateThing(editedThing);
     }
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -644,7 +644,7 @@ public abstract class BaseThingHandler implements ThingHandler {
             ConfigDescriptionRegistry configDescriptionRegistry) {
         logger.info("Synchronizing channels for thing {}", getThing().getUID());
         List<Channel> channels = ThingFactoryHelper.createChannels(thingType, getThing().getUID(),
-                configDescriptionRegistry);
+                configDescriptionRegistry, getThing().getChannels());
 
         ThingBuilder thingBuilder = editThing();
         thingBuilder.withChannels(channels);

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/BridgeBuilder.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.internal.BridgeImpl;
@@ -99,6 +100,15 @@ public class BridgeBuilder extends ThingBuilder {
     @Override
     public BridgeBuilder withLocation(@Nullable String location) {
         return (BridgeBuilder) super.withLocation(location);
+    }
+
+    public BridgeBuilder withThings(@Nullable List<Thing> things) {
+        BridgeImpl bridge = ((BridgeImpl) thing);
+        if (things != null) {
+            things.forEach(t -> bridge.addThing(t));
+        }
+
+        return this;
     }
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
@@ -40,7 +40,7 @@ import org.eclipse.smarthome.core.thing.util.ThingHelper;
 public class ThingBuilder {
 
     private final List<Channel> channels = new ArrayList<>();
-    private final ThingImpl thing;
+    protected final ThingImpl thing;
 
     protected ThingBuilder(ThingImpl thing) {
         this.thing = thing;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -65,6 +65,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeMigrationService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.UID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.BridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
@@ -756,6 +757,15 @@ public class ThingManagerImpl
     }
 
     private void doInitializeHandler(final ThingHandler thingHandler) {
+
+        if (thingHandler instanceof BaseThingHandler) {
+            ThingType thingType = getThingType(thingHandler.getThing());
+            if (thingType != null) {
+                ((BaseThingHandler) thingHandler).setChannelsFromThingTypeDefinition(thingType,
+                        configDescriptionRegistry);
+            }
+        }
+
         logger.debug("Calling initialize handler for thing '{}' at '{}'.", thingHandler.getThing().getUID(),
                 thingHandler);
         safeCaller.create(thingHandler, ThingHandler.class).onTimeout(() -> {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -192,7 +192,8 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
 
         waitForAssert(() -> {
-            ThingHandler handler = thing.getHandler();
+            Thing t = managedThingProvider.get(thingUID);
+            ThingHandler handler = t.getHandler();
             assertThat(handler, is(not(nullValue())));
         });
 
@@ -348,14 +349,18 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         // ThingHandler.initialize() has not been called; thing with status UNINITIALIZED.HANDLER_CONFIGURATION_PENDING
         ThingStatusInfo uninitialized = ThingStatusInfoBuilder
                 .create(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_CONFIGURATION_PENDING).build();
-        assertThat(thing.getStatusInfo(), is(uninitialized));
+        waitForAssert(() -> {
+            Thing t = managedThingProvider.get(thingUID);
+            assertThat(t.getStatusInfo(), is(uninitialized));
+        });
 
         thingRegistry.updateConfiguration(thingUID, singletonMap("parameter", "value"));
 
         // ThingHandler.initialize() has been called; thing with status ONLINE.NONE
         final ThingStatusInfo online = ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build();
         waitForAssert(() -> {
-            assertThat(thing.getStatusInfo(), is(online));
+            Thing t = thingRegistry.get(thingUID);
+            assertThat(t.getStatusInfo(), is(online));
         }, 4000, DFL_SLEEP_TIME);
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/factory/ManagedThingProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/factory/ManagedThingProviderOSGiTest.java
@@ -14,20 +14,42 @@ package org.eclipse.smarthome.core.thing.factory;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.eclipse.smarthome.core.thing.internal.SimpleThingTypeProvider;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
+import org.eclipse.smarthome.core.thing.type.ThingType;
+import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.test.AsyncResultWrapper;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.osgi.service.component.ComponentContext;
 
 /**
  * Tests for {@link ManagedThingProvider}.
@@ -43,12 +65,25 @@ public class ManagedThingProviderOSGiTest extends JavaOSGiTest {
     private final static String THING1_ID = "testThing1";
     private final static String THING2_ID = "testThing2";
 
+    private final static String THING_TYPE_ID_2 = "testThingType2";
+    private final static ThingTypeUID THING_TYPE_UID_2 = new ThingTypeUID(BINDIND_ID, THING_TYPE_ID_2);
+    private final static String CHANNEL_DEF_1_ID = "channel1";
+    private final static String CHANNEL_DEF_2_ID = "channel2";
+    private final static ChannelDefinition CHANNEL_DEF_1 = new ChannelDefinitionBuilder(CHANNEL_DEF_1_ID,
+            DefaultSystemChannelTypeProvider.SYSTEM_BRIGHTNESS.getUID()).build();
+    private final static ChannelDefinition CHANNEL_DEF_2 = new ChannelDefinitionBuilder(CHANNEL_DEF_2_ID,
+            DefaultSystemChannelTypeProvider.SYSTEM_BRIGHTNESS.getUID()).build();
+    private final static ThingType THING_TYPE_2 = ThingTypeBuilder.instance(THING_TYPE_UID_2, "test")
+            .withChannelDefinitions(Arrays.asList(CHANNEL_DEF_1, CHANNEL_DEF_2)).build();
+
     private ManagedThingProvider managedThingProvider;
     private ProviderChangeListener<Thing> thingChangeListener;
 
     @Before
     public void setup() {
         registerVolatileStorageService();
+        SimpleThingTypeProvider simpleThingTypeProvider = new SimpleThingTypeProvider(Arrays.asList(THING_TYPE_2));
+        registerService(simpleThingTypeProvider);
         managedThingProvider = getService(ManagedThingProvider.class);
         assertThat(managedThingProvider, is(notNullValue()));
         unregisterCurrentThingsChangeListener();
@@ -87,6 +122,27 @@ public class ManagedThingProviderOSGiTest extends JavaOSGiTest {
         assertThat(things.size(), is(2));
         assertTrue(things.contains(thing1));
         assertTrue(things.contains(thing2));
+    }
+
+    @Test
+    public void assertThatThingChannelCanBeModified() {
+        Thing thing1 = ThingBuilder.create(THING_TYPE_UID_2, THING1_ID).build();
+        managedThingProvider.add(thing1);
+        Thing thing = managedThingProvider.get(thing1.getUID());
+        assertThat(thing, is(notNullValue()));
+        assertThat(thing.getChannels().size(), is(0));
+        registerThingHandlerFactory(THING_TYPE_UID_2, t -> new BaseThingHandler(t) {
+            @Override
+            public void handleCommand(@NonNull ChannelUID channelUID, @NonNull Command command) {
+            }
+
+            @Override
+            public void initialize() {
+                updateStatus(ThingStatus.ONLINE);
+            }
+        });
+        thing = managedThingProvider.get(thing1.getUID());
+        assertThat(thing.getChannels().size(), is(2));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -175,4 +231,52 @@ public class ManagedThingProviderOSGiTest extends JavaOSGiTest {
         assertThat(updatedThingWrapper.getWrappedObject(), is(thing2));
     }
 
+    private void registerThingHandlerFactory(ThingTypeUID thingTypeUID,
+            Function<Thing, ThingHandler> thingHandlerProducer) {
+        ComponentContext context = mock(ComponentContext.class);
+        when(context.getBundleContext()).thenReturn(bundleContext);
+
+        TestThingHandlerFactory mockThingHandlerFactory = new TestThingHandlerFactory(thingTypeUID,
+                thingHandlerProducer);
+        mockThingHandlerFactory.activate(context);
+        registerService(mockThingHandlerFactory, ThingHandlerFactory.class.getName());
+    }
+
+    private static class TestThingHandlerFactory extends BaseThingHandlerFactory {
+
+        private final ThingTypeUID thingTypeUID;
+        private final Function<Thing, ThingHandler> thingHandlerProducer;
+
+        public TestThingHandlerFactory(ThingTypeUID thingTypeUID, Function<Thing, ThingHandler> thingHandlerProducer) {
+            this.thingTypeUID = thingTypeUID;
+            this.thingHandlerProducer = thingHandlerProducer;
+        }
+
+        @Override
+        public void activate(ComponentContext context) {
+            super.activate(context);
+        }
+
+        @Override
+        public boolean supportsThingType(@NonNull ThingTypeUID thingTypeUID) {
+            return this.thingTypeUID.equals(thingTypeUID);
+        }
+
+        @Override
+        protected @Nullable ThingHandler createHandler(@NonNull Thing thing) {
+            return thingHandlerProducer.apply(thing);
+        }
+
+        @Override
+        public @Nullable Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration,
+                @Nullable ThingUID thingUID, @Nullable ThingUID bridgeUID) {
+            if (thingUID != null) {
+                return ThingFactory.createThing(THING_TYPE_2, thingUID, configuration, bridgeUID,
+                        getConfigDescriptionRegistry());
+            } else {
+                return null;
+            }
+        }
+
+    }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -983,7 +983,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         waitForAssert(() -> {
             assertThat(thingRegistry.get(THING.getUID()), is(equalTo(null)));
         }, SafeCaller.DEFAULT_TIMEOUT - 100, 50);
-        
+
         assertThat(storage.containsKey(THING_UID.getAsString()), is(true));
     }
 
@@ -1000,8 +1000,9 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
 
         waitForAssert(() -> {
-            assertEquals(status, thing.getStatus());
-            assertEquals(statusDetail, thing.getStatusInfo().getStatusDetail());
+            Thing thing1 = managedThingProvider.get(THING_UID);
+            assertEquals(status, thing1.getStatus());
+            assertEquals(statusDetail, thing1.getStatusInfo().getStatusDetail());
         });
 
         managedThingProvider.remove(thing.getUID());


### PR DESCRIPTION
This is a new approach to solve the problem that I was trying to solve in #628 that in turn was based on another PR of @J-N-K (#527). 

It works as long as there are no user-defined channels, therefore it's still work in progress. I'd like to ask for our comments about this approach. 

`ThingManager#doInitializeHandler` calls `BaseThingHandler#setChannelsFromThingTypeDefinition` to only create channels, that are actually defined in the XML. This allows updated XML descriptions for already existing things to be taken into account.

Signed-off-by: André Füchsel <andre.fuechsel@telekom.de>