### PR TITLE
[scheduler] Use constructor injection to simplify lifecycle

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemUpdater.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemUpdater.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.items.events.AbstractItemEventSubscriber;
 import org.eclipse.smarthome.core.items.events.ItemCommandEvent;
 import org.eclipse.smarthome.core.items.events.ItemStateEvent;
 import org.eclipse.smarthome.core.types.State;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -39,15 +40,11 @@ public class ItemUpdater extends AbstractItemEventSubscriber {
 
     private final Logger logger = LoggerFactory.getLogger(ItemUpdater.class);
 
-    private ItemRegistry itemRegistry;
+    private final ItemRegistry itemRegistry;
 
-    @Reference
-    protected void setItemRegistry(ItemRegistry itemRegistry) {
+    @Activate
+    public ItemUpdater(final @Reference ItemRegistry itemRegistry) {
         this.itemRegistry = itemRegistry;
-    }
-
-    protected void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/CronSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/CronSchedulerImpl.java
@@ -23,9 +23,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.scheduler.CronJob;
 import org.eclipse.smarthome.core.scheduler.CronScheduler;
+import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
 import org.eclipse.smarthome.core.scheduler.Scheduler;
 import org.eclipse.smarthome.core.scheduler.SchedulerRunnable;
-import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -36,7 +37,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation of a {@link CronScheduler}.
  *
- * @author Peter Kriens - Initial contribution and API
+ * @author Peter Kriens - Initial contribution
  * @author Simon Kaufmann - adapted to CompletableFutures
  * @author Hilbrand Bouwkamp - moved cron scheduling to it's own interface
  */
@@ -48,7 +49,12 @@ public class CronSchedulerImpl implements CronScheduler {
 
     private final List<Cron> crons = new ArrayList<>();
 
-    private @NonNullByDefault({}) Scheduler scheduler;
+    private final Scheduler scheduler;
+
+    @Activate
+    public CronSchedulerImpl(final @Reference Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
 
     @Override
     public ScheduledCompletableFuture<@Nullable Void> schedule(SchedulerRunnable runnable, String cronExpression) {
@@ -68,15 +74,6 @@ public class CronSchedulerImpl implements CronScheduler {
         } else {
             return scheduler.schedule(runnable, cronAdjuster);
         }
-    }
-
-    @Reference
-    void setScheduler(Scheduler scheduler) {
-        this.scheduler = scheduler;
-    }
-
-    void unsetScheduler(Scheduler scheduler) {
-        this.scheduler = null;
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/DelegatedSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/DelegatedSchedulerImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
 import org.eclipse.smarthome.core.scheduler.Scheduler;
 import org.eclipse.smarthome.core.scheduler.SchedulerRunnable;
 import org.eclipse.smarthome.core.scheduler.SchedulerTemporalAdjuster;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
@@ -33,14 +34,20 @@ import org.osgi.service.component.annotations.Reference;
  * Wraps the actual Scheduler and keeps track of scheduled jobs.
  * It shuts down jobs in case the service is deactivated.
  *
- * @author Peter Kriens - Initial contribution and API
+ * @author Peter Kriens - Initial contribution
  */
 @Component(service = Scheduler.class, immediate = true)
 @NonNullByDefault
 public class DelegatedSchedulerImpl implements Scheduler {
 
     private final Set<ScheduledCompletableFuture<?>> scheduledJobs = new HashSet<>();
-    private @NonNullByDefault({}) SchedulerImpl delegate;
+
+    private @NonNullByDefault({}) Scheduler delegate;
+
+    @Activate
+    public DelegatedSchedulerImpl(final @Reference Scheduler scheduler) {
+        this.delegate = scheduler;
+    }
 
     @Deactivate
     void deactivate() {
@@ -103,12 +110,4 @@ public class DelegatedSchedulerImpl implements Scheduler {
         return t;
     }
 
-    @Reference
-    void setDelegate(SchedulerImpl delegate) {
-        this.delegate = delegate;
-    }
-
-    void unsetDelegate(SchedulerImpl delegate) {
-        this.delegate = null;
-    }
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/PeriodicSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/scheduler/PeriodicSchedulerImpl.java
@@ -19,13 +19,14 @@ import org.eclipse.smarthome.core.scheduler.PeriodicScheduler;
 import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
 import org.eclipse.smarthome.core.scheduler.Scheduler;
 import org.eclipse.smarthome.core.scheduler.SchedulerRunnable;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * Implementation of a {@link PeriodicScheduler}.
  *
- * @author Peter Kriens - Initial contribution and API
+ * @author Peter Kriens - Initial contribution
  * @author Simon Kaufmann - adapted to CompletableFutures
  * @author Hilbrand Bouwkamp - moved periodic scheduling to it's own interface
  */
@@ -33,19 +34,16 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class PeriodicSchedulerImpl implements PeriodicScheduler {
 
-    private @NonNullByDefault({}) Scheduler scheduler;
+    private final Scheduler scheduler;
+
+    @Activate
+    public PeriodicSchedulerImpl(final @Reference Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
 
     @Override
     public <T> ScheduledCompletableFuture<T> schedule(SchedulerRunnable runnable, Duration... delays) {
         return scheduler.schedule(runnable, new PeriodicAdjuster(delays));
     }
 
-    @Reference
-    void setScheduler(Scheduler scheduler) {
-        this.scheduler = scheduler;
-    }
-
-    void unsetScheduler(Scheduler scheduler) {
-        this.scheduler = null;
-    }
 }

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/CronSchedulerImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/CronSchedulerImplTest.java
@@ -21,31 +21,18 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.smarthome.core.scheduler.CronJob;
 import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Test class for {@link CronSchedulerImpl}.
  * Because the test run on scheduler all tests are guarded by a timeout to avoid having a test blocking.
  *
- * @author Peter Kriens - Initial contribution and API
+ * @author Peter Kriens - Initial contribution
  * @author Simon Kaufmann - adapted to Java 8
  * @author Hilbrand Bouwkamp - moved cron scheduling to it's own class
  */
 public class CronSchedulerImplTest {
-    private final CronSchedulerImpl cronScheduler = new CronSchedulerImpl();
-    private final SchedulerImpl scheduler = new SchedulerImpl();
-
-    @Before
-    public void setUp() {
-        cronScheduler.setScheduler(scheduler);
-    }
-
-    @After
-    public void tearDown() {
-        cronScheduler.unsetScheduler(scheduler);
-    }
+    private final CronSchedulerImpl cronScheduler = new CronSchedulerImpl(new SchedulerImpl());
 
     @Test(timeout = 1000)
     public void testCronReboot() throws Exception {

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/DelegatedSchedulerTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/DelegatedSchedulerTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
 import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
+import org.eclipse.smarthome.core.scheduler.Scheduler;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -36,10 +37,10 @@ import org.mockito.Mock;
  */
 public class DelegatedSchedulerTest {
 
-    private DelegatedSchedulerImpl delegatedscheduler = new DelegatedSchedulerImpl();
+    private DelegatedSchedulerImpl delegatedscheduler;
 
     @Mock
-    private SchedulerImpl scheduler;
+    private Scheduler scheduler;
     @Mock
     private ScheduledCompletableFuture<Instant> temporalScheduledFuture;
     @Mock
@@ -50,7 +51,7 @@ public class DelegatedSchedulerTest {
         initMocks(this);
         when(scheduler.after(any())).thenReturn(temporalScheduledFuture);
         when(temporalScheduledFuture.getPromise()).thenReturn(completableFuture);
-        delegatedscheduler.setDelegate(scheduler);
+        delegatedscheduler = new DelegatedSchedulerImpl(scheduler);
     }
 
     @Test

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -22,31 +22,18 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.scheduler.ScheduledCompletableFuture;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
  * Test class for {@link PeriodicSchedulerImpl}.
  * Because the test run on scheduler all tests are guarded by a timeout to avoid having a test blocking.
  *
- * @author Peter Kriens - Initial contribution and API
+ * @author Peter Kriens - Initial contribution
  * @author Simon Kaufmann - adapted to Java 8
  * @author Hilbrand Bouwkamp - moved periodic scheduling to it's own interface, rewritten test not to use sleep
  */
 public class PeriodicSchedulerImplTest {
-    private final PeriodicSchedulerImpl periodicScheduler = new PeriodicSchedulerImpl();
-    private final SchedulerImpl scheduler = new SchedulerImpl();
-
-    @Before
-    public void setUp() {
-        periodicScheduler.setScheduler(scheduler);
-    }
-
-    @After
-    public void tearDown() {
-        periodicScheduler.unsetScheduler(scheduler);
-    }
+    private final PeriodicSchedulerImpl periodicScheduler = new PeriodicSchedulerImpl(new SchedulerImpl());
 
     @Test(timeout = 5000)
     public void testSchedule() throws InterruptedException, IOException {


### PR DESCRIPTION
- Use constructor injection to simplify lifecycle

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>