### PR TITLE
[core] Removed access to 'ThingRegistry' from 'BaseThingHandler'

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
@@ -541,9 +542,10 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @return returns the bridge of the thing or null if the thing has no bridge
      */
     protected @Nullable Bridge getBridge() {
+        ThingUID bridgeUID = thing.getBridgeUID();
         synchronized (this) {
-            if (callback != null) {
-                return callback.getBridge(thing.getBridgeUID());
+            if (bridgeUID != null && callback != null) {
+                return callback.getBridge(bridgeUID);
             } else {
                 logger.warn(
                         "Handler {} of thing {} tried accessing its bridge although the handler was already disposed.",

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -544,8 +544,8 @@ public abstract class BaseThingHandler implements ThingHandler {
     protected @Nullable Bridge getBridge() {
         ThingUID bridgeUID = thing.getBridgeUID();
         synchronized (this) {
-            if (bridgeUID != null && callback != null) {
-                return callback.getBridge(bridgeUID);
+            if (callback != null) {
+                return bridgeUID != null ? callback.getBridge(bridgeUID) : null;
             } else {
                 logger.warn(
                         "Handler {} of thing {} tried accessing its bridge although the handler was already disposed.",

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -160,10 +160,10 @@ public interface ThingHandlerCallback {
     /**
      * Returns the bridge of the thing.
      *
-     * @param bridgeUID {@link ThingUID} UID of the bridge
+     * @param bridgeUID {@link ThingUID} UID of the bridge (must not be null)
      * @return returns the bridge of the thing or null if the thing has no bridge
      */
     @Nullable
-    Bridge getBridge(@Nullable ThingUID bridgeUID);
+    Bridge getBridge(ThingUID bridgeUID);
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -16,14 +16,17 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelGroupUID;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
@@ -153,5 +156,14 @@ public interface ThingHandlerCallback {
      * @return true if at least one item is linked, false otherwise
      */
     boolean isChannelLinked(ChannelUID channelUID);
+
+    /**
+     * Returns the bridge of the thing.
+     *
+     * @param bridgeUID {@link ThingUID} UID of the bridge
+     * @return returns the bridge of the thing or null if the thing has no bridge
+     */
+    @Nullable
+    Bridge getBridge(@Nullable ThingUID bridgeUID);
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -336,8 +336,8 @@ public class ThingManagerImpl
         }
 
         @Override
-        public @Nullable Bridge getBridge(@Nullable ThingUID bridgeUID) {
-            return bridgeUID == null ? null : (Bridge) thingRegistry.get(bridgeUID);
+        public @Nullable Bridge getBridge(ThingUID bridgeUID) {
+            return (Bridge) thingRegistry.get(bridgeUID);
         }
     };
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -34,6 +34,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
@@ -119,7 +120,6 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Added preconfigured ChannelGroupBuilder
  * @author Yordan Zhelev - Added thing disabling mechanism
  */
-
 @Component(immediate = true, service = { ThingTypeMigrationService.class, ThingManager.class })
 public class ThingManagerImpl
         implements ThingManager, ThingTracker, ThingTypeMigrationService, ReadyService.ReadyTracker {
@@ -333,6 +333,11 @@ public class ThingManagerImpl
         @Override
         public boolean isChannelLinked(ChannelUID channelUID) {
             return itemChannelLinkRegistry.isLinked(channelUID);
+        }
+
+        @Override
+        public @Nullable Bridge getBridge(@Nullable ThingUID bridgeUID) {
+            return bridgeUID == null ? null : (Bridge) thingRegistry.get(bridgeUID);
         }
     };
 


### PR DESCRIPTION
- Removed access to `ThingRegistry` from `BaseThingHandler`

See https://github.com/eclipse/smarthome/issues/5182

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>