### PR TITLE
Fix MQTT gracefulStop test

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttAsyncClientEx.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttAsyncClientEx.java
@@ -107,10 +107,12 @@ public class MqttAsyncClientEx extends MqttAsyncClient {
     public IMqttToken disconnect(long quiesceTimeout, Object userContext, IMqttActionListener callback)
             throws MqttException {
         connection.connectionStateOverwrite = MqttConnectionState.DISCONNECTED;
-        if (connection.disconnectSuccess) {
-            callback.onSuccess(getToken(userContext, callback, null));
-        } else {
-            callback.onFailure(getToken(userContext, callback, null), new MqttException(0));
+        if (callback != null) {
+            if (connection.disconnectSuccess) {
+                callback.onSuccess(getToken(userContext, callback, null));
+            } else {
+                callback.onFailure(getToken(userContext, callback, null), new MqttException(0));
+            }
         }
         return getToken(userContext, callback, null);
     }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -343,11 +343,14 @@ public class MqttBrokerConnectionTests {
         MqttAsyncClientEx client = (MqttAsyncClientEx) connection.client;
 
         // Stop
-        connection.stop();
+        CompletableFuture<Boolean> future = connection.stop();
 
         // Restart strategy must be stopped
         PeriodicReconnectStrategy p = (PeriodicReconnectStrategy) connection.getReconnectStrategy();
         assertThat(p.isStarted(), is(false));
+
+        // Wait to complete stop
+        future.get(1000, TimeUnit.MILLISECONDS);
 
         verify(connection).unsubscribeAll();
         verify(client).disconnect(anyLong(), any(), any());


### PR DESCRIPTION
Wait for stop future to complete and fix the NPE that would cause the future not to complete.

When disconnecting the client the callback is null.

https://github.com/openhab/openhab-core/blob/0b2de2bfea0e735d13a69755c22b16a59a74fe87/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java#L833

```java
	public IMqttToken disconnect(long quiesceTimeout) throws MqttException {
		return this.disconnect(quiesceTimeout, null, null);
	}
```

See: https://github.com/openhab/openhab-core/pull/1056#issuecomment-536447153