### PR TITLE
Fix ExpiringCacheAsyncTest.testFetchValue unreliability

### DIFF
--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheAsyncTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheAsyncTest.java
@@ -38,7 +38,7 @@ public class ExpiringCacheAsyncTest extends JavaTest {
 
     @Test
     public void testFetchValue() throws InterruptedException, ExecutionException {
-        ExpiringCacheAsync<Double> t = new ExpiringCacheAsync<Double>(100);
+        ExpiringCacheAsync<Double> t = new ExpiringCacheAsync<Double>(500);
         assertTrue(t.isExpired());
         // We should always be able to get the raw value, expired or not
         assertNull(t.getLastKnownValue());


### PR DESCRIPTION
Increasing the expiration hopefully prevents the item from expiring too soon occasionally:

```
TEST testFetchValue(org.eclipse.smarthome.core.cache.ExpiringCacheAsyncTest) <<< ERROR: null
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertFalse(Assert.java:64)
	at org.junit.Assert.assertFalse(Assert.java:74)
	at org.eclipse.smarthome.core.cache.ExpiringCacheAsyncTest.testFetchValue(ExpiringCacheAsyncTest.java:55)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```

See: https://ci.openhab.org/job/PR-openHAB-Core/1655/