### PR TITLE
Consider more than one value when applying the default value(s) for Things and Channels

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
@@ -83,11 +83,11 @@ public class ConfigurationNormalizer {
             if (parameter != null) {
                 String parameterName = entry.getKey();
                 final Object value = configuration.get(parameterName);
-                final Object defaultValue = parameter.getDefault();
                 if (value instanceof String && ((String) value).contains("${")) {
                     continue; // It is a reference
                 }
                 if (value == null) {
+                    final Object defaultValue = parameter.getDefault();
                     if (defaultValue == null) {
                         configuration.remove(parameterName);
                     } else {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
@@ -49,10 +49,10 @@ public class ConfigUtil {
     /**
      * Maps the provided (default) value of the given {@link ConfigDescriptionParameter} to the corresponding Java type.
      *
-     * In case the provided value is supposed to be a number and cannot be converted into the target type correctly,
-     * this method will return <code>null</code> while logging a warning.
+     * In case the provided (default) value is supposed to be a number and cannot be converted into the target type
+     * correctly, this method will return <code>null</code> while logging a warning.
      *
-     * @param parameter the {@link ConfigDescriptionParameter} wich default value should be normalized (must not be
+     * @param parameter the {@link ConfigDescriptionParameter} which default value should be normalized (must not be
      *            null)
      * @return the given value as the corresponding Java type or <code>null</code> if the value could not be converted
      */
@@ -60,7 +60,8 @@ public class ConfigUtil {
         return getDefaultValueAsCorrectType(parameter.getName(), parameter.getType(), parameter.getDefault());
     }
 
-    static @Nullable Object getDefaultValueAsCorrectType(String parameterName, Type parameterType, String defaultValue) {
+    static @Nullable Object getDefaultValueAsCorrectType(String parameterName, Type parameterType,
+            String defaultValue) {
         try {
             switch (parameterType) {
                 case TEXT:
@@ -83,7 +84,7 @@ public class ConfigUtil {
             }
         } catch (NumberFormatException e) {
             LoggerFactory.getLogger(ConfigUtil.class).warn(
-                    "Could not parse default value '{}' as type '{}' for paramerter '{}': {}", defaultValue,
+                    "Could not parse default value '{}' as type '{}' for parameter '{}': {}", defaultValue,
                     parameterType, parameterName, e.getMessage(), e);
             return null;
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
@@ -22,9 +22,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 import org.eclipse.smarthome.config.core.internal.normalization.Normalizer;
 import org.eclipse.smarthome.config.core.internal.normalization.NormalizerFactory;
 import org.eclipse.smarthome.config.core.validation.ConfigDescriptionValidator;
+import org.slf4j.LoggerFactory;
 
 /**
  * The configuration admin service provides us with a map of key->values. Values can be any
@@ -39,6 +41,37 @@ import org.eclipse.smarthome.config.core.validation.ConfigDescriptionValidator;
  * @author Thomas Höfer - Minor changes for type normalization based on config description
  */
 public class ConfigUtil {
+    /**
+     * Maps the provided (default) value of the given {@link Type} to the corresponding Java type.
+     *
+     * In case the provided value is supposed to be a number and cannot be converted into the target type correctly,
+     * this method will return <code>null</code> while logging a warning.
+     *
+     * @param parameterType the {@link Type} of the value
+     * @param defaultValue the value that should be converted
+     * @return the given value as the corresponding Java type or <code>null</code> if the value could not be converted
+     */
+    public static @Nullable Object normalizeDefaultType(Type parameterType, String defaultValue) {
+        try {
+            switch (parameterType) {
+                case TEXT:
+                    return defaultValue;
+                case BOOLEAN:
+                    return Boolean.parseBoolean(defaultValue);
+                case INTEGER:
+                    return new BigDecimal(defaultValue);
+                case DECIMAL:
+                    return new BigDecimal(defaultValue);
+                default:
+                    return null;
+            }
+        } catch (NumberFormatException e) {
+            LoggerFactory.getLogger(ConfigUtil.class).warn("Could not parse default value '{}' as type '{}': {}",
+                    defaultValue, parameterType, e.getMessage(), e);
+            return null;
+        }
+    }
+
     /**
      * Normalizes the types to the ones allowed for configurations.
      *

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
@@ -42,7 +42,7 @@ public class ConfigUtil {
     /**
      * Normalizes the types to the ones allowed for configurations.
      *
-     * @param configuration the configuration that needs to be normalzed
+     * @param configuration the configuration that needs to be normalized
      * @return normalized configuration
      */
     public static Map<String, Object> normalizeTypes(Map<String, Object> configuration) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/ListNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/ListNormalizer.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 final class ListNormalizer extends AbstractNormalizer {
 
-    private Normalizer delegate;
+    private final Normalizer delegate;
 
     ListNormalizer(Normalizer delegate) {
         this.delegate = delegate;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/NormalizerFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/NormalizerFactory.java
@@ -12,9 +12,12 @@
  */
 package org.eclipse.smarthome.config.core.internal.normalization;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
@@ -28,16 +31,12 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
  */
 public final class NormalizerFactory {
 
-    private static final Map<Type, Normalizer> NORMALIZERS;
-
-    static {
-        Map<Type, Normalizer> map = new HashMap<>(11);
-        map.put(Type.BOOLEAN, new BooleanNormalizer());
-        map.put(Type.TEXT, new TextNormalizer());
-        map.put(Type.INTEGER, new IntNormalizer());
-        map.put(Type.DECIMAL, new DecimalNormalizer());
-        NORMALIZERS = Collections.unmodifiableMap(map);
-    }
+    private static final Map<Type, Normalizer> NORMALIZERS = Collections.unmodifiableMap(Stream
+            .of(new SimpleEntry<>(Type.BOOLEAN, new BooleanNormalizer()),
+                    new SimpleEntry<>(Type.TEXT, new TextNormalizer()),
+                    new SimpleEntry<>(Type.INTEGER, new IntNormalizer()),
+                    new SimpleEntry<>(Type.DECIMAL, new DecimalNormalizer()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
     private NormalizerFactory() {
         // prevent instantiation
@@ -56,12 +55,7 @@ public final class NormalizerFactory {
         }
 
         Normalizer ret = NORMALIZERS.get(configDescriptionParameter.getType());
-
-        if (configDescriptionParameter.isMultiple()) {
-            ret = new ListNormalizer(ret);
-        }
-
-        return ret;
+        return configDescriptionParameter.isMultiple() ? new ListNormalizer(ret) : ret;
     }
 
 }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
@@ -25,7 +25,6 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 import org.junit.Test;
 
 /**
- *
  * @author Simon Kaufmann - Initial contribution
  */
 public class ConfigUtilTest {
@@ -55,4 +54,5 @@ public class ConfigUtilTest {
                         Arrays.asList(configDescriptionString, configDescriptionInteger)).get("foo"),
                 is(instanceOf(String.class)));
     }
+
 }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
@@ -12,16 +12,17 @@
  */
 package org.eclipse.smarthome.config.core;
 
+import static org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 import org.junit.Test;
 
 /**
@@ -30,12 +31,38 @@ import org.junit.Test;
 public class ConfigUtilTest {
 
     @Test
+    public void verifyNormalizeDefaultTypeForTextReturnsString() {
+        assertThat(ConfigUtil.normalizeDefaultType(TEXT, "foo"), is("foo"));
+        assertThat(ConfigUtil.normalizeDefaultType(TEXT, "1.0"), is("1.0"));
+    }
+
+    @Test
+    public void verifyNormalizeDefaultTypeForBooleanReturnsBoolean() {
+        assertThat(ConfigUtil.normalizeDefaultType(BOOLEAN, "true"), is(Boolean.TRUE));
+        assertThat(ConfigUtil.normalizeDefaultType(BOOLEAN, "YES"), is(Boolean.FALSE));
+    }
+
+    @Test
+    public void verifyNormalizeDefaultTypeForIntegerReturnsIntegerOrNull() {
+        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "1"), is(BigInteger.ONE));
+        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "1.2"), is(nullValue()));
+        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "foo"), is(nullValue()));
+    }
+
+    @Test
+    public void verifyNormalizeDefaultTypeForDecimalReturnsimalBigDecOrNull() {
+        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "1"), is(BigDecimal.ONE));
+        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "1.2"), is(new BigDecimal("1.2")));
+        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "foo"), is(nullValue()));
+    }
+
+    @Test
     public void firstDesciptionWinsForNormalization() throws URISyntaxException {
         ConfigDescription configDescriptionInteger = new ConfigDescription(new URI("thing:fooThing"),
-                Arrays.asList(new ConfigDescriptionParameter("foo", Type.INTEGER)));
+                Arrays.asList(new ConfigDescriptionParameter("foo", INTEGER)));
 
         ConfigDescription configDescriptionString = new ConfigDescription(new URI("thingType:fooThing"),
-                Arrays.asList(new ConfigDescriptionParameter("foo", Type.TEXT)));
+                Arrays.asList(new ConfigDescriptionParameter("foo", TEXT)));
 
         assertThat(
                 ConfigUtil.normalizeTypes(Collections.singletonMap("foo", "1"), Arrays.asList(configDescriptionInteger))

--- a/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/eclipse/smarthome/config/core/ConfigUtilTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
@@ -36,32 +35,74 @@ public class ConfigUtilTest {
     private final ConfigDescriptionParameterBuilder configDescriptionParameterBuilder1 = ConfigDescriptionParameterBuilder
             .create("p1", DECIMAL).withMultiple(true).withMultipleLimit(7);
     private final ConfigDescriptionParameterBuilder configDescriptionParameterBuilder2 = ConfigDescriptionParameterBuilder
-            .create("p2", TEXT).withMultiple(true).withMultipleLimit(7);
+            .create("p2", TEXT).withMultiple(true).withMultipleLimit(2);
 
     @Test
     public void verifyNormalizeDefaultTypeForTextReturnsString() {
-        assertThat(ConfigUtil.normalizeDefaultType(TEXT, "foo"), is("foo"));
-        assertThat(ConfigUtil.normalizeDefaultType(TEXT, "1.0"), is("1.0"));
+        assertThat(ConfigUtil.getDefaultValueAsCorrectType(
+                ConfigDescriptionParameterBuilder.create("test", TEXT).withDefault("foo").build()), is("foo"));
+        assertThat(ConfigUtil.getDefaultValueAsCorrectType(
+                ConfigDescriptionParameterBuilder.create("test", TEXT).withDefault("1.0").build()), is("1.0"));
     }
 
     @Test
     public void verifyNormalizeDefaultTypeForBooleanReturnsBoolean() {
-        assertThat(ConfigUtil.normalizeDefaultType(BOOLEAN, "true"), is(Boolean.TRUE));
-        assertThat(ConfigUtil.normalizeDefaultType(BOOLEAN, "YES"), is(Boolean.FALSE));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", BOOLEAN).withDefault("true").build()),
+                is(Boolean.TRUE));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", BOOLEAN).withDefault("YES").build()),
+                is(Boolean.FALSE));
     }
 
     @Test
     public void verifyNormalizeDefaultTypeForIntegerReturnsIntegerOrNull() {
-        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "1"), is(BigInteger.ONE));
-        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "1.2"), is(nullValue()));
-        assertThat(ConfigUtil.normalizeDefaultType(INTEGER, "foo"), is(nullValue()));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", INTEGER).withDefault("1").build()),
+                is(BigDecimal.ONE));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", INTEGER).withDefault("1.2").build()),
+                is(BigDecimal.ONE));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", INTEGER).withDefault("foo").build()),
+                is(nullValue()));
     }
 
     @Test
     public void verifyNormalizeDefaultTypeForDecimalReturnsimalBigDecOrNull() {
-        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "1"), is(BigDecimal.ONE));
-        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "1.2"), is(new BigDecimal("1.2")));
-        assertThat(ConfigUtil.normalizeDefaultType(DECIMAL, "foo"), is(nullValue()));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", DECIMAL).withDefault("1").build()),
+                is(BigDecimal.ONE));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", DECIMAL).withDefault("1.2").build()),
+                is(new BigDecimal("1.2")));
+        assertThat(
+                ConfigUtil.getDefaultValueAsCorrectType(
+                        ConfigDescriptionParameterBuilder.create("test", DECIMAL).withDefault("foo").build()),
+                is(nullValue()));
+    }
+
+    @Test
+    public void verifyGetNumberOfDecimalPlacesWorksCorrectly() {
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("0.001")), is(3));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("0.01")), is(2));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("0.1")), is(1));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("1.000")), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("1.00")), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("1.0")), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(BigDecimal.ONE), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("10")), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("100")), is(0));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("100.1")), is(1));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("100.01")), is(2));
+        assertThat(ConfigUtil.getNumberOfDecimalPlaces(new BigDecimal("100.001")), is(3));
     }
 
     @Test

--- a/bundles/org.openhab.core.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -13,8 +13,8 @@
 package org.eclipse.smarthome.model.thing.internal
 
 import java.util.ArrayList
+import java.util.Arrays
 import java.util.Collection
-import java.util.Collections
 import java.util.HashSet
 import java.util.List
 import java.util.Map
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CopyOnWriteArraySet
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
+import org.eclipse.smarthome.config.core.ConfigUtil
 import org.eclipse.smarthome.config.core.Configuration
 import org.eclipse.smarthome.core.common.registry.AbstractProvider
 import org.eclipse.smarthome.core.i18n.LocaleProvider
@@ -39,6 +40,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
 import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
+import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition
 import org.eclipse.smarthome.core.thing.type.ChannelKind
 import org.eclipse.smarthome.core.thing.type.ChannelType
@@ -59,8 +61,6 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy
-import org.eclipse.smarthome.config.core.ConfigUtil
 
 /**
  * {@link ThingProvider} implementation which computes *.things files.
@@ -411,19 +411,19 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                             ]?.filter [ v |
                                 !v.isEmpty
                             ]?.map [ v |
-                                ConfigUtil.normalizeType(v, it)
+                                ConfigUtil.normalizeDefaultType(it.type, v)
                             ]?.filter [ v |
                                 v !== null
                             ]
                             configuration.put(name, values)
                         } else {
-                            val value = ConfigUtil.normalizeType(^default, it)
+                            val value = ConfigUtil.normalizeDefaultType(it.type, ^default)
                             if (value !== null) {
-                                configuration.put(name, Collections.singletonList(value))
+                                configuration.put(name, Arrays.asList(value))
                             }
                         }
                     } else {
-                        val value = ConfigUtil.normalizeType(^default, it)
+                        val value = ConfigUtil.normalizeDefaultType(it.type, ^default)
                         if (value !== null) {
                             configuration.put(name, value);
                         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
@@ -15,7 +15,6 @@ package org.eclipse.smarthome.core.thing.internal;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -239,18 +238,18 @@ public class ThingFactoryHelper {
                                         .stream()//
                                         .map(v -> v.trim())//
                                         .filter(v -> !v.isEmpty())//
-                                        .map(v -> ConfigUtil.normalizeType(v, parameter))//
+                                        .map(v -> ConfigUtil.normalizeDefaultType(parameter.getType(), v))//
                                         .filter(v -> v != null)//
                                         .collect(Collectors.toList());
                                 configuration.put(parameter.getName(), values);
                             } else {
-                                Object value = ConfigUtil.normalizeType(defaultValue, parameter);
+                                Object value = ConfigUtil.normalizeDefaultType(parameter.getType(), defaultValue);
                                 if (value != null) {
-                                    configuration.put(parameter.getName(), Collections.singletonList(value));
+                                    configuration.put(parameter.getName(), Arrays.asList(value));
                                 }
                             }
                         } else {
-                            Object value = ConfigUtil.normalizeType(defaultValue, parameter);
+                            Object value = ConfigUtil.normalizeDefaultType(parameter.getType(), defaultValue);
                             if (value != null) {
                                 configuration.put(parameter.getName(), value);
                             }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -391,8 +391,10 @@ public class ThingManagerImpl
                     ((ThingImpl) thing).setChannels(channels);
 
                     // Set the given configuration
-                    ThingFactoryHelper.applyDefaultConfiguration(configuration, thingType, configDescriptionRegistry);
-                    ((ThingImpl) thing).setConfiguration(configuration);
+                    Configuration editConfiguration = configuration != null ? configuration : new Configuration();
+                    ThingFactoryHelper.applyDefaultConfiguration(editConfiguration, thingType,
+                            configDescriptionRegistry);
+                    ((ThingImpl) thing).setConfiguration(editConfiguration);
 
                     // Set the new properties (keeping old properties, unless they have the same name as a new property)
                     for (Entry<String, String> entry : thingType.getProperties().entrySet()) {
@@ -540,7 +542,7 @@ public class ThingManagerImpl
         return null;
     }
 
-    private ThingType getThingType(Thing thing) {
+    private @Nullable ThingType getThingType(Thing thing) {
         return thingTypeRegistry.getThingType(thing.getThingTypeUID());
     }
 
@@ -650,7 +652,10 @@ public class ThingManagerImpl
                 }
             }
             ThingType thingType = getThingType(thing);
-            applyDefaultConfiguration(thing, thingType);
+            if (thingType != null) {
+                ThingFactoryHelper.applyDefaultConfiguration(thing.getConfiguration(), thingType,
+                        configDescriptionRegistry);
+            }
 
             if (isInitializable(thing, thingType)) {
                 setThingStatus(thing, buildStatusInfo(ThingStatus.INITIALIZING, ThingStatusDetail.NONE));
@@ -662,13 +667,6 @@ public class ThingManagerImpl
             }
         } finally {
             lock.unlock();
-        }
-    }
-
-    private void applyDefaultConfiguration(Thing thing, ThingType thingType) {
-        if (thingType != null) {
-            ThingFactoryHelper.applyDefaultConfiguration(thing.getConfiguration(), thingType,
-                    configDescriptionRegistry);
         }
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
@@ -191,7 +191,18 @@ public class ThingFactoryTest extends JavaOSGiTest {
                                 .withDefault("invalid").withLabel("label").withDescription("description")
                                 .withLimitToOptions(true).build();
 
-                        List<ConfigDescriptionParameter> parameters = Stream.of(p1, p2, p3, p4).collect(toList());
+                        ConfigDescriptionParameter p5 = ConfigDescriptionParameterBuilder
+                                .create("p5", ConfigDescriptionParameter.Type.DECIMAL).withContext("context")
+                                .withDefault("2.3").withLabel("label").withDescription("description").withMultiple(true)
+                                .withLimitToOptions(true).build();
+
+                        ConfigDescriptionParameter p6 = ConfigDescriptionParameterBuilder
+                                .create("p6", ConfigDescriptionParameter.Type.DECIMAL).withContext("context")
+                                .withDefault("2.3,2.4,2.5").withLabel("label").withDescription("description")
+                                .withMultiple(true).withLimitToOptions(true).build();
+
+                        List<ConfigDescriptionParameter> parameters = Stream.of(p1, p2, p3, p4, p5, p6)
+                                .collect(toList());
 
                         return new ConfigDescription(uri, parameters);
                     }
@@ -205,6 +216,14 @@ public class ThingFactoryTest extends JavaOSGiTest {
         assertThat(((BigDecimal) thing.getConfiguration().get("p2")).compareTo(new BigDecimal("5")), is(0));
         assertThat(((BigDecimal) thing.getConfiguration().get("p3")).compareTo(new BigDecimal("2.3")), is(0));
         assertThat(thing.getConfiguration().get("p4"), is(nullValue()));
+        assertThat(thing.getConfiguration().get("p5"), is(instanceOf(List.class)));
+        assertThat(((List<?>) thing.getConfiguration().get("p5")).size(), is(1));
+        assertThat(((List<?>) thing.getConfiguration().get("p5")).get(0), is(instanceOf(BigDecimal.class)));
+        assertThat(
+                ((BigDecimal) ((List<?>) thing.getConfiguration().get("p5")).get(0)).compareTo(new BigDecimal("2.3")),
+                is(0));
+        assertThat(thing.getConfiguration().get("p6"), is(instanceOf(List.class)));
+        assertThat(((List<?>) thing.getConfiguration().get("p6")).size(), is(3));
         assertThat(thing.getProperties().size(), is(0));
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
@@ -63,7 +63,8 @@ import org.mockito.stubbing.Answer;
 /**
  * ThingFactoryTest is a test for the ThingFactory class.
  *
- * @author Dennis Nobel - Initial contribution, added test for different default types
+ * @author Dennis Nobel - Initial contribution
+ * @author Dennis Nobel - Added test for different default types
  * @author Alex Tugarev - Adapted for constructor modification of ConfigDescriptionParameter
  * @author Thomas Höfer - Thing type constructor modified because of thing properties introduction
  * @author Wouter Born - Migrate tests from Groovy to Java


### PR DESCRIPTION
- Consider more than one value when applying the default value(s) for Things and Channels

We have a really powerful normalization tool `ConfigUtil` for parameters. ~I tried to use this tool for determining the correct type of the default value which unfortunately did not work because the normalization tool returns the given object, if it was not possible to convert it. We expect `null` for the default value if we cannot convert it. Any ideas?~

My approach was not needed because the default value is always a `String`. I now moved the normalization of the default value and the method to apply the default configuration to the `ConfigUtil` tool. As s side effect it leads to a nice code clean-up / streamlining in the helper calsses.

TODOs:
- [x] Add unit test cases

Related to #998

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>