### PR TITLE
Bump compile version of jetty to 9.4 (equal to runtime)

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -16,7 +16,7 @@
   <description>The dependencies that are used to compile the core bundles</description>
 
   <properties>
-    <jetty.version>9.3.25.v20180904</jetty.version>
+    <jetty.version>9.4.11.v20180605</jetty.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Current jetty version is missing ability to initialize WebSocketClient with HttpClient object that can be reused from the framework by Thing factory.
See this thread for more details: https://github.com/openhab/openhab2-addons/issues/6013
I would like to use this initialization in Loxone binding and get rid of custom thread pool.

Signed-off-by: Pawel Pieczul <pieczul@gmail.com>