### PR TITLE
[OAuth2] redirectURI should be optional on getAccessTokenResponseByAu…

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.util.StringUtil;
@@ -159,7 +158,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     }
 
     @Override
-    public String extractAuthCodeFromAuthResponse(@NonNull String redirectURLwithParams) throws OAuthException {
+    public String extractAuthCodeFromAuthResponse(String redirectURLwithParams) throws OAuthException {
         // parse the redirectURL
         try {
             URL redirectURLObject = new URL(redirectURLwithParams);

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -186,8 +186,8 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     }
 
     @Override
-    public AccessTokenResponse getAccessTokenResponseByAuthorizationCode(String authorizationCode, String redirectURI)
-            throws OAuthException, IOException, OAuthResponseException {
+    public AccessTokenResponse getAccessTokenResponseByAuthorizationCode(String authorizationCode,
+            @Nullable String redirectURI) throws OAuthException, IOException, OAuthResponseException {
 
         if (isClosed()) {
             throw new OAuthException(EXCEPTION_MESSAGE_CLOSED);

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthConnector.java
@@ -207,7 +207,7 @@ public class OAuthConnector {
      *             Response
      */
     public AccessTokenResponse grantTypeAuthorizationCode(String tokenUrl, String authorizationCode, String clientId,
-            @Nullable String clientSecret, String redirectUrl, boolean supportsBasicAuth)
+            @Nullable String clientSecret, @Nullable String redirectUrl, boolean supportsBasicAuth)
             throws OAuthResponseException, OAuthException, IOException {
         HttpClient httpClient = null;
         try {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthClientService.java
@@ -152,8 +152,8 @@ public interface OAuthClientService extends AutoCloseable {
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.3">Access Token Request - rfc6749 section-4.1.3</a>
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">Error Response - rfc6749 section-5.2</a>
      */
-    AccessTokenResponse getAccessTokenResponseByAuthorizationCode(String authorizationCode, String redirectURI)
-            throws OAuthException, IOException, OAuthResponseException;
+    AccessTokenResponse getAccessTokenResponseByAuthorizationCode(String authorizationCode,
+            @Nullable String redirectURI) throws OAuthException, IOException, OAuthResponseException;
 
     /**
      * Use case 2 - Resource Owner Password Credentials


### PR DESCRIPTION
…thorizationCode

The redirectURI should be optional (Nullable) on getAccessTokenResponseByAuthorizationCode as in the JavaDoc is stated (as is stated in the refered specification).

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>