### PR TITLE
Add STOP to IncreaseDecreaseType

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -23,7 +23,8 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
 @NonNullByDefault
 public enum IncreaseDecreaseType implements PrimitiveType, Command {
     INCREASE,
-    DECREASE;
+    DECREASE,
+    STOP;
 
     @Override
     public String format(String pattern) {


### PR DESCRIPTION
Maybe there's another way to do this, but currently an ```IncreaseDecreaseType``` can only have ```INCREASE``` and ```DECREASE``` - there seems no way to  set this to ```STOP``` to stop the movement.

It seems that this should therefore be a useful addition - I don't think it should be a breaking change. I'm happy to hear if there's an alternative to this if this change isn't needed, but I'd like to be able to use this in a ```Dimmer``` when someone pressed a button, and then to stop the movement when someone releases the button. This directly maps to a ZigBee concept which uses a ```Move``` command (with an Increase / Decrease parameter), and a ```Stop``` command.

https://community.openhab.org/t/knx-dpt-3-increasedecreasetype/18401

Signed-off-by: Chris Jackson <chris@cd-jackson.com>