### PR TITLE
Fix SAT constant/variable name findings

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -32,7 +32,7 @@ import org.openhab.core.automation.module.script.internal.provider.ScriptModuleT
 @NonNullByDefault
 public interface ScriptEngineFactory {
 
-    static final ScriptEngineManager engineManager = new ScriptEngineManager();
+    static final ScriptEngineManager ENGINE_MANAGER = new ScriptEngineManager();
 
     /**
      * This method returns a list of file extensions and MimeTypes that are supported by the ScriptEngine, e.g. py,

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/AbstractScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/AbstractScriptEngineFactory.java
@@ -40,7 +40,7 @@ public abstract class AbstractScriptEngineFactory implements ScriptEngineFactory
     public List<String> getScriptTypes() {
         List<String> scriptTypes = new ArrayList<>();
 
-        for (javax.script.ScriptEngineFactory f : engineManager.getEngineFactories()) {
+        for (javax.script.ScriptEngineFactory f : ENGINE_MANAGER.getEngineFactories()) {
             scriptTypes.addAll(f.getExtensions());
             scriptTypes.addAll(f.getMimeTypes());
         }
@@ -56,12 +56,12 @@ public abstract class AbstractScriptEngineFactory implements ScriptEngineFactory
 
     @Override
     public @Nullable ScriptEngine createScriptEngine(String scriptType) {
-        ScriptEngine scriptEngine = engineManager.getEngineByExtension(scriptType);
+        ScriptEngine scriptEngine = ENGINE_MANAGER.getEngineByExtension(scriptType);
         if (scriptEngine == null) {
-            scriptEngine = engineManager.getEngineByMimeType(scriptType);
+            scriptEngine = ENGINE_MANAGER.getEngineByMimeType(scriptType);
         }
         if (scriptEngine == null) {
-            scriptEngine = engineManager.getEngineByName(scriptType);
+            scriptEngine = ENGINE_MANAGER.getEngineByName(scriptType);
         }
         return scriptEngine;
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/NashornScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/NashornScriptEngineFactory.java
@@ -43,7 +43,7 @@ public class NashornScriptEngineFactory extends AbstractScriptEngineFactory {
     public List<String> getScriptTypes() {
         List<String> scriptTypes = new ArrayList<>();
 
-        for (javax.script.ScriptEngineFactory f : engineManager.getEngineFactories()) {
+        for (javax.script.ScriptEngineFactory f : ENGINE_MANAGER.getEngineFactories()) {
             List<String> extensions = f.getExtensions();
 
             if (extensions.contains(SCRIPT_TYPE)) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -70,7 +70,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
             }
         }
         logger.debug("Added {}", engineFactory.getClass().getSimpleName());
-        for (javax.script.ScriptEngineFactory f : ScriptEngineFactory.engineManager.getEngineFactories()) {
+        for (javax.script.ScriptEngineFactory f : ScriptEngineFactory.ENGINE_MANAGER.getEngineFactories()) {
             logger.debug(
                     "ScriptEngineFactory details for {} ({}): supports {} ({}) with file extensions {}, names {}, and mimetypes {}",
                     f.getEngineName(), f.getEngineVersion(), f.getLanguageName(), f.getLanguageVersion(),

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptThingActions.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptThingActions.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  */
 public class ScriptThingActions {
 
-    private static final Map<String, ThingActions> thingActionsMap = new HashMap<>();
+    private static final Map<String, ThingActions> THING_ACTIONS_MAP = new HashMap<>();
 
     ScriptThingActions(ThingRegistry thingRegistry) {
         this.thingRegistry = thingRegistry;
@@ -61,7 +61,7 @@ public class ScriptThingActions {
         if (thing != null) {
             ThingHandler handler = thing.getHandler();
             if (handler != null) {
-                ThingActions thingActions = thingActionsMap.get(getKey(scope, thingUid));
+                ThingActions thingActions = THING_ACTIONS_MAP.get(getKey(scope, thingUid));
                 return thingActions;
             }
         }
@@ -71,12 +71,12 @@ public class ScriptThingActions {
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
     void addThingActions(ThingActions thingActions) {
         String key = getKey(thingActions);
-        thingActionsMap.put(key, thingActions);
+        THING_ACTIONS_MAP.put(key, thingActions);
     }
 
     void removeThingActions(ThingActions thingActions) {
         String key = getKey(thingActions);
-        thingActionsMap.remove(key);
+        THING_ACTIONS_MAP.remove(key);
     }
 
     private static String getKey(ThingActions thingActions) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -134,7 +134,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     public void setScriptEngineFactory(ScriptEngineFactory engineFactory) {
         parameterOptions.clear();
-        for (javax.script.ScriptEngineFactory f : ScriptEngineFactory.engineManager.getEngineFactories()) {
+        for (javax.script.ScriptEngineFactory f : ScriptEngineFactory.ENGINE_MANAGER.getEngineFactories()) {
             String languageName = String.format("%s (%s)", StringUtils.capitalize(f.getLanguageName()),
                     f.getLanguageVersion());
             List<String> mimeTypes = new ArrayList<>();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
@@ -43,14 +43,14 @@ public class ChannelEventTriggerHandler extends BaseTriggerModuleHandler impleme
 
     public static final String MODULE_TYPE_ID = "core.ChannelEventTrigger";
 
+    private static final String CFG_CHANNEL_EVENT = "event";
+    private static final String CFG_CHANNEL = "channelUID";
+    private static final String TOPIC = "smarthome/channels/*/triggered";
+
     private final String eventOnChannel;
     private final String channelUID;
-    private final String TOPIC = "smarthome/channels/*/triggered";
-    private final Set<String> types = new HashSet<String>();
+    private final Set<String> types = new HashSet<>();
     private final BundleContext bundleContext;
-
-    private final String CFG_CHANNEL_EVENT = "event";
-    private final String CFG_CHANNEL = "channelUID";
 
     @SuppressWarnings("rawtypes")
     private ServiceRegistration eventSubscriberRegistration;
@@ -63,7 +63,7 @@ public class ChannelEventTriggerHandler extends BaseTriggerModuleHandler impleme
         this.bundleContext = bundleContext;
         this.types.add("ChannelTriggeredEvent");
 
-        Dictionary<String, Object> properties = new Hashtable<String, Object>();
+        Dictionary<String, Object> properties = new Hashtable<>();
         properties.put("event.topics", TOPIC);
         eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
                 properties);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
@@ -66,7 +66,7 @@ public class RuleEnablementActionHandler extends BaseActionModuleHandler {
     /**
      * This field stores the UIDs of the rules to which the action will be applied.
      */
-    private final List<String> UIDs;
+    private final List<String> uids;
 
     /**
      * This field stores the value for the setEnabled() method of {@link RuleRegistry}.
@@ -84,15 +84,15 @@ public class RuleEnablementActionHandler extends BaseActionModuleHandler {
         }
         this.enable = enable.booleanValue();
 
-        UIDs = (List<String>) config.get(RULE_UIDS_KEY);
-        if (UIDs == null) {
+        uids = (List<String>) config.get(RULE_UIDS_KEY);
+        if (uids == null) {
             throw new IllegalArgumentException("'ruleUIDs' property can not be null.");
         }
     }
 
     @Override
     public Map<String, Object> execute(Map<String, Object> context) {
-        for (String uid : UIDs) {
+        for (String uid : uids) {
             if (callback != null) {
                 callback.setEnabled(uid, enable);
             } else {

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/AbstractActiveBinding.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/binding/AbstractActiveBinding.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractActiveBinding<P extends BindingProvider> extends AbstractBinding<P> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractActiveBinding.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractActiveBinding.class);
 
     /** embedded active service to allow the binding to have some code executed in a given interval. */
     protected AbstractActiveService activeService = new BindingActiveService();
@@ -138,7 +138,7 @@ public abstract class AbstractActiveBinding<P extends BindingProvider> extends A
             if (!bindingsExist()) {
                 super.interrupt();
             } else {
-                logger.trace("{} won't be interrupted because bindings exist.", getName());
+                LOGGER.trace("{} won't be interrupted because bindings exist.", getName());
             }
         }
 

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/events/EventPublisherDelegate.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/events/EventPublisherDelegate.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 @Component(immediate = true)
 public class EventPublisherDelegate implements org.openhab.core.events.EventPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(EventPublisherDelegate.class);
+    private final Logger logger = LoggerFactory.getLogger(EventPublisherDelegate.class);
 
     private EventPublisher eventPublisher;
 

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/items/GroupItem.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GroupItem extends GenericItem implements StateChangeListener {
 
-    private static final Logger logger = LoggerFactory.getLogger(GroupItem.class);
+    private final Logger logger = LoggerFactory.getLogger(GroupItem.class);
 
     protected final GenericItem baseItem;
 

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -73,7 +73,7 @@ public class LocationItem extends GenericItem {
             double a = dLat + Math.cos(Math.toRadians(me.getLatitude().doubleValue()))
                     * Math.cos(Math.toRadians(away.getLatitude().doubleValue())) * dLng;
 
-            dist = PointType.WGS84_a * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+            dist = PointType.WGS84_A * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         }
 
         return new DecimalType(dist);

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/library/types/PointType.java
@@ -31,7 +31,7 @@ import org.openhab.core.types.State;
 public class PointType implements ComplexType, Command, State {
 
     public static final double EARTH_GRAVITATIONAL_CONSTANT = 3.986004418e14;
-    public static final double WGS84_a = 6378137; // The equatorial radius of
+    public static final double WGS84_A = 6378137; // The equatorial radius of
                                                   // WGS84 ellipsoid (6378137
                                                   // m).
     private BigDecimal latitude = BigDecimal.ZERO; // in decimal degrees
@@ -41,9 +41,9 @@ public class PointType implements ComplexType, Command, State {
     public static final String KEY_LATITUDE = "lat";
     public static final String KEY_LONGITUDE = "long";
     public static final String KEY_ALTITUDE = "alt";
-    private static final BigDecimal circle = new BigDecimal(360);
-    private static final BigDecimal flat = new BigDecimal(180);
-    private static final BigDecimal right = new BigDecimal(90);
+    private static final BigDecimal CIRCLE = new BigDecimal(360);
+    private static final BigDecimal FLAT = new BigDecimal(180);
+    private static final BigDecimal RIGHT = new BigDecimal(90);
     public static final PointType EMPTY = new PointType(new DecimalType(0), new DecimalType(0));
 
     /**
@@ -109,7 +109,7 @@ public class PointType implements ComplexType, Command, State {
     public DecimalType getGravity() {
         double latRad = Math.toRadians(latitude.doubleValue());
         double deltaG = -2000.0 * (altitude.doubleValue() / 1000) * EARTH_GRAVITATIONAL_CONSTANT
-                / (Math.pow(WGS84_a, 3.0));
+                / (Math.pow(WGS84_A, 3.0));
         double sin2lat = Math.sin(latRad) * Math.sin(latRad);
         double sin22lat = Math.sin(2.0 * latRad) * Math.sin(2.0 * latRad);
         double result = (9.780327 * (1.0 + 5.3024e-3 * sin2lat - 5.8e-6 * sin22lat) + deltaG);
@@ -131,7 +131,7 @@ public class PointType implements ComplexType, Command, State {
         double a = Math.pow(Math.sin(dLat / 2D), 2D) + Math.cos(Math.toRadians(this.latitude.doubleValue()))
                 * Math.cos(Math.toRadians(otherPoint.latitude.doubleValue())) * Math.pow(Math.sin(dLong / 2D), 2D);
         double c = 2D * Math.atan2(Math.sqrt(a), Math.sqrt(1D - a));
-        return new DecimalType(WGS84_a * c);
+        return new DecimalType(WGS84_A * c);
     }
 
     /**
@@ -184,24 +184,24 @@ public class PointType implements ComplexType, Command, State {
      * </pre>
      */
     private void canonicalize(DecimalType aLat, DecimalType aLon) {
-        latitude = flat.add(aLat.toBigDecimal()).remainder(circle);
+        latitude = FLAT.add(aLat.toBigDecimal()).remainder(CIRCLE);
         longitude = aLon.toBigDecimal();
         if (latitude.compareTo(BigDecimal.ZERO) == -1) {
-            latitude.add(circle);
+            latitude.add(CIRCLE);
         }
-        latitude = latitude.subtract(flat);
-        if (latitude.compareTo(right) == 1) {
-            latitude = flat.subtract(latitude);
-            longitude = longitude.add(flat);
-        } else if (latitude.compareTo(right.negate()) == -1) {
-            latitude = flat.negate().subtract(latitude);
-            longitude = longitude.add(flat);
+        latitude = latitude.subtract(FLAT);
+        if (latitude.compareTo(RIGHT) == 1) {
+            latitude = FLAT.subtract(latitude);
+            longitude = longitude.add(FLAT);
+        } else if (latitude.compareTo(RIGHT.negate()) == -1) {
+            latitude = FLAT.negate().subtract(latitude);
+            longitude = longitude.add(FLAT);
         }
-        longitude = flat.add(longitude).remainder(circle);
+        longitude = FLAT.add(longitude).remainder(CIRCLE);
         if (longitude.compareTo(BigDecimal.ZERO) <= 0) {
-            longitude = longitude.add(circle);
+            longitude = longitude.add(CIRCLE);
         }
-        longitude = longitude.subtract(flat);
+        longitude = longitude.subtract(FLAT);
     }
 
     @Override

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/service/AbstractActiveService.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/core/service/AbstractActiveService.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractActiveService {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractActiveService.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractActiveService.class);
 
     /** <code>true</code> if this binding is configured properly which means that all necessary data is available */
     private boolean properlyConfigured = false;

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/exec/ExecUtil.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecUtil {
 
-    private static final Logger logger = LoggerFactory.getLogger(ExecUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecUtil.class);
 
     private static final String CMD_LINE_DELIMITER = "@@";
 
@@ -61,13 +61,13 @@ public class ExecUtil {
             if (commandLine.contains(CMD_LINE_DELIMITER)) {
                 String[] cmdArray = commandLine.split(CMD_LINE_DELIMITER);
                 Runtime.getRuntime().exec(cmdArray);
-                logger.info("executed commandLine '{}'", Arrays.asList(cmdArray));
+                LOGGER.info("executed commandLine '{}'", Arrays.asList(cmdArray));
             } else {
                 Runtime.getRuntime().exec(commandLine);
-                logger.info("executed commandLine '{}'", commandLine);
+                LOGGER.info("executed commandLine '{}'", commandLine);
             }
         } catch (IOException e) {
-            logger.error("couldn't execute commandLine '{}'", commandLine, e);
+            LOGGER.error("couldn't execute commandLine '{}'", commandLine, e);
         }
     }
 
@@ -121,9 +121,9 @@ public class ExecUtil {
 
         try {
             executor.execute(cmdLine, resultHandler);
-            logger.debug("executed commandLine '{}'", commandLine);
+            LOGGER.debug("executed commandLine '{}'", commandLine);
         } catch (IOException e) {
-            logger.error("couldn't execute commandLine '{}'", commandLine, e);
+            LOGGER.error("couldn't execute commandLine '{}'", commandLine, e);
         }
 
         // some time later the result handler callback was invoked so we
@@ -133,12 +133,12 @@ public class ExecUtil {
             int exitCode = resultHandler.getExitValue();
             retval = StringUtils.chomp(stdout.toString());
             if (resultHandler.getException() != null) {
-                logger.warn("{}", resultHandler.getException().getMessage());
+                LOGGER.warn("{}", resultHandler.getException().getMessage());
             } else {
-                logger.debug("exit code '{}', result '{}'", exitCode, retval);
+                LOGGER.debug("exit code '{}', result '{}'", exitCode, retval);
             }
         } catch (InterruptedException e) {
-            logger.error("Timeout occurred when executing commandLine '{}'", commandLine, e);
+            LOGGER.error("Timeout occurred when executing commandLine '{}'", commandLine, e);
         }
 
         return retval;

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpUtil {
 
-    private static final Logger logger = LoggerFactory.getLogger(HttpUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
 
     /** {@link Pattern} which matches the credentials out of an URL */
     private static final Pattern URL_CREDENTIALS_PATTERN = Pattern.compile("http://(.*?):(.*?)@.*");
@@ -122,7 +122,7 @@ public class HttpUtil {
                 try {
                     proxyPort = Integer.valueOf(proxyPortString);
                 } catch (NumberFormatException e) {
-                    logger.warn("'{}' is not a valid proxy port - using port 80 instead");
+                    LOGGER.warn("'{}' is not a valid proxy port - using port 80 instead");
                 }
             }
             proxyUser = System.getProperty("http.proxyUser");
@@ -187,11 +187,11 @@ public class HttpUtil {
             client.getState().setCredentials(AuthScope.ANY, credentials);
         }
 
-        if (logger.isDebugEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             try {
-                logger.debug("About to execute '{}'", method.getURI());
+                LOGGER.debug("About to execute '{}'", method.getURI());
             } catch (URIException e) {
-                logger.debug("{}", e.getMessage());
+                LOGGER.debug("{}", e.getMessage());
             }
         }
 
@@ -199,19 +199,19 @@ public class HttpUtil {
 
             int statusCode = client.executeMethod(method);
             if (statusCode != HttpStatus.SC_OK) {
-                logger.debug("Method failed: {}", method.getStatusLine());
+                LOGGER.debug("Method failed: {}", method.getStatusLine());
             }
 
             String responseBody = IOUtils.toString(method.getResponseBodyAsStream());
             if (!responseBody.isEmpty()) {
-                logger.debug("{}", responseBody);
+                LOGGER.debug("{}", responseBody);
             }
 
             return responseBody;
         } catch (HttpException he) {
-            logger.error("Fatal protocol violation: {}", he.toString());
+            LOGGER.error("Fatal protocol violation: {}", he.toString());
         } catch (IOException ioe) {
-            logger.error("Fatal transport error: {}", ioe.toString());
+            LOGGER.error("Fatal transport error: {}", ioe.toString());
         } finally {
             method.releaseConnection();
         }
@@ -239,7 +239,7 @@ public class HttpUtil {
                 URL url = new URL(urlString);
                 givenHost = url.getHost();
             } catch (MalformedURLException e) {
-                logger.error("the given url {} is malformed", urlString);
+                LOGGER.error("the given url {} is malformed", urlString);
             }
 
             String[] hosts = nonProxyHosts.split("\\|");
@@ -301,13 +301,13 @@ public class HttpUtil {
 
     /**
      * Factory method to create a {@link HttpMethod}-object according to the
-     * given String <code>httpMethod</codde>
+     * given String <code>httpMethod</code>
      *
-     * &#64;param httpMethodString the name of the {@link HttpMethod} to create
-     * &#64;param url
+     * @param httpMethodString the name of the {@link HttpMethod} to create
+     * @param url
      *
-     * &#64;return an object of type {@link GetMethod}, {@link PutMethod},
-     * {@link PostMethod} or {@link DeleteMethod}
+     * @return an object of type {@link GetMethod}, {@link PutMethod},
+     *         {@link PostMethod} or {@link DeleteMethod}
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of
      *             <code>GET</code>, <code>PUT</code>, <code>POST</POST> or <code>DELETE</code>
      */

--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/model/item/binding/AbstractGenericBindingProvider.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractGenericBindingProvider implements BindingConfigReader, BindingProvider {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractGenericBindingProvider.class);
+    private final Logger logger = LoggerFactory.getLogger(AbstractGenericBindingProvider.class);
 
     private Set<BindingChangeListener> listeners = new CopyOnWriteArraySet<>();
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ConfigMapper {
-    private static final transient Logger logger = LoggerFactory.getLogger(ConfigMapper.class);
+    private static final transient Logger LOGGER = LoggerFactory.getLogger(ConfigMapper.class);
 
     /**
      * Use this method to automatically map a configuration collection to a Configuration holder object. A common
@@ -78,7 +78,7 @@ public class ConfigMapper {
 
             // Consider RequiredField annotations
             if (value == null) {
-                logger.trace("Skipping field '{}', because config has no entry for {}", fieldName, configKey);
+                LOGGER.trace("Skipping field '{}', because config has no entry for {}", fieldName, configKey);
                 continue;
             }
 
@@ -97,12 +97,12 @@ public class ConfigMapper {
 
             try {
                 value = objectConvert(value, type);
-                logger.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
+                LOGGER.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
                         value, fieldName, configurationClass.getName());
                 FieldUtils.writeField(configuration, fieldName, value, true);
 
             } catch (Exception ex) {
-                logger.warn("Could not set field value for field '{}': {}", fieldName, ex.getMessage(), ex);
+                LOGGER.warn("Could not set field value for field '{}': {}", fieldName, ex.getMessage(), ex);
             }
         }
 

--- a/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/eclipse/smarthome/io/console/eclipse/internal/ConsoleSupportEclipse.java
+++ b/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/eclipse/smarthome/io/console/eclipse/internal/ConsoleSupportEclipse.java
@@ -44,7 +44,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 @Component
 public class ConsoleSupportEclipse implements CommandProvider {
 
-    private final String BASE = "smarthome";
+    private static final String BASE = "smarthome";
 
     private final SortedMap<String, ConsoleCommandExtension> consoleCommandExtensions = Collections
             .synchronizedSortedMap(new TreeMap<String, ConsoleCommandExtension>());

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResource.java
@@ -88,9 +88,9 @@ public class PersistenceResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(PersistenceResource.class);
 
-    private final String MODIFYABLE = "Modifiable";
-    private final String QUERYABLE = "Queryable";
-    private final String STANDARD = "Standard";
+    private static final String MODIFYABLE = "Modifiable";
+    private static final String QUERYABLE = "Queryable";
+    private static final String STANDARD = "Standard";
 
     // The URI path to this resource
     public static final String PATH = "persistence";

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -72,7 +72,7 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
 
     private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(POOL_NAME);
 
-    private final int DEFAULT_POLLING_INTERVAL = 60;
+    private static final int DEFAULT_POLLING_INTERVAL = 60;
     private static final String POOL_NAME = "upnp-io";
 
     private UpnpService upnpService;

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -81,13 +81,13 @@ public class FeatureInstaller implements ConfigurationListener {
     public static final String PREFIX = "openhab-";
     public static final String PREFIX_PACKAGE = "package-";
 
-    public static final String[] addonTypes = new String[] { "binding", "ui", "persistence", "action", "voice",
+    public static final String[] ADDON_TYPES = new String[] { "binding", "ui", "persistence", "action", "voice",
             "transformation", "misc" };
 
     private final Logger logger = LoggerFactory.getLogger(FeatureInstaller.class);
 
-    private String online_repo_url = null;
-    private URI legacy_addons_url = null;
+    private String onlineRepoUrl = null;
+    private URI legacyAddonsUrl = null;
 
     private FeaturesService featuresService;
     private ConfigurationAdmin configurationAdmin;
@@ -264,7 +264,7 @@ public class FeatureInstaller implements ConfigurationListener {
 
         String repo = prop.getProperty("online-repo");
         if (repo != null && !repo.trim().isEmpty()) {
-            this.online_repo_url = repo.trim() + "@id=openhab@snapshots";
+            this.onlineRepoUrl = repo.trim() + "@id=openhab@snapshots";
         } else {
             logger.warn("Cannot determine online repo url - online repo support will be disabled.");
         }
@@ -283,7 +283,7 @@ public class FeatureInstaller implements ConfigurationListener {
 
         String version = prop.getProperty("openhab-distro");
         if (version != null && !version.trim().isEmpty()) {
-            this.legacy_addons_url = URI
+            this.legacyAddonsUrl = URI
                     .create("mvn:org.openhab.distro/openhab-addons-legacy/" + version.trim() + "/xml/features");
         } else {
             logger.warn("Cannot determine distro version - legacy addon support will be disabled.");
@@ -291,17 +291,17 @@ public class FeatureInstaller implements ConfigurationListener {
     }
 
     private void setLegacyExtensions(FeaturesService service, Map<String, Object> config) {
-        if (legacy_addons_url != null) {
+        if (legacyAddonsUrl != null) {
             if (config.get(CFG_LEGACY) != null && "true".equals(config.get(CFG_LEGACY).toString())) {
                 try {
-                    service.addRepository(legacy_addons_url);
+                    service.addRepository(legacyAddonsUrl);
                 } catch (Exception e) {
                     logger.debug("Failed adding feature repo for legacy features - we might be offline: {}",
                             e.getMessage());
                 }
             } else {
                 try {
-                    service.removeRepository(legacy_addons_url);
+                    service.removeRepository(legacyAddonsUrl);
                 } catch (Exception e) {
                     // This usually throws an error like
                     // "Feature named 'openhab-binding-homematic1/1.9.0.SNAPSHOT' is not installed"
@@ -314,7 +314,7 @@ public class FeatureInstaller implements ConfigurationListener {
     }
 
     private boolean getOnlineStatus() {
-        if (online_repo_url != null) {
+        if (onlineRepoUrl != null) {
             try {
                 Configuration paxCfg = configurationAdmin.getConfiguration(PAX_URL_PID, null);
                 Dictionary<String, Object> properties = paxCfg.getProperties();
@@ -325,7 +325,7 @@ public class FeatureInstaller implements ConfigurationListener {
                 List<String> repoCfg;
                 if (repos instanceof String) {
                     repoCfg = Arrays.asList(((String) repos).split(","));
-                    return repoCfg.contains(online_repo_url);
+                    return repoCfg.contains(onlineRepoUrl);
                 }
             } catch (IOException e) {
                 logger.error("Failed getting the add-on management online/offline mode: {}", e.getMessage());
@@ -336,7 +336,7 @@ public class FeatureInstaller implements ConfigurationListener {
 
     private boolean setOnlineStatus(boolean status) {
         boolean changed = false;
-        if (online_repo_url != null) {
+        if (onlineRepoUrl != null) {
             try {
                 Configuration paxCfg = configurationAdmin.getConfiguration(PAX_URL_PID, null);
                 paxCfg.setBundleLocation("?");
@@ -351,16 +351,16 @@ public class FeatureInstaller implements ConfigurationListener {
                     repoCfg.remove("");
                 }
                 if (status) {
-                    if (!repoCfg.contains(online_repo_url)) {
-                        repoCfg.add(online_repo_url);
+                    if (!repoCfg.contains(onlineRepoUrl)) {
+                        repoCfg.add(onlineRepoUrl);
                         changed = true;
-                        logger.debug("Added repo '{}' to feature repo list.", online_repo_url);
+                        logger.debug("Added repo '{}' to feature repo list.", onlineRepoUrl);
                     }
                 } else {
-                    if (repoCfg.contains(online_repo_url)) {
-                        repoCfg.remove(online_repo_url);
+                    if (repoCfg.contains(onlineRepoUrl)) {
+                        repoCfg.remove(onlineRepoUrl);
                         changed = true;
-                        logger.debug("Removed repo '{}' from feature repo list.", online_repo_url);
+                        logger.debug("Removed repo '{}' from feature repo list.", onlineRepoUrl);
                     }
                 }
                 if (changed) {
@@ -380,7 +380,7 @@ public class FeatureInstaller implements ConfigurationListener {
         final Set<String> targetAddons = new HashSet<>(); // the target we want to have installed afterwards
         final Set<String> installAddons = new HashSet<>(); // the ones to be installed (the diff)
 
-        for (String type : addonTypes) {
+        for (String type : ADDON_TYPES) {
             Object install = config.get(type);
             if (install instanceof String) {
                 String[] entries = ((String) install).split(",");

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafExtensionService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafExtensionService.java
@@ -72,7 +72,7 @@ public class KarafExtensionService implements ExtensionService {
         try {
             for (Feature feature : featuresService.listFeatures()) {
                 if (feature.getName().startsWith(FeatureInstaller.PREFIX)
-                        && Arrays.asList(FeatureInstaller.addonTypes).contains(getType(feature.getName()))) {
+                        && Arrays.asList(FeatureInstaller.ADDON_TYPES).contains(getType(feature.getName()))) {
                     Extension extension = getExtension(feature);
                     // for simple packaging, we filter out all openHAB 1 add-ons as they cannot be used through the UI
                     if (!"simple".equals(featureInstaller.getCurrentPackage())

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicChattyThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicChattyThingHandler.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
 public class MagicChattyThingHandler extends BaseThingHandler {
 
     private static Logger logger = LoggerFactory.getLogger(MagicChattyThingHandler.class);
-    private static String PARAM_INTERVAL = "interval";
-    private static int START_DELAY = 3;
+    private static final String PARAM_INTERVAL = "interval";
+    private static final int START_DELAY = 3;
 
-    private static final List<String> randomTexts = Stream
+    private static final List<String> RANDOM_TEXTS = Stream
             .of("OPEN", "CLOSED", "ON", "OFF", "Hello", "This is a sentence").collect(Collectors.toList());
 
     private final Set<ChannelUID> numberChannelUIDs = new HashSet<>();
@@ -107,8 +107,8 @@ public class MagicChattyThingHandler extends BaseThingHandler {
                 }
 
                 for (ChannelUID channelUID : textChannelUIDs) {
-                    int pos = (int) (Math.random() * (randomTexts.size() - 1));
-                    String randomValue = randomTexts.get(pos);
+                    int pos = (int) (Math.random() * (RANDOM_TEXTS.size() - 1));
+                    String randomValue = RANDOM_TEXTS.get(pos);
 
                     StringType cmd = new StringType(randomValue);
                     updateState(channelUID, cmd);

--- a/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
@@ -73,7 +73,7 @@ public class SyntheticBundleInstaller {
     /**
      * A list of default extensions to be included in the synthetic bundle.
      */
-    private static Set<String> DEFAULT_EXTENSIONS = Collections
+    private static final Set<String> DEFAULT_EXTENSIONS = Collections
             .unmodifiableSet(Stream.of("*.xml", "*.properties", "*.json", ".keep").collect(Collectors.toSet()));
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -61,9 +61,9 @@ import org.slf4j.LoggerFactory;
 @Component(configurationPid = "org.eclipse.smarthome.channelitemprovider", immediate = true)
 public class ChannelItemProvider implements ItemProvider {
 
-    private final Logger logger = LoggerFactory.getLogger(ChannelItemProvider.class);
+    private static final long INITIALIZATION_DELAY_NANOS = TimeUnit.SECONDS.toNanos(2);
 
-    private final long INITIALIZATION_DELAY_NANOS = TimeUnit.SECONDS.toNanos(2);
+    private final Logger logger = LoggerFactory.getLogger(ChannelItemProvider.class);
 
     private final Set<ProviderChangeListener<Item>> listeners = new HashSet<>();
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
@@ -25,7 +25,7 @@ public class ChartThemeBlack implements ChartTheme {
 
     private static final String THEME_NAME = "black";
 
-    private Color[] LINECOLORS = new Color[] { //
+    private static final Color[] LINECOLORS = new Color[] { //
             new Color(244, 67, 54), // red
             new Color(76, 175, 80), // green
             new Color(63, 81, 181), // blue

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
@@ -25,7 +25,7 @@ public class ChartThemeDark implements ChartTheme {
 
     private static final String THEME_NAME = "dark";
 
-    private Color[] LINECOLORS = new Color[] { //
+    private static final Color[] LINECOLORS = new Color[] { //
             new Color(244, 67, 54), // red
             new Color(76, 175, 80), // green
             new Color(63, 81, 181), // blue

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
@@ -25,7 +25,7 @@ public class ChartThemeWhite implements ChartTheme {
 
     private static final String THEME_NAME = "white";
 
-    private Color[] LINECOLORS = new Color[] { //
+    private static final Color[] LINECOLORS = new Color[] { //
             new Color(244, 67, 54), // red
             new Color(76, 175, 80), // green
             new Color(63, 81, 181), // blue

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -53,11 +53,11 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     public static final HSBType BLUE = new HSBType("240,100,100");
 
     // 1931 CIE XYZ to sRGB (D65 reference white)
-    private static float Xy2Rgb[][] = { { 3.2406f, -1.5372f, -0.4986f }, { -0.9689f, 1.8758f, 0.0415f },
+    private static final float XY2RGB[][] = { { 3.2406f, -1.5372f, -0.4986f }, { -0.9689f, 1.8758f, 0.0415f },
             { 0.0557f, -0.2040f, 1.0570f } };
 
     // sRGB to 1931 CIE XYZ (D65 reference white)
-    private static float Rgb2Xy[][] = { { 0.4124f, 0.3576f, 0.1805f }, { 0.2126f, 0.7152f, 0.0722f },
+    private static final float RGB2XY[][] = { { 0.4124f, 0.3576f, 0.1805f }, { 0.2126f, 0.7152f, 0.0722f },
             { 0.0193f, 0.1192f, 0.9505f } };
 
     protected BigDecimal hue;
@@ -169,13 +169,13 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
      * @return new HSBType object representing the given CIE XY color, full brightness
      */
     public static HSBType fromXY(float x, float y) {
-        float Yo = 1.0f;
-        float X = (Yo / y) * x;
-        float Z = (Yo / y) * (1.0f - x - y);
+        float tmpY = 1.0f;
+        float tmpX = (tmpY / y) * x;
+        float tmpZ = (tmpY / y) * (1.0f - x - y);
 
-        float r = X * Xy2Rgb[0][0] + Yo * Xy2Rgb[0][1] + Z * Xy2Rgb[0][2];
-        float g = X * Xy2Rgb[1][0] + Yo * Xy2Rgb[1][1] + Z * Xy2Rgb[1][2];
-        float b = X * Xy2Rgb[2][0] + Yo * Xy2Rgb[2][1] + Z * Xy2Rgb[2][2];
+        float r = tmpX * XY2RGB[0][0] + tmpY * XY2RGB[0][1] + tmpZ * XY2RGB[0][2];
+        float g = tmpX * XY2RGB[1][0] + tmpY * XY2RGB[1][1] + tmpZ * XY2RGB[1][2];
+        float b = tmpX * XY2RGB[2][0] + tmpY * XY2RGB[2][1] + tmpZ * XY2RGB[2][2];
 
         float max = r > g ? r : g;
         if (b > max) {
@@ -366,16 +366,16 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
         float g = gammaDecompress(sRGB[1].floatValue() / 100.0f);
         float b = gammaDecompress(sRGB[2].floatValue() / 100.0f);
 
-        float X = r * Rgb2Xy[0][0] + g * Rgb2Xy[0][1] + b * Rgb2Xy[0][2];
-        float Y = r * Rgb2Xy[1][0] + g * Rgb2Xy[1][1] + b * Rgb2Xy[1][2];
-        float Z = r * Rgb2Xy[2][0] + g * Rgb2Xy[2][1] + b * Rgb2Xy[2][2];
+        float tmpX = r * RGB2XY[0][0] + g * RGB2XY[0][1] + b * RGB2XY[0][2];
+        float tmpY = r * RGB2XY[1][0] + g * RGB2XY[1][1] + b * RGB2XY[1][2];
+        float tmpZ = r * RGB2XY[2][0] + g * RGB2XY[2][1] + b * RGB2XY[2][2];
 
-        float x = X / (X + Y + Z);
-        float y = Y / (X + Y + Z);
+        float x = tmpX / (tmpX + tmpY + tmpZ);
+        float y = tmpY / (tmpX + tmpY + tmpZ);
 
         return new PercentType[] { new PercentType(Float.valueOf(x * 100.0f).toString()),
                 new PercentType(Float.valueOf(y * 100.0f).toString()),
-                new PercentType(Float.valueOf(Y * getBrightness().floatValue()).toString()) };
+                new PercentType(Float.valueOf(tmpY * getBrightness().floatValue()).toString()) };
     }
 
     private int convertPercentToByte(PercentType percent) {

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -82,9 +82,8 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
     private Event ruleEvent;
     public Event itemEvent;
 
-    public static VolatileStorageService VOLATILE_STORAGE_SERVICE = new VolatileStorageService(); // keep storage with
-                                                                                                  // rules imported from
-                                                                                                  // json files
+    // keep storage rules imported from json files
+    public static final VolatileStorageService VOLATILE_STORAGE_SERVICE = new VolatileStorageService();
 
     @Before
     public void before() {

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/HostFragmentSupportTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/HostFragmentSupportTest.java
@@ -44,12 +44,12 @@ public class HostFragmentSupportTest extends JavaOSGiTest {
     private ModuleTypeRegistry moduleTypeRegistry;
     private PackageAdmin pkgAdmin;
 
-    private final String EXT = ".jar";
-    private final String PATH = "/";
-    private final String RESOURCES_TEST_BUNDLE_1 = "host-tb1";
-    private final String RESOURCES_TEST_BUNDLE_2 = "host-tb2";
-    private final String RESOURCES_TEST_BUNDLE_3 = "fragment-tb1";
-    private final String RESOURCES_TEST_BUNDLE_4 = "fragment-tb2";
+    private static final String EXT = ".jar";
+    private static final String PATH = "/";
+    private static final String RESOURCES_TEST_BUNDLE_1 = "host-tb1";
+    private static final String RESOURCES_TEST_BUNDLE_2 = "host-tb2";
+    private static final String RESOURCES_TEST_BUNDLE_3 = "fragment-tb1";
+    private static final String RESOURCES_TEST_BUNDLE_4 = "fragment-tb2";
 
     private final String trigger1 = "Trigger1";
     private final String trigger2 = "Trigger2";

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleRegistryTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleRegistryTest.java
@@ -67,9 +67,9 @@ public class RuleRegistryTest extends JavaOSGiTest {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         name = "rule_without_tag";
-        final RuleImpl rule_without_tag = new RuleImpl(name);
+        final RuleImpl ruleWithoutTag = new RuleImpl(name);
 
-        addedRule = ruleRegistry.add(rule_without_tag);
+        addedRule = ruleRegistry.add(ruleWithoutTag);
         Assert.assertNotNull("RuleImpl for:" + name, addedRule);
 
         getRule = ruleRegistry.get(name);
@@ -96,10 +96,10 @@ public class RuleRegistryTest extends JavaOSGiTest {
         tags = new HashSet<>();
         tags.add(tag1);
 
-        final RuleImpl rule_with_tag1 = new RuleImpl(name);
-        rule_with_tag1.setTags(tags);
+        final RuleImpl ruleWithTag1 = new RuleImpl(name);
+        ruleWithTag1.setTags(tags);
 
-        addedRule = ruleRegistry.add(rule_with_tag1);
+        addedRule = ruleRegistry.add(ruleWithTag1);
         Assert.assertNotNull("RuleImpl for:" + name, addedRule);
 
         getRule = ruleRegistry.get(name);
@@ -112,8 +112,8 @@ public class RuleRegistryTest extends JavaOSGiTest {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         Assert.assertEquals("RuleImpl list size", 2, ruleRegistry.stream().collect(Collectors.toList()).size());
 
-        Collection<Rule> rules_with_tag1 = ruleRegistry.getByTags(tag1);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_tag1.size());
+        Collection<Rule> rulesWithTag1 = ruleRegistry.getByTags(tag1);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithTag1.size());
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // checking predicates
@@ -140,10 +140,10 @@ public class RuleRegistryTest extends JavaOSGiTest {
         tags.add(tag1);
         tags.add(tag2);
 
-        final RuleImpl rule_with_tag1_tag2 = new RuleImpl(name);
-        rule_with_tag1_tag2.setTags(tags);
+        final RuleImpl ruleWithTag1Tag2 = new RuleImpl(name);
+        ruleWithTag1Tag2.setTags(tags);
 
-        addedRule = ruleRegistry.add(rule_with_tag1_tag2);
+        addedRule = ruleRegistry.add(ruleWithTag1Tag2);
         Assert.assertNotNull("RuleImpl for:" + name, addedRule);
 
         getRule = ruleRegistry.get(name);
@@ -156,14 +156,14 @@ public class RuleRegistryTest extends JavaOSGiTest {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         Assert.assertEquals("RuleImpl list size", 3, ruleRegistry.stream().collect(Collectors.toList()).size());
 
-        rules_with_tag1 = ruleRegistry.getByTags(tag1);
-        Assert.assertEquals("RuleImpl list size", 2, rules_with_tag1.size());
+        rulesWithTag1 = ruleRegistry.getByTags(tag1);
+        Assert.assertEquals("RuleImpl list size", 2, rulesWithTag1.size());
 
-        Collection<Rule> rules_with_tag2 = ruleRegistry.getByTags(tag2);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_tag2.size());
+        Collection<Rule> rulesWithTag2 = ruleRegistry.getByTags(tag2);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithTag2.size());
 
-        Collection<Rule> rules_with_all_of_tag1_tag2 = ruleRegistry.getByTags(tag1, tag2);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_all_of_tag1_tag2.size());
+        Collection<Rule> rulesWithAllOfTag1Tag2 = ruleRegistry.getByTags(tag1, tag2);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithAllOfTag1Tag2.size());
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // checking predicates
@@ -207,10 +207,10 @@ public class RuleRegistryTest extends JavaOSGiTest {
         tags.add(tag2);
         tags.add(tag3);
 
-        final RuleImpl rule_with_tag1_tag2_tag3 = new RuleImpl("rule_with_tag1_tag2_tag3");
-        rule_with_tag1_tag2_tag3.setTags(tags);
+        final RuleImpl ruleWithTag1Tag2Tag3 = new RuleImpl("rule_with_tag1_tag2_tag3");
+        ruleWithTag1Tag2Tag3.setTags(tags);
 
-        addedRule = ruleRegistry.add(rule_with_tag1_tag2_tag3);
+        addedRule = ruleRegistry.add(ruleWithTag1Tag2Tag3);
         Assert.assertNotNull("RuleImpl for:" + name, addedRule);
 
         getRule = ruleRegistry.get(name);
@@ -223,23 +223,23 @@ public class RuleRegistryTest extends JavaOSGiTest {
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         Assert.assertEquals("RuleImpl list size", 4, ruleRegistry.stream().collect(Collectors.toList()).size());
 
-        rules_with_tag1 = ruleRegistry.getByTags(tag1);
-        Assert.assertEquals("RuleImpl list size", 3, rules_with_tag1.size());
+        rulesWithTag1 = ruleRegistry.getByTags(tag1);
+        Assert.assertEquals("RuleImpl list size", 3, rulesWithTag1.size());
 
-        rules_with_tag2 = ruleRegistry.getByTags(tag2);
-        Assert.assertEquals("RuleImpl list size", 2, rules_with_tag2.size());
+        rulesWithTag2 = ruleRegistry.getByTags(tag2);
+        Assert.assertEquals("RuleImpl list size", 2, rulesWithTag2.size());
 
-        Collection<Rule> rules_with_tag3 = ruleRegistry.getByTags(tag3);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_tag3.size());
+        Collection<Rule> rulesWithTag3 = ruleRegistry.getByTags(tag3);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithTag3.size());
 
-        rules_with_all_of_tag1_tag2 = ruleRegistry.getByTags(tag1, tag2);
-        Assert.assertEquals("RuleImpl list size", 2, rules_with_all_of_tag1_tag2.size());
+        rulesWithAllOfTag1Tag2 = ruleRegistry.getByTags(tag1, tag2);
+        Assert.assertEquals("RuleImpl list size", 2, rulesWithAllOfTag1Tag2.size());
 
-        Collection<Rule> rules_with_all_tag1_tag3 = ruleRegistry.getByTags(tag1, tag3);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_all_tag1_tag3.size());
+        Collection<Rule> rulesWithAllTag1Tag3 = ruleRegistry.getByTags(tag1, tag3);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithAllTag1Tag3.size());
 
-        Collection<Rule> rules_with_all_of_tag1_tag2_tag3 = ruleRegistry.getByTags(tag1, tag2, tag3);
-        Assert.assertEquals("RuleImpl list size", 1, rules_with_all_of_tag1_tag2_tag3.size());
+        Collection<Rule> rulesWithAllOfTag1Tag2Tag3 = ruleRegistry.getByTags(tag1, tag2, tag3);
+        Assert.assertEquals("RuleImpl list size", 1, rulesWithAllOfTag1Tag2Tag3.size());
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // checking predicates

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -49,20 +49,20 @@ import org.osgi.framework.ServiceRegistration;
  */
 public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
-    private final String ANY_BINDING_ID_1 = "any2BindingId1";
-    private final String ANY_THING_TYPE_1 = "any2ThingType1";
+    private static final String ANY_BINDING_ID_1 = "any2BindingId1";
+    private static final String ANY_THING_TYPE_1 = "any2ThingType1";
 
-    private final String ANY_BINDING_ID_2 = "any2BindingId2";
-    private final String ANY_THING_TYPE_2 = "any2ThingType2";
+    private static final String ANY_BINDING_ID_2 = "any2BindingId2";
+    private static final String ANY_THING_TYPE_2 = "any2ThingType2";
 
-    private final String ANY_BINDING_ID_3 = "any2BindingId3";
-    private final String ANY_THING_TYPE_3 = "any2ThingType3";
+    private static final String ANY_BINDING_ID_3 = "any2BindingId3";
+    private static final String ANY_THING_TYPE_3 = "any2ThingType3";
 
-    private final ThingUID BRIDGE_UID_1 = new ThingUID("binding:bridge:1");
-    private final ThingUID BRIDGE_UID_2 = new ThingUID("binding:bridge:2");
+    private static final ThingUID BRIDGE_UID_1 = new ThingUID("binding:bridge:1");
+    private static final ThingUID BRIDGE_UID_2 = new ThingUID("binding:bridge:2");
 
-    private final String FAULTY_BINDING_ID = "faulty2BindingId";
-    private final String FAULTY_THING_TYPE = "faulty2ThingType";
+    private static final String FAULTY_BINDING_ID = "faulty2BindingId";
+    private static final String FAULTY_THING_TYPE = "faulty2ThingType";
 
     private static class AnotherDiscoveryService extends DiscoveryServiceMock {
         public AnotherDiscoveryService(ThingTypeUID thingType, int timeout) {

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/eclipse/smarthome/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
@@ -125,11 +125,11 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertUpdateWithDifferentConfig() {
-        final String CFG_IP_ADDRESS_KEY = "ipAddress";
-        final String CFG_IP_ADDRESS_VALUE = "127.0.0.1";
+        final String cfgIpAddressKey = "ipAddress";
+        final String cfgIpAddressValue = "127.0.0.1";
 
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_ID).build();
-        thing.getConfiguration().put(CFG_IP_ADDRESS_KEY, null);
+        thing.getConfiguration().put(cfgIpAddressKey, null);
         managedThingProvider.add(thing);
         waitForAssert(() -> {
             assertNotNull(callback);
@@ -137,8 +137,7 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
         callback.statusUpdated(thing, ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build());
 
         DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_TYPE_UID, THING_UID, null,
-                Collections.singletonMap(CFG_IP_ADDRESS_KEY, CFG_IP_ADDRESS_VALUE), "DummyRepr", "DummyLabel1",
-                DEFAULT_TTL);
+                Collections.singletonMap(cfgIpAddressKey, cfgIpAddressValue), "DummyRepr", "DummyLabel1", DEFAULT_TTL);
 
         inbox.add(discoveryResult);
 
@@ -147,7 +146,7 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
 
         Thing updatedThing = captor.getValue();
         assertNotNull(updatedThing);
-        assertEquals(CFG_IP_ADDRESS_VALUE, updatedThing.getConfiguration().get(CFG_IP_ADDRESS_KEY));
+        assertEquals(cfgIpAddressValue, updatedThing.getConfiguration().get(cfgIpAddressKey));
 
         assertEquals(0, inbox.getAll().size());
     }

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
@@ -39,8 +39,8 @@ public class NumberExtensionsTest {
     private static final QuantityType<Temperature> Q_CELSIUS_1 = new QuantityType<Temperature>("1 °C");
     private static final QuantityType<Temperature> Q_CELSIUS_2 = new QuantityType<Temperature>("2 °C");
 
-    private static final QuantityType<Length> Q_LENGTH_1m = new QuantityType<Length>("1 m");
-    private static final QuantityType<Length> Q_LENGTH_2cm = new QuantityType<Length>("2 cm");
+    private static final QuantityType<Length> Q_LENGTH_1_M = new QuantityType<Length>("1 m");
+    private static final QuantityType<Length> Q_LENGTH_2_CM = new QuantityType<Length>("2 cm");
 
     private static final QuantityType<Dimensionless> Q_ONE_1 = new QuantityType<>(1, SmartHomeUnits.ONE);
     private static final QuantityType<Dimensionless> Q_ONE_2 = new QuantityType<>(2, SmartHomeUnits.ONE);
@@ -82,92 +82,92 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorMinus_Quantity_Quantity() {
-        assertThat(NumberExtensions.operator_minus(Q_LENGTH_1m, Q_LENGTH_2cm), is(QuantityType.valueOf("0.98 m")));
+        assertThat(NumberExtensions.operator_minus(Q_LENGTH_1_M, Q_LENGTH_2_CM), is(QuantityType.valueOf("0.98 m")));
     }
 
     @Test
     public void operatorMultiply_Number_Quantity() {
-        assertThat(NumberExtensions.operator_multiply(DECIMAL2, Q_LENGTH_2cm), is(QuantityType.valueOf("4 cm")));
+        assertThat(NumberExtensions.operator_multiply(DECIMAL2, Q_LENGTH_2_CM), is(QuantityType.valueOf("4 cm")));
     }
 
     @Test
     public void operatorMultiply_Quantity_Quantity() {
-        assertThat(NumberExtensions.operator_multiply(Q_LENGTH_1m, Q_LENGTH_2cm), is(QuantityType.valueOf("2 m·cm")));
+        assertThat(NumberExtensions.operator_multiply(Q_LENGTH_1_M, Q_LENGTH_2_CM), is(QuantityType.valueOf("2 m·cm")));
     }
 
     @Test
     public void operatorDivide_Quantity_Number() {
-        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1m, DECIMAL2), is(QuantityType.valueOf("0.5 m")));
+        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1_M, DECIMAL2), is(QuantityType.valueOf("0.5 m")));
     }
 
     @Test
     public void operatorDivide_Quantity_Quantity() {
-        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1m, Q_LENGTH_2cm), is(QuantityType.valueOf("0.5 m/cm")));
+        assertThat(NumberExtensions.operator_divide(Q_LENGTH_1_M, Q_LENGTH_2_CM), is(QuantityType.valueOf("0.5 m/cm")));
     }
 
     @Test
     public void operatorDivide_Numer_Quantity() {
-        assertThat(NumberExtensions.operator_divide(DECIMAL1, Q_LENGTH_2cm), is(QuantityType.valueOf("0.5 one/cm")));
+        assertThat(NumberExtensions.operator_divide(DECIMAL1, Q_LENGTH_2_CM), is(QuantityType.valueOf("0.5 one/cm")));
     }
 
     @Test
     public void operatorEquals_Numer_Quantity() {
-        assertFalse(NumberExtensions.operator_equals((Number) DECIMAL1, Q_LENGTH_2cm));
+        assertFalse(NumberExtensions.operator_equals((Number) DECIMAL1, Q_LENGTH_2_CM));
     }
 
     @Test
     public void operatorEquals_Quantity_Number() {
-        assertFalse(NumberExtensions.operator_equals((Number) Q_LENGTH_2cm, DECIMAL1));
+        assertFalse(NumberExtensions.operator_equals((Number) Q_LENGTH_2_CM, DECIMAL1));
     }
 
     @Test
     public void operatorEquals_Quantity_Quantity_False() {
-        assertFalse(NumberExtensions.operator_equals(Q_LENGTH_1m, Q_LENGTH_2cm));
+        assertFalse(NumberExtensions.operator_equals(Q_LENGTH_1_M, Q_LENGTH_2_CM));
     }
 
     @Test
     public void operatorEquals_Quantity_Quantity_True() {
-        assertTrue(NumberExtensions.operator_equals(Q_LENGTH_1m, new QuantityType<Length>("100 cm")));
+        assertTrue(NumberExtensions.operator_equals(Q_LENGTH_1_M, new QuantityType<Length>("100 cm")));
     }
 
     @Test
     public void operatorLessThan_Number_Quantity() {
-        assertFalse(NumberExtensions.operator_lessThan((Number) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_lessThan((Number) Q_LENGTH_1_M, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorLessThan_Type_Quantity() {
-        assertFalse(NumberExtensions.operator_lessThan((Type) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_lessThan((Type) Q_LENGTH_1_M, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorLessThan_Quantity_Quantity_False() {
-        assertFalse(NumberExtensions.operator_lessThan(Q_LENGTH_1m, Q_LENGTH_2cm));
+        assertFalse(NumberExtensions.operator_lessThan(Q_LENGTH_1_M, Q_LENGTH_2_CM));
     }
 
     @Test
     public void operatorLessThan_Quantity_Quantity_True() {
-        assertTrue(NumberExtensions.operator_lessThan(Q_LENGTH_2cm, Q_LENGTH_1m));
+        assertTrue(NumberExtensions.operator_lessThan(Q_LENGTH_2_CM, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorGreaterThan_Number_Quantity() {
-        assertFalse(NumberExtensions.operator_greaterThan((Number) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_greaterThan((Number) Q_LENGTH_1_M, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorGreaterThan_Type_Quantity() {
-        assertFalse(NumberExtensions.operator_greaterThan((Type) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_greaterThan((Type) Q_LENGTH_1_M, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorGreaterThan_Quantity_Quantity_False() {
-        assertFalse(NumberExtensions.operator_greaterThan(Q_LENGTH_2cm, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_greaterThan(Q_LENGTH_2_CM, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorGreaterThan_Quantity_Quantity_True() {
-        assertTrue(NumberExtensions.operator_greaterThan(Q_LENGTH_1m, Q_LENGTH_2cm));
+        assertTrue(NumberExtensions.operator_greaterThan(Q_LENGTH_1_M, Q_LENGTH_2_CM));
     }
 
     @Test
@@ -178,17 +178,17 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorLessEqualsThan_Type_Quantity() {
-        assertTrue(NumberExtensions.operator_lessEqualsThan((Type) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertTrue(NumberExtensions.operator_lessEqualsThan((Type) Q_LENGTH_1_M, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorLessEqualsThan_Quantity_Quantity_False() {
-        assertFalse(NumberExtensions.operator_lessEqualsThan(Q_LENGTH_1m, Q_LENGTH_2cm));
+        assertFalse(NumberExtensions.operator_lessEqualsThan(Q_LENGTH_1_M, Q_LENGTH_2_CM));
     }
 
     @Test
     public void operatorLessEqualsThan_Quantity_Quantity_True() {
-        assertTrue(NumberExtensions.operator_lessEqualsThan(Q_LENGTH_2cm, Q_LENGTH_1m));
+        assertTrue(NumberExtensions.operator_lessEqualsThan(Q_LENGTH_2_CM, Q_LENGTH_1_M));
     }
 
     @Test
@@ -199,17 +199,18 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorGreaterEqualsThan_Type_Quantity() {
-        assertTrue(NumberExtensions.operator_greaterEqualsThan((Type) Q_LENGTH_1m, new QuantityType<Length>("100 cm")));
+        assertTrue(
+                NumberExtensions.operator_greaterEqualsThan((Type) Q_LENGTH_1_M, new QuantityType<Length>("100 cm")));
     }
 
     @Test
     public void operatorGreaterEqualsThan_Quantity_Quantity_False() {
-        assertFalse(NumberExtensions.operator_greaterEqualsThan(Q_LENGTH_2cm, Q_LENGTH_1m));
+        assertFalse(NumberExtensions.operator_greaterEqualsThan(Q_LENGTH_2_CM, Q_LENGTH_1_M));
     }
 
     @Test
     public void operatorGreaterEqualsThan_Quantity_Quantity_True() {
-        assertTrue(NumberExtensions.operator_greaterEqualsThan(Q_LENGTH_1m, Q_LENGTH_2cm));
+        assertTrue(NumberExtensions.operator_greaterEqualsThan(Q_LENGTH_1_M, Q_LENGTH_2_CM));
     }
 
     @Test

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/eclipse/smarthome/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
@@ -31,7 +31,7 @@ import org.eclipse.smarthome.model.core.ModelRepository;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;;
+import org.junit.Test;
 
 /**
  * @author Henning Treu - Initial contribution

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/eclipse/smarthome/model/thing/testsupport/hue/DumbThingTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/eclipse/smarthome/model/thing/testsupport/hue/DumbThingTypeProvider.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 public class DumbThingTypeProvider implements ThingTypeProvider {
 
     private final Logger logger = LoggerFactory.getLogger(DumbThingTypeProvider.class);
-    private static final Map<ThingTypeUID, ThingType> thingTypes = new HashMap<ThingTypeUID, ThingType>();
+    private static final Map<ThingTypeUID, ThingType> THING_TYPES = new HashMap<ThingTypeUID, ThingType>();
 
     public DumbThingTypeProvider() {
         logger.debug("DumbThingTypeProvider created");
@@ -47,7 +47,7 @@ public class DumbThingTypeProvider implements ThingTypeProvider {
                     new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1")).build();
             List<ChannelDefinition> channelDefinitions = Collections.singletonList(channel1);
 
-            thingTypes.put(DumbThingHandlerFactory.THING_TYPE_TEST,
+            THING_TYPES.put(DumbThingHandlerFactory.THING_TYPE_TEST,
                     ThingTypeBuilder.instance(DumbThingHandlerFactory.THING_TYPE_TEST, "DUMB")
                             .withDescription("Funky Thing").isListed(false).withChannelDefinitions(channelDefinitions)
                             .withConfigDescriptionURI(new URI("dumb:DUMB")).build());
@@ -58,12 +58,12 @@ public class DumbThingTypeProvider implements ThingTypeProvider {
 
     @Override
     public Collection<ThingType> getThingTypes(Locale locale) {
-        return thingTypes.values();
+        return THING_TYPES.values();
     }
 
     @Override
     public ThingType getThingType(ThingTypeUID thingTypeUID, Locale locale) {
-        return thingTypes.get(thingTypeUID);
+        return THING_TYPES.get(thingTypeUID);
     }
 
 }

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/eclipse/smarthome/model/thing/testsupport/hue/TestHueThingTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/eclipse/smarthome/model/thing/testsupport/hue/TestHueThingTypeProvider.java
@@ -43,12 +43,12 @@ import org.slf4j.LoggerFactory;
 public class TestHueThingTypeProvider implements ThingTypeProvider {
 
     private final Logger logger = LoggerFactory.getLogger(TestHueThingTypeProvider.class);
-    private static final Map<ThingTypeUID, ThingType> thingTypes = new HashMap<ThingTypeUID, ThingType>();
+    private static final Map<ThingTypeUID, ThingType> THING_TYPES = new HashMap<ThingTypeUID, ThingType>();
 
     public TestHueThingTypeProvider() {
         logger.debug("TestHueThingTypeProvider created");
         try {
-            thingTypes.put(TestHueThingHandlerFactory.THING_TYPE_BRIDGE,
+            THING_TYPES.put(TestHueThingHandlerFactory.THING_TYPE_BRIDGE,
                     ThingTypeBuilder.instance(TestHueThingHandlerFactory.THING_TYPE_BRIDGE, "HueBridge")
                             .withDescription("HueBridge").isListed(false).buildBridge());
 
@@ -57,13 +57,13 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
 
             ChannelDefinition colorTemp = new ChannelDefinitionBuilder("color_temperature",
                     TestHueChannelTypeProvider.COLOR_TEMP_CHANNEL_TYPE_UID).build();
-            thingTypes.put(TestHueThingHandlerFactory.THING_TYPE_LCT001, ThingTypeBuilder
+            THING_TYPES.put(TestHueThingHandlerFactory.THING_TYPE_LCT001, ThingTypeBuilder
                     .instance(TestHueThingHandlerFactory.THING_TYPE_LCT001, "LCT001")
                     .withSupportedBridgeTypeUIDs(Arrays.asList(TestHueThingHandlerFactory.THING_TYPE_BRIDGE.toString()))
                     .withDescription("Hue LAMP").isListed(false).withChannelDefinitions(Arrays.asList(color, colorTemp))
                     .withConfigDescriptionURI(new URI("hue", "LCT001", null)).build());
 
-            thingTypes.put(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE,
+            THING_TYPES.put(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE,
                     ThingTypeBuilder.instance(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE, "HueBridge")
                             .withDescription("HueBridge").isListed(false).buildBridge());
 
@@ -72,7 +72,7 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
 
             ChannelDefinition colorTempX = new ChannelDefinitionBuilder("Xcolor_temperature",
                     TestHueChannelTypeProvider.COLORX_TEMP_CHANNEL_TYPE_UID).build();
-            thingTypes.put(TestHueThingHandlerFactoryX.THING_TYPE_LCT001,
+            THING_TYPES.put(TestHueThingHandlerFactoryX.THING_TYPE_LCT001,
                     ThingTypeBuilder.instance(TestHueThingHandlerFactoryX.THING_TYPE_LCT001, "XLCT001")
                             .withSupportedBridgeTypeUIDs(
                                     Arrays.asList(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE.toString()))
@@ -82,7 +82,7 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
 
             ChannelGroupDefinition groupDefinition = new ChannelGroupDefinition("group",
                     TestHueChannelTypeProvider.GROUP_CHANNEL_GROUP_TYPE_UID);
-            thingTypes.put(TestHueThingHandlerFactory.THING_TYPE_GROUPED, ThingTypeBuilder
+            THING_TYPES.put(TestHueThingHandlerFactory.THING_TYPE_GROUPED, ThingTypeBuilder
                     .instance(TestHueThingHandlerFactory.THING_TYPE_GROUPED, "grouped")
                     .withSupportedBridgeTypeUIDs(Arrays.asList(TestHueThingHandlerFactory.THING_TYPE_BRIDGE.toString()))
                     .withDescription("Grouped Lamp").withChannelGroupDefinitions(Arrays.asList(groupDefinition))
@@ -95,12 +95,12 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
 
     @Override
     public Collection<ThingType> getThingTypes(Locale locale) {
-        return thingTypes.values();
+        return THING_TYPES.values();
     }
 
     @Override
     public ThingType getThingType(ThingTypeUID thingTypeUID, Locale locale) {
-        return thingTypes.get(thingTypeUID);
+        return THING_TYPES.get(thingTypeUID);
     }
 
 }

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/items/GroupItemOSGiTest.java
@@ -379,7 +379,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatGroupItemPostsEventsForChangesCorrectly() {
         // from ItemEventFactory.GROUPITEM_STATE_CHANGED_EVENT_TOPIC
-        String GROUPITEM_STATE_CHANGED_EVENT_TOPIC = "smarthome/items/{itemName}/{memberName}/statechanged";
+        String groupitemStateChangedEventTopic = "smarthome/items/{itemName}/{memberName}/statechanged";
 
         events.clear();
         GroupItem groupItem = new GroupItem("root", new SwitchItem("mySwitch"), new GroupFunction.Equality());
@@ -402,8 +402,8 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         GroupItemStateChangedEvent change = (GroupItemStateChangedEvent) changes.get(0);
         assertTrue(change.getItemName().equals(groupItem.getName()));
         assertTrue(change.getMemberName().equals(member.getName()));
-        assertTrue(change.getTopic().equals(GROUPITEM_STATE_CHANGED_EVENT_TOPIC
-                .replace("{memberName}", member.getName()).replace("{itemName}", groupItem.getName())));
+        assertTrue(change.getTopic().equals(groupitemStateChangedEventTopic.replace("{memberName}", member.getName())
+                .replace("{itemName}", groupItem.getName())));
         assertTrue(change.getItemState().equals(groupItem.getState()));
         assertTrue(change.getOldItemState().equals(oldGroupState));
 

--- a/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.java
@@ -47,7 +47,7 @@ public class AbstractWatchServiceTest extends JavaTest {
     private static final String WATCHED_DIRECTORY = "watchDirectory";
 
     // Fail if no event has been received within the given timeout
-    private static int NO_EVENT_TIMEOUT_IN_SECONDS;
+    private static int noEventTimeoutInSeconds;
 
     private RelativeWatchService watchService;
 
@@ -55,9 +55,9 @@ public class AbstractWatchServiceTest extends JavaTest {
     public static void setUpBeforeClass() {
         // set the NO_EVENT_TIMEOUT_IN_SECONDS according to the operating system used
         if (SystemUtils.IS_OS_MAC_OSX) {
-            NO_EVENT_TIMEOUT_IN_SECONDS = 15;
+            noEventTimeoutInSeconds = 15;
         } else {
-            NO_EVENT_TIMEOUT_IN_SECONDS = 3;
+            noEventTimeoutInSeconds = 3;
         }
     }
 
@@ -132,7 +132,7 @@ public class AbstractWatchServiceTest extends JavaTest {
         innerfile.createNewFile();
 
         // Assure that the ordering of the events will be always the same
-        Thread.sleep(NO_EVENT_TIMEOUT_IN_SECONDS * 1000);
+        Thread.sleep(noEventTimeoutInSeconds * 1000);
 
         new File(WATCHED_DIRECTORY + File.separatorChar + fileName).createNewFile();
 
@@ -187,7 +187,7 @@ public class AbstractWatchServiceTest extends JavaTest {
 
     private void assertNoEventsAreProcessed() throws Exception {
         // Wait for a possible event for the maximum timeout
-        Thread.sleep(NO_EVENT_TIMEOUT_IN_SECONDS * 1000);
+        Thread.sleep(noEventTimeoutInSeconds * 1000);
 
         assertEventCount(0);
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/FirmwareTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/FirmwareTest.java
@@ -12,11 +12,8 @@
  */
 package org.eclipse.smarthome.core.thing.binding.firmware;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -43,45 +40,45 @@ public class FirmwareTest extends JavaOSGiTest {
 
     private static final String FILE_NAME = "firmware.txt";
 
-    private static final ThingTypeUID thingTypeUID = new ThingTypeUID("binding", "thingType");
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding", "thingType");
 
-    private static final Firmware valpha = FirmwareBuilder.create(thingTypeUID, "alpha").build();
-    private static final Firmware valpha1 = FirmwareBuilder.create(thingTypeUID, "alpha1").build();
-    private static final Firmware vbeta = FirmwareBuilder.create(thingTypeUID, "beta")
-            .withPrerequisiteVersion(valpha1.getVersion()).build();
-    private static final Firmware vbetafix = FirmwareBuilder.create(thingTypeUID, "beta-fix").build();
-    private static final Firmware vgamma = FirmwareBuilder.create(thingTypeUID, "gamma")
-            .withPrerequisiteVersion(vbetafix.getVersion()).build();
-    private static final Firmware vdelta = FirmwareBuilder.create(thingTypeUID, "delta").build();
+    private static final Firmware VALPHA = FirmwareBuilder.create(THING_TYPE_UID, "alpha").build();
+    private static final Firmware VALPHA1 = FirmwareBuilder.create(THING_TYPE_UID, "alpha1").build();
+    private static final Firmware VBETA = FirmwareBuilder.create(THING_TYPE_UID, "beta")
+            .withPrerequisiteVersion(VALPHA1.getVersion()).build();
+    private static final Firmware VBETAFIX = FirmwareBuilder.create(THING_TYPE_UID, "beta-fix").build();
+    private static final Firmware VGAMMA = FirmwareBuilder.create(THING_TYPE_UID, "gamma")
+            .withPrerequisiteVersion(VBETAFIX.getVersion()).build();
+    private static final Firmware VDELTA = FirmwareBuilder.create(THING_TYPE_UID, "delta").build();
 
-    private static final Firmware xyz = FirmwareBuilder.create(thingTypeUID, "xyz_1").build();
-    private static final Firmware abc = FirmwareBuilder.create(thingTypeUID, "abc.2").build();
+    private static final Firmware XYX = FirmwareBuilder.create(THING_TYPE_UID, "xyz_1").build();
+    private static final Firmware ABC = FirmwareBuilder.create(THING_TYPE_UID, "abc.2").build();
 
-    private static final Firmware v0 = FirmwareBuilder.create(thingTypeUID, "0").build();
-    private static final Firmware v0dot0dot9 = FirmwareBuilder.create(thingTypeUID, "0.0.9").build();
-    private static final Firmware v1 = FirmwareBuilder.create(thingTypeUID, "1").build();
-    private static final Firmware v1dot0dot0 = FirmwareBuilder.create(thingTypeUID, "1.0.0").build();
-    private static final Firmware v1dot0dot1 = FirmwareBuilder.create(thingTypeUID, "1.0.1").build();
-    private static final Firmware v1dot0dot2 = FirmwareBuilder.create(thingTypeUID, "1.0.2")
-            .withPrerequisiteVersion(v1dot0dot1.getVersion()).build();
-    private static final Firmware v1dot0dot2dashfix = FirmwareBuilder.create(thingTypeUID, "1.0.2-fix").build();
-    private static final Firmware v1dot0dot3 = FirmwareBuilder.create(thingTypeUID, "1.0.3")
-            .withPrerequisiteVersion(v1dot0dot2dashfix.getVersion()).build();
-    private static final Firmware v1dash1 = FirmwareBuilder.create(thingTypeUID, "1-1").build();
-    private static final Firmware v1dot1dot0 = FirmwareBuilder.create(thingTypeUID, "1.1.0")
-            .withPrerequisiteVersion(v1dot0dot2dashfix.getVersion()).build();
-    private static final Firmware v1dot2dot0 = FirmwareBuilder.create(thingTypeUID, "1.2.0").build();
-    private static final Firmware v1dot10 = FirmwareBuilder.create(thingTypeUID, "1.10").build();
-    private static final Firmware v1dot10dot0 = FirmwareBuilder.create(thingTypeUID, "1.10.0").build();
-    private static final Firmware v1dash11dot2_1 = FirmwareBuilder.create(thingTypeUID, "1-11.2_1").build();
-    private static final Firmware v1dot11_2dasha = FirmwareBuilder.create(thingTypeUID, "1.11_2-a").build();
-    private static final Firmware v2dot0dot0 = FirmwareBuilder.create(thingTypeUID, "2.0.0")
-            .withPrerequisiteVersion(v1dot11_2dasha.getVersion()).build();
+    private static final Firmware V0 = FirmwareBuilder.create(THING_TYPE_UID, "0").build();
+    private static final Firmware V0_DOT_0_DOT_9 = FirmwareBuilder.create(THING_TYPE_UID, "0.0.9").build();
+    private static final Firmware V1 = FirmwareBuilder.create(THING_TYPE_UID, "1").build();
+    private static final Firmware V1_DOT_0_DOT_0 = FirmwareBuilder.create(THING_TYPE_UID, "1.0.0").build();
+    private static final Firmware V1_DOT_0_DOT_1 = FirmwareBuilder.create(THING_TYPE_UID, "1.0.1").build();
+    private static final Firmware V1_DOT_0_DOT_2 = FirmwareBuilder.create(THING_TYPE_UID, "1.0.2")
+            .withPrerequisiteVersion(V1_DOT_0_DOT_1.getVersion()).build();
+    private static final Firmware V1_DOT_0_DOT_2_DASH_FIX = FirmwareBuilder.create(THING_TYPE_UID, "1.0.2-fix").build();
+    private static final Firmware V1_DOT_0_DOT_3 = FirmwareBuilder.create(THING_TYPE_UID, "1.0.3")
+            .withPrerequisiteVersion(V1_DOT_0_DOT_2_DASH_FIX.getVersion()).build();
+    private static final Firmware V1_DASH_1 = FirmwareBuilder.create(THING_TYPE_UID, "1-1").build();
+    private static final Firmware V1_DOT_1_DOT_0 = FirmwareBuilder.create(THING_TYPE_UID, "1.1.0")
+            .withPrerequisiteVersion(V1_DOT_0_DOT_2_DASH_FIX.getVersion()).build();
+    private static final Firmware V1_DOT_2_DOT_0 = FirmwareBuilder.create(THING_TYPE_UID, "1.2.0").build();
+    private static final Firmware V1_DOT_10 = FirmwareBuilder.create(THING_TYPE_UID, "1.10").build();
+    private static final Firmware V1_DOT_10_DOT_0 = FirmwareBuilder.create(THING_TYPE_UID, "1.10.0").build();
+    private static final Firmware V1_DASH_11_DOT_2_1 = FirmwareBuilder.create(THING_TYPE_UID, "1-11.2_1").build();
+    private static final Firmware V1_DOT_11_2_DASH_A = FirmwareBuilder.create(THING_TYPE_UID, "1.11_2-a").build();
+    private static final Firmware V2_DOT_0_DOT_0 = FirmwareBuilder.create(THING_TYPE_UID, "2.0.0")
+            .withPrerequisiteVersion(V1_DOT_11_2_DASH_A.getVersion()).build();
 
-    private static final Firmware combined1 = FirmwareBuilder.create(thingTypeUID, "1.2.3-2.3.4").build();
-    private static final Firmware combined2 = FirmwareBuilder.create(thingTypeUID, "1.2.3-2.4.1").build();
-    private static final Firmware combined3 = FirmwareBuilder.create(thingTypeUID, "1.3.1-2.3.4").build();
-    private static final Firmware combined4 = FirmwareBuilder.create(thingTypeUID, "1.3.1-2.4.1").build();
+    private static final Firmware COMBINED1 = FirmwareBuilder.create(THING_TYPE_UID, "1.2.3-2.3.4").build();
+    private static final Firmware COMBINED2 = FirmwareBuilder.create(THING_TYPE_UID, "1.2.3-2.4.1").build();
+    private static final Firmware COMBINED3 = FirmwareBuilder.create(THING_TYPE_UID, "1.3.1-2.3.4").build();
+    private static final Firmware COMBINED4 = FirmwareBuilder.create(THING_TYPE_UID, "1.3.1-2.4.1").build();
 
     @Test
     public void testFirmwareBuilder() throws MalformedURLException {
@@ -128,48 +125,48 @@ public class FirmwareTest extends JavaOSGiTest {
 
     @Test
     public void testFirmwareSuccessorVersion() {
-        assertThat(v2dot0dot0.isSuccessorVersion(v1dot11_2dasha.getVersion()), is(true));
-        assertThat(v1dot11_2dasha.isSuccessorVersion(v2dot0dot0.getVersion()), is(false));
-        assertThat(v1dot11_2dasha.isSuccessorVersion(v1dot11_2dasha.getVersion()), is(false));
+        assertThat(V2_DOT_0_DOT_0.isSuccessorVersion(V1_DOT_11_2_DASH_A.getVersion()), is(true));
+        assertThat(V1_DOT_11_2_DASH_A.isSuccessorVersion(V2_DOT_0_DOT_0.getVersion()), is(false));
+        assertThat(V1_DOT_11_2_DASH_A.isSuccessorVersion(V1_DOT_11_2_DASH_A.getVersion()), is(false));
 
-        assertThat(v1dot11_2dasha.isSuccessorVersion(v1dash11dot2_1.getVersion()), is(true));
-        assertThat(v1dash11dot2_1.isSuccessorVersion(v1dot10dot0.getVersion()), is(true));
-        assertThat(v1dot10dot0.isSuccessorVersion(v1dot10.getVersion()), is(true));
-        assertThat(v1dot10.isSuccessorVersion(v1dot2dot0.getVersion()), is(true));
-        assertThat(v1dot2dot0.isSuccessorVersion(v1dot1dot0.getVersion()), is(true));
-        assertThat(v1dot1dot0.isSuccessorVersion(v1dash1.getVersion()), is(true));
-        assertThat(v1dash1.isSuccessorVersion(v1dot0dot3.getVersion()), is(true));
-        assertThat(v1dot0dot3.isSuccessorVersion(v1dot0dot2dashfix.getVersion()), is(true));
-        assertThat(v1dot0dot2dashfix.isSuccessorVersion(v1dot0dot2.getVersion()), is(true));
-        assertThat(v1dot0dot2.isSuccessorVersion(v1dot0dot1.getVersion()), is(true));
-        assertThat(v1dot0dot1.isSuccessorVersion(v1dot0dot0.getVersion()), is(true));
-        assertThat(v1dot0dot1.isSuccessorVersion(v1.getVersion()), is(true));
-        assertThat(v1.isSuccessorVersion(v0dot0dot9.getVersion()), is(true));
-        assertThat(v0dot0dot9.isSuccessorVersion(v0.getVersion()), is(true));
+        assertThat(V1_DOT_11_2_DASH_A.isSuccessorVersion(V1_DASH_11_DOT_2_1.getVersion()), is(true));
+        assertThat(V1_DASH_11_DOT_2_1.isSuccessorVersion(V1_DOT_10_DOT_0.getVersion()), is(true));
+        assertThat(V1_DOT_10_DOT_0.isSuccessorVersion(V1_DOT_10.getVersion()), is(true));
+        assertThat(V1_DOT_10.isSuccessorVersion(V1_DOT_2_DOT_0.getVersion()), is(true));
+        assertThat(V1_DOT_2_DOT_0.isSuccessorVersion(V1_DOT_1_DOT_0.getVersion()), is(true));
+        assertThat(V1_DOT_1_DOT_0.isSuccessorVersion(V1_DASH_1.getVersion()), is(true));
+        assertThat(V1_DASH_1.isSuccessorVersion(V1_DOT_0_DOT_3.getVersion()), is(true));
+        assertThat(V1_DOT_0_DOT_3.isSuccessorVersion(V1_DOT_0_DOT_2_DASH_FIX.getVersion()), is(true));
+        assertThat(V1_DOT_0_DOT_2_DASH_FIX.isSuccessorVersion(V1_DOT_0_DOT_2.getVersion()), is(true));
+        assertThat(V1_DOT_0_DOT_2.isSuccessorVersion(V1_DOT_0_DOT_1.getVersion()), is(true));
+        assertThat(V1_DOT_0_DOT_1.isSuccessorVersion(V1_DOT_0_DOT_0.getVersion()), is(true));
+        assertThat(V1_DOT_0_DOT_1.isSuccessorVersion(V1.getVersion()), is(true));
+        assertThat(V1.isSuccessorVersion(V0_DOT_0_DOT_9.getVersion()), is(true));
+        assertThat(V0_DOT_0_DOT_9.isSuccessorVersion(V0.getVersion()), is(true));
 
-        assertThat(vgamma.isSuccessorVersion(vbetafix.getVersion()), is(true));
-        assertThat(vbetafix.isSuccessorVersion(vbeta.getVersion()), is(true));
-        assertThat(vbeta.isSuccessorVersion(valpha1.getVersion()), is(true));
-        assertThat(valpha1.isSuccessorVersion(valpha.getVersion()), is(true));
+        assertThat(VGAMMA.isSuccessorVersion(VBETAFIX.getVersion()), is(true));
+        assertThat(VBETAFIX.isSuccessorVersion(VBETA.getVersion()), is(true));
+        assertThat(VBETA.isSuccessorVersion(VALPHA1.getVersion()), is(true));
+        assertThat(VALPHA1.isSuccessorVersion(VALPHA.getVersion()), is(true));
 
-        assertThat(xyz.isSuccessorVersion(abc.getVersion()), is(true));
-        assertThat(abc.isSuccessorVersion(v2dot0dot0.getVersion()), is(true));
-        assertThat(abc.isSuccessorVersion(xyz.getVersion()), is(false));
+        assertThat(XYX.isSuccessorVersion(ABC.getVersion()), is(true));
+        assertThat(ABC.isSuccessorVersion(V2_DOT_0_DOT_0.getVersion()), is(true));
+        assertThat(ABC.isSuccessorVersion(XYX.getVersion()), is(false));
 
-        assertThat(vdelta.isSuccessorVersion(v0dot0dot9.getVersion()), is(true));
-        assertThat(v0dot0dot9.isSuccessorVersion(vdelta.getVersion()), is(false));
-        assertThat(vdelta.isSuccessorVersion(vgamma.getVersion()), is(false));
+        assertThat(VDELTA.isSuccessorVersion(V0_DOT_0_DOT_9.getVersion()), is(true));
+        assertThat(V0_DOT_0_DOT_9.isSuccessorVersion(VDELTA.getVersion()), is(false));
+        assertThat(VDELTA.isSuccessorVersion(VGAMMA.getVersion()), is(false));
 
-        assertThat(vdelta.isSuccessorVersion(null), is(false));
+        assertThat(VDELTA.isSuccessorVersion(null), is(false));
 
-        assertThat(combined4.isSuccessorVersion(combined3.getVersion()), is(true));
-        assertThat(combined3.isSuccessorVersion(combined4.getVersion()), is(false));
+        assertThat(COMBINED4.isSuccessorVersion(COMBINED3.getVersion()), is(true));
+        assertThat(COMBINED3.isSuccessorVersion(COMBINED4.getVersion()), is(false));
 
-        assertThat(combined3.isSuccessorVersion(combined2.getVersion()), is(true));
-        assertThat(combined2.isSuccessorVersion(combined3.getVersion()), is(false));
+        assertThat(COMBINED3.isSuccessorVersion(COMBINED2.getVersion()), is(true));
+        assertThat(COMBINED2.isSuccessorVersion(COMBINED3.getVersion()), is(false));
 
-        assertThat(combined2.isSuccessorVersion(combined1.getVersion()), is(true));
-        assertThat(combined1.isSuccessorVersion(combined2.getVersion()), is(false));
+        assertThat(COMBINED2.isSuccessorVersion(COMBINED1.getVersion()), is(true));
+        assertThat(COMBINED1.isSuccessorVersion(COMBINED2.getVersion()), is(false));
     }
 
     @Test
@@ -251,32 +248,32 @@ public class FirmwareTest extends JavaOSGiTest {
     @Test
     public void firmwareRestrictedFirmwareIsSuitable() {
         String label = "label";
-        Firmware firmware = FirmwareBuilder.create(thingTypeUID, "1.2.3")
+        Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1.2.3")
                 .withFirmwareRestriction(thing -> thing.getLabel().equals(label)).build();
 
-        Thing thing = ThingBuilder.create(thingTypeUID, "thing").withLabel(label).build();
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, "thing").withLabel(label).build();
 
         assertThat(firmware.isSuitableFor(thing), is(true));
     }
 
     @Test
     public void firmwareRestrictedFirmwareIsNotSuitable() {
-        Firmware firmware = FirmwareBuilder.create(thingTypeUID, "1.2.3")
+        Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1.2.3")
                 .withFirmwareRestriction(thing -> thing.getLabel().equals("label")).build();
 
-        Thing thing = ThingBuilder.create(thingTypeUID, "thing").withLabel("invalid_label").build();
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, "thing").withLabel("invalid_label").build();
 
         assertThat(firmware.isSuitableFor(thing), is(false));
     }
 
     @Test
     public void assertThatColonCanBeUsedAsPartOfTheFirmwareVersion() {
-        FirmwareBuilder.create(thingTypeUID, "1.2:3");
+        FirmwareBuilder.create(THING_TYPE_UID, "1.2:3");
     }
 
     @Test
     public void assertThatFirmwareWithValidMD5HashValueDoesNotThrowExceptionForGetBytes() throws IOException {
-        Firmware firmware = FirmwareBuilder.create(thingTypeUID, "1")
+        Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1")
                 .withInputStream(bundleContext.getBundle().getResource(FILE_NAME).openStream())
                 .withMd5Hash("78805a221a988e79ef3f42d7c5bfd418").build();
 
@@ -286,7 +283,7 @@ public class FirmwareTest extends JavaOSGiTest {
 
     @Test(expected = IllegalStateException.class)
     public void assertThatFirmwareWithInvalidMD5HashValueThrowsExceptionForGetBytes() throws IOException {
-        Firmware firmware = FirmwareBuilder.create(thingTypeUID, "1")
+        Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1")
                 .withInputStream(bundleContext.getBundle().getResource(FILE_NAME).openStream())
                 .withMd5Hash("78805a221a988e79ef3f42d7c5bfd419").build();
         firmware.getBytes();
@@ -294,7 +291,7 @@ public class FirmwareTest extends JavaOSGiTest {
 
     @Test
     public void assertThatFirmwareWithoutMD5HashValueDoesNotThrowExceptionForGetBytes() throws IOException {
-        Firmware firmware = FirmwareBuilder.create(thingTypeUID, "1")
+        Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1")
                 .withInputStream(bundleContext.getBundle().getResource(FILE_NAME).openStream()).build();
 
         byte[] bytes = firmware.getBytes();
@@ -315,12 +312,12 @@ public class FirmwareTest extends JavaOSGiTest {
         properties.put("prop2", "val2");
         InputStream openStream = bundleContext.getBundle().getResource(FILE_NAME).openStream();
 
-        Firmware firmware1 = FirmwareBuilder.create(thingTypeUID, "1").withInputStream(openStream)
+        Firmware firmware1 = FirmwareBuilder.create(THING_TYPE_UID, "1").withInputStream(openStream)
                 .withChangelog(changelog).withDescription(description).withModel(model)
                 .withModelRestricted(modelRestricted).withOnlineChangelog(onlineChangelog)
                 .withPrerequisiteVersion(prerequisiteVersion).withVendor(vendor).withProperties(properties).build();
 
-        Firmware firmware2 = FirmwareBuilder.create(thingTypeUID, "1").withInputStream(openStream)
+        Firmware firmware2 = FirmwareBuilder.create(THING_TYPE_UID, "1").withInputStream(openStream)
                 .withChangelog(changelog).withDescription(description).withModel(model)
                 .withModelRestricted(modelRestricted).withOnlineChangelog(onlineChangelog)
                 .withPrerequisiteVersion(prerequisiteVersion).withVendor(vendor).withProperties(properties).build();
@@ -343,12 +340,12 @@ public class FirmwareTest extends JavaOSGiTest {
         properties.put("prop2", "val2");
         InputStream openStream = bundleContext.getBundle().getResource(FILE_NAME).openStream();
 
-        Firmware firmware1 = FirmwareBuilder.create(thingTypeUID, "1").withInputStream(openStream)
+        Firmware firmware1 = FirmwareBuilder.create(THING_TYPE_UID, "1").withInputStream(openStream)
                 .withChangelog(changelog).withDescription(description).withModel(model)
                 .withModelRestricted(modelRestricted).withOnlineChangelog(onlineChangelog)
                 .withPrerequisiteVersion(prerequisiteVersion).withVendor(vendor).withProperties(properties).build();
 
-        Firmware firmware2 = FirmwareBuilder.create(thingTypeUID, "1").withInputStream(openStream)
+        Firmware firmware2 = FirmwareBuilder.create(THING_TYPE_UID, "1").withInputStream(openStream)
                 .withChangelog(changelog).withDescription(description).withModel(model)
                 .withModelRestricted(modelRestricted).withOnlineChangelog(onlineChangelog)
                 .withPrerequisiteVersion(prerequisiteVersion).withVendor(vendor).withProperties(properties).build();
@@ -363,25 +360,25 @@ public class FirmwareTest extends JavaOSGiTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullFirmwareVersionOnCreation() {
-        FirmwareBuilder.create(thingTypeUID, giveNull());
+        FirmwareBuilder.create(THING_TYPE_UID, giveNull());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testEmptyVersionOnCreation() {
-        FirmwareBuilder.create(thingTypeUID, "");
+        FirmwareBuilder.create(THING_TYPE_UID, "");
     }
 
     private Firmware firmwareWithVersion(String version) {
-        return FirmwareBuilder.create(thingTypeUID, version).build();
+        return FirmwareBuilder.create(THING_TYPE_UID, version).build();
     }
 
     private Firmware firmwareWithVersionAndPrerequisiteVersion(String version, String prerequisiteVersion) {
-        return FirmwareBuilder.create(thingTypeUID, version).withPrerequisiteVersion(prerequisiteVersion).build();
+        return FirmwareBuilder.create(THING_TYPE_UID, version).withPrerequisiteVersion(prerequisiteVersion).build();
     }
 
     private Thing thingWithFirmwareVersion(String version) {
         Map<String, String> properties = new HashMap<>();
         properties.put(Thing.PROPERTY_FIRMWARE_VERSION, version);
-        return ThingBuilder.create(thingTypeUID, "testThing").withProperties(properties).build();
+        return ThingBuilder.create(THING_TYPE_UID, "testThing").withProperties(properties).build();
     }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactoryTest.java
@@ -39,7 +39,7 @@ import com.google.gson.Gson;
  * @author Stefan Bußweiler - Initial contribution
  */
 public class ThingEventFactoryTest extends JavaOSGiTest {
-    private final ThingStatusInfo THING_STATUS_INFO = ThingStatusInfoBuilder
+    private static final ThingStatusInfo THING_STATUS_INFO = ThingStatusInfoBuilder
             .create(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR).withDescription("Some description")
             .build();
 
@@ -49,18 +49,18 @@ public class ThingEventFactoryTest extends JavaOSGiTest {
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
     private static final Thing THING = ThingBuilder.create(THING_TYPE_UID, THING_UID).build();
 
-    private final String THING_STATUS_EVENT_TOPIC = ThingEventFactory.THING_STATUS_INFO_EVENT_TOPIC
+    private static final String THING_STATUS_EVENT_TOPIC = ThingEventFactory.THING_STATUS_INFO_EVENT_TOPIC
             .replace("{thingUID}", THING_UID.getAsString());
-    private final String THING_ADDED_EVENT_TOPIC = ThingEventFactory.THING_ADDED_EVENT_TOPIC.replace("{thingUID}",
-            THING_UID.getAsString());
+    private static final String THING_ADDED_EVENT_TOPIC = ThingEventFactory.THING_ADDED_EVENT_TOPIC
+            .replace("{thingUID}", THING_UID.getAsString());
 
-    private final String THING_STATUS_EVENT_PAYLOAD = new Gson().toJson(THING_STATUS_INFO);
-    private final String THING_ADDED_EVENT_PAYLOAD = new Gson().toJson(ThingDTOMapper.map(THING));
+    private static final String THING_STATUS_EVENT_PAYLOAD = new Gson().toJson(THING_STATUS_INFO);
+    private static final String THING_ADDED_EVENT_PAYLOAD = new Gson().toJson(ThingDTOMapper.map(THING));
 
-    private final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
-    private final String CHANNEL_TRIGGERED_EVENT_TOPIC = ThingEventFactory.CHANNEL_TRIGGERED_EVENT_TOPIC
+    private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
+    private static final String CHANNEL_TRIGGERED_EVENT_TOPIC = ThingEventFactory.CHANNEL_TRIGGERED_EVENT_TOPIC
             .replace("{channelUID}", CHANNEL_UID.getAsString());
-    private final String CHANNEL_TRIGGERED_EVENT_PAYLOAD = new Gson()
+    private static final String CHANNEL_TRIGGERED_EVENT_PAYLOAD = new Gson()
             .toJson(new TriggerEventPayloadBean(CommonTriggerEvents.PRESSED, CHANNEL_UID.getAsString()));
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/ModelRestrictedFirmwareUpdateServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/firmware/ModelRestrictedFirmwareUpdateServiceOSGiTest.java
@@ -60,7 +60,7 @@ public class ModelRestrictedFirmwareUpdateServiceOSGiTest extends JavaOSGiTest {
     private static final String VERSION_1_0_3 = "1.0.3";
 
     /** The thing type for all things used in this test class */
-    private static final ThingType thingType = ThingTypeBuilder
+    private static final ThingType THING_TYPE = ThingTypeBuilder
             .instance(new ThingTypeUID("bindingId", "thingTypeId"), "label").build();
 
     private ThingRegistry thingRegistry;
@@ -168,7 +168,7 @@ public class ModelRestrictedFirmwareUpdateServiceOSGiTest extends JavaOSGiTest {
      * Creates a thing, adds it to the thing registry, and registers a {@link FirmwareUpdateHandler} for the thing.
      */
     private Thing createAndRegisterThing(String thingUID, String modelId, String firmwareVersion) {
-        Thing thing = ThingBuilder.create(thingType.getUID(), thingUID).build();
+        Thing thing = ThingBuilder.create(THING_TYPE.getUID(), thingUID).build();
         thing.setProperty(PROPERTY_MODEL_ID, modelId);
         thing.setProperty(PROPERTY_FIRMWARE_VERSION, firmwareVersion);
 
@@ -220,7 +220,7 @@ public class ModelRestrictedFirmwareUpdateServiceOSGiTest extends JavaOSGiTest {
 
             @Override
             public Set<Firmware> getFirmwares(Thing thing, Locale locale) {
-                if (thing.getThingTypeUID().equals(thingType.getUID())) {
+                if (thing.getThingTypeUID().equals(THING_TYPE.getUID())) {
                     return new HashSet<>(Arrays.asList(firmwares));
                 } else {
                     return Collections.emptySet();
@@ -250,7 +250,7 @@ public class ModelRestrictedFirmwareUpdateServiceOSGiTest extends JavaOSGiTest {
     }
 
     private Firmware createModelRestrictedFirmware(String model, String version) {
-        return FirmwareBuilder.create(thingType.getUID(), version).withModel(model).withModelRestricted(true).build();
+        return FirmwareBuilder.create(THING_TYPE.getUID(), version).withModel(model).withModelRestricted(true).build();
     }
 
     private void assertThatThingHasFirmware(ThingUID thingUID, String firmwareVersion) {

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/STTServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/STTServiceStub.java
@@ -12,9 +12,10 @@
  */
 package org.eclipse.smarthome.core.voice.internal;
 
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioStream;
@@ -33,10 +34,11 @@ import org.eclipse.smarthome.core.voice.STTServiceHandle;
  */
 public class STTServiceStub implements STTService {
 
-    private Set<AudioFormat> supportedFormats;
+    private static final Set<AudioFormat> SUPPORTED_FORMATS = Stream.of(AudioFormat.MP3, AudioFormat.WAV)
+            .collect(Collectors.toSet());
 
-    private final String STTSERVICE_STUB_ID = "sttServiceStubID";
-    private final String STTSERVICE_STUB_LABEL = "sttServiceStubLabel";
+    private static final String STTSERVICE_STUB_ID = "sttServiceStubID";
+    private static final String STTSERVICE_STUB_LABEL = "sttServiceStubLabel";
 
     @Override
     public String getId() {
@@ -55,10 +57,7 @@ public class STTServiceStub implements STTService {
 
     @Override
     public Set<AudioFormat> getSupportedFormats() {
-        supportedFormats = new HashSet<AudioFormat>();
-        supportedFormats.add(AudioFormat.MP3);
-        supportedFormats.add(AudioFormat.WAV);
-        return supportedFormats;
+        return SUPPORTED_FORMATS;
     }
 
     @Override

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceStub.java
@@ -28,8 +28,8 @@ public class VoiceStub implements Voice {
 
     private TTSServiceStub ttsService = new TTSServiceStub();
 
-    private final String VOICE_STUB_ID = "voiceStubID";
-    private final String VOICE_STUB_LABEL = "voiceStubLabel";
+    private static final String VOICE_STUB_ID = "voiceStubID";
+    private static final String VOICE_STUB_LABEL = "voiceStubLabel";
 
     @Override
     public String getUID() {

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/javavoicemanager/VoiceManagerTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/javavoicemanager/VoiceManagerTest.java
@@ -54,13 +54,13 @@ import org.osgi.service.cm.ConfigurationAdmin;
  *
  */
 public class VoiceManagerTest extends JavaOSGiTest {
-    private final String PID = "org.eclipse.smarthome.voice";
-    private final String CONFIG_DEFAULT_HLI = "defaultHLI";
-    private final String CONFIG_DEFAULT_KS = "defaultKS";
-    private final String CONFIG_DEFAULT_STT = "defaultSTT";
-    private final String CONFIG_DEFAULT_VOICE = "defaultVoice";
-    private final String CONFIG_DEFAULT_TTS = "defaultTTS";
-    private final String CONFIG_KEYWORD = "keyword";
+    private static final String PID = "org.eclipse.smarthome.voice";
+    private static final String CONFIG_DEFAULT_HLI = "defaultHLI";
+    private static final String CONFIG_DEFAULT_KS = "defaultKS";
+    private static final String CONFIG_DEFAULT_STT = "defaultSTT";
+    private static final String CONFIG_DEFAULT_VOICE = "defaultVoice";
+    private static final String CONFIG_DEFAULT_TTS = "defaultTTS";
+    private static final String CONFIG_KEYWORD = "keyword";
     private VoiceManagerImpl voiceManager = new VoiceManagerImpl();
     private ConsoleStub stubConsole;
     private SinkStub sink;

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
@@ -36,12 +36,12 @@ import org.osgi.service.cm.ConfigurationAdmin;
  *
  */
 public class InterpretCommandTest extends VoiceConsoleCommandExtensionTest {
-    private final String CONFIG_DEFAULT_HLI = "defaultHLI";
-    private final String CONFIG_DEFAULT_TTS = "defaultTTS";
-    private final String CONFIG_DEFAULT_VOICE = "defaultVoice";
-    private final String SUBCMD_INTERPRET = "interpret";
-    private final String INTERPRETED_TEXT = "Interpreted text";
-    private final String EXCEPTION_MESSAGE = "Exception message";
+    private static final String CONFIG_DEFAULT_HLI = "defaultHLI";
+    private static final String CONFIG_DEFAULT_TTS = "defaultTTS";
+    private static final String CONFIG_DEFAULT_VOICE = "defaultVoice";
+    private static final String SUBCMD_INTERPRET = "interpret";
+    private static final String INTERPRETED_TEXT = "Interpreted text";
+    private static final String EXCEPTION_MESSAGE = "Exception message";
 
     private HumanLanguageInterpreterStub hliStub;
     private VoiceStub voice;

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/SayCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/SayCommandTest.java
@@ -50,8 +50,8 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 @RunWith(Parameterized.class)
 public class SayCommandTest extends VoiceConsoleCommandExtensionTest {
-    private final String CONFIG_DEFAULT_TTS = "defaultTTS";
-    private final String SUBCMD_SAY = "say";
+    private static final String CONFIG_DEFAULT_TTS = "defaultTTS";
+    private static final String SUBCMD_SAY = "say";
     private boolean shouldItemsBePassed;
     private boolean shouldItemsBeRegistered;
     private boolean shouldMultipleItemsBeRegistered;

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
@@ -33,7 +33,7 @@ import org.osgi.framework.BundleContext;
  *
  */
 public class VoicesCommandTest extends VoiceConsoleCommandExtensionTest {
-    private final String SUBCMD_VOICES = "voices";
+    private static final String SUBCMD_VOICES = "voices";
     private TTSServiceStub ttsService;
     private SinkStub sink;
     private VoiceStub voice;


### PR DESCRIPTION
Fixes wrong names identified by the following rules:

* ConstantNameCheck
* LocalFinalVariableNameCheck
* LocalVariableNameCheck
* StaticVariableNameCheck

Most mismatches identified by the MemberNameCheck have also been fixed except for those where the variables are used in events/DTOs etc which would cause issues.