### PR TITLE
Suppress MavenPomderivedInClasspathCheck

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -4,6 +4,7 @@
 "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
+    <suppress files=".classpath" checks="MavenPomderivedInClasspathCheck" />
     <!-- These suppressions define which files to be suppressed for which checks. -->
     <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
     <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />


### PR DESCRIPTION
This SAT check causes 525 false positives.

See: openhab/static-code-analysis#356