### PR TITLE
Changed pid from 'org.eclipse.smarthome.core.i18nprovider' to 'org.eclipse.smarthome.i18n'

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link I18nProviderImpl} is a concrete implementation of the {@link TranslationProvider}, {@link LocaleProvider},
  * and {@link LocationProvider} service interfaces.
- * *
+ *
  * <p>
  * This implementation uses the i18n mechanism of Java ({@link ResourceBundle}) to translate a given key into text. The
  * resources must be placed under the specific directory {@link LanguageResourceBundleManager#RESOURCE_DIRECTORY} within

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -48,6 +48,7 @@ import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -76,15 +77,16 @@ import org.slf4j.LoggerFactory;
  * @author Erdoan Hadzhiyusein - Added time zone
  *
  */
-
+@Component(immediate = true, configurationPid = "org.eclipse.smarthome.i18n", property = {
+        Constants.SERVICE_PID + "=org.eclipse.smarthome.i18n", //
+        "service.config.label=Regional Settings", //
+        "service.config.category=system", //
+        "service.config.description.uri=system:i18n" })
 @NonNullByDefault
-@Component(immediate = true, configurationPid = "org.eclipse.smarthome.core.i18nprovider", property = {
-        "service.pid=org.eclipse.smarthome.core.i18nprovider", "service.config.description.uri:String=system:i18n",
-        "service.config.label:String=Regional Settings", "service.config.category:String=system" })
 public class I18nProviderImpl
         implements TranslationProvider, LocaleProvider, LocationProvider, TimeZoneProvider, UnitProvider {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(I18nProviderImpl.class);
 
     // LocaleProvider
     static final String LANGUAGE = "language";

--- a/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
@@ -89,20 +89,31 @@ public class BindingInfoI18nTest extends JavaOSGiTest {
     public void assertUsingDefaultLocale() throws Exception {
         // Set german locale
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
+        assertThat(configAdmin, is(notNullValue()));
+
         Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.i18n", null);
-        Dictionary<String, String> localeCfg = new Hashtable<>();
-        localeCfg.put("language", "de");
-        localeCfg.put("country", "DE");
-        config.update(localeCfg);
+        assertThat(config, is(notNullValue()));
+
+        Dictionary<String, Object> properties = config.getProperties();
+        if (properties == null) {
+            properties = new Hashtable<>();
+        }
+
+        properties.put("language", "de");
+        properties.put("region", "DE");
+
+        config.update(properties);
 
         // before running the test with a default locale make sure the locale has been set
         LocaleProvider localeProvider = getService(LocaleProvider.class);
-        waitForAssert(() -> assertThat(localeProvider.getLocale().toString(), is("de")));
+        assertThat(localeProvider, is(notNullValue()));
+
+        waitForAssert(() -> assertThat(localeProvider.getLocale().toString(), is("de_DE")));
 
         bindingInstaller.exec(TEST_BUNDLE_NAME, () -> {
-            Set<BindingInfo> bindingInfos = bindingInfoRegistry.getBindingInfos(/* use default locale */ null);
+            // use default locale
+            Set<BindingInfo> bindingInfos = bindingInfoRegistry.getBindingInfos(null);
             BindingInfo bindingInfo = bindingInfos.iterator().next();
-
             assertThat(bindingInfo, is(notNullValue()));
             assertThat(bindingInfo.getName(), is("Yahoo Wetter Binding"));
             assertThat(bindingInfo.getDescription(), is(

--- a/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/java/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.java
@@ -89,7 +89,7 @@ public class BindingInfoI18nTest extends JavaOSGiTest {
     public void assertUsingDefaultLocale() throws Exception {
         // Set german locale
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
-        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider", null);
+        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.i18n", null);
         Dictionary<String, String> localeCfg = new Hashtable<>();
         localeCfg.put("language", "de");
         localeCfg.put("country", "DE");

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/testutil/i18n/DefaultLocaleSetter.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/testutil/i18n/DefaultLocaleSetter.java
@@ -39,16 +39,16 @@ public class DefaultLocaleSetter {
     }
 
     /**
-     * Configures the org.eclipse.smarthome.core.i18nprovider based on the provided locale. Note that the configuration
-     * is not necessarily effective yet when this method returns, as the configuration admin might configure the
-     * i18nprovider in another thread.
+     * Configures the i18n provider based on the provided locale. Note that the configuration is not necessarily
+     * effective yet when this method returns, as the configuration admin might configure the i18n provider in another
+     * thread.
      *
      * @param locale the locale to use, must not be null.
      */
     public void setDefaultLocale(Locale locale) throws IOException {
         assertThat(locale, is(notNullValue()));
 
-        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider", null);
+        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.i18n", null);
         assertThat(config, is(notNullValue()));
 
         Dictionary<String, Object> properties = config.getProperties();


### PR DESCRIPTION
- Changed pid from 'org.eclipse.smarthome.core.i18nprovider' to 'org.eclipse.smarthome.i18n'

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>