### PR TITLE
Fix unstable MDNSDiscoveryServiceOSGiTest

### DIFF
--- a/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
@@ -46,11 +46,13 @@ public class MDNSDiscoveryServiceOSGiTest extends JavaOSGiTest {
      */
     @Test
     public void testDynamicConfigurationOfBackgroundDiscovery() throws IOException {
-        setBackgroundDiscoveryViaConfigAdmin(true);
         waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(true)), 5000, 100);
 
         setBackgroundDiscoveryViaConfigAdmin(false);
         waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(false)), 5000, 100);
+
+        setBackgroundDiscoveryViaConfigAdmin(true);
+        waitForAssert(() -> assertThat(mdnsDiscoveryService.isBackgroundDiscoveryEnabled(), is(true)), 5000, 100);
     }
 
     private void setBackgroundDiscoveryViaConfigAdmin(boolean status) throws IOException {


### PR DESCRIPTION
With these changes the test no longer fails for me. The test is also flawed because `isBackgroundDiscoveryEnabled()` returns `true` at startup without setting it `true` first. So it's better to first test disabling and then enabling.

Fixes #567