### PR TITLE
add a feature for netty

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -121,6 +121,20 @@
     <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/1.9.6</bundle>
   </feature>
 
+  <feature name="openhab.tp-netty" description="Netty bundles" version="${project.version}">
+    <capability>openhab.tp;feature=netty;version=4.1.34.Final</capability>
+    <bundle dependency="true">mvn:io.netty/netty-buffer/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-common/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-codec/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-handler/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-resolver/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-transport/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.34.Final</bundle>
+    <bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.34.Final</bundle>
+  </feature>
+
   <feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">
     <capability>openhab.tp;feature=jaxb;version=2.9.0</capability>
     <bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>


### PR DESCRIPTION
This adds a feature `openhab.tp-netty` with Netty 4.1.34.Final andthe most common bundles. 

Can/Should we define a `netty.version` which can be used by core- or addons-bundles too add additional bundles and keep them in sync?

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>