### PR TITLE
Update Mockito to 3.1.0

### DIFF
--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.25.0</version>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -31,7 +31,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.net;version='[2.5.0,2.5.1)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.auth.oauth2client;version='[2.5.0,2.5.1)',\
 	org.openhab.core.auth.oauth2client.tests;version='[2.5.0,2.5.1)',\
@@ -39,12 +38,13 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -13,8 +13,6 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -31,13 +29,10 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
-	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.automation.module.core.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.automation;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
@@ -33,7 +33,6 @@ Bundle-SymbolicName: ${project.artifactId}
 	org.openhab.core.automation;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -34,7 +34,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.automation;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -27,7 +27,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -39,12 +38,13 @@ Fragment-Host: org.openhab.core.config.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -31,7 +31,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -48,12 +47,13 @@ Fragment-Host: org.openhab.core.config.discovery
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -13,8 +13,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -25,7 +23,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.usbserial.linuxsysfs.tests;version='[2.5.0,2.5.1)',\
@@ -41,5 +38,8 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'
 

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -16,8 +16,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -35,14 +33,12 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.usbserial.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery.usbserial;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.discovery;version='[2.5.0,2.5.1)',\
 	org.openhab.core.io.console;version='[2.5.0,2.5.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -51,5 +47,7 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
-
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -30,14 +30,10 @@ Fragment-Host: org.openhab.core.config.dispatch
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
-	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.config.dispatch;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.dispatch.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -44,4 +44,4 @@ Fragment-Host: org.openhab.core.config.xml
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	org.apache.servicemix.bundles.jaxb-impl;version='[2.2.11,2.2.12)'
+	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -33,7 +33,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[5.0.4,5.0.5)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
@@ -53,8 +52,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
@@ -62,4 +59,7 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -39,8 +39,6 @@ Fragment-Host: org.openhab.core.model.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	com.google.guava;version='[21.0.0,21.0.1)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
@@ -51,7 +49,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.xtext;version='[2.17.0,2.17.1)',\
 	org.eclipse.xtext.util;version='[2.17.0,2.17.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.17.0,2.17.1)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.model.core.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
@@ -98,4 +95,7 @@ Fragment-Host: org.openhab.core.model.core
 	jollyday;version='[0.5.8,0.5.9)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.persistence.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.persistence.tests/itest.bndrun
@@ -95,6 +95,7 @@ Fragment-Host: org.openhab.core.model.persistence
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
-	org.openhab.core.model.thing.runtime;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
+	org.openhab.core.model.rule.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -95,6 +95,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
-	org.openhab.core.storage.json;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -69,7 +69,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.voice;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.rule;version='[2.5.0,2.5.1)',\
 	org.openhab.core.model.thing;version='[2.5.0,2.5.1)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core.model.thing.tests;version='[2.5.0,2.5.1)',\
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
@@ -82,8 +81,6 @@ Fragment-Host: org.openhab.core.model.thing
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.guava;version='[21.0.0,21.0.1)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
@@ -107,5 +104,8 @@ Fragment-Host: org.openhab.core.model.thing
 	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'
 

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
-	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -27,7 +26,6 @@ Fragment-Host: org.openhab.core
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
@@ -38,12 +36,13 @@ Fragment-Host: org.openhab.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -31,7 +31,6 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.server;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.servlet;version='[9.4.11,9.4.12)',\
 	org.eclipse.jetty.util;version='[9.4.11,9.4.12)',\
-	org.mockito.mockito-core;version='[2.25.0,2.25.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.openhab.core;version='[2.5.0,2.5.1)',\
 	org.openhab.core.config.core;version='[2.5.0,2.5.1)',\
@@ -48,12 +47,13 @@ Fragment-Host: org.openhab.core.thing
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	net.bytebuddy.byte-buddy;version='[1.9.7,1.9.8)',\
-	net.bytebuddy.byte-buddy-agent;version='[1.9.7,1.9.8)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)'
+	tec.uom.se;version='[1.0.10,1.0.11)',\
+	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.9.10,1.9.11)',\
+	org.mockito.mockito-core;version='[3.1.0,3.1.1)'


### PR DESCRIPTION
Mockito 3 does not introduce any breaking API changes, but now requires Java 8 over Java 6 for Mockito 2.

---

Hopefully this update helps with resolving unstable tests or makes it easier to debug them.
This repo as well as the add-ons build successfully locally after the update so I've also created a PR for updating the runbundles in openhab2-addons: https://github.com/openhab/openhab2-addons/pull/6216.