### PR TITLE
Add null annotations to registries

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
@@ -45,7 +45,7 @@ public interface AudioSink {
      * @return a localized string to be used in UIs
      */
     @Nullable
-    String getLabel(Locale locale);
+    String getLabel(@Nullable Locale locale);
 
     /**
      * Processes the passed {@link AudioStream}

--- a/bundles/org.openhab.core.audio/src/test/java/org/eclipse/smarthome/core/audio/internal/fake/AudioSinkFake.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/eclipse/smarthome/core/audio/internal/fake/AudioSinkFake.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioSink;
 import org.eclipse.smarthome.core.audio.AudioStream;
@@ -35,14 +37,15 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Migrate tests from Groovy to Java
  */
+@NonNullByDefault
 public class AudioSinkFake implements AudioSink {
 
-    public AudioStream audioStream;
-    public AudioFormat audioFormat;
+    public @Nullable AudioStream audioStream;
+    public @Nullable AudioFormat audioFormat;
 
     public boolean isStreamProcessed;
     public boolean isStreamStopped;
-    public PercentType volume;
+    public @Nullable PercentType volume;
     public boolean isIOExceptionExpected;
     public boolean isUnsupportedAudioFormatExceptionExpected;
     public boolean isUnsupportedAudioStreamExceptionExpected;
@@ -58,12 +61,12 @@ public class AudioSinkFake implements AudioSink {
     }
 
     @Override
-    public String getLabel(Locale locale) {
+    public @Nullable String getLabel(@Nullable Locale locale) {
         return "testSinkLabel";
     }
 
     @Override
-    public void process(AudioStream audioStream)
+    public void process(@Nullable AudioStream audioStream)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         if (isUnsupportedAudioFormatExceptionExpected) {
             throw new UnsupportedAudioFormatException("Expected audio format exception", null);
@@ -80,7 +83,7 @@ public class AudioSinkFake implements AudioSink {
         isStreamProcessed = true;
     }
 
-    public AudioFormat getAudioFormat() {
+    public @Nullable AudioFormat getAudioFormat() {
         return audioFormat;
     }
 
@@ -96,10 +99,11 @@ public class AudioSinkFake implements AudioSink {
 
     @Override
     public PercentType getVolume() throws IOException {
-        if (isIOExceptionExpected) {
+        PercentType localVolume = volume;
+        if (localVolume == null || isIOExceptionExpected) {
             throw new IOException();
         }
-        return volume;
+        return localVolume;
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
@@ -44,14 +46,15 @@ import org.osgi.service.component.annotations.Reference;
  * @author Kai Kreuzer - Initial contribution
  * @author Simon Kaufmann - added "say" action
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class MediaActionTypeProvider implements ModuleTypeProvider {
 
-    private AudioManager audioManager;
+    private @NonNullByDefault({}) AudioManager audioManager;
 
     @SuppressWarnings("unchecked")
     @Override
-    public ModuleType getModuleType(String UID, Locale locale) {
+    public @Nullable ModuleType getModuleType(String UID, @Nullable Locale locale) {
         if (PlayActionHandler.TYPE_ID.equals(UID)) {
             return getPlayActionType(locale);
         } else if (SayActionHandler.TYPE_ID.equals(UID)) {
@@ -62,36 +65,36 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
     }
 
     @Override
-    public Collection<ModuleType> getModuleTypes(Locale locale) {
+    public Collection<ModuleType> getModuleTypes(@Nullable Locale locale) {
         return Stream.of(getPlayActionType(locale), getSayActionType(locale)).collect(Collectors.toList());
     }
 
-    private ModuleType getPlayActionType(Locale locale) {
+    private ModuleType getPlayActionType(@Nullable Locale locale) {
         return new ActionType(PlayActionHandler.TYPE_ID, getConfigPlayDesc(locale), "play a sound",
                 "Plays a sound file.", null, Visibility.VISIBLE, new ArrayList<>(), new ArrayList<>());
     }
 
-    private ModuleType getSayActionType(Locale locale) {
+    private ModuleType getSayActionType(@Nullable Locale locale) {
         return new ActionType(SayActionHandler.TYPE_ID, getConfigSayDesc(locale), "say something",
                 "Speaks a given text through a natural voice.", null, Visibility.VISIBLE, new ArrayList<>(),
                 new ArrayList<>());
     }
 
-    private List<ConfigDescriptionParameter> getConfigPlayDesc(Locale locale) {
+    private List<ConfigDescriptionParameter> getConfigPlayDesc(@Nullable Locale locale) {
         ConfigDescriptionParameter param1 = ConfigDescriptionParameterBuilder
                 .create(PlayActionHandler.PARAM_SOUND, Type.TEXT).withRequired(true).withLabel("Sound")
                 .withDescription("the sound to play").withOptions(getSoundOptions()).withLimitToOptions(true).build();
         return Stream.of(param1, getAudioSinkConfigDescParam(locale)).collect(Collectors.toList());
     }
 
-    private List<ConfigDescriptionParameter> getConfigSayDesc(Locale locale) {
+    private List<ConfigDescriptionParameter> getConfigSayDesc(@Nullable Locale locale) {
         ConfigDescriptionParameter param1 = ConfigDescriptionParameterBuilder
                 .create(SayActionHandler.PARAM_TEXT, Type.TEXT).withRequired(true).withLabel("Text")
                 .withDescription("the text to speak").build();
         return Stream.of(param1, getAudioSinkConfigDescParam(locale)).collect(Collectors.toList());
     }
 
-    private ConfigDescriptionParameter getAudioSinkConfigDescParam(Locale locale) {
+    private ConfigDescriptionParameter getAudioSinkConfigDescParam(@Nullable Locale locale) {
         ConfigDescriptionParameter param2 = ConfigDescriptionParameterBuilder
                 .create(SayActionHandler.PARAM_SINK, Type.TEXT).withRequired(false).withLabel("Sink")
                 .withDescription("the audio sink id").withOptions(getSinkOptions(locale)).withLimitToOptions(true)
@@ -124,7 +127,7 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
      *
      * @return a list of parameter options representing the audio sinks
      */
-    private List<ParameterOption> getSinkOptions(Locale locale) {
+    private List<ParameterOption> getSinkOptions(@Nullable Locale locale) {
         List<ParameterOption> options = new ArrayList<>();
 
         for (AudioSink sink : audioManager.getAllSinks()) {

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
@@ -16,7 +16,11 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.openhab.core.automation.type.ModuleType;
 import org.openhab.core.automation.type.ModuleTypeProvider;
@@ -29,11 +33,12 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Simon Merschjohann - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, service = { ScriptedCustomModuleTypeProvider.class, ModuleTypeProvider.class })
 public class ScriptedCustomModuleTypeProvider implements ModuleTypeProvider {
-    private final HashMap<String, ModuleType> modulesTypes = new HashMap<>();
+    private final Map<String, ModuleType> modulesTypes = new HashMap<>();
 
-    private final HashSet<ProviderChangeListener<ModuleType>> listeners = new HashSet<>();
+    private final Set<ProviderChangeListener<ModuleType>> listeners = new HashSet<>();
 
     @Override
     public Collection<ModuleType> getAll() {
@@ -52,15 +57,13 @@ public class ScriptedCustomModuleTypeProvider implements ModuleTypeProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
-        ModuleType handler = modulesTypes.get(UID);
-
-        return (T) handler;
+    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
+        return (T) modulesTypes.get(UID);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
+    public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
         return (Collection<T>) modulesTypes.values();
     }
 
@@ -89,7 +92,7 @@ public class ScriptedCustomModuleTypeProvider implements ModuleTypeProvider {
 
         if (modType != null) {
             for (ProviderChangeListener<ModuleType> listener : listeners) {
-                listener.updated(this, null, modType);
+                listener.updated(this, modType, modType);
             }
         }
     }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
@@ -17,6 +17,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.RuleRegistry;
@@ -28,6 +30,7 @@ import org.openhab.core.automation.RuleRegistry;
  *
  * @author Simon Merschjohann - Initial contribution
  */
+@NonNullByDefault
 public class RuleSupportRuleRegistryDelegate implements RuleRegistry {
     private final RuleRegistry ruleRegistry;
 
@@ -56,7 +59,7 @@ public class RuleSupportRuleRegistryDelegate implements RuleRegistry {
     }
 
     @Override
-    public Rule get(String key) {
+    public @Nullable Rule get(String key) {
         return ruleRegistry.get(key);
     }
 
@@ -83,12 +86,12 @@ public class RuleSupportRuleRegistryDelegate implements RuleRegistry {
     }
 
     @Override
-    public Rule update(Rule element) {
+    public @Nullable Rule update(Rule element) {
         return ruleRegistry.update(element);
     }
 
     @Override
-    public Rule remove(String key) {
+    public @Nullable Rule remove(String key) {
         if (rules.remove(key)) {
             ruleProvider.removeRule(key);
         }
@@ -97,7 +100,7 @@ public class RuleSupportRuleRegistryDelegate implements RuleRegistry {
     }
 
     @Override
-    public Collection<Rule> getByTag(String tag) {
+    public Collection<Rule> getByTag(@Nullable String tag) {
         return ruleRegistry.getByTag(tag);
     }
 

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
@@ -28,6 +28,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.rest.LocaleService;
 import org.eclipse.smarthome.io.rest.RESTResource;
 import org.openhab.core.automation.dto.ActionTypeDTOMapper;
@@ -62,14 +64,15 @@ import io.swagger.annotations.ApiResponses;
  */
 @Path("module-types")
 @Api("module-types")
+@NonNullByDefault
 @Component
 public class ModuleTypeResource implements RESTResource {
 
-    private ModuleTypeRegistry moduleTypeRegistry;
-    private LocaleService localeService;
+    private @NonNullByDefault({}) ModuleTypeRegistry moduleTypeRegistry;
+    private @NonNullByDefault({}) LocaleService localeService;
 
     @Context
-    private UriInfo uriInfo;
+    private @NonNullByDefault({}) UriInfo uriInfo;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setModuleTypeRegistry(ModuleTypeRegistry moduleTypeRegistry) {
@@ -94,11 +97,11 @@ public class ModuleTypeResource implements RESTResource {
     @ApiOperation(value = "Get all available module types.", response = ModuleTypeDTO.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = ModuleTypeDTO.class, responseContainer = "List") })
-    public Response getAll(@HeaderParam("Accept-Language") @ApiParam(value = "language") String language,
-            @QueryParam("tags") @ApiParam(value = "tags for filtering", required = false) String tagList,
-            @QueryParam("type") @ApiParam(value = "filtering by action, condition or trigger", required = false) String type) {
+    public Response getAll(@HeaderParam("Accept-Language") @ApiParam(value = "language") @Nullable String language,
+            @QueryParam("tags") @ApiParam(value = "tags for filtering", required = false) @Nullable String tagList,
+            @QueryParam("type") @ApiParam(value = "filtering by action, condition or trigger", required = false) @Nullable String type) {
         final Locale locale = localeService.getLocale(language);
-        final String[] tags = tagList != null ? tagList.split(",") : null;
+        final String[] tags = tagList != null ? tagList.split(",") : new String[0];
         final List<ModuleTypeDTO> modules = new ArrayList<>();
 
         if (type == null || type.equals("trigger")) {
@@ -119,7 +122,7 @@ public class ModuleTypeResource implements RESTResource {
     @ApiOperation(value = "Gets a module type corresponding to the given UID.", response = ModuleTypeDTO.class)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ModuleTypeDTO.class),
             @ApiResponse(code = 404, message = "Module Type corresponding to the given UID does not found.") })
-    public Response getByUID(@HeaderParam("Accept-Language") @ApiParam(value = "language") String language,
+    public Response getByUID(@HeaderParam("Accept-Language") @ApiParam(value = "language") @Nullable String language,
             @PathParam("moduleTypeUID") @ApiParam(value = "moduleTypeUID", required = true) String moduleTypeUID) {
         Locale locale = localeService.getLocale(language);
         final ModuleType moduleType = moduleTypeRegistry.get(moduleTypeUID, locale);

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
@@ -27,6 +27,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.io.rest.LocaleService;
 import org.eclipse.smarthome.io.rest.RESTResource;
 import org.openhab.core.automation.dto.RuleTemplateDTO;
@@ -52,14 +54,15 @@ import io.swagger.annotations.ApiResponses;
  */
 @Path("templates")
 @Api("templates")
+@NonNullByDefault
 @Component
 public class TemplateResource implements RESTResource {
 
-    private TemplateRegistry<RuleTemplate> templateRegistry;
-    private LocaleService localeService;
+    private @NonNullByDefault({}) TemplateRegistry<@NonNull RuleTemplate> templateRegistry;
+    private @NonNullByDefault({}) LocaleService localeService;
 
     @Context
-    private UriInfo uriInfo;
+    private @NonNullByDefault({}) UriInfo uriInfo;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setTemplateRegistry(TemplateRegistry<RuleTemplate> templateRegistry) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleProvider.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.automation;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.common.registry.Provider;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.smarthome.core.common.registry.Provider;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public interface RuleProvider extends Provider<Rule> {
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation;
 
 import java.util.Collection;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Registry;
 
 /**
@@ -50,6 +52,7 @@ import org.eclipse.smarthome.core.common.registry.Registry;
  *
  * @author Yordan Mihaylov - Initial contribution
  */
+@NonNullByDefault
 public interface RuleRegistry extends Registry<Rule, String> {
 
     /**
@@ -61,8 +64,8 @@ public interface RuleRegistry extends Registry<Rule, String> {
      * @param rule a {@link Rule} instance which have to be added into the {@link RuleRegistry}.
      * @return a copy of the added {@link Rule}
      * @throws IllegalArgumentException when a rule with the same UID already exists or some of the conditions or
-     *                                  actions has wrong format of input reference.
-     * @throws IllegalStateException    when the RuleManagedProvider is unavailable.
+     *             actions has wrong format of input reference.
+     * @throws IllegalStateException when the RuleManagedProvider is unavailable.
      */
     @Override
     public Rule add(Rule rule);
@@ -73,7 +76,7 @@ public interface RuleRegistry extends Registry<Rule, String> {
      * @param tag specifies a tag that will filter the rules.
      * @return collection of {@link Rule}s having specified tag.
      */
-    public Collection<Rule> getByTag(String tag);
+    public Collection<Rule> getByTag(@Nullable String tag);
 
     /**
      * Gets a collection of {@link Rule}s which has specified tags.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommands.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommands.java
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.RuleStatus;
@@ -40,6 +42,7 @@ import org.osgi.framework.BundleContext;
  * @author Ana Dimova - Initial contribution
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  */
+@NonNullByDefault
 public abstract class AutomationCommands {
 
     /**
@@ -200,17 +203,17 @@ public abstract class AutomationCommands {
     /**
      * This field holds a reference to the {@link CommandlineModuleTypeProvider} instance.
      */
-    protected CommandlineModuleTypeProvider moduleTypeProvider;
+    protected @NonNullByDefault({}) CommandlineModuleTypeProvider moduleTypeProvider;
 
     /**
      * This field holds a reference to the {@link CommandlineTemplateProvider} instance.
      */
-    protected CommandlineTemplateProvider templateProvider;
+    protected @NonNullByDefault({}) CommandlineTemplateProvider templateProvider;
 
     /**
      * This field holds a reference to the {@link CommandlineRuleImporter} instance.
      */
-    protected CommandlineRuleImporter ruleImporter;
+    protected @NonNullByDefault({}) CommandlineRuleImporter ruleImporter;
 
     /**
      * This method is used for getting the rule corresponding to the specified UID from the RuleManager.
@@ -219,7 +222,7 @@ public abstract class AutomationCommands {
      *            specifies the wanted {@link Rule} uniquely.
      * @return a {@link Rule}, corresponding to the specified UID.
      */
-    public abstract Rule getRule(String uid);
+    public abstract @Nullable Rule getRule(String uid);
 
     /**
      * This method is used to get the all existing rules from the RuleManager.
@@ -233,7 +236,7 @@ public abstract class AutomationCommands {
      * @param uid
      * @return
      */
-    public abstract RuleStatus getRuleStatus(String uid);
+    public abstract @Nullable RuleStatus getRuleStatus(String uid);
 
     /**
      *
@@ -253,7 +256,7 @@ public abstract class AutomationCommands {
      *            Can be <code>null</code> and then the default locale will be used.
      * @return a {@link RuleTemplate}, corresponding to the specified UID and locale.
      */
-    public abstract Template getTemplate(String templateUID, Locale locale);
+    public abstract @Nullable Template getTemplate(String templateUID, @Nullable Locale locale);
 
     /**
      * This method is used for getting the collection of {@link RuleTemplate}s corresponding to the specified locale
@@ -264,7 +267,7 @@ public abstract class AutomationCommands {
      *            Can be <code>null</code> and then the default locale will be used.
      * @return a collection of {@link RuleTemplate}s, corresponding to the specified locale.
      */
-    public abstract Collection<RuleTemplate> getTemplates(Locale locale);
+    public abstract Collection<RuleTemplate> getTemplates(@Nullable Locale locale);
 
     /**
      * This method is used for getting the {@link ModuleType} corresponding to the specified UID from the manager of the
@@ -277,7 +280,7 @@ public abstract class AutomationCommands {
      *            be <code>null</code> and then the default locale will be used.
      * @return a {@link ModuleType}, corresponding to the specified UID and locale.
      */
-    public abstract ModuleType getModuleType(String typeUID, Locale locale);
+    public abstract @Nullable ModuleType getModuleType(String typeUID, @Nullable Locale locale);
 
     /**
      * This method is used for getting the collection of {@link TriggerType}s corresponding to
@@ -288,7 +291,7 @@ public abstract class AutomationCommands {
      *            be <code>null</code> and then the default locale will be used.
      * @return a collection of {@link ModuleType}s from given class and locale.
      */
-    public abstract <T extends ModuleType> Collection<T> getTriggers(Locale locale);
+    public abstract <T extends ModuleType> Collection<T> getTriggers(@Nullable Locale locale);
 
     /**
      * This method is used for getting the collection of {@link ConditionType}s corresponding to
@@ -299,7 +302,7 @@ public abstract class AutomationCommands {
      *            be <code>null</code> and then the default locale will be used.
      * @return a collection of {@link ModuleType}s from given class and locale.
      */
-    public abstract <T extends ModuleType> Collection<T> getConditions(Locale locale);
+    public abstract <T extends ModuleType> Collection<T> getConditions(@Nullable Locale locale);
 
     /**
      * This method is used for getting the collection of {@link ActionType}s corresponding to
@@ -310,7 +313,7 @@ public abstract class AutomationCommands {
      *            be <code>null</code> and then the default locale will be used.
      * @return a collection of {@link ModuleType}s from given class and locale.
      */
-    public abstract <T extends ModuleType> Collection<T> getActions(Locale locale);
+    public abstract <T extends ModuleType> Collection<T> getActions(@Nullable Locale locale);
 
     /**
      * This method is used for removing a rule corresponding to the specified UID from the RuleManager.
@@ -341,7 +344,7 @@ public abstract class AutomationCommands {
      *            order for their description is a random.
      * @return an instance of the class corresponding to the identifier of the command.
      */
-    protected abstract AutomationCommand parseCommand(String command, String[] parameterValues);
+    protected abstract @Nullable AutomationCommand parseCommand(String command, String[] parameterValues);
 
     /**
      * Initializing method.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
@@ -14,10 +14,14 @@ package org.openhab.core.automation.internal.commands;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.console.Console;
 import org.eclipse.smarthome.io.console.extensions.ConsoleCommandExtension;
 import org.openhab.core.automation.Rule;
@@ -45,6 +49,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Ana Dimova - Initial contribution
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  */
+@NonNullByDefault
 @Component
 public class AutomationCommandsPluggable extends AutomationCommands implements ConsoleCommandExtension {
 
@@ -79,23 +84,23 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
     /**
      * This field holds the reference to the {@code RuleRegistry} providing the {@code Rule} automation objects.
      */
-    protected RuleRegistry ruleRegistry;
+    protected @NonNullByDefault({}) RuleRegistry ruleRegistry;
 
     /**
      * This field holds the reference to the {@code RuleManager}.
      */
-    protected RuleManager ruleManager;
+    protected @NonNullByDefault({}) RuleManager ruleManager;
 
     /**
      * This field holds the reference to the {@code TemplateRegistry} providing the {@code Template} automation objects.
      */
-    protected TemplateRegistry<RuleTemplate> templateRegistry;
+    protected @NonNullByDefault({}) TemplateRegistry<@NonNull RuleTemplate> templateRegistry;
 
     /**
      * This field holds the reference to the {@code ModuleTypeRegistry} providing the {@code ModuleType} automation
      * objects.
      */
-    protected ModuleTypeRegistry moduleTypeRegistry;
+    protected @NonNullByDefault({}) ModuleTypeRegistry moduleTypeRegistry;
 
     /**
      * Activating this component - called from DS.
@@ -241,7 +246,7 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
     }
 
     @Override
-    public Rule getRule(String uid) {
+    public @Nullable Rule getRule(String uid) {
         if (ruleRegistry != null) {
             return ruleRegistry.get(uid);
         }
@@ -249,7 +254,7 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
     }
 
     @Override
-    public RuleTemplate getTemplate(String templateUID, Locale locale) {
+    public @Nullable RuleTemplate getTemplate(String templateUID, @Nullable Locale locale) {
         if (templateRegistry != null) {
             return templateRegistry.get(templateUID, locale);
         }
@@ -257,15 +262,15 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
     }
 
     @Override
-    public Collection<RuleTemplate> getTemplates(Locale locale) {
+    public Collection<RuleTemplate> getTemplates(@Nullable Locale locale) {
         if (templateRegistry != null) {
             return templateRegistry.getAll(locale);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @Override
-    public ModuleType getModuleType(String typeUID, Locale locale) {
+    public @Nullable ModuleType getModuleType(String typeUID, @Nullable Locale locale) {
         if (moduleTypeRegistry != null) {
             return moduleTypeRegistry.get(typeUID, locale);
         }
@@ -274,29 +279,29 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
 
     @SuppressWarnings("unchecked")
     @Override
-    public Collection<TriggerType> getTriggers(Locale locale) {
+    public Collection<TriggerType> getTriggers(@Nullable Locale locale) {
         if (moduleTypeRegistry != null) {
             return moduleTypeRegistry.getTriggers(locale);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Collection<ConditionType> getConditions(Locale locale) {
+    public Collection<ConditionType> getConditions(@Nullable Locale locale) {
         if (moduleTypeRegistry != null) {
             return moduleTypeRegistry.getConditions(locale);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Collection<ActionType> getActions(Locale locale) {
+    public Collection<ActionType> getActions(@Nullable Locale locale) {
         if (moduleTypeRegistry != null) {
             return moduleTypeRegistry.getActions(locale);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     @Override
@@ -325,7 +330,7 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
     }
 
     @Override
-    protected AutomationCommand parseCommand(String command, String[] params) {
+    protected @Nullable AutomationCommand parseCommand(String command, String[] params) {
         if (command.equalsIgnoreCase(IMPORT_MODULE_TYPES)) {
             return new AutomationCommandImport(IMPORT_MODULE_TYPES, params, MODULE_TYPE_REGISTRY, this);
         }
@@ -406,12 +411,12 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
         if (ruleRegistry != null) {
             return ruleRegistry.getAll();
         } else {
-            return null;
+            return Collections.emptyList();
         }
     }
 
     @Override
-    public RuleStatus getRuleStatus(String ruleUID) {
+    public @Nullable RuleStatus getRuleStatus(String ruleUID) {
         RuleStatusInfo rsi = ruleManager.getStatusInfo(ruleUID);
         return rsi != null ? rsi.getStatus() : null;
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.openhab.core.automation.parser.Parser;
 import org.openhab.core.automation.parser.ParsingException;
@@ -55,14 +57,15 @@ import org.osgi.framework.ServiceRegistration;
  * @author Ana Dimova - Initial contribution
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  */
+@NonNullByDefault
 public class CommandlineModuleTypeProvider extends AbstractCommandProvider<ModuleType> implements ModuleTypeProvider {
 
     /**
      * This field holds a reference to the {@link TemplateProvider} service registration.
      */
     @SuppressWarnings("rawtypes")
-    protected ServiceRegistration mtpReg;
-    private ModuleTypeRegistry moduleTypeRegistry;
+    protected @Nullable ServiceRegistration mtpReg;
+    private final ModuleTypeRegistry moduleTypeRegistry;
 
     /**
      * This constructor creates instances of this particular implementation of {@link ModuleTypeProvider}. It does not
@@ -72,10 +75,9 @@ public class CommandlineModuleTypeProvider extends AbstractCommandProvider<Modul
      * @param context is the {@code BundleContext}, used for creating a tracker for {@link Parser} services.
      * @param moduleTypeRegistry a ModuleTypeRegistry service
      */
-    public CommandlineModuleTypeProvider(BundleContext context, ModuleTypeRegistry moduleTypeRegistry) {
-        super(context);
-        listeners = new LinkedList<>();
-        mtpReg = bc.registerService(ModuleTypeProvider.class.getName(), this, null);
+    public CommandlineModuleTypeProvider(BundleContext bundleContext, ModuleTypeRegistry moduleTypeRegistry) {
+        super(bundleContext);
+        mtpReg = bundleContext.registerService(ModuleTypeProvider.class.getName(), this, null);
         this.moduleTypeRegistry = moduleTypeRegistry;
     }
 
@@ -86,7 +88,7 @@ public class CommandlineModuleTypeProvider extends AbstractCommandProvider<Modul
      * @see AbstractCommandProvider#addingService(org.osgi.framework.ServiceReference)
      */
     @Override
-    public Object addingService(@SuppressWarnings("rawtypes") ServiceReference reference) {
+    public @Nullable Object addingService(@SuppressWarnings("rawtypes") @Nullable ServiceReference reference) {
         if (reference.getProperty(Parser.PARSER_TYPE).equals(Parser.PARSER_MODULE_TYPE)) {
             return super.addingService(reference);
         }
@@ -136,14 +138,14 @@ public class CommandlineModuleTypeProvider extends AbstractCommandProvider<Modul
 
     @SuppressWarnings("unchecked")
     @Override
-    public ModuleType getModuleType(String UID, Locale locale) {
+    public @Nullable ModuleType getModuleType(String UID, @Nullable Locale locale) {
         synchronized (providedObjectsHolder) {
             return providedObjectsHolder.get(UID);
         }
     }
 
     @Override
-    public Collection<ModuleType> getModuleTypes(Locale locale) {
+    public Collection<ModuleType> getModuleTypes(@Nullable Locale locale) {
         synchronized (providedObjectsHolder) {
             return !providedObjectsHolder.isEmpty() ? providedObjectsHolder.values()
                     : Collections.<ModuleType> emptyList();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.openhab.core.automation.parser.Parser;
 import org.openhab.core.automation.parser.ParsingException;
@@ -52,13 +54,14 @@ import org.osgi.framework.ServiceRegistration;
  * @author Ana Dimova - Initial contribution
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  */
+@NonNullByDefault
 public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTemplate> implements RuleTemplateProvider {
 
     /**
      * This field holds a reference to the {@link ModuleTypeProvider} service registration.
      */
     @SuppressWarnings("rawtypes")
-    protected ServiceRegistration tpReg;
+    protected @Nullable ServiceRegistration tpReg;
     private final TemplateRegistry<RuleTemplate> templateRegistry;
 
     /**
@@ -66,12 +69,11 @@ public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTem
      * any new functionality to the constructors of the providers. Only provides consistency by invoking the parent's
      * constructor.
      *
-     * @param context is the {@link BundleContext}, used for creating a tracker for {@link Parser} services.
+     * @param bundleContext is the {@link BundleContext}, used for creating a tracker for {@link Parser} services.
      */
-    public CommandlineTemplateProvider(BundleContext context, TemplateRegistry<RuleTemplate> templateRegistry) {
-        super(context);
-        listeners = new LinkedList<>();
-        tpReg = bc.registerService(RuleTemplateProvider.class.getName(), this, null);
+    public CommandlineTemplateProvider(BundleContext bundleContext, TemplateRegistry<RuleTemplate> templateRegistry) {
+        super(bundleContext);
+        tpReg = bundleContext.registerService(RuleTemplateProvider.class.getName(), this, null);
         this.templateRegistry = templateRegistry;
     }
 
@@ -82,7 +84,7 @@ public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTem
      * @see AbstractCommandProvider#addingService(org.osgi.framework.ServiceReference)
      */
     @Override
-    public Object addingService(@SuppressWarnings("rawtypes") ServiceReference reference) {
+    public @Nullable Object addingService(@SuppressWarnings("rawtypes") @Nullable ServiceReference reference) {
         if (reference.getProperty(Parser.PARSER_TYPE).equals(Parser.PARSER_TEMPLATE)) {
             return super.addingService(reference);
         }
@@ -128,14 +130,14 @@ public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTem
     }
 
     @Override
-    public RuleTemplate getTemplate(String UID, Locale locale) {
+    public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
         synchronized (providerPortfolio) {
             return providedObjectsHolder.get(UID);
         }
     }
 
     @Override
-    public Collection<RuleTemplate> getTemplates(Locale locale) {
+    public Collection<RuleTemplate> getTemplates(@Nullable Locale locale) {
         synchronized (providedObjectsHolder) {
             return providedObjectsHolder.values();
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
@@ -21,6 +21,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.openhab.core.automation.Action;
@@ -50,19 +52,20 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 @Component(service = { ModuleTypeProvider.class, ModuleHandlerFactory.class })
 public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory implements ModuleTypeProvider {
 
     private final Collection<ProviderChangeListener<ModuleType>> changeListeners = ConcurrentHashMap.newKeySet();
-    private Map<String, Set<ModuleInformation>> moduleInformation = new ConcurrentHashMap<>();
+    private final Map<String, Set<ModuleInformation>> moduleInformation = new ConcurrentHashMap<>();
     private final AnnotationActionModuleTypeHelper helper = new AnnotationActionModuleTypeHelper();
 
-    private ModuleTypeI18nService moduleTypeI18nService;
+    private @NonNullByDefault({}) ModuleTypeI18nService moduleTypeI18nService;
 
     @Override
     @Deactivate
     protected void deactivate() {
-        this.moduleInformation = null;
+        moduleInformation.clear();
     }
 
     @Override
@@ -79,7 +82,7 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
     public Collection<ModuleType> getAll() {
         Collection<ModuleType> moduleTypes = new ArrayList<>();
         for (String moduleUID : moduleInformation.keySet()) {
-            ModuleType mt = helper.buildModuleType(moduleUID, this.moduleInformation);
+            ModuleType mt = helper.buildModuleType(moduleUID, moduleInformation);
             if (mt != null) {
                 moduleTypes.add(mt);
             }
@@ -89,13 +92,13 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
+    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
         return (T) localizeModuleType(UID, locale);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
+    public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
         List<T> result = new ArrayList<>();
         for (Entry<String, Set<ModuleInformation>> entry : moduleInformation.entrySet()) {
             ModuleType localizedModuleType = localizeModuleType(entry.getKey(), locale);
@@ -106,7 +109,7 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
         return result;
     }
 
-    private ModuleType localizeModuleType(String uid, Locale locale) {
+    private @Nullable ModuleType localizeModuleType(String uid, @Nullable Locale locale) {
         Set<ModuleInformation> mis = moduleInformation.get(uid);
         if (mis != null && !mis.isEmpty()) {
             ModuleInformation mi = mis.iterator().next();
@@ -130,17 +133,17 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
             mi.setConfigName(configName);
 
             ModuleType oldType = null;
-            if (this.moduleInformation.containsKey(mi.getUID())) {
-                oldType = helper.buildModuleType(mi.getUID(), this.moduleInformation);
-                Set<ModuleInformation> availableModuleConfigs = this.moduleInformation.get(mi.getUID());
+            if (moduleInformation.containsKey(mi.getUID())) {
+                oldType = helper.buildModuleType(mi.getUID(), moduleInformation);
+                Set<ModuleInformation> availableModuleConfigs = moduleInformation.get(mi.getUID());
                 availableModuleConfigs.add(mi);
             } else {
                 Set<ModuleInformation> configs = ConcurrentHashMap.newKeySet();
                 configs.add(mi);
-                this.moduleInformation.put(mi.getUID(), configs);
+                moduleInformation.put(mi.getUID(), configs);
             }
 
-            ModuleType mt = helper.buildModuleType(mi.getUID(), this.moduleInformation);
+            ModuleType mt = helper.buildModuleType(mi.getUID(), moduleInformation);
             if (mt != null) {
                 for (ProviderChangeListener<ModuleType> l : changeListeners) {
                     if (oldType != null) {
@@ -162,16 +165,16 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
             mi.setConfigName(configName);
             ModuleType oldType = null;
 
-            Set<ModuleInformation> availableModuleConfigs = this.moduleInformation.get(mi.getUID());
+            Set<ModuleInformation> availableModuleConfigs = moduleInformation.get(mi.getUID());
             if (availableModuleConfigs != null) {
                 if (availableModuleConfigs.size() > 1) {
-                    oldType = helper.buildModuleType(mi.getUID(), this.moduleInformation);
+                    oldType = helper.buildModuleType(mi.getUID(), moduleInformation);
                     availableModuleConfigs.remove(mi);
                 } else {
-                    this.moduleInformation.remove(mi.getUID());
+                    moduleInformation.remove(mi.getUID());
                 }
 
-                ModuleType mt = helper.buildModuleType(mi.getUID(), this.moduleInformation);
+                ModuleType mt = helper.buildModuleType(mi.getUID(), moduleInformation);
                 for (ProviderChangeListener<ModuleType> l : changeListeners) {
                     if (oldType != null) {
                         l.updated(this, oldType, mt);
@@ -183,7 +186,7 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
         }
     }
 
-    private String getConfigNameFromService(Map<String, Object> properties) {
+    private @Nullable String getConfigNameFromService(Map<String, Object> properties) {
         Object o = properties.get(ConfigConstants.SERVICE_CONTEXT);
         String configName = null;
         if (o instanceof String) {
@@ -200,7 +203,7 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
     }
 
     @Override
-    protected ModuleHandler internalCreate(Module module, String ruleUID) {
+    protected @Nullable ModuleHandler internalCreate(Module module, String ruleUID) {
         if (module instanceof Action) {
             Action actionModule = (Action) module;
 
@@ -209,7 +212,7 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
                         false);
 
                 if (finalMI != null) {
-                    ActionType moduleType = helper.buildModuleType(module.getTypeUID(), this.moduleInformation);
+                    ActionType moduleType = helper.buildModuleType(module.getTypeUID(), moduleInformation);
                     return new AnnotationActionHandler(actionModule, moduleType, finalMI.getMethod(),
                             finalMI.getActionProvider());
                 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/AbstractGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/AbstractGSONParser.java
@@ -15,6 +15,7 @@ package org.openhab.core.automation.internal.parser.gson;
 import java.io.OutputStreamWriter;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.ConfigurationDeserializer;
 import org.eclipse.smarthome.config.core.ConfigurationSerializer;
@@ -34,6 +35,7 @@ import com.google.gson.GsonBuilder;
  *
  * @param <T> the type of the entities to parse
  */
+@NonNullByDefault
 public abstract class AbstractGSONParser<T> implements Parser<T> {
 
     // A Gson instance to use by the parsers

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/RuleGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/RuleGSONParser.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.dto.RuleDTO;
 import org.openhab.core.automation.dto.RuleDTOMapper;
@@ -36,6 +37,7 @@ import com.google.gson.stream.JsonToken;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, service = Parser.class, property = { "parser.type=parser.rule", "format=json" })
 public class RuleGSONParser extends AbstractGSONParser<Rule> {
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TemplateGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TemplateGSONParser.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.dto.RuleTemplateDTO;
 import org.openhab.core.automation.dto.RuleTemplateDTOMapper;
 import org.openhab.core.automation.parser.Parser;
@@ -36,6 +37,7 @@ import com.google.gson.stream.JsonToken;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, service = Parser.class, property = { "parser.type=parser.template", "format=json" })
 public class TemplateGSONParser extends AbstractGSONParser<Template> {
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
@@ -54,7 +54,7 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
      * @param registry the managing service of the {@link Rule}s.
      */
     public RuleResourceBundleImporter() {
-        path = ROOT_DIRECTORY + "/rules/";
+        super(ROOT_DIRECTORY + "/rules/");
     }
 
     protected void setManagedRuleProvider(ManagedRuleProvider mProvider) {
@@ -110,12 +110,12 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
                 updateWaitingProviders(parser, bundle, url);
                 if (parser != null) {
                     Set<Rule> parsedObjects = parseData(parser, url, bundle);
-                    if (parsedObjects != null && !parsedObjects.isEmpty()) {
-                        addNewProvidedObjects(null, null, parsedObjects);
+                    if (!parsedObjects.isEmpty()) {
+                        addNewProvidedObjects(Collections.emptyList(), Collections.emptyList(), parsedObjects);
                     }
                 }
             }
-            putNewPortfolio(vendor, Collections.<String> emptyList());
+            putNewPortfolio(vendor, Collections.emptyList());
         }
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
@@ -47,12 +48,13 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractFileProvider<E> implements Provider<E> {
 
     protected static final String CONFIG_PROPERTY_ROOTS = "roots";
     protected final Logger logger = LoggerFactory.getLogger(AbstractFileProvider.class);
 
-    protected String rootSubdirectory;
+    protected final String rootSubdirectory;
     protected String[] configurationRoots;
 
     /**
@@ -62,7 +64,7 @@ public abstract class AbstractFileProvider<E> implements Provider<E> {
      * <p>
      * The Map has for keys URLs of the files containing automation objects and for values - parsed objects.
      */
-    protected Map<String, E> providedObjectsHolder = new ConcurrentHashMap<>();
+    protected final Map<String, E> providedObjectsHolder = new ConcurrentHashMap<>();
 
     /**
      * This Map provides structure for fast access to the {@link Parser}s. This provides opportunity for high

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.type.ModuleType;
 import org.openhab.core.automation.type.ModuleTypeProvider;
 
@@ -26,6 +28,7 @@ import org.openhab.core.automation.type.ModuleTypeProvider;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public abstract class ModuleTypeFileProvider extends AbstractFileProvider<ModuleType> implements ModuleTypeProvider {
 
     public ModuleTypeFileProvider() {
@@ -44,16 +47,16 @@ public abstract class ModuleTypeFileProvider extends AbstractFileProvider<Module
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
+    public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
         return (T) providedObjectsHolder.get(UID);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
+    public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
         Collection<ModuleType> values = providedObjectsHolder.values();
         if (values.isEmpty()) {
-            return Collections.<T> emptyList();
+            return Collections.emptyList();
         }
         return (Collection<T>) new LinkedList<>(values);
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProviderWatcher.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProviderWatcher.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.internal.provider.file;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.parser.Parser;
 import org.openhab.core.automation.type.ModuleType;
 import org.openhab.core.automation.type.ModuleTypeProvider;
@@ -27,6 +28,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, service = ModuleTypeProvider.class)
 public class ModuleTypeFileProviderWatcher extends ModuleTypeFileProvider {
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.template.RuleTemplate;
 import org.openhab.core.automation.template.RuleTemplateProvider;
 import org.openhab.core.automation.template.TemplateProvider;
@@ -27,6 +29,7 @@ import org.openhab.core.automation.template.TemplateProvider;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public abstract class TemplateFileProvider extends AbstractFileProvider<RuleTemplate> implements RuleTemplateProvider {
 
     public TemplateFileProvider() {
@@ -44,15 +47,15 @@ public abstract class TemplateFileProvider extends AbstractFileProvider<RuleTemp
     }
 
     @Override
-    public RuleTemplate getTemplate(String UID, Locale locale) {
+    public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
         return providedObjectsHolder.get(UID);
     }
 
     @Override
-    public Collection<RuleTemplate> getTemplates(Locale locale) {
+    public Collection<RuleTemplate> getTemplates(@Nullable Locale locale) {
         Collection<RuleTemplate> values = providedObjectsHolder.values();
         if (values.isEmpty()) {
-            return Collections.<RuleTemplate> emptyList();
+            return Collections.emptyList();
         }
         return new LinkedList<>(values);
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.Action;
@@ -31,22 +33,26 @@ import org.osgi.framework.Bundle;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class ModuleI18nUtil {
 
     public static <T extends Module> List<T> getLocalizedModules(TranslationProvider i18nProvider, List<T> modules,
-            Bundle bundle, String uid, String prefix, Locale locale) {
+            Bundle bundle, String uid, String prefix, @Nullable Locale locale) {
         List<T> lmodules = new ArrayList<>();
         for (T module : modules) {
             String label = getModuleLabel(i18nProvider, bundle, uid, module.getId(), module.getLabel(), prefix, locale);
-            String description = getModuleDescription(i18nProvider, bundle, uid, prefix, module.getId(),
-                    module.getDescription(), locale);
-            lmodules.add(createLocalizedModule(module, label, description));
+            String description = getModuleDescription(i18nProvider, bundle, uid, module.getId(),
+                    module.getDescription(), prefix, locale);
+            @Nullable
+            T lmodule = createLocalizedModule(module, label, description);
+            lmodules.add(lmodule == null ? module : lmodule);
         }
         return lmodules;
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends Module> T createLocalizedModule(T module, String label, String description) {
+    private static <T extends Module> @Nullable T createLocalizedModule(T module, @Nullable String label,
+            @Nullable String description) {
         if (module instanceof Action) {
             return (T) createLocalizedAction((Action) module, label, description);
         }
@@ -59,26 +65,28 @@ public class ModuleI18nUtil {
         return null;
     }
 
-    private static Trigger createLocalizedTrigger(Trigger module, String label, String description) {
+    private static Trigger createLocalizedTrigger(Trigger module, @Nullable String label,
+            @Nullable String description) {
         return ModuleBuilder.createTrigger(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Condition createLocalizedCondition(Condition module, String label, String description) {
+    private static Condition createLocalizedCondition(Condition module, @Nullable String label,
+            @Nullable String description) {
         return ModuleBuilder.createCondition(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Action createLocalizedAction(Action module, String label, String description) {
+    private static Action createLocalizedAction(Action module, @Nullable String label, @Nullable String description) {
         return ModuleBuilder.createAction(module).withLabel(label).withDescription(description).build();
     }
 
-    private static String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid, String moduleName,
-            String defaultLabel, String prefix, Locale locale) {
+    private static @Nullable String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultLabel, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleKey(prefix, uid, moduleName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
-            String moduleName, String defaultDescription, String prefix, Locale locale) {
+    private static @Nullable String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultDescription, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleKey(prefix, uid, moduleName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.type.Input;
@@ -29,25 +31,26 @@ import org.osgi.framework.Bundle;
  * @author Ana Dimova - Initial contribution
  * @author Yordan Mihaylov - updates related to api changes
  */
+@NonNullByDefault
 public class ModuleTypeI18nUtil {
 
     public static final String MODULE_TYPE = "module-type";
 
-    public static String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultLabel, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleTypeKey(moduleTypeUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultDescription, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleTypeKey(moduleTypeUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, List<Input> inputs, Bundle bundle,
-            String uid, Locale locale) {
+    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, @Nullable List<Input> inputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Input> linputs = new ArrayList<>();
         if (inputs != null) {
             for (Input input : inputs) {
@@ -63,8 +66,8 @@ public class ModuleTypeI18nUtil {
         return linputs;
     }
 
-    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, List<Output> outputs,
-            Bundle bundle, String uid, Locale locale) {
+    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, @Nullable List<Output> outputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Output> loutputs = new ArrayList<>();
         if (outputs != null) {
             for (Output output : outputs) {
@@ -80,27 +83,27 @@ public class ModuleTypeI18nUtil {
         return loutputs;
     }
 
-    private static String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
+            String inputName, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferInputKey(moduleTypeUID, inputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static String getInputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getInputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String inputName, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferInputKey(moduleTypeUID, inputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle, String ruleTemplateUID,
-            String outputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String ruleTemplateUID, String outputName, String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferOutputKey(ruleTemplateUID, outputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String outputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String outputName, String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferOutputKey(moduleTypeUID, outputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/template/RuleTemplateRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/template/RuleTemplateRegistry.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.openhab.core.automation.template.RuleTemplate;
@@ -35,6 +37,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Yordan Mihaylov - Initial contribution
  * @author Ana Dimova - TemplateRegistry extends AbstractRegistry
  */
+@NonNullByDefault
 @Component(service = { TemplateRegistry.class, RuleTemplateRegistry.class }, immediate = true)
 public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String, RuleTemplateProvider>
         implements TemplateRegistry<RuleTemplate> {
@@ -51,19 +54,19 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     }
 
     @Override
-    public RuleTemplate get(String templateUID) {
+    public @Nullable RuleTemplate get(String templateUID) {
         return get(templateUID, null);
     }
 
     @Override
-    public RuleTemplate get(String templateUID, Locale locale) {
+    public @Nullable RuleTemplate get(String templateUID, @Nullable Locale locale) {
         Entry<Provider<RuleTemplate>, RuleTemplate> prt = getValueAndProvider(templateUID);
         if (prt == null) {
             return null;
         } else {
             RuleTemplate t = locale == null ? prt.getValue()
                     : ((RuleTemplateProvider) prt.getKey()).getTemplate(templateUID, locale);
-            return createCopy(t);
+            return t != null ? createCopy(t) : null;
         }
     }
 
@@ -75,18 +78,18 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     }
 
     @Override
-    public Collection<RuleTemplate> getByTag(String tag) {
+    public Collection<RuleTemplate> getByTag(@Nullable String tag) {
         return getByTag(tag, null);
     }
 
     @Override
-    public Collection<RuleTemplate> getByTag(String tag, Locale locale) {
+    public Collection<RuleTemplate> getByTag(@Nullable String tag, @Nullable Locale locale) {
         Collection<RuleTemplate> result = new ArrayList<>();
         forEach((provider, resultTemplate) -> {
             Collection<String> tags = resultTemplate.getTags();
             RuleTemplate t = locale == null ? resultTemplate
                     : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
-            if (tag == null || tags.contains(tag)) {
+            if (t != null && (tag == null || tags.contains(tag))) {
                 result.add(t);
             }
         });
@@ -99,14 +102,14 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     }
 
     @Override
-    public Collection<RuleTemplate> getByTags(Locale locale, String... tags) {
-        Set<String> tagSet = tags != null ? new HashSet<>(Arrays.asList(tags)) : null;
+    public Collection<RuleTemplate> getByTags(@Nullable Locale locale, String... tags) {
+        Set<String> tagSet = new HashSet<>(Arrays.asList(tags));
         Collection<RuleTemplate> result = new ArrayList<>();
         forEach((provider, resultTemplate) -> {
             Collection<String> tTags = resultTemplate.getTags();
             RuleTemplate t = locale == null ? resultTemplate
                     : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
-            if (tTags.containsAll(tagSet)) {
+            if (t != null && tTags.containsAll(tagSet)) {
                 result.add(t);
             }
         });
@@ -114,7 +117,7 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     }
 
     @Override
-    public Collection<RuleTemplate> getAll(Locale locale) {
+    public Collection<RuleTemplate> getAll(@Nullable Locale locale) {
         return getByTag(null, locale);
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.module.provider.i18n;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.type.ModuleType;
 import org.osgi.framework.Bundle;
 
@@ -22,6 +24,7 @@ import org.osgi.framework.Bundle;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 public interface ModuleTypeI18nService {
 
     /**
@@ -32,6 +35,7 @@ public interface ModuleTypeI18nService {
      * @param bundle the bundle containing the localization files
      * @return the localized ModuleType
      */
-    ModuleType getModuleTypePerLocale(ModuleType defModuleType, Locale locale, Bundle bundle);
+    @Nullable
+    ModuleType getModuleTypePerLocale(@Nullable ModuleType defModuleType, @Nullable Locale locale, Bundle bundle);
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
@@ -16,11 +16,14 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This interface provides opportunity to plug different parsers, for example JSON, GSON or other.
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public interface Parser<T> {
 
     /**
@@ -65,7 +68,7 @@ public interface Parser<T> {
      * @param reader {@link InputStreamReader} which reads from a file containing automation object representations.
      * @return a set of automation objects. Each object represents the result of parsing of one object.
      * @throws ParsingException is thrown when json format is wrong or there is a semantic error in description of
-     *                          the automation objects.
+     *             the automation objects.
      */
     public Set<T> parse(InputStreamReader reader) throws ParsingException;
 
@@ -73,9 +76,9 @@ public interface Parser<T> {
      * Records the automation objects in a file with some particular format.
      *
      * @param dataObjects provides an objects for export.
-     * @param writer      is {@link OutputStreamWriter} used to write the automation objects in a file.
+     * @param writer is {@link OutputStreamWriter} used to write the automation objects in a file.
      * @throws Exception is thrown when I/O operation has failed or has been interrupted or generating of the text fails
-     *                   for some reasons.
+     *             for some reasons.
      */
     public void serialize(Set<T> dataObjects, OutputStreamWriter writer) throws Exception;
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplateProvider.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.template;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 
@@ -29,6 +30,7 @@ import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public interface RuleTemplateProvider extends TemplateProvider<RuleTemplate> {
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
@@ -15,6 +15,8 @@ package org.openhab.core.automation.template;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Provider;
 
 /**
@@ -25,29 +27,31 @@ import org.eclipse.smarthome.core.common.registry.Provider;
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  * @author Ana Dimova - add registration property - rule.templates
  */
+@NonNullByDefault
 public interface TemplateProvider<E extends Template> extends Provider<E> {
 
     /**
      * Gets the localized Templates defined by this provider. When the localization is not specified or it is not
      * supported a Template localized with default locale is returned.
      *
-     * @param UID    unique identifier of the desired Template.
+     * @param UID unique identifier of the desired Template.
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned element. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               element is returned with the default localization.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            element is returned with the default localization.
      * @return the desired localized Template.
      */
-    E getTemplate(String UID, Locale locale);
+    @Nullable
+    E getTemplate(String UID, @Nullable Locale locale);
 
     /**
      * Gets the localized Templates defined by this provider. When localization is not specified or it is not supported
      * a Templates with default localization is returned.
      *
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned elements. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               elements are returned with the default localization.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            elements are returned with the default localization.
      * @return a collection of localized {@link Template}s provided by this provider.
      */
-    Collection<E> getTemplates(Locale locale);
+    Collection<E> getTemplates(@Nullable Locale locale);
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
@@ -15,6 +15,8 @@ package org.openhab.core.automation.template;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Registry;
 
 /**
@@ -26,19 +28,20 @@ import org.eclipse.smarthome.core.common.registry.Registry;
  * @author Ana Dimova - Initial contribution
  * @author Vasil Ilchev - Initial contribution
  */
+@NonNullByDefault
 public interface TemplateRegistry<E extends Template> extends Registry<E, String> {
 
     /**
      * Gets a template specified by unique identifier.
      *
-     * @param uid    the unique identifier in scope of registered templates.
+     * @param uid the unique identifier in scope of registered templates.
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned element. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               element is returned with the default localization.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            element is returned with the default localization.
      * @return the desired template instance or {@code null} if a template with such UID does not exist or the passed
      *         UID is {@code null}.
      */
-    public E get(String uid, Locale locale);
+    public @Nullable E get(String uid, @Nullable Locale locale);
 
     /**
      * Gets the templates filtered by tag.
@@ -47,25 +50,25 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            {@code null} then the result will contain all available templates.
      * @return a collection of templates, which correspond to the specified tag.
      */
-    public Collection<E> getByTag(String tag);
+    public Collection<E> getByTag(@Nullable String tag);
 
     /**
      * Gets the templates filtered by tag.
      *
-     * @param tag    determines the tag that the templates must have, to be included in the returned result. If it is
-     *               {@code null} then the result will contain all available templates.
+     * @param tag determines the tag that the templates must have, to be included in the returned result. If it is
+     *            {@code null} then the result will contain all available templates.
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned elements. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               elements are returned with the default localization.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            elements are returned with the default localization.
      * @return a collection of localized templates, which correspond to the specified tag.
      */
-    public Collection<E> getByTag(String tag, Locale locale);
+    public Collection<E> getByTag(@Nullable String tag, @Nullable Locale locale);
 
     /**
      * Gets the templates filtered by tags.
      *
      * @param tags determines the set of tags that the templates must have, to be included in the returned result. If it
-     *             is {@code null} then the result will contain all templates.
+     *            is {@code null} then the result will contain all templates.
      * @return a collection of templates, which correspond to the specified set of tags.
      */
     public Collection<E> getByTags(String... tags);
@@ -74,22 +77,22 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      * Gets the templates filtered by tags.
      *
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned elements. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               elements are returned with the default localization.
-     * @param tags   determines the set of tags that the templates must have, to be included in the returned result. If
-     *               it is {@code null} then the result will contain all templates.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            elements are returned with the default localization.
+     * @param tags determines the set of tags that the templates must have, to be included in the returned result. If
+     *            it is {@code null} then the result will contain all templates.
      * @return the templates, which correspond to the specified set of tags.
      */
-    public Collection<E> getByTags(Locale locale, String... tags);
+    public Collection<E> getByTags(@Nullable Locale locale, String... tags);
 
     /**
      * Gets all available templates, localized by specified locale.
      *
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned elements. If
-     *               localization resources for this locale are not available or the passed locale is {@code null} the
-     *               elements are returned with the default localization.
+     *            localization resources for this locale are not available or the passed locale is {@code null} the
+     *            elements are returned with the default localization.
      * @return a collection of localized templates, corresponding to the parameterized type.
      */
-    public Collection<E> getAll(Locale locale);
+    public Collection<E> getAll(@Nullable Locale locale);
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
@@ -21,6 +21,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.thing.binding.ThingActions;
 import org.eclipse.smarthome.core.thing.binding.ThingActionsScope;
@@ -49,6 +51,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 @Component(service = { ModuleTypeProvider.class, ModuleHandlerFactory.class })
 public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFactory implements ModuleTypeProvider {
 
@@ -56,7 +59,7 @@ public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFac
     private final Map<String, Set<ModuleInformation>> moduleInformation = new ConcurrentHashMap<>();
     private final AnnotationActionModuleTypeHelper helper = new AnnotationActionModuleTypeHelper();
 
-    private ModuleTypeI18nService moduleTypeI18nService;
+    private @NonNullByDefault({}) ModuleTypeI18nService moduleTypeI18nService;
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
     public void addAnnotatedThingActions(ThingActions annotatedThingActions) {
@@ -155,13 +158,13 @@ public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFac
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
+    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
         return (T) localizeModuleType(UID, locale);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
+    public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
         List<T> result = new ArrayList<>();
         for (Entry<String, Set<ModuleInformation>> entry : moduleInformation.entrySet()) {
             ModuleType localizedModuleType = localizeModuleType(entry.getKey(), locale);
@@ -172,7 +175,7 @@ public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFac
         return result;
     }
 
-    private ModuleType localizeModuleType(String uid, Locale locale) {
+    private @Nullable ModuleType localizeModuleType(String uid, @Nullable Locale locale) {
         Set<ModuleInformation> mis = moduleInformation.get(uid);
         if (mis != null && !mis.isEmpty()) {
             ModuleInformation mi = mis.iterator().next();
@@ -187,7 +190,7 @@ public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFac
     }
 
     @Override
-    protected ModuleHandler internalCreate(Module module, String ruleUID) {
+    protected @Nullable ModuleHandler internalCreate(Module module, String ruleUID) {
         if (module instanceof Action) {
             Action actionModule = (Action) module;
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
@@ -15,6 +15,8 @@ package org.openhab.core.automation.type;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Provider;
 
 /**
@@ -25,27 +27,28 @@ import org.eclipse.smarthome.core.common.registry.Provider;
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  * @author Ana Dimova - add registration property - module.types
  */
+@NonNullByDefault
 public interface ModuleTypeProvider extends Provider<ModuleType> {
 
     /**
      * Gets the localized {@link ModuleType} defined by this provider. When the localization is not specified
      * or it is not supported a {@link ModuleType} with default locale is returned.
      *
-     * @param UID    unique identifier of the {@link ModuleType}.
+     * @param UID unique identifier of the {@link ModuleType}.
      * @param locale defines localization of label and description of the {@link ModuleType} or null.
-     * @param        <T> the type of the required object.
+     * @param <T> the type of the required object.
      * @return localized module type.
      */
-    <T extends ModuleType> T getModuleType(String UID, Locale locale);
+    <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale);
 
     /**
      * Gets the localized {@link ModuleType}s defined by this provider. When localization is not specified or
      * it is not supported the {@link ModuleType}s with default localization is returned.
      *
      * @param locale defines localization of label and description of the {@link ModuleType}s or null.
-     * @param        <T> the type of the required object.
+     * @param <T> the type of the required object.
      * @return collection of localized {@link ModuleType} provided by this provider.
      */
-    <T extends ModuleType> Collection<T> getModuleTypes(Locale locale);
+    <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale);
 
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
@@ -15,6 +15,8 @@ package org.openhab.core.automation.type;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Registry;
 
 /**
@@ -26,46 +28,47 @@ import org.eclipse.smarthome.core.common.registry.Registry;
  * @author Ana Dimova - Initial contribution
  * @author Vasil Ilchev - Initial contribution
  */
+@NonNullByDefault
 public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
 
     /**
      * Gets the localized {@link ModuleType} by specified UID and locale.
      *
      * @param moduleTypeUID the an unique id in scope of registered {@link ModuleType}s.
-     * @param locale        used for localization of the {@link ModuleType}.
-     * @param               <T> the type of the required object.
+     * @param locale used for localization of the {@link ModuleType}.
+     * @param <T> the type of the required object.
      * @return the desired {@link ModuleType} instance or {@code null} if a module type with such UID does not exist or
      *         the passed UID is {@code null}.
      */
-    public <T extends ModuleType> T get(String moduleTypeUID, Locale locale);
+    public <T extends ModuleType> @Nullable T get(String moduleTypeUID, @Nullable Locale locale);
 
     /**
      * Gets the {@link ModuleType}s filtered by tag.
      *
      * @param moduleTypeTag specifies the filter for getting the {@link ModuleType}s, if it is {@code null} then returns
-     *                      all {@link ModuleType}s.
-     * @param               <T> the type of the required object.
+     *            all {@link ModuleType}s.
+     * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the specified filter.
      */
-    public <T extends ModuleType> Collection<T> getByTag(String moduleTypeTag);
+    public <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag);
 
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tag.
      *
      * @param moduleTypeTag specifies the filter for getting the {@link ModuleType}s, if it is {@code null} then returns
-     *                      all {@link ModuleType}s.
-     * @param locale        used for localization of the {@link ModuleType}.
-     * @param               <T> the type of the required object.
+     *            all {@link ModuleType}s.
+     * @param locale used for localization of the {@link ModuleType}.
+     * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the specified filter.
      */
-    public <T extends ModuleType> Collection<T> getByTag(String moduleTypeTag, Locale locale);
+    public <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag, @Nullable Locale locale);
 
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tags.
      *
      * @param tags specifies the filter for getting the {@link ModuleType}s, if it is {@code null} then returns all
-     *             {@link ModuleType}s.
-     * @param      <T> the type of the required object.
+     *            {@link ModuleType}s.
+     * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the filter.
      */
     public <T extends ModuleType> Collection<T> getByTags(String... tags);
@@ -73,20 +76,20 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tags.
      *
-     * @param locale        used for localization of the {@link ModuleType}.
+     * @param locale used for localization of the {@link ModuleType}.
      * @param moduleTypeTag specifies the filter for getting the {@link ModuleType}s, if it is {@code null} then returns
-     *                      all {@link ModuleType}s.
-     * @param               <T> the type of the required object.
+     *            all {@link ModuleType}s.
+     * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the filter.
      */
-    public <T extends ModuleType> Collection<T> getByTags(Locale locale, String... tags);
+    public <T extends ModuleType> Collection<T> getByTags(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link TriggerType}s. The returned {@link TriggerType}s are
      * localized by default locale.
      *
      * @param tags specifies the filter for getting the {@link TriggerType}s, if it is {@code null} then returns all
-     *             {@link TriggerType}s.
+     *            {@link TriggerType}s.
      * @return collection of all available {@link TriggerType}s, localized by default locale.
      */
     public Collection<TriggerType> getTriggers(String... tags);
@@ -97,19 +100,19 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * {@link TriggerType}s are localized by default locale.
      *
      * @param locale defines the localization of returned {@link TriggerType}s.
-     * @param tags   specifies the filter for getting the {@link TriggerType}s, if it is {@code null} then returns all
-     *               {@link TriggerType}s.
+     * @param tags specifies the filter for getting the {@link TriggerType}s, if it is {@code null} then returns all
+     *            {@link TriggerType}s.
      * @return a collection of all available {@link TriggerType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<TriggerType> getTriggers(Locale locale, String... tags);
+    public Collection<TriggerType> getTriggers(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link ConditionType}s. The returned {@link ConditionType}s are
      * localized by default locale.
      *
      * @param tags specifies the filter for getting the {@link ConditionType}s, if it is {@code null} then returns all
-     *             {@link ConditionType}s.
+     *            {@link ConditionType}s.
      * @return collection of all available {@link ConditionType}s, localized by default locale.
      */
     public Collection<ConditionType> getConditions(String... tags);
@@ -120,19 +123,19 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * returned {@link ConditionType}s are localized by default locale.
      *
      * @param locale defines the localization of returned {@link ConditionType}s.
-     * @param tags   specifies the filter for getting the {@link ConditionType}s, if it is {@code null} then returns all
-     *               {@link ConditionType}s.
+     * @param tags specifies the filter for getting the {@link ConditionType}s, if it is {@code null} then returns all
+     *            {@link ConditionType}s.
      * @return a collection of all available {@link ConditionType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<ConditionType> getConditions(Locale locale, String... tags);
+    public Collection<ConditionType> getConditions(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link ActionType}s. The returned {@link ActionType}s are
      * localized by default locale.
      *
      * @param tags specifies the filter for getting the {@link ActionType}s, if it is {@code null} then returns all
-     *             {@link ActionType}s.
+     *            {@link ActionType}s.
      * @return collection of all available {@link ActionType}s, localized by default locale.
      */
     public Collection<ActionType> getActions(String... tags);
@@ -143,11 +146,11 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * {@link ActionType}s are localized by default locale.
      *
      * @param locale defines the localization of returned {@link ActionType}s.
-     * @param tags   specifies the filter for getting the {@link ActionType}s, if it is {@code null} then returns all
-     *               {@link ActionType}s.
+     * @param tags specifies the filter for getting the {@link ActionType}s, if it is {@code null} then returns all
+     *            {@link ActionType}s.
      * @return a collection of all available {@link ActionType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<ActionType> getActions(Locale locale, String... tags);
+    public Collection<ActionType> getActions(@Nullable Locale locale, String... tags);
 
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionI18nUtil.java
@@ -16,6 +16,8 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.osgi.framework.Bundle;
@@ -30,6 +32,7 @@ import org.osgi.framework.FrameworkUtil;
  * @author Alex Tugarev - Extended for pattern and option label
  * @author Thomas Höfer - Extended for unit label
  */
+@NonNullByDefault
 public class ConfigDescriptionI18nUtil {
 
     private final TranslationProvider i18nProvider;
@@ -40,29 +43,29 @@ public class ConfigDescriptionI18nUtil {
         this.i18nProvider = i18nProvider;
     }
 
-    public String getParameterPattern(Bundle bundle, URI configDescriptionURI, String parameterName,
-            String defaultPattern, Locale locale) {
+    public @Nullable String getParameterPattern(Bundle bundle, URI configDescriptionURI, String parameterName,
+            @Nullable String defaultPattern, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultPattern,
                 () -> inferKey(configDescriptionURI, parameterName, "pattern"));
         return i18nProvider.getText(bundle, key, defaultPattern, locale);
     }
 
-    public String getParameterDescription(Bundle bundle, URI configDescriptionURI, String parameterName,
-            String defaultDescription, Locale locale) {
+    public @Nullable String getParameterDescription(Bundle bundle, URI configDescriptionURI, String parameterName,
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferKey(configDescriptionURI, parameterName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public String getParameterLabel(Bundle bundle, URI configDescriptionURI, String parameterName, String defaultLabel,
-            Locale locale) {
+    public @Nullable String getParameterLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel,
                 () -> inferKey(configDescriptionURI, parameterName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public String getParameterOptionLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
-            String optionValue, String defaultOptionLabel, Locale locale) {
+    public @Nullable String getParameterOptionLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
+            @Nullable String optionValue, @Nullable String defaultOptionLabel, @Nullable Locale locale) {
         if (!isValidPropertyKey(optionValue)) {
             return defaultOptionLabel;
         }
@@ -73,8 +76,8 @@ public class ConfigDescriptionI18nUtil {
         return i18nProvider.getText(bundle, key, defaultOptionLabel, locale);
     }
 
-    public String getParameterUnitLabel(Bundle bundle, URI configDescriptionURI, String parameterName, String unit,
-            String defaultUnitLabel, Locale locale) {
+    public @Nullable String getParameterUnitLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
+            @Nullable String unit, @Nullable String defaultUnitLabel, @Nullable Locale locale) {
         if (unit != null && defaultUnitLabel == null) {
             String label = i18nProvider.getText(FrameworkUtil.getBundle(this.getClass()), "unit." + unit, null, locale);
             if (label != null) {
@@ -91,7 +94,7 @@ public class ConfigDescriptionI18nUtil {
         return configDescriptionURI.getScheme() + ".config." + uri + "." + parameterName + "." + lastSegment;
     }
 
-    private boolean isValidPropertyKey(String key) {
+    private boolean isValidPropertyKey(@Nullable String key) {
         if (key != null) {
             return !DELIMITER.matcher(key).find();
         }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -17,6 +17,7 @@ import static org.eclipse.smarthome.config.discovery.inbox.InboxPredicates.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
@@ -155,11 +156,10 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         if (autoIgnore) {
             String value = getRepresentationValue(result);
             if (value != null) {
-                Thing thing = thingRegistry.stream()
+                Optional<Thing> thing = thingRegistry.stream()
                         .filter(t -> Objects.equals(value, getRepresentationPropertyValueForThing(t)))
-                        .filter(t -> Objects.equals(t.getThingTypeUID(), result.getThingTypeUID())).findFirst()
-                        .orElse(null);
-                if (thing != null) {
+                        .filter(t -> Objects.equals(t.getThingTypeUID(), result.getThingTypeUID())).findFirst();
+                if (thing.isPresent()) {
                     logger.debug("Auto-ignoring the inbox entry for the representation value {}", value);
                     inbox.setFlag(result.getThingUID(), DiscoveryResultFlag.IGNORED);
                 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingRegistry.java
@@ -14,7 +14,7 @@ package org.eclipse.smarthome.core.thing;
 
 import java.util.Map;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.thing.internal.ThingTracker;
  * @author Oliver Libutzki - Extracted ManagedThingProvider
  * @auther Thomas Höfer - Added config description validation exception to updateConfiguration operation
  */
+@NonNullByDefault
 public interface ThingRegistry extends Registry<Thing, ThingUID> {
 
     /**
@@ -40,6 +41,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @return thing for a given UID or null if no thing was found
      */
     @Override
+    @Nullable
     Thing get(ThingUID uid);
 
     /**
@@ -49,7 +51,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @return channel for the given channel UID or null of no channel was found
      */
     @Nullable
-    Channel getChannel(@NonNull ChannelUID channelUID);
+    Channel getChannel(ChannelUID channelUID);
 
     /**
      * Updates the configuration of a thing for the given UID.
@@ -61,7 +63,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @throws IllegalArgumentException if no thing with the given UID exists
      * @throws IllegalStateException if no handler is attached to the thing
      */
-    void updateConfiguration(@NonNull ThingUID thingUID, Map<@NonNull String, Object> configurationParameters);
+    void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters);
 
     /**
      * Initiates the removal process for the {@link Thing} specified by the given {@link ThingUID}.
@@ -77,6 +79,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @return the {@link Thing} that was removed, or null if no {@link Thing} with the given {@link ThingUID} exists
      */
     @Override
+    @Nullable
     Thing remove(ThingUID thingUID);
 
     /**
@@ -89,7 +92,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @return the {@link Thing} that was removed, or null if no {@link Thing} with the given {@link ThingUID} exists
      */
     @Nullable
-    Thing forceRemove(@NonNull ThingUID thingUID);
+    Thing forceRemove(ThingUID thingUID);
 
     /**
      * Creates a thing based on the given configuration properties
@@ -97,11 +100,12 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @param thingTypeUID thing type unique id
      * @param thingUID thing unique id which should be created. This id might be
      *            null.
-     * @param bridge the thing's bridge. Null if there is no bridge or if the thing
+     * @param bridgeUID the thing's bridge. Null if there is no bridge or if the thing
      *            is a bridge by itself.
      * @param configuration the configuration
      * @return the created thing
      */
-    Thing createThingOfType(@NonNull ThingTypeUID thingTypeUID, ThingUID thingUIDObject, ThingUID bridgeUID,
-            String label, Configuration configuration);
+    @Nullable
+    Thing createThingOfType(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID, @Nullable ThingUID bridgeUID,
+            @Nullable String label, Configuration configuration);
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -262,7 +262,13 @@ public class ThingManagerImpl
                     } else {
                         logger.debug("Only updating thing {} in the registry because provider {} is not managed.",
                                 thing.getUID().getAsString(), provider);
-                        thingRegistry.updated(provider, thingRegistry.get(thing.getUID()), thing);
+                        Thing oldThing = thingRegistry.get(thing.getUID());
+                        if (oldThing == null) {
+                            throw new IllegalArgumentException(MessageFormat.format(
+                                    "Cannot update thing {0} because it is not known to the registry",
+                                    thing.getUID().getAsString()));
+                        }
+                        thingRegistry.updated(provider, oldThing, thing);
                     }
                     return null;
                 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -16,7 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.events.EventPublisher;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author Chris Jackson - ensure thing added event is sent before linked events
  * @auther Thomas Höfer - Added config description validation exception to updateConfiguration operation
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingProvider> implements ThingRegistry {
 
@@ -73,7 +75,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     @Override
-    public Channel getChannel(ChannelUID channelUID) {
+    public @Nullable Channel getChannel(ChannelUID channelUID) {
         ThingUID thingUID = channelUID.getThingUID();
         Thing thing = get(thingUID);
         if (thing != null) {
@@ -83,7 +85,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     @Override
-    public void updateConfiguration(ThingUID thingUID, Map<@NonNull String, Object> configurationParameters) {
+    public void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters) {
         Thing thing = get(thingUID);
         if (thing != null) {
             ThingHandler thingHandler = thing.getHandler();
@@ -98,12 +100,12 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     @Override
-    public Thing forceRemove(ThingUID thingUID) {
+    public @Nullable Thing forceRemove(ThingUID thingUID) {
         return super.remove(thingUID);
     }
 
     @Override
-    public Thing remove(ThingUID thingUID) {
+    public @Nullable Thing remove(ThingUID thingUID) {
         Thing thing = get(thingUID);
         if (thing != null) {
             notifyTrackers(thing, ThingTrackerEvent.THING_REMOVING);
@@ -240,8 +242,8 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     @Override
-    public Thing createThingOfType(ThingTypeUID thingTypeUID, ThingUID thingUID, ThingUID bridgeUID, String label,
-            Configuration configuration) {
+    public @Nullable Thing createThingOfType(ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID,
+            @Nullable ThingUID bridgeUID, @Nullable String label, Configuration configuration) {
         logger.debug("Creating thing for type '{}'.", thingTypeUID);
         for (ThingHandlerFactory thingHandlerFactory : thingHandlerFactories) {
             if (thingHandlerFactory.supportsThingType(thingTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLink.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLink.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.thing.link;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Identifiable;
 import org.eclipse.smarthome.core.items.ItemUtil;
 import org.eclipse.smarthome.core.thing.UID;
@@ -21,6 +23,7 @@ import org.eclipse.smarthome.core.thing.UID;
  *
  * @author Dennis Nobel - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractLink implements Identifiable<String> {
 
     /**
@@ -34,7 +37,7 @@ public abstract class AbstractLink implements Identifiable<String> {
         return itemName + " -> " + uid.toString();
     }
 
-    private final String itemName;
+    private final @NonNullByDefault({}) String itemName;
 
     /**
      * Constructor.
@@ -52,7 +55,7 @@ public abstract class AbstractLink implements Identifiable<String> {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj instanceof AbstractLink) {
             AbstractLink link = (AbstractLink) obj;
             return this.getUID().equals(link.getUID());

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.thing.UID;
@@ -33,6 +34,7 @@ import org.eclipse.smarthome.core.thing.UID;
  *
  * @param <L> Concrete type of the abstract link
  */
+@NonNullByDefault
 public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Provider<L>>
         extends AbstractRegistry<L, String, P> {
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -15,7 +15,10 @@ package org.eclipse.smarthome.core.thing.link;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemRegistry;
@@ -39,6 +42,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Markus Rathgeb - Linked items returns only existing items
  * @author Markus Rathgeb - Rewrite collection handling to improve performance
  */
+@NonNullByDefault
 @Component(immediate = true, service = ItemChannelLinkRegistry.class)
 public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLink, ItemChannelLinkProvider> {
 
@@ -70,8 +74,8 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     }
 
     public Set<Item> getLinkedItems(final UID uid) {
-        return super.getLinkedItemNames(uid).parallelStream().map(itemName -> itemRegistry.get(itemName))
-                .filter(Objects::nonNull).collect(Collectors.toSet());
+        return ((Stream<@NonNull Item>) super.getLinkedItemNames(uid).parallelStream()
+                .map(itemName -> itemRegistry.get(itemName)).filter(Objects::nonNull)).collect(Collectors.toSet());
     }
 
     /**
@@ -81,9 +85,9 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
      * @return an unmodifiable set of bound things for the given item name
      */
     public Set<Thing> getBoundThings(final String itemName) {
-        return getBoundChannels(itemName).parallelStream()
-                .map(channelUID -> thingRegistry.get(channelUID.getThingUID())).filter(Objects::nonNull)
-                .collect(Collectors.toSet());
+        return ((Stream<@NonNull Thing>) getBoundChannels(itemName).parallelStream()
+                .map(channelUID -> thingRegistry.get(channelUID.getThingUID())).filter(Objects::nonNull))
+                        .collect(Collectors.toSet());
     }
 
     @Reference

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -33,7 +33,7 @@ import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.eclipse.smarthome.core.items.GroupItem;
@@ -105,6 +105,7 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Triller - Method to convert a state into something a sitemap entity can understand
  * @author Erdoan Hadzhiyusein - Adapted the class to work with the new DateTimeType
  */
+@NonNullByDefault
 @Component
 public class ItemUIRegistryImpl implements ItemUIRegistry {
 
@@ -123,9 +124,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     protected Set<ItemUIProvider> itemUIProviders = new HashSet<>();
 
-    protected ItemRegistry itemRegistry;
+    protected @Nullable ItemRegistry itemRegistry;
 
-    private ItemBuilderFactory itemBuilderFactory;
+    private @Nullable ItemBuilderFactory itemBuilderFactory;
 
     private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -160,7 +161,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public String getCategory(String itemName) {
+    public @Nullable String getCategory(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
             String currentCategory = provider.getCategory(itemName);
             if (currentCategory != null) {
@@ -193,7 +194,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public String getLabel(String itemName) {
+    public @Nullable String getLabel(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
             String currentLabel = provider.getLabel(itemName);
             if (currentLabel != null) {
@@ -212,7 +213,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Widget getWidget(String itemName) {
+    public @Nullable Widget getWidget(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
             Widget currentWidget = provider.getWidget(itemName);
             if (currentWidget != null) {
@@ -223,7 +224,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Widget getDefaultWidget(Class<? extends Item> targetItemType, String itemName) {
+    public @Nullable Widget getDefaultWidget(@Nullable Class<? extends Item> targetItemType, String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
             Widget widget = provider.getDefaultWidget(targetItemType, itemName);
             if (widget != null) {
@@ -310,7 +311,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public String getLabel(Widget w) {
+    public @Nullable String getLabel(Widget w) {
         String label = getLabelFromWidget(w);
 
         String itemName = w.getItem();
@@ -406,7 +407,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         }
 
                         // The widget may define its own unit in the widget label. Convert to this unit:
-                        quantityState = convertStateToWidgetUnit(quantityState, w);
+                        if (quantityState != null) {
+                            quantityState = convertStateToWidgetUnit(quantityState, w);
+                        }
                         state = quantityState;
                     } else if (state instanceof DateTimeType) {
                         // Translate a DateTimeType state to the local time zone
@@ -446,7 +449,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return transform(label, considerTransform, labelMappedOption);
     }
 
-    private QuantityType<?> convertStateToWidgetUnit(QuantityType<?> quantityState, @NonNull Widget w) {
+    private @Nullable QuantityType<?> convertStateToWidgetUnit(QuantityType<?> quantityState, Widget w) {
         Unit<?> widgetUnit = UnitUtils.parseUnit(getFormatPattern(w.getLabel()));
         if (widgetUnit != null && !widgetUnit.equals(quantityState.getUnit())) {
             return quantityState.toUnit(widgetUnit);
@@ -455,7 +458,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return quantityState;
     }
 
-    private String getFormatPattern(String label) {
+    private @Nullable String getFormatPattern(@Nullable String label) {
         if (label == null) {
             return null;
         }
@@ -518,7 +521,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
      * If the value does not start with the call to a transformation service,
      * we return the label with the mapped option value if provided (not null).
      */
-    private String transform(String label, boolean matchTransform, String labelMappedOption) {
+    private String transform(String label, boolean matchTransform, @Nullable String labelMappedOption) {
         String ret = label;
         String formatPattern = getFormatPattern(label);
         if (formatPattern != null) {
@@ -557,7 +560,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public String getCategory(Widget w) {
+    public @Nullable String getCategory(Widget w) {
         String widgetTypeName = w.eClass().getInstanceTypeName()
                 .substring(w.eClass().getInstanceTypeName().lastIndexOf(".") + 1);
 
@@ -581,7 +584,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public State getState(Widget w) {
+    public @Nullable State getState(Widget w) {
         String itemName = w.getItem();
         if (itemName != null) {
             try {
@@ -604,7 +607,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
      * @return the converted state or the original if conversion was not possible
      */
     @Override
-    public State convertState(Widget w, Item i, State state) {
+    public @Nullable State convertState(Widget w, Item i, State state) {
         State returnState = null;
 
         State itemState = i.getState();
@@ -637,7 +640,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Widget getWidget(Sitemap sitemap, String id) {
+    public @Nullable Widget getWidget(Sitemap sitemap, String id) {
         if (id.length() > 0) {
             // see if the id is an itemName and try to get the a widget for it
             Widget w = getWidget(id);
@@ -703,12 +706,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public EObject getParent(Widget w) {
+    public @Nullable EObject getParent(Widget w) {
         Widget w2 = defaultWidgets.get(w);
         return (w2 == null) ? w.eContainer() : w2.eContainer();
     }
 
-    private Widget resolveDefault(Widget widget) {
+    private @Nullable Widget resolveDefault(@Nullable Widget widget) {
         if (!(widget instanceof Default)) {
             return widget;
         } else {
@@ -800,7 +803,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return 0;
     }
 
-    private Class<? extends Item> getItemType(@NonNull String itemName) {
+    private @Nullable Class<? extends Item> getItemType(String itemName) {
         try {
             Item item = itemRegistry.getItem(itemName);
             return item.getClass();
@@ -810,7 +813,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public State getItemState(String itemName) {
+    public @Nullable State getItemState(String itemName) {
         try {
             Item item = itemRegistry.getItem(itemName);
             return item.getState();
@@ -819,7 +822,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    public String getItemCategory(@NonNull String itemName) {
+    public @Nullable String getItemCategory(String itemName) {
         try {
             Item item = itemRegistry.getItem(itemName);
             return item.getCategory();
@@ -1079,7 +1082,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return matched;
     }
 
-    private String processColorDefinition(State state, List<ColorArray> colorList) {
+    private @Nullable String processColorDefinition(@Nullable State state, List<ColorArray> colorList) {
         // Sanity check
         if (colorList == null) {
             return null;
@@ -1151,12 +1154,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public String getLabelColor(Widget w) {
+    public @Nullable String getLabelColor(Widget w) {
         return processColorDefinition(getState(w), w.getLabelColor());
     }
 
     @Override
-    public String getValueColor(Widget w) {
+    public @Nullable String getValueColor(Widget w) {
         return processColorDefinition(getState(w), w.getValueColor());
     }
 
@@ -1233,7 +1236,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             this.value = value;
         }
 
-        public static Condition fromString(String text) {
+        public static @Nullable Condition fromString(String text) {
             if (text != null) {
                 for (Condition c : Condition.values()) {
                     if (text.equalsIgnoreCase(c.value)) {
@@ -1286,7 +1289,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Item update(Item element) {
+    public @Nullable Item update(Item element) {
         if (itemRegistry != null) {
             return itemRegistry.update(element);
         } else {
@@ -1295,7 +1298,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Item remove(String key) {
+    public @Nullable Item remove(String key) {
         if (itemRegistry != null) {
             return itemRegistry.remove(key);
         } else {
@@ -1304,7 +1307,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Item get(String key) {
+    public @Nullable Item get(String key) {
         if (itemRegistry != null) {
             return itemRegistry.get(key);
         } else {
@@ -1313,13 +1316,12 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public Item remove(String itemName, boolean recursive) {
+    public @Nullable Item remove(String itemName, boolean recursive) {
         if (itemRegistry != null) {
             return itemRegistry.remove(itemName, recursive);
         } else {
             return null;
         }
-
     }
 
     @Override
@@ -1367,7 +1369,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return state;
     }
 
-    private String getUnitFromLabel(String label) {
+    private @Nullable String getUnitFromLabel(String label) {
         if (StringUtils.isBlank(label)) {
             return null;
         }

--- a/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/items/ItemUIProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/eclipse/smarthome/ui/items/ItemUIProvider.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.ui.items;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.model.sitemap.Widget;
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.model.sitemap.Widget;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public interface ItemUIProvider {
 
     /**
@@ -31,7 +32,7 @@ public interface ItemUIProvider {
      * @param itemName the name of the item to return the icon for
      * @return the name of the category to use or null if undefined.
      */
-    public @Nullable String getCategory(@NonNull String itemName);
+    public @Nullable String getCategory(String itemName);
 
     /**
      * Returns the label text to be used for an item in the UI.
@@ -39,7 +40,7 @@ public interface ItemUIProvider {
      * @param item the name of the item to return the label text for
      * @return the label text to be used in the UI or null if undefined.
      */
-    public @Nullable String getLabel(@NonNull String itemName);
+    public @Nullable String getLabel(String itemName);
 
     /**
      * Provides a default widget for a given item (class). This is used whenever
@@ -51,7 +52,7 @@ public interface ItemUIProvider {
      * @return a widget implementation that can be used for the given item or null, if no default is available for the
      *         type
      */
-    public @Nullable Widget getDefaultWidget(@Nullable Class<? extends Item> itemType, @NonNull String itemName);
+    public @Nullable Widget getDefaultWidget(@Nullable Class<? extends Item> itemType, String itemName);
 
     /**
      * <p>
@@ -65,5 +66,5 @@ public interface ItemUIProvider {
      * @param itemName the item name to get the widget for
      * @return a widget to use for the given item or <code>null</code> if sitemap should not be overridden.
      */
-    public @Nullable Widget getWidget(@NonNull String itemName);
+    public @Nullable Widget getWidget(String itemName);
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/Registry.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/common/registry/Registry.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.core.common.registry;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -28,6 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  * @param <E> type of the elements in the registry
  */
+@NonNullByDefault
 public interface Registry<E extends Identifiable<K>, K> {
 
     /**
@@ -35,15 +36,14 @@ public interface Registry<E extends Identifiable<K>, K> {
      *
      * @param listener registry change listener
      */
-    void addRegistryChangeListener(@NonNull RegistryChangeListener<E> listener);
+    void addRegistryChangeListener(RegistryChangeListener<E> listener);
 
     /**
      * Returns a collection of all elements in the registry.
      *
      * @return collection of all elements in the registry
      */
-    @NonNull
-    Collection<@NonNull E> getAll();
+    Collection<E> getAll();
 
     /**
      * Returns a stream of all elements in the registry.
@@ -65,7 +65,7 @@ public interface Registry<E extends Identifiable<K>, K> {
      *
      * @param listener registry change listener
      */
-    void removeRegistryChangeListener(@NonNull RegistryChangeListener<E> listener);
+    void removeRegistryChangeListener(RegistryChangeListener<E> listener);
 
     /**
      * Adds the given element to the according {@link ManagedProvider}.
@@ -74,7 +74,7 @@ public interface Registry<E extends Identifiable<K>, K> {
      * @return the added element or newly created object of the same type
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public @NonNull E add(@NonNull E element);
+    public E add(E element);
 
     /**
      * Updates the given element at the according {@link ManagedProvider}.
@@ -84,7 +84,7 @@ public interface Registry<E extends Identifiable<K>, K> {
      *         exists
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public @Nullable E update(@NonNull E element);
+    public @Nullable E update(E element);
 
     /**
      * Removes the given element from the according {@link ManagedProvider}.
@@ -94,5 +94,5 @@ public interface Registry<E extends Identifiable<K>, K> {
      *         key exists
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public @Nullable E remove(@NonNull K key);
+    public @Nullable E remove(K key);
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.events.EventPublisher;
@@ -57,17 +59,18 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  * @author Stefan Bußweiler - Migration to new event mechanism
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvider> implements ItemRegistry {
 
     private final Logger logger = LoggerFactory.getLogger(ItemRegistryImpl.class);
 
     private final List<RegistryHook<Item>> registryHooks = new CopyOnWriteArrayList<>();
-    private StateDescriptionService stateDescriptionService;
-    private CommandDescriptionService commandDescriptionService;
+    private @Nullable StateDescriptionService stateDescriptionService;
+    private @Nullable CommandDescriptionService commandDescriptionService;
     private final MetadataRegistry metadataRegistry;
-    private UnitProvider unitProvider;
-    private ItemStateConverter itemStateConverter;
+    private @Nullable UnitProvider unitProvider;
+    private @Nullable ItemStateConverter itemStateConverter;
 
     @Activate
     public ItemRegistryImpl(final @Reference MetadataRegistry metadataRegistry) {
@@ -353,7 +356,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     }
 
     @Override
-    public Item remove(String itemName, boolean recursive) {
+    public @Nullable Item remove(String itemName, boolean recursive) {
         return ((ManagedItemProvider) getManagedProvider()
                 .orElseThrow(() -> new IllegalStateException("ManagedProvider is not available"))).remove(itemName,
                         recursive);

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.internal.items;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.ManagedMetadataProvider;
@@ -33,6 +34,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, service = { MetadataRegistry.class })
 public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey, MetadataProvider>
         implements MetadataRegistry {

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.core.items;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Registry;
 import org.eclipse.smarthome.core.internal.items.ItemBuilderImpl;
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public interface ItemRegistry extends Registry<Item, String> {
 
     /**
@@ -41,7 +42,7 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @return the uniquely identified item
      * @throws ItemNotFoundException if no item matches the input
      */
-    public @NonNull Item getItem(String name) throws ItemNotFoundException;
+    public Item getItem(String name) throws ItemNotFoundException;
 
     /**
      * This method retrieves a single item from the registry.
@@ -52,68 +53,61 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @throws ItemNotFoundException if no item matches the input
      * @throws ItemNotUniqueException if multiply items match the input
      */
-    public @NonNull Item getItemByPattern(@NonNull String name) throws ItemNotFoundException, ItemNotUniqueException;
+    public Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException;
 
     /**
      * This method retrieves all items that are currently available in the registry
      *
      * @return a collection of all available items
      */
-    public @NonNull Collection<@NonNull Item> getItems();
+    public Collection<Item> getItems();
 
     /**
      * This method retrieves all items with the given type
      *
-     * @param type
-     *            - item type as defined by {@link ItemFactory}s
+     * @param type item type as defined by {@link ItemFactory}s
      * @return a collection of all items of the given type
      */
-    public @NonNull Collection<Item> getItemsOfType(@NonNull String type);
+    public Collection<Item> getItemsOfType(String type);
 
     /**
      * This method retrieves all items that match a given search pattern
      *
      * @return a collection of all items matching the search pattern
      */
-    public @NonNull Collection<@NonNull Item> getItems(@NonNull String pattern);
+    public Collection<Item> getItems(String pattern);
 
     /**
      * Returns list of items which contains all of the given tags.
      *
-     * @param tags
-     *            - array of tags to be present on the returned items.
+     * @param tags array of tags to be present on the returned items.
      * @return list of items which contains all of the given tags.
      */
-    public @NonNull Collection<Item> getItemsByTag(@NonNull String... tags);
+    public Collection<Item> getItemsByTag(String... tags);
 
     /**
      * Returns list of items with a certain type containing all of the given tags.
      *
-     * @param type
-     *            - item type as defined by {@link ItemFactory}s
-     * @param tags
-     *            - array of tags to be present on the returned items.
+     * @param type item type as defined by {@link ItemFactory}s
+     * @param tags array of tags to be present on the returned items.
      * @return list of items which contains all of the given tags.
      */
-    public @NonNull Collection<Item> getItemsByTagAndType(@NonNull String type, @NonNull String... tags);
+    public Collection<Item> getItemsByTagAndType(String type, String... tags);
 
     /**
      * Returns list of items which contains all of the given tags.
      *
-     * @param typeFilter
-     *            - subclass of {@link GenericItem} to filter the resulting list
-     *            for.
-     * @param tags
-     *            - array of tags to be present on the returned items.
+     * @param typeFilter subclass of {@link GenericItem} to filter the resulting list for.
+     * @param tags array of tags to be present on the returned items.
      * @return list of items which contains all of the given tags, which is
      *         filtered by the given type filter.
      */
-    public @NonNull <T extends Item> Collection<T> getItemsByTag(@NonNull Class<T> typeFilter, @NonNull String... tags);
+    public <T extends Item> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags);
 
     /**
      * @see ManagedItemProvider#remove(String, boolean)
      */
-    public @Nullable Item remove(@NonNull String itemName, boolean recursive);
+    public @Nullable Item remove(String itemName, boolean recursive);
 
     /**
      * Add a hook to be informed before adding/after removing items.

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
@@ -143,7 +143,7 @@ public class UnitUtils {
      * @return the unit symbol extracted from the string or {@code null} if no unit could be parsed
      *
      */
-    public static @Nullable Unit<?> parseUnit(String pattern) {
+    public static @Nullable Unit<?> parseUnit(@Nullable String pattern) {
         if (StringUtils.isBlank(pattern)) {
             return null;
         }

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -225,18 +225,19 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         // WAIT until Rule modules types are parsed and the rule becomes IDLE
         waitForAssert(() -> {
             assertThat(ruleRegistry.getAll().isEmpty(), is(false));
-            Rule rule2 = ruleRegistry.stream().filter(
+            Optional<Rule> rule2 = ruleRegistry.stream().filter(
                     RulePredicates.hasAnyOfTags("jsonTest").and(RulePredicates.hasAnyOfTags("references").negate()))
-                    .findFirst().orElse(null);
-            assertThat(rule2, is(notNullValue()));
-            RuleStatusInfo ruleStatus2 = ruleManager.getStatusInfo(rule2.getUID());
+                    .findFirst();
+            assertThat(rule2.isPresent(), is(true));
+            RuleStatusInfo ruleStatus2 = ruleManager.getStatusInfo(rule2.get().getUID());
             assertThat(ruleStatus2.getStatus(), is(RuleStatus.IDLE));
         }, 10000, 200);
 
-        Rule rule = ruleRegistry.stream()
+        Optional<Rule> optionalRule = ruleRegistry.stream()
                 .filter(RulePredicates.hasAnyOfTags("jsonTest").and(RulePredicates.hasAnyOfTags("references").negate()))
-                .findFirst().orElse(null);
-        assertThat(rule, is(notNullValue()));
+                .findFirst();
+        assertThat(optionalRule.isPresent(), is(true));
+        Rule rule = optionalRule.get();
         assertThat(rule.getName(), is("ItemSampleRule"));
         assertTrue(rule.getTags().contains("sample"));
         assertTrue(rule.getTags().contains("item"));
@@ -266,15 +267,16 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         // WAIT until Rule modules types are parsed and the rule becomes IDLE
         waitForAssert(() -> {
             assertThat(ruleRegistry.getAll().isEmpty(), is(false));
-            Rule rule2 = ruleRegistry.stream().filter(RulePredicates.hasAllTags("jsonTest", "references")).findFirst()
-                    .orElse(null);
-            assertThat(rule2, is(notNullValue()));
-            RuleStatusInfo ruleStatus2 = ruleManager.getStatusInfo(rule2.getUID());
+            Optional<Rule> rule2 = ruleRegistry.stream().filter(RulePredicates.hasAllTags("jsonTest", "references"))
+                    .findFirst();
+            assertThat(rule2.isPresent(), is(true));
+            RuleStatusInfo ruleStatus2 = ruleManager.getStatusInfo(rule2.get().getUID());
             assertThat(ruleStatus2.getStatus(), is(RuleStatus.IDLE));
         }, 10000, 200);
-        Rule rule = ruleRegistry.stream().filter(RulePredicates.hasAllTags("jsonTest", "references")).findFirst()
-                .orElse(null);
-        assertThat(rule, is(notNullValue()));
+        Optional<Rule> optionalRule = ruleRegistry.stream().filter(RulePredicates.hasAllTags("jsonTest", "references"))
+                .findFirst();
+        assertThat(optionalRule.isPresent(), is(true));
+        Rule rule = optionalRule.get();
         assertThat(rule.getName(), is("ItemSampleRuleWithReferences"));
         assertTrue(rule.getTags().contains("sample"));
         assertTrue(rule.getTags().contains("item"));
@@ -286,11 +288,6 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         assertThat(trigger.get().getTypeUID(), is("core.GenericEventTrigger"));
         assertThat(trigger.get().getConfiguration().get("eventTopic"), is("smarthome/items/*"));
         assertThat(trigger.get().getConfiguration().get("eventTypes"), is("ItemStateEvent"));
-        // def condition1 = rule.conditions.find{it.id.equals("ItemStateConditionID")} as Condition
-        // assertThat(condition1, is(notNullValue())
-        // assertThat(condition1.typeUID, is("core.GenericEventCondition")
-        // assertThat(condition1.configuration.get("topic"), is("smarthome/items/myMotionItem/state")
-        // assertThat(condition1.configuration.get("payload"), is(".*ON.*")
         Optional<? extends Action> action = rule.getActions().stream()
                 .filter(a -> a.getId().equals("ItemPostCommandActionID")).findFirst();
         assertThat(action.isPresent(), is(true));

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -85,27 +85,28 @@ import org.slf4j.LoggerFactory;
  * @author Benedikt Niehues - Initial contribution
  * @author Marin Mitev - various fixes and extracted JSON parser test to separate file
  */
+@NonNullByDefault
 public class AutomationIntegrationTest extends JavaOSGiTest {
 
     private final Logger logger = LoggerFactory.getLogger(AutomationIntegrationTest.class);
-    private EventPublisher eventPublisher;
-    private ItemRegistry itemRegistry;
-    private RuleRegistry ruleRegistry;
-    private RuleManager ruleEngine;
-    private ManagedRuleProvider managedRuleProvider;
-    private ModuleTypeRegistry moduleTypeRegistry;
-    private TemplateRegistry<RuleTemplate> templateRegistry;
+    private @Nullable EventPublisher eventPublisher;
+    private @Nullable ItemRegistry itemRegistry;
+    private @Nullable RuleRegistry ruleRegistry;
+    private @Nullable RuleManager ruleEngine;
+    private @Nullable ManagedRuleProvider managedRuleProvider;
+    private @Nullable ModuleTypeRegistry moduleTypeRegistry;
+    private @Nullable TemplateRegistry<RuleTemplate> templateRegistry;
 
-    Event ruleEvent = null;
-    Event itemEvent = null;
+    private @Nullable Event ruleEvent;
+    private @Nullable Event itemEvent;
 
     @Before
     public void before() {
         logger.info("@Before.begin");
 
         getService(ItemRegistry.class);
+        
         ItemProvider itemProvider = new ItemProvider() {
-
             @Override
             public void addProviderChangeListener(ProviderChangeListener<Item> listener) {
             }
@@ -179,9 +180,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     public void assertThatARuleCanBeAddedUpdatedAndRemovedByTheApi() {
         logger.info("assert that a rule can be added, updated and removed by the api");
 
-        @NonNullByDefault
         EventSubscriber ruleEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Stream.of(RuleAddedEvent.TYPE, RuleRemovedEvent.TYPE, RuleUpdatedEvent.TYPE).collect(toSet());
@@ -283,9 +282,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
         List<RuleStatusInfoEvent> ruleEvents = new CopyOnWriteArrayList<>();
 
-        @NonNullByDefault
         EventSubscriber ruleEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(RuleStatusInfoEvent.TYPE);
@@ -392,9 +389,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         EventPublisher eventPublisher = getService(EventPublisher.class);
         eventPublisher.post(ItemEventFactory.createStateEvent("myPresenceItem3", OnOffType.ON));
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);
@@ -461,9 +456,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
         Item myLampItem3 = itemRegistry.getItem("myLampItem3");
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);
@@ -519,9 +512,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             assertThat(ruleEngine.getStatusInfo(rule.getUID()).getStatus(), is(RuleStatus.IDLE));
         }, 3000, 100);
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);
@@ -607,7 +598,6 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         // prepare the presenceItems state to be on to match the second condition of the rule
         eventPublisher.post(ItemEventFactory.createStateEvent("myPresenceItem4", OnOffType.ON));
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
             @Override
             public Set<String> getSubscribedEventTypes() {
@@ -671,7 +661,6 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         logger.info("assert that a rule can be added by a ruleProvider");
         Rule rule = createSimpleRule();
 
-        @NonNullByDefault
         RuleProvider ruleProvider = new RuleProvider() {
             @Override
             public void addProviderChangeListener(ProviderChangeListener<Rule> listener) {
@@ -723,9 +712,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         ruleRegistry.add(templateRule);
         assertThat(ruleRegistry.get(templateRule.getUID()), is(notNullValue()));
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);
@@ -784,9 +771,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             assertThat(ruleEngine.getStatus(templateRule.getUID()), is(RuleStatus.IDLE));
         });
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);
@@ -839,9 +824,8 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         ActionType actionType = new ActionType(actionTypeUID, templateConfigDescriptionParameters, null);
 
         RuleTemplateProvider templateProvider = new RuleTemplateProvider() {
-
             @Override
-            public RuleTemplate getTemplate(String UID, Locale locale) {
+            public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
                 if (UID == templateUID) {
                     return template;
                 } else {
@@ -850,7 +834,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             }
 
             @Override
-            public Collection<RuleTemplate> getTemplates(Locale locale) {
+            public Collection<RuleTemplate> getTemplates(@Nullable Locale locale) {
                 return Collections.singleton(template);
             }
 
@@ -869,7 +853,6 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         };
 
         ModuleTypeProvider moduleTypeProvider = new ModuleTypeProvider() {
-
             @Override
             public void addProviderChangeListener(ProviderChangeListener<ModuleType> listener) {
             }
@@ -884,7 +867,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             }
 
             @Override
-            public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
+            public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
                 if (UID == triggerTypeUID) {
                     return (T) triggerType;
                 } else if (UID == actionTypeUID) {
@@ -895,7 +878,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             }
 
             @Override
-            public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
+            public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
                 return (Collection<T>) Stream.of(triggerType, actionType).collect(toSet());
             }
         };
@@ -1005,9 +988,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         SwitchItem myMotionItem = (SwitchItem) itemRegistry.getItem("myPresenceItem5");
         myMotionItem.setState(OnOffType.ON);
 
-        @NonNullByDefault
         EventSubscriber itemEventHandler = new EventSubscriber() {
-
             @Override
             public Set<String> getSubscribedEventTypes() {
                 return Collections.singleton(ItemCommandEvent.TYPE);

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
@@ -17,13 +17,15 @@ import static java.util.stream.Collectors.toSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.openhab.core.automation.type.ActionType;
 import org.openhab.core.automation.type.ConditionType;
@@ -39,6 +41,7 @@ import org.openhab.core.automation.type.TriggerType;
  *
  * @author Yordan Mihaylov - Initial contribution
  */
+@NonNullByDefault
 public class TestModuleTypeProvider implements ModuleTypeProvider {
 
     public static final String TRIGGER_TYPE = "triggerTypeUID";
@@ -92,26 +95,26 @@ public class TestModuleTypeProvider implements ModuleTypeProvider {
     }
 
     @Override
-    public void addProviderChangeListener(@NonNull ProviderChangeListener<ModuleType> listener) {
+    public void addProviderChangeListener(ProviderChangeListener<ModuleType> listener) {
     }
 
     @Override
-    public @NonNull Collection<ModuleType> getAll() {
+    public Collection<ModuleType> getAll() {
         return Stream.of(createTriggerType(), createConditionType(), createActionType()).collect(toSet());
     }
 
     @Override
-    public void removeProviderChangeListener(@NonNull ProviderChangeListener<ModuleType> listener) {
+    public void removeProviderChangeListener(ProviderChangeListener<ModuleType> listener) {
     }
 
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, Locale locale) {
+    public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
         return null;
     }
 
     @Override
-    public <T extends ModuleType> Collection<T> getModuleTypes(Locale locale) {
-        return null;
+    public <T extends ModuleType> Collection<T> getModuleTypes(@Nullable Locale locale) {
+        return Collections.emptyList();
     }
 
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -583,7 +584,10 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
 
         managedThingProvider.add(thing);
 
-        thingRegistry.updateConfiguration(thingUID, singletonMap("parameter", null));
+        Map<String, Object> configuration = new HashMap<>();
+        configuration.put("parameter", null);
+
+        thingRegistry.updateConfiguration(thingUID, singletonMap("parameter", configuration));
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.java
@@ -160,7 +160,11 @@ public class ThingLinkManagerOSGiTest extends JavaOSGiTest {
         ThingUID thingUID = new ThingUID("hue:lamp:lamp1");
         Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), thingUID, null, "test thing",
                 new Configuration());
-        managedThingProvider.add(thing);
+        if (thing != null) {
+            managedThingProvider.add(thing);
+        } else {
+            throw new AssertionError("thing is null");
+        }
 
         ChannelUID channelUID = new ChannelUID(thingUID, "1");
 

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/SinkStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/eclipse/smarthome/core/voice/internal/SinkStub.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioSink;
 import org.eclipse.smarthome.core.audio.AudioStream;
@@ -33,10 +35,10 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * @author Velin Yordanov - migrated from groovy to java
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  */
+@NonNullByDefault
 public class SinkStub implements AudioSink {
 
     private boolean isStreamProcessed;
-    private PercentType volume;
     private static final Set<AudioFormat> SUPPORTED_AUDIO_FORMATS = Collections
             .unmodifiableSet(Stream.of(AudioFormat.MP3, AudioFormat.WAV).collect(Collectors.toSet()));
     private static final Set<Class<? extends AudioStream>> SUPPORTED_AUDIO_STREAMS = Collections
@@ -51,7 +53,7 @@ public class SinkStub implements AudioSink {
     }
 
     @Override
-    public String getLabel(Locale locale) {
+    public @Nullable String getLabel(@Nullable Locale locale) {
         return SINK_STUB_LABEL;
     }
 
@@ -60,7 +62,7 @@ public class SinkStub implements AudioSink {
     }
 
     @Override
-    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+    public void process(@Nullable AudioStream audioStream) throws UnsupportedAudioFormatException {
         isStreamProcessed = true;
     }
 
@@ -72,13 +74,12 @@ public class SinkStub implements AudioSink {
     @Override
     public PercentType getVolume() throws IOException {
         // this method will no be used in the tests
-        return volume;
+        return PercentType.ZERO;
     }
 
     @Override
     public void setVolume(PercentType volume) throws IOException {
         // this method will not be used in the tests
-        this.volume = volume;
     }
 
     public boolean isStreamProcessed() {


### PR DESCRIPTION
Adds null annotations to all registries, the interfaces they implement and a few other classes.

---

There's also a PR to update the add-ons for this: https://github.com/openhab/openhab2-addons/pull/6233