### PR TITLE
[ephemeris] Removed default configuration for ephemeris service from feature file

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -119,10 +119,6 @@
     <feature dependency="true">openhab.tp-jollyday</feature>
     <feature>openhab-core-base</feature>
     <bundle>mvn:org.openhab.core.bundles/org.openhab.core.ephemeris/${project.version}</bundle>
-    <config name="org.openhab.ephemeris">
-        dayset-weekend=[SATURDAY,SUNDAY]
-        dayset-school=[MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY]
-    </config>
   </feature>
 
   <feature name="openhab-core-io-bin2json" description="Binary to JSON converter" version="${project.version}">


### PR DESCRIPTION
- Removed default configuration for ephemeris service from feature file

Closes #1121 
Related to https://github.com/openhab/openhab-distro/pull/984

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>