### PR TITLE
Improve ThingTypeXmlProvider exception handling

### DIFF
--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
@@ -13,9 +13,7 @@
 package org.eclipse.smarthome.core.thing.xml.internal;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
@@ -117,7 +115,7 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
         if (configDescription != null) {
             try {
                 configDescriptionProvider.add(bundle, configDescription);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Could not register ConfigDescription: {}", configDescription.getUID(), e);
             }
         }
@@ -125,14 +123,12 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
 
     @Override
     public synchronized void addingFinished() {
-        Map<String, ChannelType> channelTypes = new HashMap<>(10);
         // create channel types
         for (ChannelTypeXmlResult type : channelTypeRefs) {
             ChannelType channelType = type.toChannelType();
             try {
-                channelTypes.put(channelType.getUID().getAsString(), channelType);
                 channelTypeProvider.add(bundle, channelType);
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Could not register ChannelType: {}", channelType.getUID(), e);
             }
         }
@@ -141,7 +137,7 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
         for (ChannelGroupTypeXmlResult type : channelGroupTypeRefs) {
             try {
                 channelGroupTypeProvider.add(bundle, type.toChannelGroupType());
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Could not register ChannelGroupType: {}", type.getUID(), e);
             }
         }
@@ -150,7 +146,7 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
         for (ThingTypeXmlResult type : thingTypeRefs) {
             try {
                 thingTypeProvider.add(bundle, type.toThingType());
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
                 logger.error("Could not register ThingType: {}", type.getUID(), e);
             }
         }

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
@@ -62,9 +62,9 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
     private final XmlThingTypeProvider thingTypeProvider;
 
     // temporary cache
-    private final List<ThingTypeXmlResult> thingTypeRefs;
-    private final List<ChannelGroupTypeXmlResult> channelGroupTypeRefs;
-    private final List<ChannelTypeXmlResult> channelTypeRefs;
+    private final List<ThingTypeXmlResult> thingTypeRefs = new ArrayList<>(10);
+    private final List<ChannelGroupTypeXmlResult> channelGroupTypeRefs = new ArrayList<>(10);
+    private final List<ChannelTypeXmlResult> channelTypeRefs = new ArrayList<>(10);
 
     private final XmlChannelTypeProvider channelTypeProvider;
     private final XmlChannelGroupTypeProvider channelGroupTypeProvider;
@@ -89,10 +89,6 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
         this.thingTypeProvider = thingTypeProvider;
         this.channelTypeProvider = channelTypeProvider;
         this.channelGroupTypeProvider = channelGroupTypeProvider;
-
-        thingTypeRefs = new ArrayList<>(10);
-        channelGroupTypeRefs = new ArrayList<>(10);
-        channelTypeRefs = new ArrayList<>(10);
     }
 
     @Override

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
@@ -79,8 +79,12 @@ public class ThingTypeXmlResult {
         this.configDescription = (ConfigDescription) configDescriptionObjects[1];
     }
 
+    public ThingTypeUID getUID() {
+        return thingTypeUID;
+    }
+
     public ConfigDescription getConfigDescription() {
-        return this.configDescription;
+        return configDescription;
     }
 
     protected List<ChannelDefinition> toChannelDefinitions(List<ChannelXmlResult> channelTypeReferences)


### PR DESCRIPTION
When a binding such as ZWave has hundreds of ThingTypes it's hard to debug thing type definition issues.

This PR adds a UID (ConfigDescription, ChannelType, ChannelGroupType and ThingType) to the logging so it will be easier to find the root cause of exceptions.

Because the exceptions are caught, an error in one ThingType definition will no longer prevent other perfectly fine ThingTypes to be registered so the impact of definition issues is reduced.

---

This improvement was inspired by https://github.com/openhab/org.openhab.binding.zwave/issues/1249 which would now result in the following error:

```
21:47:32.641 [ERROR] [ing.xml.internal.ThingTypeXmlProvider] - Could not register ThingType: zwave:zwaveme_zuno_01_000
java.lang.IllegalArgumentException: UID must have at least 2 segments.
	at org.eclipse.smarthome.core.common.AbstractUID.<init>(AbstractUID.java:70) ~[133:org.openhab.core:2.5.0.201910150342]
	at org.eclipse.smarthome.core.common.AbstractUID.<init>(AbstractUID.java:49) ~[133:org.openhab.core:2.5.0.201910150342]
	at org.eclipse.smarthome.core.thing.UID.<init>(UID.java:48) ~[185:org.openhab.core.thing:2.5.0.201910150345]
	at org.eclipse.smarthome.core.thing.type.ChannelTypeUID.<init>(ChannelTypeUID.java:40) ~[185:org.openhab.core.thing:2.5.0.201910150345]
	at org.eclipse.smarthome.core.thing.xml.internal.ChannelXmlResult.toChannelDefinition(ChannelXmlResult.java:135) ~[186:org.openhab.core.thing.xml:2.5.0.201910161946]
	at org.eclipse.smarthome.core.thing.xml.internal.ThingTypeXmlResult.toChannelDefinitions(ThingTypeXmlResult.java:98) ~[186:org.openhab.core.thing.xml:2.5.0.201910161946]
	at org.eclipse.smarthome.core.thing.xml.internal.ThingTypeXmlResult.getBuilder(ThingTypeXmlResult.java:149) ~[186:org.openhab.core.thing.xml:2.5.0.201910161946]
	at org.eclipse.smarthome.core.thing.xml.internal.ThingTypeXmlResult.toThingType(ThingTypeXmlResult.java:157) ~[186:org.openhab.core.thing.xml:2.5.0.201910161946]
	at org.eclipse.smarthome.core.thing.xml.internal.ThingTypeXmlProvider.addingFinished(ThingTypeXmlProvider.java:156) [186:org.openhab.core.thing.xml:2.5.0.201910161946]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.addingFinished(XmlDocumentBundleTracker.java:265) [142:org.openhab.core.config.xml:2.5.0.201910150357]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.parseDocuments(XmlDocumentBundleTracker.java:424) [142:org.openhab.core.config.xml:2.5.0.201910150357]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:398) [142:org.openhab.core.config.xml:2.5.0.201910150357]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker.access$6(XmlDocumentBundleTracker.java:393) [142:org.openhab.core.config.xml:2.5.0.201910150357]
	at org.eclipse.smarthome.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:363) [142:org.openhab.core.config.xml:2.5.0.201910150357]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]
```