### PR TITLE
Fix unstable ChannelTypesTest

### DIFF
--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/eclipse/smarthome/core/thing/xml/test/ChannelTypesTest.java
@@ -76,8 +76,11 @@ public class ChannelTypesTest extends JavaOSGiTest {
                     .get();
             assertThat(channelType2, is(not(nullValue())));
 
-            Collection<ChannelGroupType> channelGroupTypes = channelGroupTypeProvider.getChannelGroupTypes(null);
-            assertThat(channelGroupTypes.size(), is(initialNumberOfChannelGroupTypes + 1));
+            Collection<ChannelGroupType> channelGroupTypes = waitForAssert(() -> {
+                Collection<ChannelGroupType> channelGroupTypesTmp = channelGroupTypeProvider.getChannelGroupTypes(null);
+                assertThat(channelGroupTypesTmp.size(), is(initialNumberOfChannelGroupTypes + 1));
+                return channelGroupTypesTmp;
+            });
 
             ChannelGroupType channelGroupType = channelGroupTypes.stream()
                     .filter(it -> it.getUID().toString().equals("somebinding:channelgroup")).findFirst().get();


### PR DESCRIPTION
Most likely the test is unstable because the `ChannelGroupTypeProvider` is still processing the bundle XML. So using `waitForAssert` may fix this. It's also used like this to assert the channel types got added by the `ChannelTypeProvider`.

Fixes #1090