### PR TITLE
Fix unstable AutomationIntegrationJsonTest

### DIFF
--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -341,6 +341,7 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
             assertThat(ruleRegistry.getAll().isEmpty(), is(false));
             Rule r = ruleRegistry.get("ItemSampleRule");
             assertThat(r, is(notNullValue()));
+            assertThat(ruleManager.getStatusInfo(r.getUID()), is(notNullValue()));
             assertThat(ruleManager.getStatusInfo(r.getUID()).getStatus(), is(RuleStatus.IDLE));
         }, 9000, 200);
 


### PR DESCRIPTION
Sometimes the method returns null causing the test to fail because `waitForAssert` doesn't catch NPEs:

https://github.com/openhab/openhab-core/blob/7279ddbbf661c8b47357a081e00c81c5d44fd955/bundles/org.openhab.core.test/src/main/java/org/eclipse/smarthome/test/java/JavaTest.java#L142

Fixes:

```
TEST assertThatARuleFromJsonFileIsExecutedCorrectly(org.openhab.core.automation.integration.test.AutomationIntegrationJsonTest) <<< ERROR: null
java.lang.NullPointerException
	at org.openhab.core.automation.integration.test.AutomationIntegrationJsonTest.lambda$13(AutomationIntegrationJsonTest.java:344)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:136)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:120)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:84)
	at org.openhab.core.automation.integration.test.AutomationIntegrationJsonTest.assertThatARuleFromJsonFileIsExecutedCorrectly(AutomationIntegrationJsonTest.java:340)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)
```