### PR TITLE
Fix ConcurrentModificationException in AutomationIntegrationTest

### DIFF
--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -16,7 +16,6 @@ import static java.util.stream.Collectors.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -268,7 +268,6 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         inputs.put("topic", "ItemStateChangeTrigger.topic");
         inputs.put("event", "ItemStateChangeTrigger.event");
 
-        // def conditionInputs=[topicConnection] as Set
         List<Condition> conditions = Collections.singletonList(
                 ModuleBuilder.createCondition().withId("EventCondition_2").withTypeUID("core.GenericEventCondition")
                         .withConfiguration(condition1Config).withInputs(inputs).build());
@@ -282,7 +281,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
         logger.info("Rule created and added: {}", rule.getUID());
 
-        List<RuleStatusInfoEvent> ruleEvents = new ArrayList<>();
+        List<RuleStatusInfoEvent> ruleEvents = new CopyOnWriteArrayList<>();
 
         @NonNullByDefault
         EventSubscriber ruleEventHandler = new EventSubscriber() {


### PR DESCRIPTION
When `waitForAssert` uses `ruleEvents.stream()` the `ruleEventHandler` may add an event to `ruleEvents` at the same time causing a `ConcurrentModificationException`.
Using a `CopyOnWriteArrayList` instead of an `ArrayList` should fix this.

Fixes:

```
TEST assertThatARuleWithConnectionsIsExecuted(org.openhab.core.automation.integration.test.AutomationIntegrationTest) <<< ERROR: null
java.util.ConcurrentModificationException
	at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1361)
	at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)
	at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:152)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:531)
	at org.openhab.core.automation.integration.test.AutomationIntegrationTest.lambda$4(AutomationIntegrationTest.java:311)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:136)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:120)
	at org.eclipse.smarthome.test.java.JavaTest.waitForAssert(JavaTest.java:73)
	at org.openhab.core.automation.integration.test.AutomationIntegrationTest.assertThatARuleWithConnectionsIsExecuted(AutomationIntegrationTest.java:310)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at aQute.junit.Activator.test(Activator.java:340)
	at aQute.junit.Activator.automatic(Activator.java:236)
	at aQute.junit.Activator.run(Activator.java:177)
	at aQute.launcher.Launcher.lambda$serviceChanged$0(Launcher.java:1385)
	at aQute.launcher.Launcher.run(Launcher.java:352)
	at aQute.launcher.Launcher.main(Launcher.java:152)

```