### PR TITLE
[automation] Added nullness annotations to automation i18n

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.Action;
@@ -31,22 +33,26 @@ import org.osgi.framework.Bundle;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class ModuleI18nUtil {
 
     public static <T extends Module> List<T> getLocalizedModules(TranslationProvider i18nProvider, List<T> modules,
-            Bundle bundle, String uid, String prefix, Locale locale) {
+            Bundle bundle, String uid, String prefix, @Nullable Locale locale) {
         List<T> lmodules = new ArrayList<>();
         for (T module : modules) {
             String label = getModuleLabel(i18nProvider, bundle, uid, module.getId(), module.getLabel(), prefix, locale);
-            String description = getModuleDescription(i18nProvider, bundle, uid, prefix, module.getId(),
-                    module.getDescription(), locale);
-            lmodules.add(createLocalizedModule(module, label, description));
+            String description = getModuleDescription(i18nProvider, bundle, uid, module.getId(),
+                    module.getDescription(), prefix, locale);
+            @Nullable
+            T lmodule = createLocalizedModule(module, label, description);
+            lmodules.add(lmodule == null ? module : lmodule);
         }
         return lmodules;
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends Module> T createLocalizedModule(T module, String label, String description) {
+    private static <T extends Module> @Nullable T createLocalizedModule(T module, @Nullable String label,
+            @Nullable String description) {
         if (module instanceof Action) {
             return (T) createLocalizedAction((Action) module, label, description);
         }
@@ -59,26 +65,28 @@ public class ModuleI18nUtil {
         return null;
     }
 
-    private static Trigger createLocalizedTrigger(Trigger module, String label, String description) {
+    private static Trigger createLocalizedTrigger(Trigger module, @Nullable String label,
+            @Nullable String description) {
         return ModuleBuilder.createTrigger(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Condition createLocalizedCondition(Condition module, String label, String description) {
+    private static Condition createLocalizedCondition(Condition module, @Nullable String label,
+            @Nullable String description) {
         return ModuleBuilder.createCondition(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Action createLocalizedAction(Action module, String label, String description) {
+    private static Action createLocalizedAction(Action module, @Nullable String label, @Nullable String description) {
         return ModuleBuilder.createAction(module).withLabel(label).withDescription(description).build();
     }
 
-    private static String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid, String moduleName,
-            String defaultLabel, String prefix, Locale locale) {
+    private static @Nullable String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultLabel, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleKey(prefix, uid, moduleName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
-            String moduleName, String defaultDescription, String prefix, Locale locale) {
+    private static @Nullable String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
+            String moduleName, @Nullable String defaultDescription, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleKey(prefix, uid, moduleName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.type.Input;
@@ -29,25 +31,26 @@ import org.osgi.framework.Bundle;
  * @author Ana Dimova - Initial contribution
  * @author Yordan Mihaylov - updates related to api changes
  */
+@NonNullByDefault
 public class ModuleTypeI18nUtil {
 
     public static final String MODULE_TYPE = "module-type";
 
-    public static String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultLabel, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleTypeKey(moduleTypeUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String defaultDescription, Locale locale) {
+    public static @Nullable String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleTypeKey(moduleTypeUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, List<Input> inputs, Bundle bundle,
-            String uid, Locale locale) {
+    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, @Nullable List<Input> inputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Input> linputs = new ArrayList<>();
         if (inputs != null) {
             for (Input input : inputs) {
@@ -63,8 +66,8 @@ public class ModuleTypeI18nUtil {
         return linputs;
     }
 
-    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, List<Output> outputs,
-            Bundle bundle, String uid, Locale locale) {
+    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, @Nullable List<Output> outputs,
+            Bundle bundle, String uid, @Nullable Locale locale) {
         List<Output> loutputs = new ArrayList<>();
         if (outputs != null) {
             for (Output output : outputs) {
@@ -80,27 +83,27 @@ public class ModuleTypeI18nUtil {
         return loutputs;
     }
 
-    private static String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
+            String inputName, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferInputKey(moduleTypeUID, inputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static String getInputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getInputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String inputName, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferInputKey(moduleTypeUID, inputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle, String ruleTemplateUID,
-            String outputName, String defaultLabel, Locale locale) {
+    private static @Nullable String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String ruleTemplateUID, String outputName, String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferOutputKey(ruleTemplateUID, outputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String outputName, String defaultDescription, Locale locale) {
+    private static @Nullable String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String moduleTypeUID, String outputName, String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferOutputKey(moduleTypeUID, outputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.module.provider.i18n;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.type.ModuleType;
 import org.osgi.framework.Bundle;
 
@@ -22,6 +24,7 @@ import org.osgi.framework.Bundle;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 public interface ModuleTypeI18nService {
 
     /**
@@ -32,6 +35,7 @@ public interface ModuleTypeI18nService {
      * @param bundle the bundle containing the localization files
      * @return the localized ModuleType
      */
-    ModuleType getModuleTypePerLocale(ModuleType defModuleType, Locale locale, Bundle bundle);
+    @Nullable
+    ModuleType getModuleTypePerLocale(@Nullable ModuleType defModuleType, @Nullable Locale locale, Bundle bundle);
 
 }


### PR DESCRIPTION
- Added nullness annotations to automation i18n
- Added constructor injection to `ModuleTypeI18nServiceImpl`
- Fixed a potential bug in `ModuleI18nUtil.getLocalizedModules()` because of wrong parameter ordering
- Fixed potential `IllegalArgumentException` in `ModuleTypeI18nServiceImpl.getLocalizedConfigDescriptionParameters()` which will be thrown by `ConfigDescription` constructor if `URI` is `null`
 
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>