### PR TITLE
[i18n] Refactoring and annotations

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -384,6 +384,7 @@ public abstract class AbstractResourceBundleProvider<E> {
                         .collect(Collectors.toList());
             } catch (URISyntaxException e) {
                 logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);
+                return config;
             }
         }
         return Collections.emptyList();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -376,11 +376,12 @@ public abstract class AbstractResourceBundleProvider<E> {
     protected List<ConfigDescriptionParameter> getLocalizedConfigurationDescription(
             @Nullable List<ConfigDescriptionParameter> config, Bundle bundle, String uid, String prefix,
             @Nullable Locale locale) {
-        if (config != null && configI18nService != null) {
+        ConfigI18nLocalizationService localConfigI18nService = configI18nService;
+        if (config != null && localConfigI18nService != null) {
             try {
                 URI uri = new URI(prefix + ":" + uid + ".name");
                 return config.stream()
-                        .map(p -> configI18nService.getLocalizedConfigDescriptionParameter(bundle, uri, p, locale))
+                        .map(p -> localConfigI18nService.getLocalizedConfigDescriptionParameter(bundle, uri, p, locale))
                         .collect(Collectors.toList());
             } catch (URISyntaxException e) {
                 logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -30,16 +30,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
-import org.eclipse.smarthome.config.core.ParameterOption;
-import org.eclipse.smarthome.config.core.i18n.ConfigDescriptionI18nUtil;
+import org.eclipse.smarthome.config.core.i18n.ConfigI18nLocalizationService;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
-import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.parser.Parser;
 import org.openhab.core.automation.parser.ParsingException;
@@ -83,10 +81,7 @@ public abstract class AbstractResourceBundleProvider<E> {
      */
     protected static final String ROOT_DIRECTORY = "ESH-INF/automation";
 
-    /**
-     * This field holds a reference to the service instance for internationalization support within the platform.
-     */
-    protected @NonNullByDefault({}) TranslationProvider i18nProvider;
+    protected @Nullable ConfigI18nLocalizationService configI18nService;
 
     /**
      * This field keeps instance of {@link Logger} that is used for logging.
@@ -213,14 +208,6 @@ public abstract class AbstractResourceBundleProvider<E> {
         String parserType = properties.get(Parser.FORMAT);
         parserType = parserType == null ? Parser.FORMAT_JSON : parserType;
         parsers.remove(parserType);
-    }
-
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = i18nProvider;
-    }
-
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        this.i18nProvider = null;
     }
 
     /**
@@ -386,60 +373,20 @@ public abstract class AbstractResourceBundleProvider<E> {
         return null;
     }
 
-    protected List<ConfigDescriptionParameter> getLocalizedConfigurationDescription(TranslationProvider i18nProvider,
+    protected List<ConfigDescriptionParameter> getLocalizedConfigurationDescription(
             @Nullable List<ConfigDescriptionParameter> config, Bundle bundle, String uid, String prefix,
             @Nullable Locale locale) {
-        List<ConfigDescriptionParameter> configDescriptions = new ArrayList<>();
-        if (config != null) {
-            ConfigDescriptionI18nUtil util = new ConfigDescriptionI18nUtil(i18nProvider);
-            for (ConfigDescriptionParameter parameter : config) {
-                String parameterName = parameter.getName();
-                URI uri = null;
-                try {
-                    uri = new URI(prefix + ":" + uid + ".name");
-                } catch (URISyntaxException e) {
-                    logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);
-                    return Collections.emptyList();
-                }
-                String llabel = parameter.getLabel();
-                if (llabel != null) {
-                    llabel = util.getParameterLabel(bundle, uri, parameterName, llabel, locale);
-                }
-                String ldescription = parameter.getDescription();
-                if (ldescription != null) {
-                    ldescription = util.getParameterDescription(bundle, uri, parameterName, ldescription, locale);
-                }
-                String lpattern = parameter.getPattern();
-                if (lpattern != null) {
-                    lpattern = util.getParameterPattern(bundle, uri, parameterName, lpattern, locale);
-                }
-                List<ParameterOption> loptions = parameter.getOptions();
-                if (loptions != null && !loptions.isEmpty()) {
-                    for (ParameterOption option : loptions) {
-                        String label = util.getParameterOptionLabel(bundle, uri, parameterName, option.getValue(),
-                                option.getLabel(), locale);
-                        option = new ParameterOption(option.getValue(), label);
-                    }
-                }
-                String lunitLabel = parameter.getUnitLabel();
-                if (lunitLabel != null) {
-                    lunitLabel = util.getParameterUnitLabel(bundle, uri, parameterName, parameter.getUnit(), lunitLabel,
-                            locale);
-                }
-                configDescriptions.add(ConfigDescriptionParameterBuilder.create(parameterName, parameter.getType())
-                        .withMinimum(parameter.getMinimum()).withMaximum(parameter.getMaximum())
-                        .withStepSize(parameter.getStepSize()).withPattern(lpattern)
-                        .withRequired(parameter.isRequired()).withMultiple(parameter.isMultiple())
-                        .withReadOnly(parameter.isReadOnly()).withContext(parameter.getContext())
-                        .withDefault(parameter.getDefault()).withLabel(llabel).withDescription(ldescription)
-                        .withFilterCriteria(parameter.getFilterCriteria()).withGroupName(parameter.getGroupName())
-                        .withAdvanced(parameter.isAdvanced()).withOptions(loptions)
-                        .withLimitToOptions(parameter.getLimitToOptions())
-                        .withMultipleLimit(parameter.getMultipleLimit()).withUnit(parameter.getUnit())
-                        .withUnitLabel(lunitLabel).build());
+        if (config != null && configI18nService != null) {
+            try {
+                URI uri = new URI(prefix + ":" + uid + ".name");
+                return config.stream()
+                        .map(p -> configI18nService.getLocalizedConfigDescriptionParameter(bundle, uri, p, locale))
+                        .collect(Collectors.toList());
+            } catch (URISyntaxException e) {
+                logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);
             }
         }
-        return configDescriptions;
+        return Collections.emptyList();
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
-import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.module.provider.i18n.ModuleTypeI18nService;
 import org.openhab.core.automation.parser.Parser;
 import org.openhab.core.automation.type.ModuleType;
@@ -90,17 +89,6 @@ public class ModuleTypeResourceBundleProvider extends AbstractResourceBundleProv
     @Override
     protected void removeParser(Parser<ModuleType> parser, Map<String, String> properties) {
         super.removeParser(parser, properties);
-    }
-
-    @Override
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        super.setTranslationProvider(i18nProvider);
-    }
-
-    @Override
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        super.unsetTranslationProvider(i18nProvider);
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
@@ -66,14 +66,18 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 public class TemplateResourceBundleProvider extends AbstractResourceBundleProvider<RuleTemplate>
         implements RuleTemplateProvider {
 
+    private final RuleTemplateI18nUtil ruleTemplateI18nUtil;
+
     /**
      * This constructor is responsible for initializing the path to resources and tracking the managing service of the
      * {@link ModuleType}s and the managing service of the {@link RuleTemplates}s.
      *
      * @param context is the {@code BundleContext}, used for creating a tracker for {@link Parser} services.
      */
-    public TemplateResourceBundleProvider() {
+    @Activate
+    public TemplateResourceBundleProvider(final @Reference TranslationProvider i18nProvider) {
         super(ROOT_DIRECTORY + "/templates/");
+        this.ruleTemplateI18nUtil = new RuleTemplateI18nUtil(i18nProvider);
     }
 
     @Override
@@ -167,9 +171,9 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
         Bundle bundle = getBundle(uid);
 
         if (bundle != null && defTemplate instanceof RuleTemplate) {
-            String llabel = RuleTemplateI18nUtil.getLocalizedRuleTemplateLabel(i18nProvider, bundle, uid,
-                    defTemplate.getLabel(), locale);
-            String ldescription = RuleTemplateI18nUtil.getLocalizedRuleTemplateDescription(i18nProvider, bundle, uid,
+            String llabel = ruleTemplateI18nUtil.getLocalizedRuleTemplateLabel(bundle, uid, defTemplate.getLabel(),
+                    locale);
+            String ldescription = ruleTemplateI18nUtil.getLocalizedRuleTemplateDescription(bundle, uid,
                     defTemplate.getDescription(), locale);
             List<ConfigDescriptionParameter> lconfigDescriptions = getLocalizedConfigurationDescription(i18nProvider,
                     defTemplate.getConfigurationDescriptions(), bundle, uid, RuleTemplateI18nUtil.RULE_TEMPLATE,

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.i18n.ConfigI18nLocalizationService;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
@@ -76,8 +77,10 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
      * @param context is the {@code BundleContext}, used for creating a tracker for {@link Parser} services.
      */
     @Activate
-    public TemplateResourceBundleProvider(final @Reference TranslationProvider i18nProvider) {
+    public TemplateResourceBundleProvider(final @Reference ConfigI18nLocalizationService configI18nService,
+            final @Reference TranslationProvider i18nProvider) {
         super(ROOT_DIRECTORY + "/templates/");
+        this.configI18nService = configI18nService;
         this.ruleTemplateI18nUtil = new RuleTemplateI18nUtil(i18nProvider);
         this.moduleI18nUtil = new ModuleI18nUtil(i18nProvider);
     }
@@ -103,17 +106,6 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
     @Override
     protected void removeParser(Parser<RuleTemplate> parser, Map<String, String> properties) {
         super.removeParser(parser, properties);
-    }
-
-    @Override
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setTranslationProvider(TranslationProvider i18nProvider) {
-        super.setTranslationProvider(i18nProvider);
-    }
-
-    @Override
-    protected void unsetTranslationProvider(TranslationProvider i18nProvider) {
-        super.unsetTranslationProvider(i18nProvider);
     }
 
     @Override
@@ -166,7 +158,7 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
      * @return the localized {@link Template}.
      */
     private @Nullable RuleTemplate getPerLocale(@Nullable RuleTemplate defTemplate, @Nullable Locale locale) {
-        if (locale == null || defTemplate == null || i18nProvider == null) {
+        if (locale == null || defTemplate == null) {
             return defTemplate;
         }
         String uid = defTemplate.getUID();
@@ -177,7 +169,7 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
                     locale);
             String ldescription = ruleTemplateI18nUtil.getLocalizedRuleTemplateDescription(bundle, uid,
                     defTemplate.getDescription(), locale);
-            List<ConfigDescriptionParameter> lconfigDescriptions = getLocalizedConfigurationDescription(i18nProvider,
+            List<ConfigDescriptionParameter> lconfigDescriptions = getLocalizedConfigurationDescription(
                     defTemplate.getConfigurationDescriptions(), bundle, uid, RuleTemplateI18nUtil.RULE_TEMPLATE,
                     locale);
             List<Action> lactions = moduleI18nUtil.getLocalizedModules(defTemplate.getActions(), bundle, uid,

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
@@ -67,6 +67,7 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
         implements RuleTemplateProvider {
 
     private final RuleTemplateI18nUtil ruleTemplateI18nUtil;
+    private final ModuleI18nUtil moduleI18nUtil;
 
     /**
      * This constructor is responsible for initializing the path to resources and tracking the managing service of the
@@ -78,6 +79,7 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
     public TemplateResourceBundleProvider(final @Reference TranslationProvider i18nProvider) {
         super(ROOT_DIRECTORY + "/templates/");
         this.ruleTemplateI18nUtil = new RuleTemplateI18nUtil(i18nProvider);
+        this.moduleI18nUtil = new ModuleI18nUtil(i18nProvider);
     }
 
     @Override
@@ -178,12 +180,12 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
             List<ConfigDescriptionParameter> lconfigDescriptions = getLocalizedConfigurationDescription(i18nProvider,
                     defTemplate.getConfigurationDescriptions(), bundle, uid, RuleTemplateI18nUtil.RULE_TEMPLATE,
                     locale);
-            List<Action> lactions = ModuleI18nUtil.getLocalizedModules(i18nProvider, defTemplate.getActions(), bundle,
-                    uid, RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
-            List<Condition> lconditions = ModuleI18nUtil.getLocalizedModules(i18nProvider, defTemplate.getConditions(),
-                    bundle, uid, RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
-            List<Trigger> ltriggers = ModuleI18nUtil.getLocalizedModules(i18nProvider, defTemplate.getTriggers(),
-                    bundle, uid, RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
+            List<Action> lactions = moduleI18nUtil.getLocalizedModules(defTemplate.getActions(), bundle, uid,
+                    RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
+            List<Condition> lconditions = moduleI18nUtil.getLocalizedModules(defTemplate.getConditions(), bundle, uid,
+                    RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
+            List<Trigger> ltriggers = moduleI18nUtil.getLocalizedModules(defTemplate.getTriggers(), bundle, uid,
+                    RuleTemplateI18nUtil.RULE_TEMPLATE, locale);
             return new RuleTemplate(uid, llabel, ldescription, defTemplate.getTags(), ltriggers, lconditions, lactions,
                     lconfigDescriptions, defTemplate.getVisibility());
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
@@ -36,13 +36,19 @@ import org.osgi.framework.Bundle;
 @NonNullByDefault
 public class ModuleI18nUtil {
 
-    public static <T extends Module> List<T> getLocalizedModules(TranslationProvider i18nProvider, List<T> modules,
-            Bundle bundle, String uid, String prefix, @Nullable Locale locale) {
+    private final TranslationProvider i18nProvider;
+
+    public ModuleI18nUtil(TranslationProvider i18nProvider) {
+        this.i18nProvider = i18nProvider;
+    }
+
+    public <T extends Module> List<T> getLocalizedModules(List<T> modules, Bundle bundle, String uid, String prefix,
+            @Nullable Locale locale) {
         List<T> lmodules = new ArrayList<>();
         for (T module : modules) {
-            String label = getModuleLabel(i18nProvider, bundle, uid, module.getId(), module.getLabel(), prefix, locale);
-            String description = getModuleDescription(i18nProvider, bundle, uid, module.getId(),
-                    module.getDescription(), prefix, locale);
+            String label = getModuleLabel(bundle, uid, module.getId(), module.getLabel(), prefix, locale);
+            String description = getModuleDescription(bundle, uid, module.getId(), module.getDescription(), prefix,
+                    locale);
             @Nullable
             T lmodule = createLocalizedModule(module, label, description);
             lmodules.add(lmodule == null ? module : lmodule);
@@ -51,7 +57,7 @@ public class ModuleI18nUtil {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T extends Module> @Nullable T createLocalizedModule(T module, @Nullable String label,
+    private <T extends Module> @Nullable T createLocalizedModule(T module, @Nullable String label,
             @Nullable String description) {
         if (module instanceof Action) {
             return (T) createLocalizedAction((Action) module, label, description);
@@ -65,34 +71,32 @@ public class ModuleI18nUtil {
         return null;
     }
 
-    private static Trigger createLocalizedTrigger(Trigger module, @Nullable String label,
-            @Nullable String description) {
+    private Trigger createLocalizedTrigger(Trigger module, @Nullable String label, @Nullable String description) {
         return ModuleBuilder.createTrigger(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Condition createLocalizedCondition(Condition module, @Nullable String label,
-            @Nullable String description) {
+    private Condition createLocalizedCondition(Condition module, @Nullable String label, @Nullable String description) {
         return ModuleBuilder.createCondition(module).withLabel(label).withDescription(description).build();
     }
 
-    private static Action createLocalizedAction(Action module, @Nullable String label, @Nullable String description) {
+    private Action createLocalizedAction(Action module, @Nullable String label, @Nullable String description) {
         return ModuleBuilder.createAction(module).withLabel(label).withDescription(description).build();
     }
 
-    private static @Nullable String getModuleLabel(TranslationProvider i18nProvider, Bundle bundle, String uid,
-            String moduleName, @Nullable String defaultLabel, String prefix, @Nullable Locale locale) {
+    private @Nullable String getModuleLabel(Bundle bundle, String uid, String moduleName, @Nullable String defaultLabel,
+            String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleKey(prefix, uid, moduleName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static @Nullable String getModuleDescription(TranslationProvider i18nProvider, Bundle bundle, String uid,
-            String moduleName, @Nullable String defaultDescription, String prefix, @Nullable Locale locale) {
+    private @Nullable String getModuleDescription(Bundle bundle, String uid, String moduleName,
+            @Nullable String defaultDescription, String prefix, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleKey(prefix, uid, moduleName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String inferModuleKey(String prefix, String uid, String moduleName, String lastSegment) {
+    private String inferModuleKey(String prefix, String uid, String moduleName, String lastSegment) {
         return prefix + uid + ".input." + moduleName + "." + lastSegment;
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -88,15 +88,18 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
                 defModuleType.getConfigurationDescriptions(), ModuleTypeI18nUtil.MODULE_TYPE, uid, bundle, locale);
         if (defModuleType instanceof ActionType) {
             return createLocalizedActionType((ActionType) defModuleType, bundle, uid, locale,
-                    lconfigDescriptionParameters, llabel, ldescription);
+                    lconfigDescriptionParameters, llabel == null ? defModuleType.getLabel() : llabel,
+                    ldescription == null ? defModuleType.getDescription() : ldescription);
         }
         if (defModuleType instanceof ConditionType) {
             return createLocalizedConditionType((ConditionType) defModuleType, bundle, uid, locale,
-                    lconfigDescriptionParameters, llabel, ldescription);
+                    lconfigDescriptionParameters, llabel == null ? defModuleType.getLabel() : llabel,
+                    ldescription == null ? defModuleType.getDescription() : ldescription);
         }
         if (defModuleType instanceof TriggerType) {
             return createLocalizedTriggerType((TriggerType) defModuleType, bundle, uid, locale,
-                    lconfigDescriptionParameters, llabel, ldescription);
+                    lconfigDescriptionParameters, llabel != null ? llabel : defModuleType.getLabel(),
+                    ldescription == null ? defModuleType.getDescription() : ldescription);
         }
         return null;
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -57,17 +57,17 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     /**
      * This field holds a reference to the service instance for internationalization support within the platform.
      */
-    private final TranslationProvider i18nProvider;
     private final ConfigI18nLocalizationService localizationService;
 
     private final ModuleTypeI18nUtil moduleTypeI18nUtil;
+    private final ModuleI18nUtil moduleI18nUtil;
 
     @Activate
     public ModuleTypeI18nServiceImpl(final @Reference TranslationProvider i18nProvider,
             final @Reference ConfigI18nLocalizationService localizationService) {
-        this.i18nProvider = i18nProvider;
         this.localizationService = localizationService;
         this.moduleTypeI18nUtil = new ModuleTypeI18nUtil(i18nProvider);
+        this.moduleI18nUtil = new ModuleI18nUtil(i18nProvider);
     }
 
     /**
@@ -138,9 +138,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
         List<Output> outputs = moduleTypeI18nUtil.getLocalizedOutputs(at.getOutputs(), bundle, moduleTypeUID, locale);
         ActionType lat = null;
         if (at instanceof CompositeActionType) {
-            List<Action> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,
-                    ((CompositeActionType) at).getChildren(), bundle, moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE,
-                    locale);
+            List<Action> modules = moduleI18nUtil.getLocalizedModules(((CompositeActionType) at).getChildren(), bundle,
+                    moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE, locale);
             lat = new CompositeActionType(moduleTypeUID, lconfigDescriptions, llabel, ldescription, at.getTags(),
                     at.getVisibility(), inputs, outputs, modules);
         } else {
@@ -168,9 +167,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
         List<Input> inputs = moduleTypeI18nUtil.getLocalizedInputs(ct.getInputs(), bundle, moduleTypeUID, locale);
         ConditionType lct = null;
         if (ct instanceof CompositeConditionType) {
-            List<Condition> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,
-                    ((CompositeConditionType) ct).getChildren(), bundle, moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE,
-                    locale);
+            List<Condition> modules = moduleI18nUtil.getLocalizedModules(((CompositeConditionType) ct).getChildren(),
+                    bundle, moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE, locale);
             lct = new CompositeConditionType(moduleTypeUID, lconfigDescriptions, llabel, ldescription, ct.getTags(),
                     ct.getVisibility(), inputs, modules);
         } else {
@@ -198,9 +196,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
         List<Output> outputs = moduleTypeI18nUtil.getLocalizedOutputs(tt.getOutputs(), bundle, moduleTypeUID, locale);
         TriggerType ltt = null;
         if (tt instanceof CompositeTriggerType) {
-            List<Trigger> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,
-                    ((CompositeTriggerType) tt).getChildren(), bundle, moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE,
-                    locale);
+            List<Trigger> modules = moduleI18nUtil.getLocalizedModules(((CompositeTriggerType) tt).getChildren(),
+                    bundle, moduleTypeUID, ModuleTypeI18nUtil.MODULE_TYPE, locale);
             ltt = new CompositeTriggerType(moduleTypeUID, lconfigDescriptions, llabel, ldescription, tt.getTags(),
                     tt.getVisibility(), outputs, modules);
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -60,11 +60,14 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     private final TranslationProvider i18nProvider;
     private final ConfigI18nLocalizationService localizationService;
 
+    private final ModuleTypeI18nUtil moduleTypeI18nUtil;
+
     @Activate
     public ModuleTypeI18nServiceImpl(final @Reference TranslationProvider i18nProvider,
             final @Reference ConfigI18nLocalizationService localizationService) {
         this.i18nProvider = i18nProvider;
         this.localizationService = localizationService;
+        this.moduleTypeI18nUtil = new ModuleTypeI18nUtil(i18nProvider);
     }
 
     /**
@@ -81,9 +84,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
             return defModuleType;
         }
         String uid = defModuleType.getUID();
-        String llabel = ModuleTypeI18nUtil.getLocalizedModuleTypeLabel(i18nProvider, bundle, uid,
-                defModuleType.getLabel(), locale);
-        String ldescription = ModuleTypeI18nUtil.getLocalizedModuleTypeDescription(i18nProvider, bundle, uid,
+        String llabel = moduleTypeI18nUtil.getLocalizedModuleTypeLabel(bundle, uid, defModuleType.getLabel(), locale);
+        String ldescription = moduleTypeI18nUtil.getLocalizedModuleTypeDescription(bundle, uid,
                 defModuleType.getDescription(), locale);
 
         List<ConfigDescriptionParameter> lconfigDescriptionParameters = getLocalizedConfigDescriptionParameters(
@@ -132,10 +134,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     private @Nullable ActionType createLocalizedActionType(ActionType at, Bundle bundle, String moduleTypeUID,
             @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
             @Nullable String llabel, @Nullable String ldescription) {
-        List<Input> inputs = ModuleTypeI18nUtil.getLocalizedInputs(i18nProvider, at.getInputs(), bundle, moduleTypeUID,
-                locale);
-        List<Output> outputs = ModuleTypeI18nUtil.getLocalizedOutputs(i18nProvider, at.getOutputs(), bundle,
-                moduleTypeUID, locale);
+        List<Input> inputs = moduleTypeI18nUtil.getLocalizedInputs(at.getInputs(), bundle, moduleTypeUID, locale);
+        List<Output> outputs = moduleTypeI18nUtil.getLocalizedOutputs(at.getOutputs(), bundle, moduleTypeUID, locale);
         ActionType lat = null;
         if (at instanceof CompositeActionType) {
             List<Action> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,
@@ -165,8 +165,7 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     private @Nullable ConditionType createLocalizedConditionType(ConditionType ct, Bundle bundle, String moduleTypeUID,
             @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
             @Nullable String llabel, @Nullable String ldescription) {
-        List<Input> inputs = ModuleTypeI18nUtil.getLocalizedInputs(i18nProvider, ct.getInputs(), bundle, moduleTypeUID,
-                locale);
+        List<Input> inputs = moduleTypeI18nUtil.getLocalizedInputs(ct.getInputs(), bundle, moduleTypeUID, locale);
         ConditionType lct = null;
         if (ct instanceof CompositeConditionType) {
             List<Condition> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,
@@ -196,8 +195,7 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
     private @Nullable TriggerType createLocalizedTriggerType(TriggerType tt, Bundle bundle, String moduleTypeUID,
             @Nullable Locale locale, @Nullable List<ConfigDescriptionParameter> lconfigDescriptions,
             @Nullable String llabel, @Nullable String ldescription) {
-        List<Output> outputs = ModuleTypeI18nUtil.getLocalizedOutputs(i18nProvider, tt.getOutputs(), bundle,
-                moduleTypeUID, locale);
+        List<Output> outputs = moduleTypeI18nUtil.getLocalizedOutputs(tt.getOutputs(), bundle, moduleTypeUID, locale);
         TriggerType ltt = null;
         if (tt instanceof CompositeTriggerType) {
             List<Trigger> modules = ModuleI18nUtil.getLocalizedModules(i18nProvider,

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -54,18 +54,14 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
 
     private final Logger logger = LoggerFactory.getLogger(ModuleTypeI18nServiceImpl.class);
 
-    /**
-     * This field holds a reference to the service instance for internationalization support within the platform.
-     */
-    private final ConfigI18nLocalizationService localizationService;
-
+    private final ConfigI18nLocalizationService configI18nService;
     private final ModuleTypeI18nUtil moduleTypeI18nUtil;
     private final ModuleI18nUtil moduleI18nUtil;
 
     @Activate
-    public ModuleTypeI18nServiceImpl(final @Reference TranslationProvider i18nProvider,
-            final @Reference ConfigI18nLocalizationService localizationService) {
-        this.localizationService = localizationService;
+    public ModuleTypeI18nServiceImpl(final @Reference ConfigI18nLocalizationService configI18nService,
+            final @Reference TranslationProvider i18nProvider) {
+        this.configI18nService = configI18nService;
         this.moduleTypeI18nUtil = new ModuleTypeI18nUtil(i18nProvider);
         this.moduleI18nUtil = new ModuleI18nUtil(i18nProvider);
     }
@@ -109,7 +105,7 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
             List<ConfigDescriptionParameter> parameters, String prefix, String uid, Bundle bundle,
             @Nullable Locale locale) {
         try {
-            return localizationService
+            return configI18nService
                     .getLocalizedConfigDescription(bundle,
                             new ConfigDescription(new URI(prefix + ":" + uid + ".name"), parameters), locale)
                     .getParameters();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -36,29 +36,33 @@ public class ModuleTypeI18nUtil {
 
     public static final String MODULE_TYPE = "module-type";
 
-    public static @Nullable String getLocalizedModuleTypeLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, @Nullable String defaultLabel, @Nullable Locale locale) {
+    private final TranslationProvider i18nProvider;
+
+    public ModuleTypeI18nUtil(TranslationProvider i18nProvider) {
+        this.i18nProvider = i18nProvider;
+    }
+
+    public @Nullable String getLocalizedModuleTypeLabel(Bundle bundle, String moduleTypeUID,
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferModuleTypeKey(moduleTypeUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static @Nullable String getLocalizedModuleTypeDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, @Nullable String defaultDescription, @Nullable Locale locale) {
+    public @Nullable String getLocalizedModuleTypeDescription(Bundle bundle, String moduleTypeUID,
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferModuleTypeKey(moduleTypeUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public static List<Input> getLocalizedInputs(TranslationProvider i18nProvider, @Nullable List<Input> inputs,
-            Bundle bundle, String uid, @Nullable Locale locale) {
+    public List<Input> getLocalizedInputs(@Nullable List<Input> inputs, Bundle bundle, String uid,
+            @Nullable Locale locale) {
         List<Input> linputs = new ArrayList<>();
         if (inputs != null) {
             for (Input input : inputs) {
                 String inputName = input.getName();
-                String ilabel = ModuleTypeI18nUtil.getInputLabel(i18nProvider, bundle, uid, inputName, input.getLabel(),
-                        locale);
-                String idescription = ModuleTypeI18nUtil.getInputDescription(i18nProvider, bundle, uid, inputName,
-                        input.getDescription(), locale);
+                String ilabel = getInputLabel(bundle, uid, inputName, input.getLabel(), locale);
+                String idescription = getInputDescription(bundle, uid, inputName, input.getDescription(), locale);
                 linputs.add(new Input(inputName, input.getType(), ilabel, idescription, input.getTags(),
                         input.isRequired(), input.getReference(), input.getDefaultValue()));
             }
@@ -66,16 +70,14 @@ public class ModuleTypeI18nUtil {
         return linputs;
     }
 
-    public static List<Output> getLocalizedOutputs(TranslationProvider i18nProvider, @Nullable List<Output> outputs,
-            Bundle bundle, String uid, @Nullable Locale locale) {
+    public List<Output> getLocalizedOutputs(@Nullable List<Output> outputs, Bundle bundle, String uid,
+            @Nullable Locale locale) {
         List<Output> loutputs = new ArrayList<>();
         if (outputs != null) {
             for (Output output : outputs) {
                 String outputName = output.getName();
-                String olabel = ModuleTypeI18nUtil.getOutputLabel(i18nProvider, bundle, uid, outputName,
-                        output.getLabel(), locale);
-                String odescription = ModuleTypeI18nUtil.getOutputDescription(i18nProvider, bundle, uid, outputName,
-                        output.getDescription(), locale);
+                String olabel = getOutputLabel(bundle, uid, outputName, output.getLabel(), locale);
+                String odescription = getOutputDescription(bundle, uid, outputName, output.getDescription(), locale);
                 loutputs.add(new Output(outputName, output.getType(), olabel, odescription, output.getTags(),
                         output.getReference(), output.getDefaultValue()));
             }
@@ -83,41 +85,41 @@ public class ModuleTypeI18nUtil {
         return loutputs;
     }
 
-    private static @Nullable String getInputLabel(TranslationProvider i18nProvider, Bundle bundle, String moduleTypeUID,
-            String inputName, @Nullable String defaultLabel, @Nullable Locale locale) {
+    private @Nullable String getInputLabel(Bundle bundle, String moduleTypeUID, String inputName,
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferInputKey(moduleTypeUID, inputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static @Nullable String getInputDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String inputName, @Nullable String defaultDescription, @Nullable Locale locale) {
+    private @Nullable String getInputDescription(Bundle bundle, String moduleTypeUID, String inputName,
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferInputKey(moduleTypeUID, inputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static @Nullable String getOutputLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String ruleTemplateUID, String outputName, String defaultLabel, @Nullable Locale locale) {
+    private @Nullable String getOutputLabel(Bundle bundle, String ruleTemplateUID, String outputName,
+            String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferOutputKey(ruleTemplateUID, outputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    private static @Nullable String getOutputDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String moduleTypeUID, String outputName, String defaultDescription, @Nullable Locale locale) {
+    private @Nullable String getOutputDescription(Bundle bundle, String moduleTypeUID, String outputName,
+            String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferOutputKey(moduleTypeUID, outputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String inferModuleTypeKey(String moduleTypeUID, String lastSegment) {
+    private String inferModuleTypeKey(String moduleTypeUID, String lastSegment) {
         return MODULE_TYPE + "." + moduleTypeUID + "." + lastSegment;
     }
 
-    private static String inferInputKey(String moduleTypeUID, String inputName, String lastSegment) {
+    private String inferInputKey(String moduleTypeUID, String inputName, String lastSegment) {
         return MODULE_TYPE + ".input." + moduleTypeUID + ".name." + inputName + "." + lastSegment;
     }
 
-    private static String inferOutputKey(String moduleTypeUID, String outputName, String lastSegment) {
+    private String inferOutputKey(String moduleTypeUID, String outputName, String lastSegment) {
         return MODULE_TYPE + ".output." + moduleTypeUID + ".name." + outputName + "." + lastSegment;
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.internal.provider.i18n;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.openhab.core.automation.template.RuleTemplate;
@@ -25,18 +27,19 @@ import org.osgi.framework.Bundle;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class RuleTemplateI18nUtil {
 
     public static final String RULE_TEMPLATE = "rule-template";
 
-    public static String getLocalizedRuleTemplateLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String ruleTemplateUID, String defaultLabel, Locale locale) {
+    public static @Nullable String getLocalizedRuleTemplateLabel(TranslationProvider i18nProvider, Bundle bundle,
+            String ruleTemplateUID, @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferRuleTemplateKey(ruleTemplateUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static String getLocalizedRuleTemplateDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String ruleTemplateUID, String defaultDescription, Locale locale) {
+    public static @Nullable String getLocalizedRuleTemplateDescription(TranslationProvider i18nProvider, Bundle bundle,
+            String ruleTemplateUID, @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferRuleTemplateKey(ruleTemplateUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
@@ -45,5 +48,4 @@ public class RuleTemplateI18nUtil {
     private static String inferRuleTemplateKey(String ruleTemplateUID, String lastSegment) {
         return RULE_TEMPLATE + "." + ruleTemplateUID + "." + lastSegment;
     }
-
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
@@ -32,20 +32,26 @@ public class RuleTemplateI18nUtil {
 
     public static final String RULE_TEMPLATE = "rule-template";
 
-    public static @Nullable String getLocalizedRuleTemplateLabel(TranslationProvider i18nProvider, Bundle bundle,
-            String ruleTemplateUID, @Nullable String defaultLabel, @Nullable Locale locale) {
+    private final TranslationProvider i18nProvider;
+
+    public RuleTemplateI18nUtil(TranslationProvider i18nProvider) {
+        this.i18nProvider = i18nProvider;
+    }
+
+    public @Nullable String getLocalizedRuleTemplateLabel(Bundle bundle, String ruleTemplateUID,
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferRuleTemplateKey(ruleTemplateUID, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
-    public static @Nullable String getLocalizedRuleTemplateDescription(TranslationProvider i18nProvider, Bundle bundle,
-            String ruleTemplateUID, @Nullable String defaultDescription, @Nullable Locale locale) {
+    public @Nullable String getLocalizedRuleTemplateDescription(Bundle bundle, String ruleTemplateUID,
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferRuleTemplateKey(ruleTemplateUID, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    private static String inferRuleTemplateKey(String ruleTemplateUID, String lastSegment) {
+    private String inferRuleTemplateKey(String ruleTemplateUID, String lastSegment) {
         return RULE_TEMPLATE + "." + ruleTemplateUID + "." + lastSegment;
     }
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
@@ -24,6 +24,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.ParameterOption;
+import org.eclipse.smarthome.config.core.internal.i18n.ConfigDescriptionGroupI18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
@@ -98,6 +98,20 @@ public class ConfigI18nLocalizationService {
             final ConfigDescription configDescription, final ConfigDescriptionParameter parameter,
             final @Nullable Locale locale) {
         final URI configDescriptionURI = configDescription.getUID();
+        return getLocalizedConfigDescriptionParameter(bundle, configDescriptionURI, parameter, locale);
+    }
+
+    /**
+     * Localize a config description parameter.
+     *
+     * @param bundle the bundle the i18n resources are located
+     * @param configDescriptionURI the config description URI
+     * @param parameter the parameter that should be localized
+     * @param locale the locale it should be localized to
+     * @return a localized parameter on success, a non-localized one on error (e.g. no translation is found).
+     */
+    public ConfigDescriptionParameter getLocalizedConfigDescriptionParameter(final Bundle bundle,
+            final URI configDescriptionURI, final ConfigDescriptionParameter parameter, final @Nullable Locale locale) {
         final String parameterName = parameter.getName();
 
         final String label = configDescriptionI18nUtil.getParameterLabel(bundle, configDescriptionURI, parameterName,
@@ -142,6 +156,21 @@ public class ConfigI18nLocalizationService {
             final ConfigDescription configDescription, final ConfigDescriptionParameterGroup group,
             final @Nullable Locale locale) {
         final URI configDescriptionURI = configDescription.getUID();
+        return getLocalizedConfigDescriptionGroup(bundle, configDescriptionURI, group, locale);
+    }
+
+    /**
+     * Localize a config description parameter group.
+     *
+     * @param bundle the bundle the i18n resources are located
+     * @param configDescriptionURI the config description URI
+     * @param group the parameter group that should be localized
+     * @param locale the locale it should be localized to
+     * @return a localized parameter group on success, a non-localized one on error (e.g. no translation is found).
+     */
+    public ConfigDescriptionParameterGroup getLocalizedConfigDescriptionGroup(final Bundle bundle,
+            final URI configDescriptionURI, final ConfigDescriptionParameterGroup group,
+            final @Nullable Locale locale) {
         final String name = group.getName();
 
         final String label = configDescriptionGroupI18nUtil.getGroupLabel(bundle, configDescriptionURI, name,

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.ParameterOption;
 import org.eclipse.smarthome.config.core.internal.i18n.ConfigDescriptionGroupI18nUtil;
+import org.eclipse.smarthome.config.core.internal.i18n.ConfigDescriptionI18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.annotations.Activate;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigI18nLocalizationService.java
@@ -130,18 +130,19 @@ public class ConfigI18nLocalizationService {
         final List<ParameterOption> options = getLocalizedOptions(parameter.getOptions(), bundle, configDescriptionURI,
                 parameterName, locale);
 
-        final ConfigDescriptionParameter localizedParameter = ConfigDescriptionParameterBuilder
-                .create(parameterName, parameter.getType()).withMinimum(parameter.getMinimum())
-                .withMaximum(parameter.getMaximum()).withStepSize(parameter.getStepSize()).withPattern(pattern)
+        return ConfigDescriptionParameterBuilder.create(parameterName, parameter.getType())
+                .withMinimum(parameter.getMinimum()).withMaximum(parameter.getMaximum())
+                .withStepSize(parameter.getStepSize()).withPattern(pattern == null ? parameter.getPattern() : pattern)
                 .withRequired(parameter.isRequired()).withReadOnly(parameter.isReadOnly())
                 .withMultiple(parameter.isMultiple()).withContext(parameter.getContext())
-                .withDefault(parameter.getDefault()).withLabel(label).withDescription(description).withOptions(options)
+                .withDefault(parameter.getDefault()).withLabel(label == null ? parameter.getLabel() : label)
+                .withDescription(description == null ? parameter.getDescription() : description)
+                .withOptions(options == null || options.isEmpty() ? parameter.getOptions() : options)
                 .withFilterCriteria(parameter.getFilterCriteria()).withGroupName(parameter.getGroupName())
                 .withAdvanced(parameter.isAdvanced()).withVerify(parameter.isVerifyable())
                 .withLimitToOptions(parameter.getLimitToOptions()).withMultipleLimit(parameter.getMultipleLimit())
-                .withUnit(parameter.getUnit()).withUnitLabel(unitLabel).build();
-
-        return localizedParameter;
+                .withUnit(parameter.getUnit()).withUnitLabel(unitLabel == null ? parameter.getUnitLabel() : unitLabel)
+                .build();
     }
 
     /**
@@ -180,10 +181,8 @@ public class ConfigI18nLocalizationService {
         final String description = configDescriptionGroupI18nUtil.getGroupDescription(bundle, configDescriptionURI,
                 name, group.getDescription(), locale);
 
-        final ConfigDescriptionParameterGroup localizedGroup = new ConfigDescriptionParameterGroup(name,
-                group.getContext(), group.isAdvanced(), label, description);
-
-        return localizedGroup;
+        return new ConfigDescriptionParameterGroup(name, group.getContext(), group.isAdvanced(),
+                label == null ? group.getLabel() : label, description == null ? group.getDescription() : description);
     }
 
     /**
@@ -205,12 +204,10 @@ public class ConfigI18nLocalizationService {
 
         final List<ParameterOption> localizedOptions = new ArrayList<>();
         for (final ParameterOption option : originalOptions) {
+            final String label = configDescriptionI18nUtil.getParameterOptionLabel(bundle, configDescriptionURI,
+                    parameterName, option.getValue(), option.getLabel(), locale);
 
-            final String localizedLabel = configDescriptionI18nUtil.getParameterOptionLabel(bundle,
-                    configDescriptionURI, parameterName, /* key */option.getValue(), /* fallback */option.getLabel(),
-                    locale);
-            final ParameterOption localizedOption = new ParameterOption(option.getValue(), localizedLabel);
-            localizedOptions.add(localizedOption);
+            localizedOptions.add(new ParameterOption(option.getValue(), label == null ? option.getLabel() : label));
         }
         return localizedOptions;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
@@ -15,6 +15,8 @@ package org.eclipse.smarthome.config.core.internal.i18n;
 import java.net.URI;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.osgi.framework.Bundle;
@@ -26,6 +28,7 @@ import org.osgi.framework.Bundle;
  *
  * @author Chris Jackson - Initial contribution
  */
+@NonNullByDefault
 public class ConfigDescriptionGroupI18nUtil {
 
     private final TranslationProvider i18nProvider;
@@ -34,15 +37,15 @@ public class ConfigDescriptionGroupI18nUtil {
         this.i18nProvider = i18nProvider;
     }
 
-    public String getGroupDescription(Bundle bundle, URI configDescriptionURI, String groupName,
-            String defaultDescription, Locale locale) {
+    public @Nullable String getGroupDescription(Bundle bundle, URI configDescriptionURI, String groupName,
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferKey(configDescriptionURI, groupName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);
     }
 
-    public String getGroupLabel(Bundle bundle, URI configDescriptionURI, String groupName, String defaultLabel,
-            Locale locale) {
+    public @Nullable String getGroupLabel(Bundle bundle, URI configDescriptionURI, String groupName,
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferKey(configDescriptionURI, groupName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.smarthome.config.core.i18n;
+package org.eclipse.smarthome.config.core.internal.i18n;
 
 import java.net.URI;
 import java.util.Locale;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.smarthome.config.core.i18n;
+package org.eclipse.smarthome.config.core.internal.i18n;
 
 import java.net.URI;
 import java.util.Locale;
@@ -100,5 +100,4 @@ public class ConfigDescriptionI18nUtil {
         }
         return false;
     }
-
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.thing.internal.i18n.ChannelI18nUtil;
+import org.eclipse.smarthome.core.thing.internal.i18n.ThingTypeI18nUtil;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
+import org.eclipse.smarthome.core.thing.internal.i18n.ThingTypeI18nUtil;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.internal.i18n.ChannelGroupI18nUtil;
 import org.eclipse.smarthome.core.thing.internal.i18n.ChannelI18nUtil;
+import org.eclipse.smarthome.core.thing.internal.i18n.ThingTypeI18nUtil;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ThingTypeI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ThingTypeI18nUtil.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.smarthome.core.thing.i18n;
+package org.eclipse.smarthome.core.thing.internal.i18n;
 
 import java.util.Locale;
 
@@ -170,5 +170,4 @@ public class ThingTypeI18nUtil {
         return "thing-type." + thingTypeUID.getBindingId() + "." + thingTypeUID.getId() + ".channel." + channel.getId()
                 + "." + lastSegment;
     }
-
 }

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -4,7 +4,7 @@ Bundle-SymbolicName: ${project.artifactId}
 
 -runrequires: bnd.identity;id='org.openhab.core.automation.integration.tests'
 
-# We would like to use the "volatile" storage only
+# If we would like to use a storage at all, we will use the "volatile" storage.
 -runblacklist: \
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -5,6 +5,11 @@ Fragment-Host: org.openhab.core.automation
 
 -runrequires: bnd.identity;id='org.openhab.core.automation.module.core.tests'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #

--- a/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
@@ -4,6 +4,11 @@ Bundle-SymbolicName: ${project.artifactId}
 
 -runrequires: bnd.identity;id='org.openhab.core.automation.module.script.defaultscope.tests'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -5,6 +5,11 @@ Fragment-Host: org.openhab.core.automation.module.script
 
 -runrequires: bnd.identity;id='org.openhab.core.automation.module.script.tests'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -5,6 +5,11 @@ Fragment-Host: org.openhab.core.automation
 
 -runrequires: bnd.identity;id='org.openhab.core.automation.module.timer.tests'
 
+# If we would like to use a storage at all, we will use the "volatile" storage.
+-runblacklist: \
+    bnd.identity;id='org.openhab.core.storage.json',\
+    bnd.identity;id='org.openhab.core.storage.mapdb'
+
 #
 # done
 #


### PR DESCRIPTION
- Moved i18n util classes into internal packages
- Use `ConfigI18nLocalizationService` instead of `ConfigDescriptionI18nUtil` in other packages than `o.o.c.config.*`
- Refactoring of automation i18n util classes according our default implementation for these util classes (e.g. non static)
- Added nullness annotations for i18n util classes

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>