### PR TITLE
Bump jollyday version to 0.5.9

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -282,7 +282,7 @@
     <dependency>
       <groupId>de.jollyday</groupId>
       <artifactId>jollyday</artifactId>
-      <version>0.5.8</version>
+      <version>0.5.9</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -882,7 +882,8 @@
     <dependency>
       <groupId>de.jollyday</groupId>
       <artifactId>jollyday</artifactId>
-      <version>0.5.8</version>
+      <version>0.5.9</version>
+      <scope>compile</scope>
     </dependency>
 
   </dependencies>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -157,9 +157,9 @@
   </feature>
 
   <feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-    <capability>openhab.tp;feature=jollyday;version=0.5.8</capability>
-    <bundle>mvn:org.threeten/threeten-extra/1.4</bundle>
-    <bundle>mvn:de.jollyday/jollyday/0.5.8</bundle>
+    <capability>openhab.tp;feature=jollyday;version=0.5.9</capability>
+    <bundle>mvn:org.threeten/threeten-extra/1.5.0</bundle>
+    <bundle>mvn:de.jollyday/jollyday/0.5.9</bundle>
   </feature>
 
   <feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -46,6 +46,6 @@ Bundle-SymbolicName: ${project.artifactId}
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -47,6 +47,6 @@ Fragment-Host: org.openhab.core.automation
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.defaultscope.tests/itest.bndrun
@@ -47,6 +47,6 @@ Bundle-SymbolicName: ${project.artifactId}
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -48,6 +48,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -47,6 +47,6 @@ Fragment-Host: org.openhab.core.automation
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -18,7 +18,7 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.apache.commons.collections;version='[3.2.1,3.2.2)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\
 	org.apache.commons.lang;version='[2.6.0,2.6.1)',\
@@ -44,7 +44,7 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	org.openhab.core.thing;version='[2.5.0,2.5.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -52,9 +52,9 @@ feature.openhab-config: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.openhab.core.config.xml;version='[2.5.0,2.5.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -91,8 +91,8 @@ Fragment-Host: org.openhab.core.model.core
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -66,7 +66,7 @@ Fragment-Host: org.openhab.core.model.item
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
 	joda-time;version='[2.9.2,2.9.3)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
@@ -100,6 +100,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)'

--- a/itests/org.openhab.core.model.persistence.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.persistence.tests/itest.bndrun
@@ -93,8 +93,8 @@ Fragment-Host: org.openhab.core.model.persistence
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)',\

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -88,7 +88,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
@@ -99,7 +99,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -82,7 +82,7 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.test;version='[2.5.0,2.5.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.openhab.core.model.script.runtime;version='[2.5.0,2.5.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
@@ -94,7 +94,7 @@ Fragment-Host: org.openhab.core.model.script
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.3,7.2.4)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.2.3,7.2.4)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.openhab.core.model.item.runtime;version='[2.5.0,2.5.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -101,8 +101,8 @@ Fragment-Host: org.openhab.core.model.thing
 	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.openhab.core.ephemeris;version='[2.5.0,2.5.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.5.9,0.5.10)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	net.bytebuddy.byte-buddy;version='[1.9.10,1.9.11)',\


### PR DESCRIPTION
- Bump jollyday version to 0.5.9

Changes to `itest.bndrun` files don by

```
find . -name "*.bndrun" -exec sed -i "s|jollyday;version='\[0.5.8,0.5.9)'|jollyday;version='[0.5.9,0.5.10)'|g" {} \;
find . -name "*.bndrun" -exec sed -i "s|org.threeten.extra;version='\[1.4.0,1.4.1)'|org.threeten.extra;version='\[1.5.0,1.5.1)'|g" {} \;
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

---

There are also PRs to update the distro / add-ons for these changes:

- https://github.com/openhab/openhab-distro/pull/990
- https://github.com/openhab/openhab2-addons/pull/6300