### PR TITLE
Fix unstable MqttBrokerConnectionTests

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/pom.xml
+++ b/bundles/org.openhab.core.io.transport.mqtt/pom.xml
@@ -18,6 +18,12 @@
       <artifactId>org.openhab.core.config.core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.mqtt.internal.client.MqttAsyncClientWrapper;
 import org.eclipse.smarthome.io.transport.mqtt.reconnect.AbstractReconnectStrategy;
 import org.eclipse.smarthome.io.transport.mqtt.reconnect.PeriodicReconnectStrategy;
+import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.Test;
 import org.osgi.service.cm.ConfigurationException;
 
@@ -43,7 +44,7 @@ import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
  * @author David Graeff - Initial contribution
  * @author Jan N. Klug - adjusted to HiveMQ client
  */
-public class MqttBrokerConnectionTests {
+public class MqttBrokerConnectionTests extends JavaTest {
     @Test
     public void subscribeBeforeOnlineThenConnect()
             throws ConfigurationException, MqttException, InterruptedException, ExecutionException, TimeoutException {
@@ -168,8 +169,7 @@ public class MqttBrokerConnectionTests {
 
         // Check lostConnect
         verify(mockPolicy).lostConnection();
-        Thread.sleep(10);
-        verify(connection).start();
+        waitForAssert(() -> verify(connection).start());
         assertTrue(mockPolicy.isReconnecting());
 
         // Fake connection established


### PR DESCRIPTION
Using `waitForAssert` instead of sleeping 10ms makes the tests stable when the system has some load.

Fixes #1139