### PR TITLE
[automation] Added script filename to engine, if engineIdentifier is a file

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -177,6 +177,8 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     File maybeScriptFile = Paths.get(fileURI).toFile();
                     if (maybeScriptFile.isFile()) {
                         engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
+                    } else {
+                        logger.debug("engineIdentifier '{}' is not a file", engineIdentifier);
                     }
                 }
             }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -169,11 +169,11 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
     private void tryExtractAndInjectFilename(String engineIdentifier, ScriptEngine engine) {
         try {
             File maybeScriptFile = new File(engineIdentifier);
-            if(maybeScriptFile.isFile()) {
+            if (maybeScriptFile.isFile()) {
                 engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
             }
         } catch (Exception e) {
-            logger.warn("Failure whilst inserting script filename: {}" + e.getMessage());
+            logger.warn("Failure while adding file name for script '{}' to the ScriptEngine: {}", engineIdentifier, e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -14,6 +14,9 @@ package org.openhab.core.automation.module.script.internal;
 
 import java.io.File;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -168,9 +171,14 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
 
     private void tryExtractAndInjectFilename(String engineIdentifier, ScriptEngine engine) {
         try {
-            File maybeScriptFile = new File(engineIdentifier);
-            if (maybeScriptFile.isFile()) {
-                engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
+            if(engine.getContext().getAttribute(ScriptEngine.FILENAME) == null) {
+                URI fileURI = new URL(engineIdentifier).toURI();
+                if ("file".equals(fileURI.getScheme())) {
+                    File maybeScriptFile = Paths.get(fileURI).toFile();
+                    if (maybeScriptFile.isFile()) {
+                        engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
+                    }
+                }
             }
         } catch (Exception e) {
             logger.warn("Failure while adding file name for script '{}' to the ScriptEngine: {}", engineIdentifier, e.getMessage());

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.core.automation.module.script.internal;
 
+import java.io.File;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.script.Invocable;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
@@ -145,6 +147,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
         } else {
             ScriptEngine engine = container.getScriptEngine();
             try {
+                tryExtractAndInjectFilename(engineIdentifier, engine);
                 engine.eval(scriptData);
 
                 if (engine instanceof Invocable) {
@@ -160,6 +163,17 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
             } catch (Exception ex) {
                 logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
             }
+        }
+    }
+
+    private void tryExtractAndInjectFilename(String engineIdentifier, ScriptEngine engine) {
+        try {
+            File maybeScriptFile = new File(engineIdentifier);
+            if(maybeScriptFile.isFile()) {
+                engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
+            }
+        } catch (Exception e) {
+            logger.warn("Failure whilst inserting script filename: {}" + e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -150,7 +150,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
         } else {
             ScriptEngine engine = container.getScriptEngine();
             try {
-                tryExtractAndInjectFilename(engineIdentifier, engine);
+                injectFilename(engineIdentifier, engine);
                 engine.eval(scriptData);
 
                 if (engine instanceof Invocable) {
@@ -169,14 +169,14 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
         }
     }
 
-    private void tryExtractAndInjectFilename(String engineIdentifier, ScriptEngine engine) {
+    private void injectFilename(String engineIdentifier, ScriptEngine engine) {
         try {
             if(engine.getContext().getAttribute(ScriptEngine.FILENAME) == null) {
                 URI fileURI = new URL(engineIdentifier).toURI();
                 if ("file".equals(fileURI.getScheme())) {
-                    File maybeScriptFile = Paths.get(fileURI).toFile();
-                    if (maybeScriptFile.isFile()) {
-                        engine.getContext().setAttribute(ScriptEngine.FILENAME, maybeScriptFile.getName(), ScriptContext.ENGINE_SCOPE);
+                    File scriptFile = Paths.get(fileURI).toFile();
+                    if (scriptFile.isFile()) {
+                        engine.getContext().setAttribute(ScriptEngine.FILENAME, scriptFile.getName(), ScriptContext.ENGINE_SCOPE);
                     } else {
                         logger.debug("engineIdentifier '{}' is not a file", engineIdentifier);
                     }


### PR DESCRIPTION
Attempt to determine the the filename from engineIdentifier and set it as the filename of the script being evaluated. If the engineIdentifier is not a file, then ignore.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>