### PR TITLE
Upgrade Karaf tooling and openHAB TP to 4.2.7

### DIFF
--- a/features/karaf/openhab-core/pom.xml
+++ b/features/karaf/openhab-core/pom.xml
@@ -15,8 +15,8 @@
   <description>openHAB Core Features</description>
 
   <properties>
-    <jetty.version>9.4.18.v20190429</jetty.version>
-    <jna.version>4.5.2</jna.version>
+    <jetty.version>9.4.20.v20190813</jetty.version>
+    <jna.version>5.4.0</jna.version>
   </properties>
 
   <build>

--- a/features/karaf/openhab-tp/pom.xml
+++ b/features/karaf/openhab-tp/pom.xml
@@ -14,7 +14,7 @@
   <name>openHAB Core :: Features :: Karaf :: Target Platform</name>
 
   <properties>
-    <jetty.version>9.4.18.v20190429</jetty.version>
+    <jetty.version>9.4.20.v20190813</jetty.version>
   </properties>
 
   <build>

--- a/features/karaf/pom.xml
+++ b/features/karaf/pom.xml
@@ -28,6 +28,13 @@
       <version>${karaf.tooling.version}</version>
       <type>kar</type>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <!-- This should have been an optional dependency and will be fixed in Karaf 4.2.8 (KARAF-6462). -->
+          <groupId>org.knopflerfish.kf6</groupId>
+          <artifactId>log-API</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Repositories -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <bnd.version>4.2.0</bnd.version>
     <karaf.compile.version>4.2.1</karaf.compile.version>
-    <karaf.tooling.version>4.2.6</karaf.tooling.version>
+    <karaf.tooling.version>4.2.7</karaf.tooling.version>
     <sat.version>0.8.0</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
     <xtext.version>2.19.0</xtext.version>


### PR DESCRIPTION
For Karaf 4.2.7 release notes, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12345539

Also updates the following openHAB TP dependencies:

* Jetty 9.4.20.v20190813
* JNA 5.4.0 (used by most add-ons)

---

Should be merged together with:

* https://github.com/openhab/openhab2-addons/pull/6368
* https://github.com/openhab/openhab-webui/pull/139
* https://github.com/openhab/openhab-distro/pull/996

See also : https://github.com/openhab/openhab-distro/issues/995