### PR TITLE
Upgrade bnd to 4.3.0

### DIFF
--- a/features/pom.xml
+++ b/features/pom.xml
@@ -19,4 +19,14 @@
     <module>karaf</module>
   </modules>
 
+  <dependencies>
+    <!-- BOM, so features are build after bundles in parallel builds -->
+    <dependency>
+      <groupId>org.openhab.core.bom</groupId>
+      <artifactId>org.openhab.core.bom.openhab-core</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </scm>
 
   <issueManagement>
-    <system>Github</system>
+    <system>GitHub</system>
     <url>https://github.com/openhab/openhab-core/issues</url>
   </issueManagement>
 
@@ -69,7 +69,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
-    <bnd.version>4.2.0</bnd.version>
+    <bnd.version>4.3.0</bnd.version>
     <karaf.compile.version>4.2.1</karaf.compile.version>
     <karaf.tooling.version>4.2.7</karaf.tooling.version>
     <sat.version>0.8.0</sat.version>


### PR DESCRIPTION
For bnd 4.3.0 release notes, see:

https://github.com/bndtools/bnd/wiki/Changes-in-4.3.0

Also note:

    The Bnd Maven plugins are now marked thread safe and can be used with -T.

It seems to work well so far as long as the features are build after the bundles so I've added the bundles BOM as dependency to the features POM.
We still need to make SAT thread safe (openhab/static-code-analysis#200).

When disabling SAT you can build using one thread per processor core by executing:

    mvn clean install -DskipChecks -T 1C

This significantly speeds up Maven builds and puts all your processor cores to good use. :-)