### PR TITLE
Bump Californium to 2.0.0-RC1

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -41,11 +41,11 @@
   </feature>
 
   <feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
-    <capability>openhab.tp;feature=coap;version=2.0.0-M18</capability>
-    <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0-M18</bundle>
-    <bundle>mvn:org.eclipse.californium/californium-core/2.0.0-M18</bundle>
-    <bundle>mvn:org.eclipse.californium/element-connector/2.0.0-M18</bundle>
-    <bundle>mvn:org.eclipse.californium/scandium/2.0.0-M18</bundle>
+    <capability>openhab.tp;feature=coap;version=2.0.0-RC1</capability>
+    <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0-RC1</bundle>
+    <bundle>mvn:org.eclipse.californium/californium-core/2.0.0-RC1</bundle>
+    <bundle>mvn:org.eclipse.californium/element-connector/2.0.0-RC1</bundle>
+    <bundle>mvn:org.eclipse.californium/scandium/2.0.0-RC1</bundle>
   </feature>
 
   <feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -43,6 +43,7 @@
   <feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
     <capability>openhab.tp;feature=coap;version=2.0.0-M18</capability>
     <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0-M18</bundle>
+    <bundle>mvn:org.eclipse.californium/californium-core/2.0.0-M18</bundle>
     <bundle>mvn:org.eclipse.californium/element-connector/2.0.0-M18</bundle>
     <bundle>mvn:org.eclipse.californium/scandium/2.0.0-M18</bundle>
   </feature>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -41,10 +41,10 @@
   </feature>
 
   <feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
-    <capability>openhab.tp;feature=coap;version=1.0.7</capability>
-    <bundle>mvn:org.eclipse.californium/californium-osgi/1.0.7</bundle>
-    <bundle>mvn:org.eclipse.californium/element-connector/1.0.7</bundle>
-    <bundle>mvn:org.eclipse.californium/scandium/1.0.7</bundle>
+    <capability>openhab.tp;feature=coap;version=2.0.0-M18</capability>
+    <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0-M18</bundle>
+    <bundle>mvn:org.eclipse.californium/element-connector/2.0.0-M18</bundle>
+    <bundle>mvn:org.eclipse.californium/scandium/2.0.0-M18</bundle>
   </feature>
 
   <feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">


### PR DESCRIPTION
- Bump Californium to 2.0.0-RC1

Release for Californium 2.0.0 is scheduled for December 5th 2019 (see https://github.com/eclipse/californium/issues/1131). If we want to use the updated Californium version in OH 2.5.0 release we should move to 2.0.0-RC1 now (before our next OH 2.5.0.M5 milestone - scheduled on Nov. 17th). After milestone OH 2.5.0.M5 we will freeze our code apart from major/critical bug fixes.

Before merging this we should prepare the necessary changes for the [TRÅDFRI Binding](https://github.com/openhab/openhab2-addons/tree/master/bundles/org.openhab.binding.tradfri). @markus7017 Might I ask you to prepare everything? IIRC you already did some tests with updating the binding. Don't you?

Closes #1096

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>