### PR TITLE
Feature: system.round profile for rounding numbers before reaching an item

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -66,7 +66,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Collections
             .unmodifiableSet(Stream
-                    .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE,
+                    .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, ROUND_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE,
                             RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE,
                             RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE,
                             RAWROCKER_PLAY_PAUSE_TYPE, RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE,
@@ -74,7 +74,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
                     .collect(Collectors.toSet()));
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Collections
-            .unmodifiableSet(Stream.of(DEFAULT, FOLLOW, OFFSET, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER,
+            .unmodifiableSet(Stream.of(DEFAULT, FOLLOW, OFFSET, ROUND, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER,
                     RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS,
                     RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE,
                     RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_UPDATE).collect(Collectors.toSet()));
@@ -102,6 +102,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemFollowProfile(callback);
         } else if (OFFSET.equals(profileTypeUID)) {
             return new SystemOffsetProfile(callback, context);
+        } else if (ROUND.equals(profileTypeUID)) {
+            return new SystemRoundProfile(callback, context);
         } else if (RAWBUTTON_ON_OFF_SWITCH.equals(profileTypeUID)) {
             return new RawButtonOnOffSwitchProfile(callback);
         } else if (RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfile.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfile;
+import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies the given parameter "pattern" to a QuantityType or DecimalType state
+ *
+ * @author Arne Seime - Initial contribution
+ */
+@NonNullByDefault
+public class SystemRoundProfile implements StateProfile {
+
+    private final Logger logger = LoggerFactory.getLogger(SystemRoundProfile.class);
+    private static final String ROUND_PARAM = "decimals";
+
+    private final ProfileCallback callback;
+    private final ProfileContext context;
+
+    private @Nullable DecimalFormat format;
+    private int numDecimals = 0;
+
+    public SystemRoundProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+        this.context = context;
+
+        Object paramValue = this.context.getConfiguration().get(ROUND_PARAM);
+        logger.debug("Configuring profile with {} parameter '{}'", ROUND_PARAM, paramValue);
+        try {
+            numDecimals = Integer.parseInt((String) paramValue);
+            if (Math.abs(numDecimals) <= 10) {
+                if (numDecimals <= 0) {
+                    format = new DecimalFormat("#");
+                } else if (numDecimals > 0) {
+                    format = new DecimalFormat("#." + StringUtils.rightPad("#", numDecimals));
+                }
+            } else {
+                logger.error("Parameter '{}' must be between -10 and 10, no rounding will occur", ROUND_PARAM);
+            }
+        } catch (NullPointerException | NumberFormatException e) {
+            logger.error("Parameter '{}' is not a valid integer, no rounding will occur", ROUND_PARAM);
+        }
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.ROUND;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        callback.handleUpdate((State) applyRounding(state));
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand((Command) applyRounding(command));
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        callback.sendCommand((Command) applyRounding(command));
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        callback.sendUpdate((State) applyRounding(state));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Type applyRounding(Type state) {
+        if (state instanceof UnDefType) {
+            return state;
+        }
+        Type result = state;
+        if (format != null) {
+            if (state instanceof QuantityType) {
+                QuantityType qtState = (QuantityType) state;
+                BigDecimal originalValue = qtState.toBigDecimal();
+                String roundedValue = roundAsString(originalValue);
+                result = new QuantityType<>(new BigDecimal(roundedValue), qtState.getUnit());
+            } else if (state instanceof DecimalType) {
+                BigDecimal originalValue = ((DecimalType) state).toBigDecimal();
+                String roundedValue = roundAsString(originalValue);
+                result = new DecimalType(roundedValue);
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("null")
+    private String roundAsString(BigDecimal originalValue) {
+        String formattedValue;
+        if (numDecimals < 0) {
+            double pow = Math.pow(10, Math.abs(numDecimals));
+            formattedValue = format.format((Math.round(originalValue.doubleValue() / pow) * pow));
+        } else {
+            formattedValue = format.format(originalValue.doubleValue());
+        }
+        return formattedValue;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -29,6 +29,7 @@ public interface SystemProfiles {
     ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
     ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
+    ProfileTypeUID ROUND = new ProfileTypeUID(SYSTEM_SCOPE, "round");
     ProfileTypeUID RAWBUTTON_ON_OFF_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-on-off-switch");
     ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
     ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-rollershutter");
@@ -48,6 +49,10 @@ public interface SystemProfiles {
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
     StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
+            .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
+            .build();
+
+    StateProfileType ROUND_TYPE = ProfileTypeBuilder.newState(ROUND, "Round")
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
             .build();
 

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemRoundProfileTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import javax.measure.quantity.Temperature;
+
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+import org.eclipse.smarthome.core.types.Type;
+import org.junit.Test;
+
+/**
+ * Tests for the system:round profile
+ *
+ * @author Arne Seime - Initial contribution
+ */
+public class SystemRoundProfileTest {
+
+    @Test
+    public void testDecimalType() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "1");
+
+        Type cmd = new DecimalType(1.23);
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        DecimalType decResult = (DecimalType) roundedValue;
+        assertEquals(1.2, decResult.doubleValue(), 0);
+    }
+
+    @Test
+    public void testDecimalToInt() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "0");
+
+        Type cmd = new DecimalType(123.4);
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        DecimalType decResult = (DecimalType) roundedValue;
+        assertEquals(123, decResult.doubleValue(), 0);
+    }
+
+    @Test
+    public void testDecimalToTen() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "-1");
+
+        Type cmd = new DecimalType(123.4);
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        DecimalType decResult = (DecimalType) roundedValue;
+        assertEquals(120, decResult.doubleValue(), 0);
+    }
+
+    @Test
+    public void testDecimalToHundred() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "-2");
+
+        Type cmd = new DecimalType(951);
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        DecimalType decResult = (DecimalType) roundedValue;
+        assertEquals(1000, decResult.doubleValue(), 0);
+    }
+
+    @Test
+    public void testDecimalToHundredDown() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "-2");
+
+        Type cmd = new DecimalType(949);
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        DecimalType decResult = (DecimalType) roundedValue;
+        assertEquals(900, decResult.doubleValue(), 0);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testQuantityType() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemRoundProfile offsetProfile = createProfile(callback, "1");
+
+        Type cmd = new QuantityType<>("1.55°C");
+        Type roundedValue = offsetProfile.applyRounding(cmd);
+
+        QuantityType<Temperature> decResult = (QuantityType<Temperature>) roundedValue;
+        assertEquals(1.6, decResult.doubleValue(), 0);
+        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
+
+    }
+
+    private SystemRoundProfile createProfile(ProfileCallback callback, String numDecimals) {
+        ProfileContext context = mock(ProfileContext.class);
+        Configuration config = new Configuration();
+        config.put("decimals", numDecimals);
+        when(context.getConfiguration()).thenReturn(config);
+
+        return new SystemRoundProfile(callback, context);
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -74,7 +74,7 @@ public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
     @Test
     public void systemProfileTypesAndUidsShouldBeAvailable() {
         Collection<ProfileTypeUID> systemProfileTypeUIDs = profileFactory.getSupportedProfileTypeUIDs();
-        assertEquals(15, systemProfileTypeUIDs.size());
+        assertEquals(16, systemProfileTypeUIDs.size());
 
         Collection<ProfileType> systemProfileTypes = profileFactory.getProfileTypes(null);
         assertEquals(systemProfileTypeUIDs.size(), systemProfileTypes.size());


### PR DESCRIPTION
Similar to the `system.offset` profile, just with number rounding.

Use case: Avoid getting spammed with item updates for nearly identical values. A typical example is anything that measures AC amps/volt as it fluctuates slightly on every read.

Examples: 
`{channel=":volt" [profile="round", decimals="0"]}` will round to nearest int ie 123.32 -> 123
`{channel=":volt" [profile="round", decimals="1"]}` will have 1 decimal place, similar to `DecimalFormat("#.#")` ie 123.32 -> 123.3
`{channel=":volt" [profile="round", decimals="-1"]}` will round to nearest 10 ie 123.32 -> 120
`{channel=":volt" [profile="round", decimals="-2"]}` will round to nearest 100 ie 123.32 -> 100

Any number between 10 and -10 accepted as `decimals` profile parameter.
Handles `DecimalType` and `QuantityType`.

Signed-off-by: Arne Seime <arne.seime@gmail.com>