### PR TITLE
[io.mqtt] Use constructor injection to simplify lifecycle

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/pom.xml
+++ b/bundles/org.openhab.core.io.transport.mqtt/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -207,7 +206,7 @@ public class MqttBrokerConnection {
     }
 
     /**
-     * Create a new MQTT3 client connection to a server with the given protocol, mqtt client version,  host and port.
+     * Create a new MQTT3 client connection to a server with the given protocol, mqtt client version, host and port.
      *
      * @param protocol The transport protocol
      * @param host A host name or address
@@ -265,7 +264,8 @@ public class MqttBrokerConnection {
      * state to the MQTT broker changed.
      *
      * The reconnect strategy will not be informed if the initial connection to the broker
-     * timed out. You need a timeout executor additionally, see {@link #setTimeoutExecutor(ScheduledExecutorService, int)}.
+     * timed out. You need a timeout executor additionally, see
+     * {@link #setTimeoutExecutor(ScheduledExecutorService, int)}.
      *
      * @param reconnectStrategy The reconnect strategy. May not be null.
      */

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/ClientCallback.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/ClientCallback.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.hivemq.client.mqtt.datatypes.MqttTopic;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
@@ -28,6 +27,7 @@ import org.eclipse.smarthome.io.transport.mqtt.reconnect.AbstractReconnectStrate
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.hivemq.client.mqtt.datatypes.MqttTopic;
 import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
@@ -45,16 +45,13 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class MqttBrokerConnectionServiceInstance {
     private final Logger logger = LoggerFactory.getLogger(MqttBrokerConnectionServiceInstance.class);
+
     private @Nullable MqttBrokerConnection connection;
-    private @Nullable MqttService mqttService;
+    private final MqttService mqttService;
 
-    @Reference
-    public void setMqttService(MqttService service) {
-        mqttService = service;
-    }
-
-    public void unsetMqttService(MqttService service) {
-        mqttService = null;
+    @Activate
+    public MqttBrokerConnectionServiceInstance(final @Reference MqttService mqttService) {
+        this.mqttService = mqttService;
     }
 
     /**
@@ -68,8 +65,7 @@ public class MqttBrokerConnectionServiceInstance {
         }
 
         final MqttServiceImpl service = (MqttServiceImpl) mqttService;
-
-        if (configMap == null || configMap.isEmpty() || service == null) {
+        if (configMap == null || configMap.isEmpty()) {
             return;
         }
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttServiceImpl.java
@@ -40,9 +40,8 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Added/Removed observer interface, Add/Remove/Enumerate broker connections.
  * @author Markus Rathgeb - Synchronize access to broker connections
  */
-@Component(immediate = true, service = {
-        MqttService.class }, configurationPid = "org.eclipse.smarthome.mqtt", property = {
-                Constants.SERVICE_PID + "=org.eclipse.smarthome.mqtt" })
+@Component(immediate = true, service = MqttService.class, configurationPid = "org.eclipse.smarthome.mqtt", property = {
+        Constants.SERVICE_PID + "=org.eclipse.smarthome.mqtt" })
 @NonNullByDefault
 public class MqttServiceImpl implements MqttService {
     private final Logger logger = LoggerFactory.getLogger(MqttServiceImpl.class);

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/resources/ESH-INF/config/brokerConnectionInstance.xml
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/resources/ESH-INF/config/brokerConnectionInstance.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
 	https://openhab.org/schemas/config-description-1.0.0.xsd">
@@ -11,67 +12,65 @@
 			<description>A group of connection parameters.</description>
 			<advanced>false</advanced>
 		</parameter-group>
+
 		<parameter-group name="group_message_params">
-			<label>Message parameters</label>
+			<label>Message</label>
+			<description>All message parameters.</description>
 			<advanced>true</advanced>
 		</parameter-group>
+
 		<parameter-group name="group_lastwill_params">
-			<label>Last will</label>
-			<description>All last-will parameters</description>
+			<label>Last Will</label>
+			<description>All last-will parameters.</description>
 			<advanced>true</advanced>
 		</parameter-group>
 
 		<parameter name="name" type="text" required="false" groupName="group_connection">
-			<label>Connection name</label>
-			<description>A connection name helps to identify a broker connection. If nothing is set, an automatic name based on the host and port will be generated.</description>
-			<default />
+			<label>Connection Name</label>
+			<description>A connection name helps to identify a broker connection. If nothing is set, an automatic name based on
+				the host and port will be generated.</description>
 		</parameter>
-
 		<parameter name="host" type="text" required="true" groupName="group_connection">
-			<label>Broker host</label>
-			<description>Hostname or IP of the broker</description>
-			<default />
+			<label>Broker Host</label>
+			<description>Hostname or IP of the broker.</description>
 		</parameter>
-		<parameter name="port" type="integer" required="false" groupName="group_connection">
-			<label>Broker port</label>
-			<description>A custom broker connection port. Leave empty to use the default Mqtt ports for secure or non-secure connections</description>
-			<default />
+		<parameter name="port" type="integer" min="1" max="65535" required="false" groupName="group_connection">
+			<label>Broker Port</label>
+			<description>A custom broker connection port. Leave empty to use the default MQTT ports for secure or non-secure
+				connections.</description>
 			<advanced>true</advanced>
 		</parameter>
 		<parameter name="secure" type="boolean" required="true" groupName="group_connection">
-			<label>Secure connection?</label>
-			<description>A broker connection is either a non-secure tcp connection or a tls secure connection</description>
+			<label>Secure Connection?</label>
+			<description>A broker connection is either a non-secure TCP connection or a TLS secure connection.</description>
 			<default>false</default>
 		</parameter>
-
 		<parameter name="username" type="text" required="false" groupName="group_connection">
-			<label>Broker username</label>
-			<description>Broker username</description>
-			<default />
+			<label>Broker Username</label>
+			<description>Broker username.</description>
 		</parameter>
 		<parameter name="password" type="text" required="false" groupName="group_connection">
-			<label>Broker password</label>
-			<description>Broker password</description>
-			<default />
+			<label>Broker Password</label>
+			<description>Broker password.</description>
 			<context>password</context>
 		</parameter>
 		<parameter name="clientID" type="text" required="false" groupName="group_connection">
 			<label>Client ID</label>
-			<description>An optional client ID used for this connection</description>
-			<default />
+			<description>An optional client ID used for this connection.</description>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="keepAlive" type="integer" required="false" groupName="group_connection">
-			<label>Keep-alive (sec)</label>
-			<description>Keep-alive timer in seconds. A too frequent timer could conquest the network / spam the Mqtt server, a too low value might risk that a broken connection is detected very late.</description>
+		<parameter name="keepAlive" type="integer" required="false" unit="s" groupName="group_connection">
+			<label>Keep-Alive</label>
+			<description>Keep-alive timer in seconds. A too frequent timer could conquest the network / spam the MQTT server, a
+				too low value might risk that a broken connection is detected very late.</description>
 			<default>60</default>
 			<advanced>true</advanced>
 		</parameter>
 
 		<parameter name="qos" type="integer" required="false" groupName="group_message_params">
-			<label>Quality of service</label>
-			<description>The Quality of Service (QoS) level is an agreement between sender and receiver of a message regarding the guarantees of delivering a message.</description>
-			<limitToOptions>true</limitToOptions>
+			<label>Quality of Service</label>
+			<description>The Quality of Service (QoS) level is an agreement between sender and receiver of a message regarding
+				the guarantees of delivering a message.</description>
 			<options>
 				<option value="0">At most once (best effort delivery "fire and forget")</option>
 				<option value="1">At least once (guaranteed that a message will be delivered at least once)</option>
@@ -80,26 +79,25 @@
 			<default>0</default>
 		</parameter>
 		<parameter name="retainMessages" type="boolean" required="false" groupName="group_message_params">
-			<label>Retain messages</label>
+			<label>Retain Messages</label>
 			<description>Messages send by this connection are retained</description>
 			<default>false</default>
 		</parameter>
 
-
 		<parameter name="lwtTopic" type="text" required="false" groupName="group_lastwill_params">
-			<label>Last will topic</label>
-			<description>When the connection dies, the last will is performed by the Mqtt server. This is the last-will topic. It must be set to perform a last-will.</description>
-			<default />
+			<label>Last Will - Topic</label>
+			<description>When the connection dies, the last-will is performed by the MQTT server. This is the last-will topic. It
+				must be set to perform a last-will.</description>
 		</parameter>
 		<parameter name="lwtMessage" type="text" required="false" groupName="group_lastwill_params">
-			<label>Last will message</label>
-			<description>When the connection dies, the last will is performed by the Mqtt server. This is the last-will message. Can be empty.</description>
-			<default />
+			<label>Last Will - Message</label>
+			<description>When the connection dies, the last-will is performed by the MQTT server. This is the last-will message.
+				Can be empty.</description>
 		</parameter>
 		<parameter name="lwtQos" type="integer" required="false" groupName="group_lastwill_params">
-			<label>Last will quality of service</label>
-			<description>The Quality of Service (QoS) level is an agreement between sender and receiver of a message regarding the guarantees of delivering a message.</description>
-			<limitToOptions>true</limitToOptions>
+			<label>Last Will - Quality of Service</label>
+			<description>The Quality of Service (QoS) level is an agreement between sender and receiver of a message regarding
+				the guarantees of delivering a message.</description>
 			<options>
 				<option value="0">At most once (best effort delivery "fire and forget")</option>
 				<option value="1">At least once (guaranteed that a message will be delivered at least once)</option>
@@ -108,9 +106,11 @@
 			<default>0</default>
 		</parameter>
 		<parameter name="lwtRetain" type="boolean" required="false" groupName="group_lastwill_params">
-			<label>Last will retain message</label>
-			<description>When the connection dies, the last will is performed by the Mqtt server. If retain message is checked, the message will be retained by the Mqtt server.</description>
+			<label>Last Will - Retain Message</label>
+			<description>When the connection dies, the last-will is performed by the MQTT server. If retain message is checked,
+				the message will be retained by the MQTT server.</description>
 			<default>false</default>
 		</parameter>
+
 	</config-description>
 </config-description:config-descriptions>


### PR DESCRIPTION
- Use constructor injection to simplify lifecycle
- Improved ESH-INF labels to comply with casing rules

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>