### PR TITLE
Parameterized logging fixes

### DIFF
--- a/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.compat1x/src/main/java/org/openhab/io/net/http/HttpUtil.java
@@ -118,7 +118,7 @@ public class HttpUtil {
                 try {
                     proxyPort = Integer.valueOf(proxyPortString);
                 } catch (NumberFormatException e) {
-                    LOGGER.warn("'{}' is not a valid proxy port - using port 80 instead");
+                    LOGGER.warn("'{}' is not a valid proxy port - using port 80 instead", proxyPortString);
                 }
             }
             proxyUser = System.getProperty("http.proxyUser");

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1272,7 +1272,8 @@ public class ThingManagerImpl
             return thing.isEnabled();
         }
 
-        logger.debug("Thing with UID {} is unknown. Will try to get the enabled status from the persistent storage.");
+        logger.debug("Thing with UID {} is unknown. Will try to get the enabled status from the persistent storage.",
+                thingUID);
         return !isDisabledByStorage(thingUID);
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -608,7 +608,7 @@ public class NetUtil implements NetworkAddressService {
             }
             NetworkAddressChangeListener safeListener = safeCaller.create(listener, NetworkAddressChangeListener.class)
                     .withTimeout(15000)
-                    .onException(exception -> LOGGER.debug("NetworkAddressChangeListener exception {}", exception))
+                    .onException(exception -> LOGGER.debug("NetworkAddressChangeListener exception", exception))
                     .build();
             safeListener.onChanged(unmodifiableAddedList, unmodifiableRemovedList);
         }
@@ -625,7 +625,7 @@ public class NetUtil implements NetworkAddressService {
                 }
                 NetworkAddressChangeListener safeListener = safeCaller
                         .create(listener, NetworkAddressChangeListener.class).withTimeout(15000)
-                        .onException(exception -> LOGGER.debug("NetworkAddressChangeListener exception {}", exception))
+                        .onException(exception -> LOGGER.debug("NetworkAddressChangeListener exception", exception))
                         .build();
                 safeListener.onPrimaryAddressChanged(oldPrimaryAddress, newPrimaryAddress);
             }


### PR DESCRIPTION
Make sure Throwables are not be substituted into log messages so they can be formatted according to the logging configuration.