### PR TITLE
[core] Removed access to 'BundleContext' from 'BaseThingHandler'

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -37,7 +37,6 @@ import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,9 +66,6 @@ public abstract class BaseThingHandler implements ThingHandler {
     protected final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(THING_HANDLER_THREADPOOL_NAME);
 
-    @Deprecated // this must not be used by bindings!
-    protected @NonNullByDefault({}) BundleContext bundleContext;
-
     protected Thing thing;
 
     private @Nullable ThingHandlerCallback callback;
@@ -81,14 +77,6 @@ public abstract class BaseThingHandler implements ThingHandler {
      */
     public BaseThingHandler(Thing thing) {
         this.thing = thing;
-    }
-
-    public void setBundleContext(final BundleContext bundleContext) {
-        this.bundleContext = bundleContext;
-    }
-
-    public void unsetBundleContext(final BundleContext bundleContext) {
-        this.bundleContext = null;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -73,7 +73,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
      * @param componentContext component context (must not be null)
      */
     protected void activate(ComponentContext componentContext) {
-        this.bundleContext = componentContext.getBundleContext();
+        bundleContext = componentContext.getBundleContext();
         thingTypeRegistryServiceTracker = new ServiceTracker<>(bundleContext, ThingTypeRegistry.class.getName(), null);
         thingTypeRegistryServiceTracker.open();
         configDescriptionRegistryServiceTracker = new ServiceTracker<>(bundleContext,
@@ -132,7 +132,6 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
             throw new IllegalStateException(
                     "Created handler of bridge '" + thing.getUID() + "' must implement the BridgeHandler interface.");
         }
-        setHandlerContext(thingHandler);
         registerConfigStatusProvider(thing, thingHandler);
         registerFirmwareUpdateHandler(thing, thingHandler);
         registerServices(thing, thingHandler);
@@ -174,7 +173,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                 if (!serviceNames.isEmpty()) {
                     String[] serviceNamesArray = serviceNames.toArray(new String[serviceNames.size()]);
 
-                    ServiceRegistration<?> serviceReg = this.bundleContext.registerService(serviceNamesArray,
+                    ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNamesArray,
                             serviceInstance, null);
 
                     if (serviceReg != null) {
@@ -219,16 +218,6 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
      */
     protected abstract @Nullable ThingHandler createHandler(Thing thing);
 
-    private void setHandlerContext(ThingHandler thingHandler) {
-        if (thingHandler instanceof BaseThingHandler) {
-            if (bundleContext == null) {
-                throw new IllegalStateException(
-                        "Base thing handler factory has not been properly initialized. Did you forget to call super.activate()?");
-            }
-            ((BaseThingHandler) thingHandler).setBundleContext(bundleContext);
-        }
-    }
-
     private void registerConfigStatusProvider(Thing thing, ThingHandler thingHandler) {
         if (thingHandler instanceof ConfigStatusProvider) {
             ServiceRegistration<ConfigStatusProvider> serviceRegistration = registerAsService(thingHandler,
@@ -257,7 +246,6 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         ThingHandler thingHandler = thing.getHandler();
         if (thingHandler != null) {
             removeHandler(thingHandler);
-            unsetBundleContext(thingHandler);
         }
         unregisterConfigStatusProvider(thing);
         unregisterFirmwareUpdateHandler(thing);
@@ -273,12 +261,6 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
      */
     protected void removeHandler(ThingHandler thingHandler) {
         // can be overridden
-    }
-
-    private void unsetBundleContext(ThingHandler thingHandler) {
-        if (thingHandler instanceof BaseThingHandler) {
-            ((BaseThingHandler) thingHandler).unsetBundleContext(bundleContext);
-        }
     }
 
     private void unregisterConfigStatusProvider(Thing thing) {


### PR DESCRIPTION
- Removed access to `BundleContext` from `BaseThingHandler`

Final commit to resolve eclipse/smarthome#5182

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

---

Depends on openhab/openhab2-addons/pull/6395 and openhab/openhab2-addons/pull/6396.