### PR TITLE
fix unexpected behavior while using runblacklist in itests

### DIFF
--- a/itests/itest-common.bndrun
+++ b/itests/itest-common.bndrun
@@ -1,6 +1,6 @@
 -include: itest-include.bndrun
 
 # If we would like to use a storage at all, we will use the "volatile" storage.
--runblacklist: \
+-runblacklist.itest-common: \
     bnd.identity;id='org.openhab.core.storage.json',\
     bnd.identity;id='org.openhab.core.storage.mapdb'


### PR DESCRIPTION
If you would like to use the runblacklist bnd instruction in an integration test it will not work as expected.

In my current test case it is not used at all.

This is caused because an included file overrides this instruction.

IMHO it would be better to use the "Merged Instructions" feature and use a psotfix in the included file. This way you can use the non postfixed instruction as usual.

See: https://bnd.bndtools.org/chapters/820-instructions.html#merged-instructions
