### PR TITLE
[thing] Call `removeItem()` with item name instead of `ThingUID`

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -71,16 +71,27 @@ public class ChannelItemProvider implements ItemProvider {
     private final Set<ItemFactory> itemFactories = new HashSet<>();
     private @Nullable Map<String, Item> items;
 
-    private @NonNullByDefault({}) LocaleProvider localeProvider;
-    private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
-    private @NonNullByDefault({}) ThingRegistry thingRegistry;
-    private @NonNullByDefault({}) ItemRegistry itemRegistry;
-    private @NonNullByDefault({}) ItemChannelLinkRegistry linkRegistry;
+    private final LocaleProvider localeProvider;
+    private final ChannelTypeRegistry channelTypeRegistry;
+    private final ThingRegistry thingRegistry;
+    private final ItemRegistry itemRegistry;
+    private final ItemChannelLinkRegistry linkRegistry;
 
     private boolean enabled = true;
     private volatile boolean initialized = false;
     private volatile long lastUpdate = System.nanoTime();
     private @Nullable ScheduledExecutorService executor;
+
+    @Activate
+    public ChannelItemProvider(final @Reference LocaleProvider localeProvider,
+            final @Reference ChannelTypeRegistry channelTypeRegistry, final @Reference ThingRegistry thingRegistry,
+            final @Reference ItemRegistry itemRegistry, final @Reference ItemChannelLinkRegistry linkRegistry) {
+        this.localeProvider = localeProvider;
+        this.channelTypeRegistry = channelTypeRegistry;
+        this.thingRegistry = thingRegistry;
+        this.itemRegistry = itemRegistry;
+        this.linkRegistry = linkRegistry;
+    }
 
     @Override
     public Collection<Item> getAll() {
@@ -105,15 +116,6 @@ public class ChannelItemProvider implements ItemProvider {
         listeners.remove(listener);
     }
 
-    @Reference
-    protected void setLocaleProvider(final LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
-    }
-
-    protected void unsetLocaleProvider(final LocaleProvider localeProvider) {
-        this.localeProvider = null;
-    }
-
     @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
     protected void addItemFactory(ItemFactory itemFactory) {
         this.itemFactories.add(itemFactory);
@@ -121,42 +123,6 @@ public class ChannelItemProvider implements ItemProvider {
 
     protected void removeItemFactory(ItemFactory itemFactory) {
         this.itemFactories.remove(itemFactory);
-    }
-
-    @Reference
-    protected void setThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = thingRegistry;
-    }
-
-    protected void unsetThingRegistry(ThingRegistry thingRegistry) {
-        this.thingRegistry = null;
-    }
-
-    @Reference
-    protected void setItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = itemRegistry;
-    }
-
-    protected void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
-    }
-
-    @Reference
-    protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry linkRegistry) {
-        this.linkRegistry = linkRegistry;
-    }
-
-    protected void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry linkRegistry) {
-        this.linkRegistry = null;
-    }
-
-    @Reference
-    protected void setChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = channelTypeRegistry;
-    }
-
-    protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
-        this.channelTypeRegistry = null;
     }
 
     @Activate

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -336,7 +336,7 @@ public class ChannelItemProvider implements ItemProvider {
         return enabled;
     }
 
-    RegistryChangeListener<Thing> thingRegistryListener = new RegistryChangeListener<Thing>() {
+    final RegistryChangeListener<Thing> thingRegistryListener = new RegistryChangeListener<Thing>() {
 
         @Override
         public void added(Thing element) {
@@ -355,7 +355,11 @@ public class ChannelItemProvider implements ItemProvider {
             if (!initialized) {
                 return;
             }
-            removeItem(element.getUID().toString());
+            for (Channel channel : element.getChannels()) {
+                for (ItemChannelLink link : linkRegistry.getLinks(channel.getUID())) {
+                    removeItem(link.getItemName());
+                }
+            }
         }
 
         @Override
@@ -365,7 +369,7 @@ public class ChannelItemProvider implements ItemProvider {
         }
     };
 
-    RegistryChangeListener<ItemChannelLink> linkRegistryListener = new RegistryChangeListener<ItemChannelLink>() {
+    final RegistryChangeListener<ItemChannelLink> linkRegistryListener = new RegistryChangeListener<ItemChannelLink>() {
 
         @Override
         public void added(ItemChannelLink element) {
@@ -391,7 +395,7 @@ public class ChannelItemProvider implements ItemProvider {
         }
     };
 
-    RegistryHook<Item> itemRegistryListener = new RegistryHook<Item>() {
+    final RegistryHook<Item> itemRegistryListener = new RegistryHook<Item>() {
 
         @Override
         public void beforeAdding(Item element) {
@@ -435,7 +439,6 @@ public class ChannelItemProvider implements ItemProvider {
                 }
             }
         }
-
     };
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.smarthome.core.thing.internal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,6 +22,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
@@ -59,6 +60,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas Höfer - Added modified operation
  */
 @Component(configurationPid = "org.eclipse.smarthome.channelitemprovider", immediate = true)
+@NonNullByDefault
 public class ChannelItemProvider implements ItemProvider {
 
     private static final long INITIALIZATION_DELAY_NANOS = TimeUnit.SECONDS.toNanos(2);
@@ -66,19 +68,19 @@ public class ChannelItemProvider implements ItemProvider {
     private final Logger logger = LoggerFactory.getLogger(ChannelItemProvider.class);
 
     private final Set<ProviderChangeListener<Item>> listeners = new HashSet<>();
-
-    private LocaleProvider localeProvider;
-    private ThingRegistry thingRegistry;
-    private ItemChannelLinkRegistry linkRegistry;
-    private ItemRegistry itemRegistry;
     private final Set<ItemFactory> itemFactories = new HashSet<>();
-    private Map<String, Item> items = null;
-    private ChannelTypeRegistry channelTypeRegistry;
+    private @Nullable Map<String, Item> items;
+
+    private @NonNullByDefault({}) LocaleProvider localeProvider;
+    private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
+    private @NonNullByDefault({}) ThingRegistry thingRegistry;
+    private @NonNullByDefault({}) ItemRegistry itemRegistry;
+    private @NonNullByDefault({}) ItemChannelLinkRegistry linkRegistry;
 
     private boolean enabled = true;
     private volatile boolean initialized = false;
     private volatile long lastUpdate = System.nanoTime();
-    private ScheduledExecutorService executor;
+    private @Nullable ScheduledExecutorService executor;
 
     @Override
     public Collection<Item> getAll() {
@@ -245,15 +247,15 @@ public class ChannelItemProvider implements ItemProvider {
     }
 
     private void addRegistryChangeListeners() {
-        this.linkRegistry.addRegistryChangeListener(linkRegistryListener);
-        this.itemRegistry.addRegistryHook(itemRegistryListener);
-        this.thingRegistry.addRegistryChangeListener(thingRegistryListener);
+        linkRegistry.addRegistryChangeListener(linkRegistryListener);
+        itemRegistry.addRegistryHook(itemRegistryListener);
+        thingRegistry.addRegistryChangeListener(thingRegistryListener);
     }
 
     private void removeRegistryChangeListeners() {
-        this.itemRegistry.removeRegistryHook(itemRegistryListener);
-        this.linkRegistry.removeRegistryChangeListener(linkRegistryListener);
-        this.thingRegistry.removeRegistryChangeListener(thingRegistryListener);
+        itemRegistry.removeRegistryHook(itemRegistryListener);
+        linkRegistry.removeRegistryChangeListener(linkRegistryListener);
+        thingRegistry.removeRegistryChangeListener(thingRegistryListener);
     }
 
     private void createItemForLink(ItemChannelLink link) {
@@ -292,7 +294,7 @@ public class ChannelItemProvider implements ItemProvider {
         }
     }
 
-    private String getCategory(Channel channel) {
+    private @Nullable String getCategory(Channel channel) {
         if (channel.getChannelTypeUID() != null) {
             ChannelType channelType = channelTypeRegistry.getChannelType(channel.getChannelTypeUID(),
                     localeProvider.getLocale());
@@ -303,13 +305,13 @@ public class ChannelItemProvider implements ItemProvider {
         return null;
     }
 
-    private String getLabel(Channel channel) {
+    private @Nullable String getLabel(Channel channel) {
         if (channel.getLabel() != null) {
             return channel.getLabel();
         } else {
-            final Locale locale = localeProvider.getLocale();
             if (channel.getChannelTypeUID() != null) {
-                final ChannelType channelType = channelTypeRegistry.getChannelType(channel.getChannelTypeUID(), locale);
+                final ChannelType channelType = channelTypeRegistry.getChannelType(channel.getChannelTypeUID(),
+                        localeProvider.getLocale());
                 if (channelType != null) {
                     return channelType.getLabel();
                 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
@@ -46,7 +46,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 /**
- *
  * @author Simon Kaufmann - Initial contribution
  */
 public class ChannelItemProviderTest {
@@ -59,7 +58,7 @@ public class ChannelItemProviderTest {
 
     private static final String ITEM_NAME = "test";
     private static final NumberItem ITEM = new NumberItem(ITEM_NAME);
-    // private static final ItemChannelLink LINK = new ItemChannelLink(ITEM_NAME, CHANNEL_UID);
+    private static final ItemChannelLink LINK = new ItemChannelLink(ITEM_NAME, CHANNEL_UID);
 
     @Mock
     private ItemRegistry itemRegistry;
@@ -77,7 +76,7 @@ public class ChannelItemProviderTest {
     private ChannelItemProvider provider;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         initMocks(this);
 
         provider = createProvider();
@@ -112,7 +111,7 @@ public class ChannelItemProviderTest {
 
     @Test
     public void testItemRemovalFromThingLinkRemoved() {
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        provider.linkRegistryListener.added(LINK);
 
         resetAndPrepareListener();
 
@@ -122,33 +121,33 @@ public class ChannelItemProviderTest {
     }
 
     @Test
-    public void testItemCreationFromLinkNotThere() throws Exception {
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+    public void testItemCreationFromLinkNotThere() {
+        provider.linkRegistryListener.added(LINK);
         verify(listener, only()).added(same(provider), same(ITEM));
     }
 
     @Test
-    public void testItemCreationFromLinkAlreadyExists() throws Exception {
+    public void testItemCreationFromLinkAlreadyExists() {
         when(itemRegistry.get(eq(ITEM_NAME))).thenReturn(ITEM);
 
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        provider.linkRegistryListener.added(LINK);
         verify(listener, never()).added(same(provider), same(ITEM));
     }
 
     @Test
-    public void testItemRemovalFromLinkLinkRemoved() throws Exception {
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+    public void testItemRemovalFromLinkLinkRemoved() {
+        provider.linkRegistryListener.added(LINK);
 
         resetAndPrepareListener();
 
-        provider.linkRegistryListener.removed(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        provider.linkRegistryListener.removed(LINK);
         verify(listener, never()).added(same(provider), same(ITEM));
         verify(listener, only()).removed(same(provider), same(ITEM));
     }
 
     @Test
-    public void testItemRemovalItemFromOtherProvider() throws Exception {
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+    public void testItemRemovalItemFromOtherProvider() {
+        provider.linkRegistryListener.added(LINK);
 
         resetAndPrepareListener();
 
@@ -174,7 +173,7 @@ public class ChannelItemProviderTest {
         props.put("enabled", "true");
         provider.activate(props);
 
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        provider.linkRegistryListener.added(LINK);
         verify(listener, never()).added(same(provider), same(ITEM));
         verify(linkRegistry, never()).getAll();
 
@@ -184,7 +183,7 @@ public class ChannelItemProviderTest {
 
         Thread.sleep(100);
 
-        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        provider.linkRegistryListener.added(LINK);
         verify(listener, never()).added(same(provider), same(ITEM));
         verify(linkRegistry, never()).getAll();
     }
@@ -193,18 +192,17 @@ public class ChannelItemProviderTest {
     private void resetAndPrepareListener() {
         reset(listener);
         doAnswer(invocation -> {
-            // this is crucial as it mimicks the real ItemRegistry's behavior
+            // this is crucial as it mimics the real ItemRegistry's behavior
             provider.itemRegistryListener.afterRemoving((Item) invocation.getArguments()[1]);
             return null;
         }).when(listener).removed(same(provider), any(Item.class));
         doAnswer(invocation -> {
-            // this is crucial as it mimicks the real ItemRegistry's behavior
+            // this is crucial as it mimics the real ItemRegistry's behavior
             provider.itemRegistryListener.beforeAdding((Item) invocation.getArguments()[1]);
             return null;
         }).when(listener).added(same(provider), any(Item.class));
         when(linkRegistry.getBoundChannels(eq(ITEM_NAME))).thenReturn(Collections.singleton(CHANNEL_UID));
-        when(linkRegistry.getLinks(eq(CHANNEL_UID)))
-                .thenReturn(Collections.singleton(new ItemChannelLink(ITEM_NAME, CHANNEL_UID)));
+        when(linkRegistry.getLinks(eq(CHANNEL_UID))).thenReturn(Collections.singleton(LINK));
     }
 
     private ChannelItemProvider createProvider() {

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
@@ -206,14 +206,10 @@ public class ChannelItemProviderTest {
     }
 
     private ChannelItemProvider createProvider() {
-        ChannelItemProvider provider = new ChannelItemProvider();
-        provider.setItemRegistry(itemRegistry);
-        provider.setThingRegistry(thingRegistry);
-        provider.setItemChannelLinkRegistry(linkRegistry);
+        ChannelItemProvider provider = new ChannelItemProvider(localeProvider, mock(ChannelTypeRegistry.class),
+                thingRegistry, itemRegistry, linkRegistry);
         provider.addItemFactory(itemFactory);
-        provider.setLocaleProvider(localeProvider);
         provider.addProviderChangeListener(listener);
-        provider.setChannelTypeRegistry(mock(ChannelTypeRegistry.class));
         return provider;
     }
 


### PR DESCRIPTION
- Call `removeItem()` with item name instead of `ThingUID`
- Added unit test to cover findings in #1226 
- Added nullness annotations
- Use constructor injection

Fixes #1226 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>