### PR TITLE
Removed dependency on 'org.apache.commons.collections'

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -57,12 +57,6 @@
 
     <!-- Apache Commons -->
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>1.1</version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -347,12 +347,6 @@
 
     <!-- Apache Commons -->
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-exec</artifactId>
       <version>1.1</version>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -23,12 +23,9 @@
 
     <!-- Apache Commons -->
     <bundle dependency="true">mvn:commons-codec/commons-codec/1.6</bundle>
-    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
-    <!--<bundle dependency="true">mvn:org.apache.commons/commons-collections4/4.1</bundle>-->
     <bundle dependency="true">mvn:org.apache.commons/commons-exec/1.1</bundle>
     <bundle dependency="true">mvn:commons-io/commons-io/2.2</bundle>
     <bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>
-    <!--<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>-->
 
     <!-- Measurement -->
     <bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>


### PR DESCRIPTION
- Removed dependency on `org.apache.commons.collections`

Now the question for downward compatibility: Can we risk to remove it from the feature too (e.g. openHAB 1 Add-ons)?

https://github.com/openhab/openhab-core/blob/abb558851fba83978e56c173e13533f8fa512ec7/features/karaf/openhab-tp/src/main/feature/feature.xml#L26-L27

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

---

Depends on https://github.com/openhab/openhab-core/pull/1244