### PR TITLE
Use default SslContextFactory excludes for weak ciphers and protocols

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
@@ -388,10 +388,6 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
         } catch (NoSuchAlgorithmException | KeyManagementException ex) {
             throw new HttpClientInitializationException("Cannot create an TLS context!", ex);
         }
-        // Exclude weak / insecure ciphers
-        sslContextFactory.addExcludeCipherSuites("^.*_(MD5|SHA|SHA1)$");
-        // Exclude ciphers that don't support forward secrecy
-        sslContextFactory.addExcludeCipherSuites("^TLS_RSA_.*$");
         return sslContextFactory;
     }
 
@@ -416,8 +412,6 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
             }
         }
 
-        String excludeCipherSuites[] = { "^.*_(MD5)$" };
-        sslContextFactory.setExcludeCipherSuites(excludeCipherSuites);
         return sslContextFactory;
     }
 


### PR DESCRIPTION
To prevent weak cipher/protocol warnings it's better to not customize the default excluded ciphers and protocols.
The MD5 ciphers have already been excluded by default since Jetty 9.3.11.v20160721.

Fixes #1064