### PR TITLE
Set 'UNINITIALIZED' -> 'HANDLER_MISSING_ERROR' after enabling a thing and handler / factory is missing

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1057,7 +1057,7 @@ public class ThingManagerImpl
                 initializeHandler(thing);
             } else {
                 logger.debug(
-                        "Not registering a handler at this point. The thing types of bundle {} are not fully loaded yet.",
+                        "Not registering a handler at this point. The thing types of bundle '{}' are not fully loaded yet.",
                         identifier);
             }
         } else {
@@ -1214,6 +1214,11 @@ public class ThingManagerImpl
             } else {
                 // No handler registered. Try to register handler and initialize the thing.
                 registerAndInitializeHandler(thing, findThingHandlerFactory(thing.getThingTypeUID()));
+                // Check if registration was successful
+                if (!hasBridge(thing) && !isHandlerRegistered(thing)) {
+                    setThingStatus(thing,
+                            buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_MISSING_ERROR));
+                }
             }
         } else {
             if (!thing.isEnabled()) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -683,7 +683,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         waitForAssert(() -> {
             assertThat(storage.containsKey(THING_UID.getAsString()), is(false));
             assertThat(thing.getStatus(), is(ThingStatus.UNINITIALIZED));
-            assertThat(thing.getStatusInfo().getStatusDetail(), is(ThingStatusDetail.DISABLED));
+            assertThat(thing.getStatusInfo().getStatusDetail(), is(ThingStatusDetail.HANDLER_MISSING_ERROR));
         }, SafeCaller.DEFAULT_TIMEOUT - 100, 50);
     }
 


### PR DESCRIPTION
- Set `UNINITIALIZED` -> `HANDLER_MISSING_ERROR` after enabling a thing and handler / factory is missing (for stand-alone things)

Closes #718 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>