### PR TITLE
Added profile for inverting rollershutter / blinds

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.LocalizedKey;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
@@ -66,7 +67,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * with values 0, 1, 2, 3 or 4, 0 being worst strength and 4 being best strength.
      */
     public static final ChannelType SYSTEM_CHANNEL_SIGNAL_STRENGTH = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "signal-strength"), "Signal Strength", "Number")
+            .state(new ChannelTypeUID(BINDING_ID, "signal-strength"), "Signal Strength", CoreItemFactory.NUMBER)
             .withCategory("QualityOfService")
             .withStateDescription(new StateDescription(BigDecimal.ZERO, new BigDecimal(4), BigDecimal.ONE, null, true,
                     Arrays.asList(new StateOption("0", "no signal"), new StateOption("1", "weak"),
@@ -79,8 +80,8 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * on (low battery) and off (battery ok).
      */
     public static final ChannelType SYSTEM_CHANNEL_LOW_BATTERY = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "low-battery"), "Low Battery", "Switch").withCategory("Battery")
-            .withStateDescription(
+            .state(new ChannelTypeUID(BINDING_ID, "low-battery"), "Low Battery", CoreItemFactory.SWITCH)
+            .withCategory("Battery").withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
             .build();
 
@@ -88,7 +89,8 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Battery level default system wide {@link ChannelType}. Represents the battery level as a percentage.
      */
     public static final ChannelType SYSTEM_CHANNEL_BATTERY_LEVEL = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "battery-level"), "Battery Level", "Number").withCategory("Battery")
+            .state(new ChannelTypeUID(BINDING_ID, "battery-level"), "Battery Level", CoreItemFactory.NUMBER)
+            .withCategory("Battery")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), BigDecimal.ONE, "%.0f %%", true, null))
             .build();
@@ -137,14 +139,14 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Power: default system wide {@link ChannelType} which allows turning off (potentially on) a device
      */
     public static final ChannelType SYSTEM_POWER = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "power"), "Power", "Switch")
+            .state(new ChannelTypeUID(BINDING_ID, "power"), "Power", CoreItemFactory.SWITCH)
             .withDescription("Device is operable when channel has state ON").build();
 
     /**
      * Location: default system wide {@link ChannelType} which displays a location
      */
     public static final ChannelType SYSTEM_LOCATION = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "location"), "Location", "Location")
+            .state(new ChannelTypeUID(BINDING_ID, "location"), "Location", CoreItemFactory.LOCATION)
             .withDescription("Location in lat./lon./height coordinates")
             .withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true)
                     .withPattern("%2$s°N %3$s°E %1$sm").build().toStateDescription())
@@ -154,7 +156,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Motion: default system wide {@link ChannelType} which indications whether motion was detected (state ON)
      */
     public static final ChannelType SYSTEM_MOTION = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "motion"), "Motion", "Switch")
+            .state(new ChannelTypeUID(BINDING_ID, "motion"), "Motion", CoreItemFactory.SWITCH)
             .withDescription("Motion detected by the device").withCategory("Motion").withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
             .build();
@@ -163,7 +165,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Brightness: default system wide {@link ChannelType} which allows changing the brightness from 0-100%
      */
     public static final ChannelType SYSTEM_BRIGHTNESS = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "brightness"), "Brightness", "Dimmer")
+            .state(new ChannelTypeUID(BINDING_ID, "brightness"), "Brightness", CoreItemFactory.DIMMER)
             .withDescription("Controls the brightness and switches the light on and off").withCategory("DimmableLight")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d %%", false, null))
@@ -173,14 +175,14 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Color: default system wide {@link ChannelType} which allows changing the color
      */
     public static final ChannelType SYSTEM_COLOR = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color"), "Color", "Color")
+            .state(new ChannelTypeUID(BINDING_ID, "color"), "Color", CoreItemFactory.COLOR)
             .withDescription("Controls the color of the light").withCategory("ColorLight").build();
 
     /**
      * Color-temperature: default system wide {@link ChannelType} which allows changing the color temperature
      */
     public static final ChannelType SYSTEM_COLOR_TEMPERATURE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color-temperature"), "Color Temperature", "Dimmer")
+            .state(new ChannelTypeUID(BINDING_ID, "color-temperature"), "Color Temperature", CoreItemFactory.DIMMER)
             .withDescription("Controls the color temperature of the light").withCategory("ColorLight")
             .withStateDescription(new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d", false, null))
             .build();
@@ -191,7 +193,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Volume: default system wide {@link ChannelType} which allows changing the audio volume from 0-100%
      */
     public static final ChannelType SYSTEM_VOLUME = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "volume"), "Volume", "Dimmer")
+            .state(new ChannelTypeUID(BINDING_ID, "volume"), "Volume", CoreItemFactory.DIMMER)
             .withDescription("Change the sound volume of a device")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d %%", false, null))
@@ -201,21 +203,21 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Mute: default system wide {@link ChannelType} which allows muting and un-muting audio
      */
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "mute"), "Mute", "Switch").withDescription("Mute audio of the device")
-            .withCategory("SoundVolume").build();
+            .state(new ChannelTypeUID(BINDING_ID, "mute"), "Mute", CoreItemFactory.SWITCH)
+            .withDescription("Mute audio of the device").withCategory("SoundVolume").build();
 
     /**
      * Media-control: system wide {@link ChannelType} which controls a media player
      */
     public static final ChannelType SYSTEM_MEDIA_CONTROL = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-control"), "Media Control", "Player")
+            .state(new ChannelTypeUID(BINDING_ID, "media-control"), "Media Control", CoreItemFactory.PLAYER)
             .withCategory("MediaControl").build();
 
     /**
      * Media-title: default system wide {@link ChannelType} which displays the title of a (played) song
      */
     public static final ChannelType SYSTEM_MEDIA_TITLE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-title"), "Media Title", "String")
+            .state(new ChannelTypeUID(BINDING_ID, "media-title"), "Media Title", CoreItemFactory.STRING)
             .withDescription("Title of a (played) media file").withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
             .build();
@@ -224,7 +226,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Media-artist: default system wide {@link ChannelType} which displays the artist of a (played) song
      */
     public static final ChannelType SYSTEM_MEDIA_ARTIST = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-artist"), "Media Artist", "String")
+            .state(new ChannelTypeUID(BINDING_ID, "media-artist"), "Media Artist", CoreItemFactory.STRING)
             .withDescription("Artist of a (played) media file").withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
             .build();
@@ -282,13 +284,23 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
                     .build().toStateDescription())
             .build();
 
+    /**
+     * Rollershutter: system wide {@link ChannelType} which allows controlling rollershutters or blinds
+     */
+    public static final ChannelType SYSTEM_ROLLERSHUTTER = ChannelTypeBuilder
+            .state(new ChannelTypeUID(BINDING_ID, "rollershutter"), "Rollershutter / Blinds",
+                    CoreItemFactory.ROLLERSHUTTER)
+            .withDescription("Controls the position of rollershutter or blinds").withCategory("Blinds").build();
+
     private static final Collection<ChannelType> CHANNEL_TYPES = Collections
-            .unmodifiableList(Stream.of(SYSTEM_CHANNEL_SIGNAL_STRENGTH, SYSTEM_CHANNEL_LOW_BATTERY,
-                    SYSTEM_CHANNEL_BATTERY_LEVEL, SYSTEM_TRIGGER, SYSTEM_RAWBUTTON, SYSTEM_BUTTON, SYSTEM_RAWROCKER,
-                    SYSTEM_POWER, SYSTEM_LOCATION, SYSTEM_MOTION, SYSTEM_BRIGHTNESS, SYSTEM_COLOR,
-                    SYSTEM_COLOR_TEMPERATURE, SYSTEM_VOLUME, SYSTEM_MUTE, SYSTEM_MEDIA_CONTROL, SYSTEM_MEDIA_TITLE,
-                    SYSTEM_MEDIA_ARTIST, SYSTEM_WIND_DIRECTION, SYSTEM_WIND_SPEED, SYSTEM_OUTDOOR_TEMPERATURE,
-                    SYSTEM_ATMOSPHERIC_HUMIDITY, SYSTEM_BAROMETRIC_PRESSURE).collect(Collectors.toList()));
+            .unmodifiableList(Stream
+                    .of(SYSTEM_CHANNEL_SIGNAL_STRENGTH, SYSTEM_CHANNEL_LOW_BATTERY, SYSTEM_CHANNEL_BATTERY_LEVEL,
+                            SYSTEM_TRIGGER, SYSTEM_RAWBUTTON, SYSTEM_BUTTON, SYSTEM_RAWROCKER, SYSTEM_POWER,
+                            SYSTEM_LOCATION, SYSTEM_MOTION, SYSTEM_BRIGHTNESS, SYSTEM_COLOR, SYSTEM_COLOR_TEMPERATURE,
+                            SYSTEM_VOLUME, SYSTEM_MUTE, SYSTEM_MEDIA_CONTROL, SYSTEM_MEDIA_TITLE, SYSTEM_MEDIA_ARTIST,
+                            SYSTEM_WIND_DIRECTION, SYSTEM_WIND_SPEED, SYSTEM_OUTDOOR_TEMPERATURE,
+                            SYSTEM_ATMOSPHERIC_HUMIDITY, SYSTEM_BAROMETRIC_PRESSURE, SYSTEM_ROLLERSHUTTER)
+                    .collect(Collectors.toList()));
 
     private final Map<LocalizedKey, @Nullable ChannelType> localizedChannelTypeCache = new ConcurrentHashMap<>();
 
@@ -344,9 +356,6 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     }
 
     private @Nullable ChannelType localize(Bundle bundle, ChannelType channelType, @Nullable Locale locale) {
-        if (channelTypeI18nLocalizationService == null) {
-            return null;
-        }
         return channelTypeI18nLocalizationService.createLocalizedChannelType(bundle, channelType, locale);
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemInvertRollershutterProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemInvertRollershutterProfile.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import java.math.BigDecimal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfile;
+import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the default implementation for an invert rollershutter profile.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class SystemInvertRollershutterProfile implements StateProfile {
+
+    private static final BigDecimal HUNDRED = BigDecimal.TEN.multiply(BigDecimal.TEN);
+
+    private final Logger logger = LoggerFactory.getLogger(SystemInvertRollershutterProfile.class);
+    private final ProfileCallback callback;
+
+    public SystemInvertRollershutterProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.INVERT_ROLLERSHUTTER;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        State invertedState = (State) invertType(state);
+        logger.info("Inverting state '{}' on update from item to '{}'", state, invertedState);
+        callback.handleUpdate(invertedState);
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        final Command invertedCommand = (Command) invertType(command);
+        logger.info("Inverting command '{}' from item to '{}'", command, invertedCommand);
+        callback.handleCommand(invertedCommand);
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        final Command invertedCommand = (Command) invertType(command);
+        logger.info("Inverting command '{}' from handler to '{}'", command, invertedCommand);
+        callback.sendCommand(invertedCommand);
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        State invertedState = (State) invertType(state);
+        logger.info("Inverting state '{}' on update from handler to '{}'", state, invertedState);
+        callback.sendUpdate(invertedState);
+    }
+
+    private Type invertType(Type type) {
+        if (type instanceof PercentType) {
+            return new PercentType(HUNDRED.subtract(((PercentType) type).toBigDecimal()));
+        } else if (type == UpDownType.UP) {
+            return UpDownType.DOWN;
+        } else if (type == UpDownType.DOWN) {
+            return UpDownType.UP;
+        } else {
+            return type;
+        }
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -66,15 +66,15 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Collections
             .unmodifiableSet(Stream
-                    .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE,
+                    .of(DEFAULT_TYPE, FOLLOW_TYPE, OFFSET_TYPE, INVERT_ROLLERSHUTTER_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE,
                             RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE,
                             RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE,
                             RAWROCKER_PLAY_PAUSE_TYPE, RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE,
                             RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_UPDATE_TYPE)
                     .collect(Collectors.toSet()));
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Collections
-            .unmodifiableSet(Stream.of(DEFAULT, FOLLOW, OFFSET, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER,
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Collections.unmodifiableSet(
+            Stream.of(DEFAULT, FOLLOW, OFFSET, INVERT_ROLLERSHUTTER, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER,
                     RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS,
                     RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE, RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE,
                     RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_UPDATE).collect(Collectors.toSet()));
@@ -102,6 +102,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemFollowProfile(callback);
         } else if (OFFSET.equals(profileTypeUID)) {
             return new SystemOffsetProfile(callback, context);
+        } else if (INVERT_ROLLERSHUTTER.equals(profileTypeUID)) {
+            return new SystemInvertRollershutterProfile(callback);
         } else if (RAWBUTTON_ON_OFF_SWITCH.equals(profileTypeUID)) {
             return new RawButtonOnOffSwitchProfile(callback);
         } else if (RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -29,6 +29,7 @@ public interface SystemProfiles {
     ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
     ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
+    ProfileTypeUID INVERT_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "invert-rollershutter");
     ProfileTypeUID RAWBUTTON_ON_OFF_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-on-off-switch");
     ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
     ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-rollershutter");
@@ -50,6 +51,11 @@ public interface SystemProfiles {
     StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
             .build();
+
+    StateProfileType INVERT_ROLLERSHUTTER_TYPE = ProfileTypeBuilder
+            .newState(INVERT_ROLLERSHUTTER, "Invert Rollershutter / Blinds")
+            .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER)
+            .withSupportedItemTypesOfChannel(CoreItemFactory.ROLLERSHUTTER).build();
 
     TriggerProfileType RAWBUTTON_ON_OFF_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_ON_OFF_SWITCH, "Raw Button To On Off")

--- a/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/i18n/DefaultSystemChannels_de.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/i18n/DefaultSystemChannels_de.properties
@@ -41,3 +41,5 @@ channel-type.system.atmospheric-humidity.label = Luftfeuchtigkeit
 channel-type.system.atmospheric-humidity.description = Aktuelle atmosphärische relative Luftfeuchtigkeit.
 channel-type.system.barometric-pressure.label = Luftdruck
 channel-type.system.barometric-pressure.description = Aktueller Luftdruck.
+channel-type.system.rollershutter.label = Rollladen / Jalousie
+channel-type.system.rollershutter.description = Steuert die Position von Rollläden oder Jalousien.

--- a/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/i18n/SystemProfiles_de.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/ESH-INF/i18n/SystemProfiles_de.properties
@@ -3,5 +3,6 @@ profile-type.system.follow.label = Folgen
 profile-type.system.offset.label = Versatz
 profile.config.system.offset.offset.label = Versatz
 profile.config.system.offset.offset.description = Versatz (Numerischer Wert oder numerischer Wert mit Einheit), welcher auf den Wert addiert wird. Ein negative Versatz wird vom Wert abgezogen.
+profile-type.system.invert-rollershutter.label = Rollladen / Jalousie Umkehren
 profile-type.system.timestamp-change.label = Zeitstempel bei Änderung
 profile-type.system.timestamp-update.label = Zeitstempel bei Aktualisierung

--- a/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemInvertRollershutterProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemInvertRollershutterProfileTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Tests for the system:invert-rollershutter profile
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class SystemInvertRollershutterProfileTest {
+
+    @Test
+    public void testInversionOnStateUpdateFromItem() {
+        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemInvertRollershutterProfile invertProfile = new SystemInvertRollershutterProfile(callback);
+
+        invertProfile.onStateUpdateFromItem(UpDownType.UP);
+        verify(callback, times(1)).handleUpdate(capture.capture());
+        assertEquals(UpDownType.DOWN, capture.getValue());
+
+        invertProfile.onStateUpdateFromItem(UpDownType.DOWN);
+        verify(callback, times(2)).handleUpdate(capture.capture());
+        assertEquals(UpDownType.UP, capture.getValue());
+
+        State state = new PercentType(23);
+        invertProfile.onStateUpdateFromItem(state);
+        verify(callback, times(3)).handleUpdate(capture.capture());
+        State result = capture.getValue();
+        assertEquals(77, ((PercentType) result).intValue());
+    }
+
+    @Test
+    public void testInversionOnCommandFromItem() {
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemInvertRollershutterProfile invertProfile = new SystemInvertRollershutterProfile(callback);
+
+        invertProfile.onCommandFromItem(UpDownType.UP);
+        verify(callback, times(1)).handleCommand(capture.capture());
+        assertEquals(UpDownType.DOWN, capture.getValue());
+
+        invertProfile.onCommandFromItem(UpDownType.DOWN);
+        verify(callback, times(2)).handleCommand(capture.capture());
+        assertEquals(UpDownType.UP, capture.getValue());
+
+        Command cmd = new PercentType(23);
+        invertProfile.onCommandFromItem(cmd);
+        verify(callback, times(3)).handleCommand(capture.capture());
+        Command result = capture.getValue();
+        assertEquals(77, ((PercentType) result).intValue());
+    }
+
+    @Test
+    public void testInversionOnCommandFromHandler() {
+        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemInvertRollershutterProfile invertProfile = new SystemInvertRollershutterProfile(callback);
+
+        invertProfile.onCommandFromHandler(UpDownType.UP);
+        verify(callback, times(1)).sendCommand(capture.capture());
+        assertEquals(UpDownType.DOWN, capture.getValue());
+
+        invertProfile.onCommandFromHandler(UpDownType.DOWN);
+        verify(callback, times(2)).sendCommand(capture.capture());
+        assertEquals(UpDownType.UP, capture.getValue());
+
+        Command cmd = new PercentType(23);
+        invertProfile.onCommandFromHandler(cmd);
+        verify(callback, times(3)).sendCommand(capture.capture());
+        Command result = capture.getValue();
+        assertEquals(77, ((PercentType) result).intValue());
+    }
+
+    @Test
+    public void testInversionOnStateUpdateFromHandler() {
+        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemInvertRollershutterProfile invertProfile = new SystemInvertRollershutterProfile(callback);
+
+        invertProfile.onStateUpdateFromHandler(UpDownType.UP);
+        verify(callback, times(1)).sendUpdate(capture.capture());
+        assertEquals(UpDownType.DOWN, capture.getValue());
+
+        invertProfile.onStateUpdateFromHandler(UpDownType.DOWN);
+        verify(callback, times(2)).sendUpdate(capture.capture());
+        assertEquals(UpDownType.UP, capture.getValue());
+
+        State state = new PercentType(23);
+        invertProfile.onStateUpdateFromHandler(state);
+        verify(callback, times(3)).sendUpdate(capture.capture());
+        State result = capture.getValue();
+        assertEquals(77, ((PercentType) result).intValue());
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/SystemWideChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/SystemWideChannelTypesTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
  */
 public class SystemWideChannelTypesTest extends JavaOSGiTest {
 
+    private static final int NUMBER_OF_DEFAULT_SYSTEM_CHANNEL_TYPES = 24;
     private static final ChannelTypeUID SIGNAL_STRENGTH_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
             "signal-strength");
     private static final ChannelTypeUID LOW_BATTERY_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "low-battery");
@@ -65,6 +66,8 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
             "atmospheric-humidity");
     private static final ChannelTypeUID BAROMETRIC_PRESSURE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
             "barometric-pressure");
+    private static final ChannelTypeUID ROLLERSHUTTER_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
+            "rollershutter");
 
     private ChannelTypeProvider systemChannelTypeProvider;
 
@@ -78,7 +81,8 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
     @Test
     public void systemChannelTypesShouldBeAvailable() {
         Collection<ChannelType> sytemChannelTypes = systemChannelTypeProvider.getChannelTypes(null);
-        assertEquals(23, sytemChannelTypes.size());
+        assertNotNull(sytemChannelTypes);
+        assertEquals(NUMBER_OF_DEFAULT_SYSTEM_CHANNEL_TYPES, sytemChannelTypes.size());
 
         assertNotNull(systemChannelTypeProvider.getChannelType(SIGNAL_STRENGTH_CHANNEL_TYPE_UID, null));
         assertNotNull(systemChannelTypeProvider.getChannelType(LOW_BATTERY_CHANNEL_TYPE_UID, null));
@@ -103,12 +107,14 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         assertNotNull(systemChannelTypeProvider.getChannelType(OUTDOOR_TEMPERATURE_CHANNEL_TYPE_UID, null));
         assertNotNull(systemChannelTypeProvider.getChannelType(ATMOSPHERIC_HUMIDITY_CHANNEL_TYPE_UID, null));
         assertNotNull(systemChannelTypeProvider.getChannelType(BAROMETRIC_PRESSURE_CHANNEL_TYPE_UID, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(ROLLERSHUTTER_CHANNEL_TYPE_UID, null));
     }
 
     @Test
     public void systemChannelTypesShouldBeTranslatedProperly() {
         Collection<ChannelType> localizedChannelTypes = systemChannelTypeProvider.getChannelTypes(Locale.GERMAN);
-        assertEquals(23, localizedChannelTypes.size());
+        assertNotNull(localizedChannelTypes);
+        assertEquals(NUMBER_OF_DEFAULT_SYSTEM_CHANNEL_TYPES, localizedChannelTypes.size());
 
         ChannelType signalStrengthChannelType = systemChannelTypeProvider
                 .getChannelType(SIGNAL_STRENGTH_CHANNEL_TYPE_UID, Locale.GERMAN);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -45,6 +45,8 @@ import org.mockito.Mock;
  */
 public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
 
+    private static final int NUMBER_OF_DEFAULT_SYSTEM_PROFILES = 16;
+
     private final Map<String, Object> properties = new HashMap<String, Object>() {
         private static final long serialVersionUID = 1L;
         {
@@ -74,7 +76,7 @@ public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
     @Test
     public void systemProfileTypesAndUidsShouldBeAvailable() {
         Collection<ProfileTypeUID> systemProfileTypeUIDs = profileFactory.getSupportedProfileTypeUIDs();
-        assertEquals(15, systemProfileTypeUIDs.size());
+        assertEquals(NUMBER_OF_DEFAULT_SYSTEM_PROFILES, systemProfileTypeUIDs.size());
 
         Collection<ProfileType> systemProfileTypes = profileFactory.getProfileTypes(null);
         assertEquals(systemProfileTypeUIDs.size(), systemProfileTypes.size());


### PR DESCRIPTION
- Added default system wide channel type for rollershutter / blinds 
- Added profile for inverting rollershutter / blinds

For discussion: Currently we are mapping `UpDownType.UP` to `PercentType.ZERO` and `UpDownType.DOWN` to `PercentType.HUNDRED`. In some cases people / bindings / vendors want to have / require the opposite direction and a lot of bindings provide a specific channel configuration for inverting the state / commands for rollershutter / blinds.

See https://community.openhab.org/t/item-profile-to-invert-blinds-orientation/83626
See https://github.com/openhab/openhab2-addons/pull/6389#discussion_r350985672

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>