### PR TITLE
Reduce logging level in 'FeatureInstaller' when uninstalling a binding

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -504,7 +504,7 @@ public class FeatureInstaller implements ConfigurationListener {
             Feature[] features = featuresService.listInstalledFeatures();
             if (isInstalled(features, name)) {
                 featuresService.uninstallFeature(name);
-                logger.info("Uninstalled '{}'", name);
+                logger.debug("Uninstalled '{}'", name);
                 postUninstalledEvent(name);
                 return true;
             }


### PR DESCRIPTION
- Reduce logging level in `FeatureInstaller` when uninstalling a binding

Currently we can see an `INFO` logging in `openhab.log` when an extension got uninstalled but nothing when an extension got installed:

openhab.log:
```
...
2019-11-29 14:57:32.774 [INFO ] [core.karaf.internal.FeatureInstaller] - Uninstalled 'openhab-binding-kodi'
...
...
...
```

Both events are logged in the `event.log`:

events.log
```
...
2019-11-29 14:57:32.774 [thome.event.ExtensionEvent] - Extension 'binding-kodi' has been uninstalled.
...
2019-11-29 14:57:46.682 [thome.event.ExtensionEvent] - Extension 'binding-kodi' has been installed.
...
```

Closes #119

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>