### PR TITLE
Fix check which allows QoS 3

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -387,7 +387,7 @@ public class MqttBrokerConnection {
      * @param qos level.
      */
     public void setQos(int qos) {
-        if (qos < 0 || qos > 3) {
+        if (qos < 0 || qos > 2) {
             throw new IllegalArgumentException();
         }
         this.qos = qos;


### PR DESCRIPTION
MQTT does only support the levels 0, 1 and 2 as described in the JavaDoc of the setQos() method. The current check allows however setting the QoS level to 3.