### PR TITLE
[automation] Prepare automation for custom ScriptEngineFactories

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/AbstractScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/AbstractScriptEngineFactory.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.internal;
+package org.openhab.core.automation.module.script;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,7 +22,6 @@ import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class AbstractScriptEngineFactory implements ScriptEngineFactory {
 
-    protected final Logger logger = LoggerFactory.getLogger(AbstractScriptEngineFactory.class);
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public List<String> getScriptTypes() {
@@ -65,5 +64,4 @@ public abstract class AbstractScriptEngineFactory implements ScriptEngineFactory
         }
         return scriptEngine;
     }
-
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/GenericScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/GenericScriptEngineFactory.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.osgi.service.component.annotations.Component;
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/NashornScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/NashornScriptEngineFactory.java
@@ -24,6 +24,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.module.script.AbstractScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.osgi.service.component.annotations.Component;
 


### PR DESCRIPTION
These changes prepare for custom ScriptEngineFactories and does not
include any breaking changes.

* Moved AbstractScriptEngineFactory out of internal so that it can be
used by custom factories
* Modified ScriptEngineModuleTypeProvider to include engines from custom
factories
* Cleaned up some logging

Signed-off-by: Scott Rushworth <openhab@5iver.com>