### PR TITLE
[automation] Added API for ScriptEngineFactory implementations to pull presets

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManager.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManager.java
@@ -12,10 +12,7 @@
  */
 package org.openhab.core.automation.module.script.internal;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.script.ScriptEngine;
@@ -100,15 +97,18 @@ public class ScriptExtensionManager {
         }
     }
 
-    public void importPreset(String preset, ScriptEngineFactory engineProvider, ScriptEngine scriptEngine,
+    public Map<String, Object> importPreset(String preset, ScriptEngineFactory engineProvider, ScriptEngine scriptEngine,
             String scriptIdentifier) {
+        Map<String, Object> allValues = new HashMap<>();
         for (ScriptExtensionProvider provider : scriptExtensionProviders) {
             if (provider.getPresets().contains(preset)) {
                 Map<String, Object> scopeValues = provider.importPreset(scriptIdentifier, preset);
 
                 engineProvider.scopeValues(scriptEngine, scopeValues);
+                allValues.putAll(scopeValues);
             }
         }
+        return allValues;
     }
 
     public void dispose(String scriptIdentifier) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapper.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.openhab.core.automation.module.script.ScriptExtensionProvider;
 
 /**
@@ -57,6 +58,21 @@ public class ScriptExtensionManagerWrapper {
         return manager.getDefaultPresets();
     }
 
+    /**
+     * Imports a collection of named host objects/classes into a script engine instance. Sets of objects are provided
+     * under their object name, and categorized by preset name. This method will import all named objects for a specific
+     * preset name.
+     *
+     * @implNote This call both returns the imported objects, and requests that the {@link ScriptEngineFactory} import them.
+     * The mechanism of how they are imported by the ScriptEngineFactory, or whether they are imported at all (aside from
+     * being returned by this call) is dependent of the implementation of the ScriptEngineFactory.
+     *
+     * @apiNote Objects may appear in multiple named presets.
+     * @see ScriptExtensionManager
+     *
+     * @param preset the name of the preset to import
+     * @return a map of host object names to objects
+     */
     public Map<String, Object> importPreset(String preset) {
         return manager.importPreset(preset, container.getFactory(), container.getScriptEngine(), container.getIdentifier());
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapper.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script.internal;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
@@ -56,7 +57,7 @@ public class ScriptExtensionManagerWrapper {
         return manager.getDefaultPresets();
     }
 
-    public void importPreset(String preset) {
-        manager.importPreset(preset, container.getFactory(), container.getScriptEngine(), container.getIdentifier());
+    public Map<String, Object> importPreset(String preset) {
+        return manager.importPreset(preset, container.getFactory(), container.getScriptEngine(), container.getIdentifier());
     }
 }


### PR DESCRIPTION
Existing API only allows engine factory implementors to request presets are pushed into existing scopes, rather than returning them directory, so that they can be bound into module or library systems. This change allows implementors to capture the presets requested (and potentially ignore any pushed), and therefore expose them via idiomatic import mechanisms for the language being implemented.

Specifically, I am using this for Javascript CommonJS module support. Without this change it's possible, but ugly (using reflection) and tricky (using weakrefs to ensure engines can be collected). This change is minimal and backwards compatible with the current API.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>