### PR TITLE
Bump Californium to 2.0.0

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -41,11 +41,11 @@
   </feature>
 
   <feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
-    <capability>openhab.tp;feature=coap;version=2.0.0-RC1</capability>
-    <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0-RC1</bundle>
-    <bundle>mvn:org.eclipse.californium/californium-core/2.0.0-RC1</bundle>
-    <bundle>mvn:org.eclipse.californium/element-connector/2.0.0-RC1</bundle>
-    <bundle>mvn:org.eclipse.californium/scandium/2.0.0-RC1</bundle>
+    <capability>openhab.tp;feature=coap;version=2.0.0</capability>
+    <bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0</bundle>
+    <bundle>mvn:org.eclipse.californium/californium-core/2.0.0</bundle>
+    <bundle>mvn:org.eclipse.californium/element-connector/2.0.0</bundle>
+    <bundle>mvn:org.eclipse.californium/scandium/2.0.0</bundle>
   </feature>
 
   <feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">


### PR DESCRIPTION
- Bump Californium to 2.0.0

// CC @markus7017

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>