### PR TITLE
fix multiple MQTT subscriptions

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
@@ -56,7 +56,7 @@ public class Mqtt3AsyncClientWrapper extends MqttAsyncClientWrapper {
         }
 
         client = clientBuilder.buildAsync();
-    };
+    }
 
     @Override
     public MqttClientState getState() {
@@ -64,14 +64,14 @@ public class Mqtt3AsyncClientWrapper extends MqttAsyncClientWrapper {
     }
 
     @Override
-    public CompletableFuture<?> subscribe(String topic, int qos, ClientCallback clientCallback) {
+    public CompletableFuture<?> internalSubscribe(String topic, int qos, ClientCallback clientCallback) {
         Mqtt3Subscribe subscribeMessage = Mqtt3Subscribe.builder().topicFilter(topic).qos(getMqttQosFromInt(qos))
                 .build();
         return client.subscribe(subscribeMessage, clientCallback::messageArrived);
     }
 
     @Override
-    public CompletableFuture<?> unsubscribe(String topic) {
+    public CompletableFuture<?> internalUnsubscribe(String topic) {
         Mqtt3Unsubscribe unsubscribeMessage = Mqtt3Unsubscribe.builder().topicFilter(topic).build();
         return client.unsubscribe(unsubscribeMessage);
     }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
@@ -57,7 +57,7 @@ public class Mqtt5AsyncClientWrapper extends MqttAsyncClientWrapper {
         }
 
         client = clientBuilder.buildAsync();
-    };
+    }
 
     @Override
     public MqttClientState getState() {
@@ -65,14 +65,14 @@ public class Mqtt5AsyncClientWrapper extends MqttAsyncClientWrapper {
     }
 
     @Override
-    public CompletableFuture<?> subscribe(String topic, int qos, ClientCallback clientCallback) {
+    public CompletableFuture<?> internalSubscribe(String topic, int qos, ClientCallback clientCallback) {
         Mqtt5Subscribe subscribeMessage = Mqtt5Subscribe.builder().topicFilter(topic).qos(getMqttQosFromInt(qos))
                 .build();
         return client.subscribe(subscribeMessage, clientCallback::messageArrived);
     }
 
     @Override
-    public CompletableFuture<?> unsubscribe(String topic) {
+    public CompletableFuture<?> internalUnsubscribe(String topic) {
         Mqtt5Unsubscribe unsubscribeMessage = Mqtt5Unsubscribe.builder().topicFilter(topic).build();
         return client.unsubscribe(unsubscribeMessage);
     }


### PR DESCRIPTION
Paho and HiveMQ have differences in handling multiple subscriptions to the same topic. This ensures that only one subscription within the client is made even if more than one callback is subscribing to a given topic.

See https://github.com/openhab/openhab2-addons/issues/6488

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>