### PR TITLE
added Californium to runtime bom

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -390,6 +390,23 @@
       <scope>compile</scope>
     </dependency>
 
+    <!-- Californium -->
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>californium-core</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>scandium</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.californium</groupId>
+      <artifactId>element-connector</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+
     <!-- Gson -->
     <dependency>
       <groupId>org.eclipse.orbit.bundles</groupId>


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/1262

This makes the libs also available in the demo app / IDE.

Signed-off-by: Kai Kreuzer <kai@openhab.org>