### PR TITLE
contains + get can be replaced by get and a null check

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceManagerImpl.java
@@ -382,8 +382,8 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, Persi
 
     private void startEventHandling(final String serviceName) {
         synchronized (persistenceServiceConfigs) {
-            if (persistenceServiceConfigs.containsKey(serviceName)) {
-                final PersistenceServiceConfiguration config = persistenceServiceConfigs.get(serviceName);
+            final PersistenceServiceConfiguration config = persistenceServiceConfigs.get(serviceName);
+            if (config != null) {
                 for (SimpleItemConfiguration itemConfig : config.getConfigs()) {
                     if (hasStrategy(config, itemConfig, SimpleStrategy.Globals.RESTORE)) {
                         for (Item item : getAllItems(itemConfig)) {


### PR DESCRIPTION
contains + get will do its job as long as all collection access uses the same synchronization locks and as long as every put ensures there will never by a null value be inserted.

If the map implementation checks if a key is available, we can also get the value already (IMHO there is no need for the overhead to first lookup if the key is present and after that is checked, we call the get function). It should be better to get the value and check if it differs from null.
