### PR TITLE
[actions] Add the ability to send HTTP headers in sendHttpXXXRequest

### DIFF
--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -45,6 +45,7 @@ Import-Package: \
  javax.measure.*,\
  org.apache.*,\
  org.eclipse.jdt.annotation;resolution:=optional,\
+ org.eclipse.jetty.http.*,\
  org.eclipse.xtext.xbase.lib,\
  org.joda.*,\
  org.osgi.*,\

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/HTTP.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/HTTP.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ public class HTTP {
     static public String sendHttpGetRequest(String url, int timeout) {
         String response = null;
         try {
-            return HttpUtil.executeUrl("GET", url, timeout);
+            return HttpUtil.executeUrl(HttpMethod.GET.name(), url, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -72,9 +73,9 @@ public class HTTP {
      */
     public static String sendHttpGetRequest(String url, Map<String, String> headers, int timeout) {
         try {
-            Properties h = new Properties();
-            h.putAll(headers);
-            return HttpUtil.executeUrl("GET", url, h, null, null, timeout);
+            Properties headerProperties = new Properties();
+            headerProperties.putAll(headers);
+            return HttpUtil.executeUrl(HttpMethod.GET.name(), url, headerProperties, null, null, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -101,7 +102,7 @@ public class HTTP {
     static public String sendHttpPutRequest(String url, int timeout) {
         String response = null;
         try {
-            response = HttpUtil.executeUrl("PUT", url, timeout);
+            response = HttpUtil.executeUrl(HttpMethod.PUT.name(), url, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -134,7 +135,7 @@ public class HTTP {
     static public String sendHttpPutRequest(String url, String contentType, String content, int timeout) {
         String response = null;
         try {
-            response = HttpUtil.executeUrl("PUT", url, IOUtils.toInputStream(content), contentType, timeout);
+            response = HttpUtil.executeUrl(HttpMethod.PUT.name(), url, IOUtils.toInputStream(content), contentType, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -153,9 +154,9 @@ public class HTTP {
      */
     static public String sendHttpPutRequest(String url, String contentType, String content, Map<String, String> headers, int timeout) {
         try {
-            Properties h = new Properties();
-            h.putAll(headers);
-            return HttpUtil.executeUrl("PUT", url, h, IOUtils.toInputStream(content), contentType, timeout);
+            Properties headerProperties = new Properties();
+            headerProperties.putAll(headers);
+            return HttpUtil.executeUrl(HttpMethod.PUT.name(), url, headerProperties, IOUtils.toInputStream(content), contentType, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -182,7 +183,7 @@ public class HTTP {
     static public String sendHttpPostRequest(String url, int timeout) {
         String response = null;
         try {
-            response = HttpUtil.executeUrl("POST", url, timeout);
+            response = HttpUtil.executeUrl(HttpMethod.POST.name(), url, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -215,7 +216,7 @@ public class HTTP {
     static public String sendHttpPostRequest(String url, String contentType, String content, int timeout) {
         String response = null;
         try {
-            response = HttpUtil.executeUrl("POST", url, IOUtils.toInputStream(content), contentType, timeout);
+            response = HttpUtil.executeUrl(HttpMethod.POST.name(), url, IOUtils.toInputStream(content), contentType, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -234,9 +235,9 @@ public class HTTP {
      */
     public static String sendHttpPostRequest(String url, String contentType, String content, Map<String, String> headers, int timeout) {
         try {
-            Properties h = new Properties();
-            h.putAll(headers);
-            return HttpUtil.executeUrl("POST", url, h, IOUtils.toInputStream(content), contentType, timeout);
+            Properties headerProperties = new Properties();
+            headerProperties.putAll(headers);
+            return HttpUtil.executeUrl(HttpMethod.POST.name(), url, headerProperties, IOUtils.toInputStream(content), contentType, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -263,7 +264,7 @@ public class HTTP {
     static public String sendHttpDeleteRequest(String url, int timeout) {
         String response = null;
         try {
-            response = HttpUtil.executeUrl("DELETE", url, timeout);
+            response = HttpUtil.executeUrl(HttpMethod.DELETE.name(), url, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
@@ -280,9 +281,9 @@ public class HTTP {
      */
     static public String sendHttpDeleteRequest(String url, Map<String, String> headers, int timeout) {
         try {
-            Properties h = new Properties();
-            h.putAll(headers);
-            return HttpUtil.executeUrl("DELETE", url, h, null, null, timeout);
+            Properties headerProperties = new Properties();
+            headerProperties.putAll(headers);
+            return HttpUtil.executeUrl(HttpMethod.DELETE.name(), url, headerProperties, null, null, timeout);
         } catch (IOException e) {
             logger.error("Fatal transport error: {}", e.getMessage());
         }

--- a/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/HTTP.java
+++ b/bundles/org.openhab.core.model.script/src/org/eclipse/smarthome/model/script/actions/HTTP.java
@@ -13,6 +13,8 @@
 package org.eclipse.smarthome.model.script.actions;
 
 import java.io.IOException;
+import java.util.Properties;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.smarthome.io.net.http.HttpUtil;
@@ -58,6 +60,25 @@ public class HTTP {
             logger.error("Fatal transport error: {}", e.getMessage());
         }
         return response;
+    }
+
+    /**
+     * Send out a GET-HTTP request. Errors will be logged, returned values just ignored.
+     * 
+     * @param url the URL to be used for the GET request.
+     * @param headers the HTTP headers to be sent in the request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpGetRequest(String url, Map<String, String> headers, int timeout) {
+        try {
+            Properties h = new Properties();
+            h.putAll(headers);
+            return HttpUtil.executeUrl("GET", url, h, null, null, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
     }
 
     /**
@@ -121,6 +142,27 @@ public class HTTP {
     }
 
     /**
+     * Send out a PUT-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the PUT request.
+     * @param contentType the content type of the given <code>content</code>
+     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be sent.
+     * @param headers the HTTP headers to be sent in the request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    static public String sendHttpPutRequest(String url, String contentType, String content, Map<String, String> headers, int timeout) {
+        try {
+            Properties h = new Properties();
+            h.putAll(headers);
+            return HttpUtil.executeUrl("PUT", url, h, IOUtils.toInputStream(content), contentType, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
      * Send out a POST-HTTP request. Errors will be logged, returned values just ignored.
      *
      * @param url the URL to be used for the POST request.
@@ -181,6 +223,27 @@ public class HTTP {
     }
 
     /**
+     * Send out a POST-HTTP request. Errors will be logged, returned values just ignored.
+     * 
+     * @param url the URL to be used for the GET request.
+     * @param contentType the content type of the given <code>content</code>
+     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be sent.
+     * @param headers the HTTP headers to be sent in the request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    public static String sendHttpPostRequest(String url, String contentType, String content, Map<String, String> headers, int timeout) {
+        try {
+            Properties h = new Properties();
+            h.putAll(headers);
+            return HttpUtil.executeUrl("POST", url, h, IOUtils.toInputStream(content), contentType, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
      * Send out a DELETE-HTTP request. Errors will be logged, returned values just ignored.
      *
      * @param url the URL to be used for the DELETE request.
@@ -207,4 +270,22 @@ public class HTTP {
         return response;
     }
 
+    /**
+     * Send out a DELETE-HTTP request. Errors will be logged, returned values just ignored.
+     *
+     * @param url the URL to be used for the DELETE request.
+     * @param headers the HTTP headers to be sent in the request.
+     * @param timeout timeout in ms
+     * @return the response body or <code>NULL</code> when the request went wrong
+     */
+    static public String sendHttpDeleteRequest(String url, Map<String, String> headers, int timeout) {
+        try {
+            Properties h = new Properties();
+            h.putAll(headers);
+            return HttpUtil.executeUrl("DELETE", url, h, null, null, timeout);
+        } catch (IOException e) {
+            logger.error("Fatal transport error: {}", e.getMessage());
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
Add an additional version for each type of HTTP request (GET, PUT, POST, DELETE) that accepts HTTP headers to be sent along with the request.

Addressed issue #1271 

This was tested in a jython script, passing a python's dictionary object to the header argument. RulesDSL user can use newHashMap.