### PR TITLE
Added missing JavaDoc to 'createGroupStateChangedEvent' method in 'ItemEventFactory'

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
@@ -15,8 +15,7 @@ package org.eclipse.smarthome.core.items.events;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * {@link GroupItemStateChangedEvent}s can be used to deliver group item state changes through the openHAB
- * event bus. In
+ * {@link GroupItemStateChangedEvent}s can be used to deliver group item state changes through the openHAB event bus. In
  * contrast to the {@link GroupItemStateEvent} the {@link GroupItemStateChangedEvent} is only sent if the state changed.
  * State events must be created with the {@link ItemEventFactory}.
  *
@@ -53,4 +52,5 @@ public class GroupItemStateChangedEvent extends ItemStateChangedEvent {
     public String toString() {
         return String.format("%s through %s", super.toString(), memberName);
     }
+
 }

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -304,6 +304,16 @@ public class ItemEventFactory extends AbstractEventFactory {
         return new ItemStateChangedEvent(topic, payload, itemName, newState, oldState);
     }
 
+    /**
+     * Creates a group item state changed event.
+     *
+     * @param itemName the name of the group item to send the state changed event for
+     * @param memberName the name of the member causing the group item state change
+     * @param newState the new state to send
+     * @param oldState the old state of the group item
+     * @return the created group item state changed event
+     * @throws IllegalArgumentException if itemName or state is null
+     */
     public static GroupItemStateChangedEvent createGroupStateChangedEvent(String itemName, String memberName,
             State newState, State oldState) {
         assertValidArguments(itemName, memberName, newState, "state");

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
@@ -16,9 +16,9 @@ import org.eclipse.smarthome.core.events.AbstractEvent;
 import org.eclipse.smarthome.core.types.State;
 
 /**
- * {@link ItemStateChangedEvent}s can be used to deliver item state changes through the openHAB event bus. In
- * contrast to the {@link ItemStateEvent} the {@link ItemStateChangedEvent} is only sent if the state changed.
- * State events must be created with the {@link ItemEventFactory}.
+ * {@link ItemStateChangedEvent}s can be used to deliver item state changes through the openHAB event bus. In contrast
+ * to the {@link ItemStateEvent} the {@link ItemStateChangedEvent} is only sent if the state changed. State events must
+ * be created with the {@link ItemEventFactory}.
  *
  * @author Dennis Nobel - Initial contribution
  */


### PR DESCRIPTION
- Added missing JavaDoc to `createGroupStateChangedEvent` method in `ItemEventFactory`

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>