### PR TITLE
[rest] Suppress error message in REST response

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
@@ -173,7 +173,7 @@ public class JSONResponse {
                 gson.toJson(entity, entity.getClass(), jsonWriter);
                 jsonWriter.flush();
             } catch (IOException | JsonIOException e) {
-                logger.error("Error streaming JSON through PipedInpuStream/PipedOutputStream: ", e);
+                logger.debug("Error streaming JSON through PipedInputStream / PipedOutputStream: ", e);
             }
         });
 
@@ -193,13 +193,9 @@ public class JSONResponse {
 
         private final Logger logger = LoggerFactory.getLogger(ExceptionMapper.class);
 
-        /**
-         * create JSON Response
-         */
-
         @Override
         public Response toResponse(Exception e) {
-            logger.debug("exception during REST Handling", e);
+            logger.debug("Exception during REST handling: ", e);
 
             Response.StatusType status = Response.Status.INTERNAL_SERVER_ERROR;
 

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
@@ -173,7 +173,7 @@ public class JSONResponse {
                 gson.toJson(entity, entity.getClass(), jsonWriter);
                 jsonWriter.flush();
             } catch (IOException | JsonIOException e) {
-                logger.debug("Error streaming JSON through PipedInputStream / PipedOutputStream: ", e);
+                logger.debug("Error streaming JSON through PipedInputStream / PipedOutputStream.", e);
             }
         });
 
@@ -195,7 +195,7 @@ public class JSONResponse {
 
         @Override
         public Response toResponse(Exception e) {
-            logger.debug("Exception during REST handling: ", e);
+            logger.debug("Exception during REST handling.", e);
 
             Response.StatusType status = Response.Status.INTERNAL_SERVER_ERROR;
 


### PR DESCRIPTION
- Suppress error message in REST response

I am wondering if we can suppress this error message as the REST interface can handle it without any consequences. It often occurs when a request is interrupted or canceled.

```
2019-12-30 14:24:44.491 [ERROR] [lipse.smarthome.io.rest.JSONResponse] - Error streaming JSON through PipedInpuStream/PipedOutputStream: 
com.google.gson.JsonIOException: java.io.IOException: Pipe closed
	at com.google.gson.Gson.toJson(Gson.java:671) ~[?:?]
	at org.eclipse.smarthome.io.rest.JSONResponse.lambda$0(JSONResponse.java:173) ~[?:?]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
	Suppressed: java.io.IOException: Pipe closed
		at java.io.PipedInputStream.checkStateForReceive(PipedInputStream.java:260) ~[?:1.8.0_152]
		at java.io.PipedInputStream.receive(PipedInputStream.java:226) ~[?:1.8.0_152]
		at java.io.PipedOutputStream.write(PipedOutputStream.java:149) ~[?:1.8.0_152]
		at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) ~[?:1.8.0_152]
		at sun.nio.cs.StreamEncoder.implClose(StreamEncoder.java:316) ~[?:1.8.0_152]
		at sun.nio.cs.StreamEncoder.close(StreamEncoder.java:149) ~[?:1.8.0_152]
		at java.io.OutputStreamWriter.close(OutputStreamWriter.java:233) ~[?:1.8.0_152]
		at java.io.BufferedWriter.close(BufferedWriter.java:266) ~[?:1.8.0_152]
		at com.google.gson.stream.JsonWriter.close(JsonWriter.java:555) ~[?:?]
		at org.eclipse.smarthome.io.rest.JSONResponse.lambda$0(JSONResponse.java:175) ~[?:?]
		at java.lang.Thread.run(Thread.java:748) [?:1.8.0_152]
Caused by: java.io.IOException: Pipe closed
	at java.io.PipedInputStream.checkStateForReceive(PipedInputStream.java:260) ~[?:1.8.0_152]
	at java.io.PipedInputStream.awaitSpace(PipedInputStream.java:268) ~[?:1.8.0_152]
	at java.io.PipedInputStream.receive(PipedInputStream.java:231) ~[?:1.8.0_152]
	at java.io.PipedOutputStream.write(PipedOutputStream.java:149) ~[?:1.8.0_152]
	at sun.nio.cs.StreamEncoder.writeBytes(StreamEncoder.java:221) ~[?:1.8.0_152]
	at sun.nio.cs.StreamEncoder.implWrite(StreamEncoder.java:282) ~[?:1.8.0_152]
	at sun.nio.cs.StreamEncoder.write(StreamEncoder.java:125) ~[?:1.8.0_152]
	at java.io.OutputStreamWriter.write(OutputStreamWriter.java:207) ~[?:1.8.0_152]
	at java.io.BufferedWriter.flushBuffer(BufferedWriter.java:129) ~[?:1.8.0_152]
	at java.io.BufferedWriter.write(BufferedWriter.java:230) ~[?:1.8.0_152]
	at java.io.Writer.write(Writer.java:157) ~[?:1.8.0_152]
	at java.io.Writer.append(Writer.java:227) ~[?:1.8.0_152]
	at com.google.gson.stream.JsonWriter.value(JsonWriter.java:534) ~[?:?]
	at com.google.gson.internal.bind.TypeAdapters$11.write(TypeAdapters.java:310) ~[?:?]
	at com.google.gson.internal.bind.TypeAdapters$11.write(TypeAdapters.java:295) ~[?:?]
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69) ~[?:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:125) ~[?:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:243) ~[?:?]
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69) ~[?:?]
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:97) ~[?:?]
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:61) ~[?:?]
	at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:69) ~[?:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.write(ReflectiveTypeAdapterFactory.java:125) ~[?:?]
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:243) ~[?:?]
	at com.google.gson.Gson.toJson(Gson.java:669) ~[?:?]
	... 2 more
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>