### PR TITLE
[archetype] new binding feature should use ohc.version

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
@@ -14,10 +14,9 @@
 
 -->
 <features name="${rootArtifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
-	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${project.version}/xml/features</repository>
+	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
-	<feature name="openhab-binding-${bindingId}" description="${bindingIdCamelCase} Binding"
-		version="${project.version}">
+	<feature name="openhab-binding-${bindingId}" description="${bindingIdCamelCase} Binding" version="${project.version}">	
 		<feature>openhab-runtime-base</feature>
 		<bundle start-level="80">mvn:org.openhab.addons.bundles/${rootArtifactId}/${project.version}</bundle>
 	</feature>


### PR DESCRIPTION
When generating a new binding with the maven archetype it should refer to openhab core via the variable `ohc.version` In the feature.xml.