### PR TITLE
Changed configurationPid prefixes from 'org.openhab.core' ot 'org.openhab'

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * @author Wouter Born - Sort audio sink and source options
  */
 @NonNullByDefault
-@Component(immediate = true, configurationPid = "org.openhab.core.audio", property = { //
+@Component(immediate = true, configurationPid = "org.openhab.audio", property = { //
         Constants.SERVICE_PID + "=org.openhab.core.audio", //
         ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system", //
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + AudioManagerImpl.CONFIG_URI, //

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
@@ -45,7 +45,7 @@ import org.osgi.service.component.annotations.Modified;
  * @author Łukasz Dywicki - Initial contribution
  * @author Kai Kreuzer - Removed ManagedService and used DS configuration instead
  */
-@Component(configurationPid = "org.openhab.core.jaas")
+@Component(configurationPid = "org.openhab.jaas")
 public class JaasAuthenticationProvider implements AuthenticationProvider {
 
     private String realmName;

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -86,7 +86,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - added auto-approve functionality
  * @author Henning Sudbrock - added hook for selectively auto-approving inbox entries
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.inbox", service = EventSubscriber.class, property = {
+@Component(immediate = true, configurationPid = "org.openhab.inbox", service = EventSubscriber.class, property = {
         Constants.SERVICE_PID + "=org.openhab.core.inbox", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Inbox",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=system:inbox" })

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthenticationHandler.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthenticationHandler.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Łukasz Dywicki - Initial contribution.
  */
-@Component(configurationPid = "org.openhab.core.auth")
+@Component(configurationPid = "org.openhab.auth")
 public class AuthenticationHandler implements Handler {
 
     private static final String AUTHENTICATION_ENABLED = "enabled";

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - added web socket support
  * @author Martin van Wingerden - Add support for ESHTrustManager
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.webclient")
+@Component(immediate = true, configurationPid = "org.openhab.webclient")
 @NonNullByDefault
 public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory {
 

--- a/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
+++ b/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Kai Kreuzer - Initial contribution
  * @author Markus Rathgeb - Use HTTP service utility functions
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.mdns", property = {
+@Component(immediate = true, configurationPid = "org.openhab.mdns", property = {
         Constants.SERVICE_PID + "=org.openhab.core.mdns" //
 })
 public class MDNSAnnouncer {

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  */
 @Component(service = { SitemapSubscriptionService.class,
-        EventSubscriber.class }, configurationPid = "org.openhab.core.sitemapsubscription")
+        EventSubscriber.class }, configurationPid = "org.openhab.sitemapsubscription")
 public class SitemapSubscriptionService implements ModelRepositoryChangeListener, EventSubscriber {
 
     private static final String SITEMAP_PAGE_SEPARATOR = "#";

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 @Provider
 @Component(immediate = true, property = {
-        "service.pid=org.openhab.core.cors" }, configurationPid = "org.openhab.core.cors", configurationPolicy = ConfigurationPolicy.REQUIRE)
+        "service.pid=org.openhab.core.cors" }, configurationPid = "org.openhab.cors", configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class CorsFilter implements ContainerResponseFilter {
 
     static final String HTTP_HEAD_METHOD = "HEAD";

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 @Provider
 @PreMatching
-@Component(configurationPid = "org.openhab.io.rest.proxyfilter", immediate = true, service = ProxyFilter.class)
+@Component(configurationPid = "org.openhab.proxyfilter", immediate = true, service = ProxyFilter.class)
 public class ProxyFilter implements ContainerRequestFilter {
 
     static final String PROTO_PROXY_HEADER = "x-forwarded-proto";

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 @Provider
 @PreMatching
-@Component(configurationPid = "org.openhab.core.io.rest.proxyfilter", immediate = true, service = ProxyFilter.class)
+@Component(configurationPid = "org.openhab.io.rest.proxyfilter", immediate = true, service = ProxyFilter.class)
 public class ProxyFilter implements ContainerRequestFilter {
 
     static final String PROTO_PROXY_HEADER = "x-forwarded-proto";

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  */
 @Path("/")
-@Component(service = RootResource.class, configurationPid = "org.openhab.core.io.rest.root")
+@Component(service = RootResource.class, configurationPid = "org.openhab.io.rest.root")
 public class RootResource {
 
     private final transient Logger logger = LoggerFactory.getLogger(RootResource.class);

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  */
 @Path("/")
-@Component(service = RootResource.class, configurationPid = "org.openhab.io.rest.root")
+@Component(service = RootResource.class, configurationPid = "org.openhab.restroot")
 public class RootResource {
 
     private final transient Logger logger = LoggerFactory.getLogger(RootResource.class);

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author David Graeff - Initial contribution
  */
-@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MqttBrokerConnectionServiceInstance.class, configurationPid = "org.openhab.core.mqttbroker")
+@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MqttBrokerConnectionServiceInstance.class, configurationPid = "org.openhab.mqttbroker")
 @NonNullByDefault
 public class MqttBrokerConnectionServiceInstance {
     private final Logger logger = LoggerFactory.getLogger(MqttBrokerConnectionServiceInstance.class);

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttServiceImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Added/Removed observer interface, Add/Remove/Enumerate broker connections.
  * @author Markus Rathgeb - Synchronize access to broker connections
  */
-@Component(immediate = true, service = MqttService.class, configurationPid = "org.openhab.core.mqtt", property = {
+@Component(immediate = true, service = MqttService.class, configurationPid = "org.openhab.mqtt", property = {
         Constants.SERVICE_PID + "=org.openhab.core.mqtt" })
 @NonNullByDefault
 public class MqttServiceImpl implements MqttService {

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
@@ -44,14 +44,14 @@ import com.google.inject.Injector;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(immediate = true, service = ModelServer.class, configurationPid = ModelServer.CONFIG_PID, property = {
-        Constants.SERVICE_PID + "=" + ModelServer.CONFIG_PID,
+@Component(immediate = true, service = ModelServer.class, configurationPid = ModelServer.CONFIGURATION_PID, property = {
+        Constants.SERVICE_PID + "=org.openhab.core.lsp",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=misc:lsp",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Language Server (LSP)",
         ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=misc" })
 public class ModelServer {
 
-    static final String CONFIG_PID = "org.openhab.core.lsp";
+    public static final String CONFIGURATION_PID = "org.openhab.lsp";
     private static final String KEY_PORT = "port";
     private static final int DEFAULT_PORT = 5007;
     private final ExecutorService pool = ThreadPoolManager.getPool("lsp");

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
@@ -42,9 +42,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(immediate = true, service = HumanLanguageInterpreter.class, configurationPid = "org.openhab.core.rulehli", property = {
-        Constants.SERVICE_PID + "=org.openhab.core.rulehli",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=voice",
+@Component(immediate = true, service = HumanLanguageInterpreter.class, configurationPid = "org.openhab.rulehli", property = {
+        Constants.SERVICE_PID + "=org.openhab.core.rulehli", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=voice",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Rule Voice Interpreter",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + RuleHumanLanguageInterpreter.CONFIG_URI })
 public class RuleHumanLanguageInterpreter implements HumanLanguageInterpreter {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.persistence", property = {
+@Component(immediate = true, configurationPid = "org.openhab.persistence", property = {
         Constants.SERVICE_PID + "=org.openhab.core.persistence",
         ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Persistence",

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Henning Treu - Initial contribution
  */
-@Component(configurationPid = "org.openhab.core.magic", service = ConfigOptionProvider.class, immediate = true, property = {
+@Component(configurationPid = "org.openhab.magic", service = ConfigOptionProvider.class, immediate = true, property = {
         "service.pid=org.openhab.core.magic", "service.config.description.uri=test:magic", "service.config.label=Magic",
         "service.config.category=test" })
 public class MagicServiceImpl implements MagicService {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = "org.openhab.core.MagicMultiAction")
+@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = "org.openhab.MagicMultiAction")
 @ActionScope(name = "binding.magic")
 public class MagicMultiServiceMultiActions implements AnnotatedActions {
 

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = "org.openhab.MagicMultiAction")
+@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, configurationPid = "org.openhab.magicmultiaction")
 @ActionScope(name = "binding.magic")
 public class MagicMultiServiceMultiActions implements AnnotatedActions {
 

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(configurationPid = "org.openhab.core.automation.action.magicSingleActionService", property = {
+@Component(configurationPid = "org.openhab.automation.action.magicSingleActionService", property = {
         Constants.SERVICE_PID + "=org.openhab.core.automation.action.magicSingleActionService",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=automationAction:magicSingleAction",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Magic Single Action Service",

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(configurationPid = "org.openhab.automation.action.magicSingleActionService", property = {
+@Component(configurationPid = "org.openhab.magicsingleaction", property = {
         Constants.SERVICE_PID + "=org.openhab.core.automation.action.magicSingleActionService",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=automationAction:magicSingleAction",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Magic Single Action Service",

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MagicMultiInstanceService.class, configurationPid = "org.openhab.magicMultiInstance")
+@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MagicMultiInstanceService.class, configurationPid = "org.openhab.magicmultiinstance")
 public class MagicMultiInstanceService {
 
     private final Logger logger = LoggerFactory.getLogger(MagicMultiInstanceService.class);

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MagicMultiInstanceService.class, configurationPid = "org.openhab.core.magicMultiInstance")
+@Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, service = MagicMultiInstanceService.class, configurationPid = "org.openhab.magicMultiInstance")
 public class MagicMultiInstanceService {
 
     private final Logger logger = LoggerFactory.getLogger(MagicMultiInstanceService.class);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 @Component(immediate = true, service = {
-        AutoUpdateManager.class }, configurationPid = "org.openhab.core.autoupdate", configurationPolicy = ConfigurationPolicy.OPTIONAL)
+        AutoUpdateManager.class }, configurationPid = "org.openhab.autoupdate", configurationPolicy = ConfigurationPolicy.OPTIONAL)
 public class AutoUpdateManager {
 
     private static final String AUTOUPDATE_KEY = "autoupdate";

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelItemProvider.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * @author Markus Rathgeb - Add locale provider support
  * @author Thomas Höfer - Added modified operation
  */
-@Component(configurationPid = "org.openhab.core.channelitemprovider", immediate = true)
+@Component(configurationPid = "org.openhab.channelitemprovider", immediate = true)
 @NonNullByDefault
 public class ChannelItemProvider implements ItemProvider {
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ThingLinkManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ThingLinkManager.java
@@ -57,12 +57,16 @@ import org.slf4j.LoggerFactory;
  *         ThingSetupManager)
  * @author Markus Rathgeb - Send link notification if item and link exists and unlink on the first removal
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.links", service = { ThingLinkManager.class,
+@Component(immediate = true, configurationPid = ThingLinkManager.CONFIGURATION_PID, service = { ThingLinkManager.class,
         EventSubscriber.class }, property = { "service.config.description.uri:String=system:links",
                 "service.config.label:String=Item Linking", "service.config.category:String=system",
                 "service.pid:String=org.openhab.core.links" })
 @NonNullByDefault
 public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusInfoChangedEvent> {
+
+    public static final String CONFIGURATION_PID = "org.openhab.links";
+
+    public static final String AUTO_LINKS = "autoLinks";
 
     private static final String THREADPOOL_NAME = "thingLinkManager";
 
@@ -103,7 +107,7 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
     protected void modified(ComponentContext context) {
         // check whether we want to enable the automatic link creation or not
         if (context != null) {
-            Object value = context.getProperties().get("autoLinks");
+            Object value = context.getProperties().get(AUTO_LINKS);
             autoLinks = value == null || !value.toString().equals("false");
         }
     }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
@@ -69,7 +69,7 @@ import org.osgi.service.http.HttpService;
  * @author Chris Jackson - Initial contribution
  * @author Holger Reichert - Support for themes, DPI, legend hiding
  */
-@Component(immediate = true, service = ChartServlet.class, configurationPid = "org.openhab.core.chart", property = {
+@Component(immediate = true, service = ChartServlet.class, configurationPid = "org.openhab.chart", property = {
         Constants.SERVICE_PID + "=org.openhab.core.chart", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Charts",
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + "system:chart" })

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -71,13 +71,15 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Sort TTS options
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.voice", property = { //
+@Component(immediate = true, configurationPid = VoiceManagerImpl.CONFIGURATION_PID, property = { //
         Constants.SERVICE_PID + "=org.openhab.core.voice", //
         ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system", //
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Voice", //
         ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + VoiceManagerImpl.CONFIG_URI //
 })
 public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
+
+    public static final String CONFIGURATION_PID = "org.openhab.voice";
 
     // the default keyword to use if no other is configured
     private static final String DEFAULT_KEYWORD = "Wakeup";

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 @Component(configurationPid = ThreadPoolManager.CONFIGURATION_PID)
 public class ThreadPoolManager {
 
-    public static final String CONFIGURATION_PID = "org.openhab.core.threadpool";
+    public static final String CONFIGURATION_PID = "org.openhab.threadpool";
 
     /**
      * The common thread pool is reserved for occasional, light weight tasks that run quickly, and

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerImpl.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Modified;
  * @author Simon Kaufmann - Initial contribution
  */
 @NonNullByDefault
-@Component(configurationPid = "org.openhab.core.safecaller", immediate = true)
+@Component(configurationPid = "org.openhab.safecaller", immediate = true)
 public class SafeCallerImpl implements SafeCaller {
 
     private static final String SAFE_CALL_POOL_NAME = "safeCall";

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Triller - Initial contribution
  * @author Erdoan Hadzhiyusein - Added time zone
  */
-@Component(immediate = true, configurationPid = "org.openhab.core.i18n", property = {
+@Component(immediate = true, configurationPid = I18nProviderImpl.CONFIGURATION_PID, property = {
         Constants.SERVICE_PID + "=org.openhab.core.i18n", //
         "service.config.label=Regional Settings", //
         "service.config.category=system", //
@@ -87,11 +87,13 @@ public class I18nProviderImpl
 
     private final Logger logger = LoggerFactory.getLogger(I18nProviderImpl.class);
 
+    public static final String CONFIGURATION_PID = "org.openhab.i18n";
+
     // LocaleProvider
-    static final String LANGUAGE = "language";
-    static final String SCRIPT = "script";
-    static final String REGION = "region";
-    static final String VARIANT = "variant";
+    public static final String LANGUAGE = "language";
+    public static final String SCRIPT = "script";
+    public static final String REGION = "region";
+    public static final String VARIANT = "variant";
     private @Nullable Locale locale;
 
     // TranslationProvider

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Network address change listener
  * @author Tim Roberts - Added primary address change to network address change listener
  */
-@Component(configurationPid = "org.openhab.core.network", property = { "service.pid=org.openhab.core.network",
+@Component(configurationPid = "org.openhab.network", property = { "service.pid=org.openhab.core.network",
         "service.config.description.uri=system:network", "service.config.label=Network Settings",
         "service.config.category=system" })
 @NonNullByDefault

--- a/itests/org.openhab.core.binding.xml.tests/src/main/java/org/openhab/core/binding/xml/test/BindingInfoI18nTest.java
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/java/org/openhab/core/binding/xml/test/BindingInfoI18nTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.openhab.core.binding.BindingInfo;
 import org.openhab.core.binding.BindingInfoRegistry;
 import org.openhab.core.i18n.LocaleProvider;
+import org.openhab.core.internal.i18n.I18nProviderImpl;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -91,7 +92,7 @@ public class BindingInfoI18nTest extends JavaOSGiTest {
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
         assertThat(configAdmin, is(notNullValue()));
 
-        Configuration config = configAdmin.getConfiguration("org.openhab.core.i18n", null);
+        Configuration config = configAdmin.getConfiguration(I18nProviderImpl.CONFIGURATION_PID, null);
         assertThat(config, is(notNullValue()));
 
         Dictionary<String, Object> properties = config.getProperties();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -75,6 +75,7 @@ import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.link.ManagedItemChannelLinkProvider;
+import org.openhab.core.thing.link.ThingLinkManager;
 import org.openhab.core.thing.type.ChannelDefinitionBuilder;
 import org.openhab.core.thing.type.ChannelGroupType;
 import org.openhab.core.thing.type.ChannelGroupTypeBuilder;
@@ -1055,12 +1056,12 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
 
     private void configureAutoLinking(Boolean on) throws IOException {
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
-        org.osgi.service.cm.Configuration config = configAdmin.getConfiguration("org.openhab.core.links", null);
+        org.osgi.service.cm.Configuration config = configAdmin.getConfiguration(ThingLinkManager.CONFIGURATION_PID);
         Dictionary<String, Object> properties = config.getProperties();
         if (properties == null) {
             properties = new Hashtable<>();
         }
-        properties.put("autoLinks", on.toString());
+        properties.put(ThingLinkManager.AUTO_LINKS, on.toString());
         config.update(properties);
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/testutil/i18n/DefaultLocaleSetter.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/testutil/i18n/DefaultLocaleSetter.java
@@ -21,6 +21,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Locale;
 
+import org.openhab.core.internal.i18n.I18nProviderImpl;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
@@ -48,7 +49,7 @@ public class DefaultLocaleSetter {
     public void setDefaultLocale(Locale locale) throws IOException {
         assertThat(locale, is(notNullValue()));
 
-        Configuration config = configAdmin.getConfiguration("org.openhab.core.i18n", null);
+        Configuration config = configAdmin.getConfiguration(I18nProviderImpl.CONFIGURATION_PID, null);
         assertThat(config, is(notNullValue()));
 
         Dictionary<String, Object> properties = config.getProperties();
@@ -56,10 +57,10 @@ public class DefaultLocaleSetter {
             properties = new Hashtable<>();
         }
 
-        properties.put("language", locale.getLanguage());
-        properties.put("script", locale.getScript());
-        properties.put("region", locale.getCountry());
-        properties.put("variant", locale.getVariant());
+        properties.put(I18nProviderImpl.LANGUAGE, locale.getLanguage());
+        properties.put(I18nProviderImpl.SCRIPT, locale.getScript());
+        properties.put(I18nProviderImpl.REGION, locale.getCountry());
+        properties.put(I18nProviderImpl.VARIANT, locale.getVariant());
 
         config.update(properties);
     }

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/javavoicemanager/VoiceManagerTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/javavoicemanager/VoiceManagerTest.java
@@ -53,7 +53,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
  * @author Velin Yordanov - migrated tests from groovy to java
  */
 public class VoiceManagerTest extends JavaOSGiTest {
-    private static final String PID = "org.openhab.core.voice";
     private static final String CONFIG_DEFAULT_HLI = "defaultHLI";
     private static final String CONFIG_DEFAULT_KS = "defaultKS";
     private static final String CONFIG_DEFAULT_STT = "defaultSTT";
@@ -92,7 +91,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         Dictionary<String, Object> voiceConfig = new Hashtable<>();
         voiceConfig.put(CONFIG_DEFAULT_TTS, ttsService.getId());
         ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
-        Configuration configuration = configAdmin.getConfiguration(PID);
+        Configuration configuration = configAdmin.getConfiguration(VoiceManagerImpl.CONFIGURATION_PID);
         configuration.update(voiceConfig);
 
         audioManager = new AudioManagerStub();
@@ -164,8 +163,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         Dictionary<String, Object> voiceConfig = new Hashtable<>();
         voiceConfig.put("defaultHLI", hliStub.getId());
         ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
-        String pid = "org.openhab.core.voice";
-        Configuration configuration = configAdmin.getConfiguration(pid);
+        Configuration configuration = configAdmin.getConfiguration(VoiceManagerImpl.CONFIGURATION_PID);
         configuration.update(voiceConfig);
 
         String result = voiceManager.interpret("something", hliStub.getId());
@@ -249,8 +247,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         config.put(CONFIG_DEFAULT_VOICE, voice.getUID());
 
         ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
-        String pid = "org.openhab.core.voice";
-        Configuration configuration = configAdmin.getConfiguration(pid);
+        Configuration configuration = configAdmin.getConfiguration(VoiceManagerImpl.CONFIGURATION_PID);
         configuration.update(config);
 
         waitForAssert(() -> {

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openhab.core.voice.internal.HumanLanguageInterpreterStub;
 import org.openhab.core.voice.internal.TTSServiceStub;
+import org.openhab.core.voice.internal.VoiceManagerImpl;
 import org.openhab.core.voice.internal.VoiceStub;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -61,8 +62,7 @@ public class InterpretCommandTest extends VoiceConsoleCommandExtensionTest {
         config.put(CONFIG_DEFAULT_HLI, hliStub.getId());
         config.put(CONFIG_DEFAULT_VOICE, voice.getUID());
         ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
-        String pid = "org.openhab.core.voice";
-        Configuration configuration = configAdmin.getConfiguration(pid);
+        Configuration configuration = configAdmin.getConfiguration(VoiceManagerImpl.CONFIGURATION_PID);
         configuration.update(config);
     }
 

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
@@ -35,6 +35,7 @@ import org.openhab.core.thing.ThingProvider;
 import org.openhab.core.voice.TTSService;
 import org.openhab.core.voice.internal.SinkStub;
 import org.openhab.core.voice.internal.TTSServiceStub;
+import org.openhab.core.voice.internal.VoiceManagerImpl;
 import org.openhab.core.voice.internal.VoiceStub;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
@@ -112,8 +113,7 @@ public class SayCommandTest extends VoiceConsoleCommandExtensionTest {
             Dictionary<String, Object> config = new Hashtable<>();
             config.put(CONFIG_DEFAULT_TTS, defaultTTSService);
             ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
-            String pid = "org.openhab.core.voice";
-            Configuration configuration = configAdmin.getConfiguration(pid);
+            Configuration configuration = configAdmin.getConfiguration(VoiceManagerImpl.CONFIGURATION_PID);
             configuration.update(config);
         }
 


### PR DESCRIPTION
- Changed configurationPid prefixes from 'org.openhab.core' ot 'org.openhab'
- Minor improvements for integration tests using configurationPids

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>