### PR TITLE
Fix FolderObserver configuration PID

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -56,7 +56,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Fabio Marini - Refactoring to use WatchService
  * @author Ana Dimova - reduce to a single watch thread for all class instances
  */
-@Component(name = "org.openhab.core.folder", immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE)
+@Component(name = "org.openhab.core.folder", immediate = true, configurationPid = "org.openhab.folder", configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class FolderObserver extends AbstractWatchService {
 
     public FolderObserver() {


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/1314 was missing an update for this PID. Without it all file based configuration won't work.

I did some basic testing for https://github.com/openhab/openhab-core/issues/1287 with my Java 11 PRs (+ this PR + https://github.com/openhab/openhab-distro/pull/1030) and didn't run into any Java 11 or Xtext issues.

