### PR TITLE
Correction of unit spellings Ampere hour

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
@@ -197,7 +197,7 @@ public final class SmartHomeUnits extends CustomUnits {
      */
     static {
         // Ordered alphabetical by name
-        SimpleUnitFormat.getInstance().label(AMPERE_HOUR, "A h");
+        SimpleUnitFormat.getInstance().label(AMPERE_HOUR, "Ah");
         SimpleUnitFormat.getInstance().label(BAR, BAR.getSymbol());
         SimpleUnitFormat.getInstance().label(BIT, BIT.getSymbol());
         SimpleUnitFormat.getInstance().label(BIT_PER_SECOND, "bit/s");
@@ -229,7 +229,7 @@ public final class SmartHomeUnits extends CustomUnits {
         SimpleUnitFormat.getInstance().label(MEGAWATT_HOUR, "MWh");
         SimpleUnitFormat.getInstance().label(MICROGRAM_PER_CUBICMETRE, "µg/m³");
         SimpleUnitFormat.getInstance().label(MICROWATT_PER_SQUARE_CENTIMETRE, "µW/cm²");
-        SimpleUnitFormat.getInstance().label(MILLIAMPERE_HOUR, "mA h");
+        SimpleUnitFormat.getInstance().label(MILLIAMPERE_HOUR, "mAh");
         SimpleUnitFormat.getInstance().label(MILLIBAR, "mbar");
         SimpleUnitFormat.getInstance().label(MILLIMETRE_OF_MERCURY, MILLIMETRE_OF_MERCURY.getSymbol());
         SimpleUnitFormat.getInstance().label(OCTET, "o");

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
@@ -300,7 +300,7 @@ public class SmartHomeUnitsTest {
         QuantityType<?> converted = oneAh.toUnit(SmartHomeUnits.AMPERE_HOUR);
         QuantityType<?> converted2 = oneAh.toUnit(SmartHomeUnits.MILLIAMPERE_HOUR);
         assertThat(converted.doubleValue(), is(closeTo(1.00, DEFAULT_ERROR)));
-        assertEquals("1000 mA h", converted2.toString());
+        assertEquals("1000 mAh", converted2.toString());
     }
 
     @Test


### PR DESCRIPTION
SI units are written without spaces.
Fixes #1295 

Signed-off-by: Markus Schraufstetter <markus.schraufstetter@gmail.com>