### PR TITLE
Streamline format of event outputs

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoChangedEvent.java
@@ -86,7 +86,7 @@ public class ThingStatusInfoChangedEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return "'" + thingUID + "' changed from " + oldStatusInfo.toString() + " to " + thingStatusInfo.toString();
+        return String.format("Thing '%s' changed from %s to %s", thingUID, oldStatusInfo, thingStatusInfo);
     }
 
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
@@ -72,7 +72,7 @@ public class ThingStatusInfoEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return "'" + thingUID + "' updated: " + thingStatusInfo.toString();
+        return String.format("Thing '%s' updated: %s", thingUID, thingStatusInfo);
     }
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -18,7 +18,7 @@ import org.openhab.core.types.Command;
 /**
  * {@link ItemCommandEvent}s can be used to deliver commands through the openHAB event bus.
  * Command events must be created with the {@link ItemEventFactory}.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
 public class ItemCommandEvent extends AbstractEvent {
@@ -34,7 +34,7 @@ public class ItemCommandEvent extends AbstractEvent {
 
     /**
      * Constructs a new item command event object.
-     * 
+     *
      * @param topic the topic
      * @param payload the payload
      * @param itemName the item name
@@ -54,7 +54,7 @@ public class ItemCommandEvent extends AbstractEvent {
 
     /**
      * Gets the item name.
-     * 
+     *
      * @return the item name
      */
     public String getItemName() {
@@ -63,7 +63,7 @@ public class ItemCommandEvent extends AbstractEvent {
 
     /**
      * Gets the item command.
-     * 
+     *
      * @return the item command
      */
     public Command getItemCommand() {
@@ -72,7 +72,7 @@ public class ItemCommandEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return "Item '" + itemName + "' received command " + command;
+        return String.format("Item '%s' received command %s", itemName, command);
     }
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
@@ -86,7 +86,7 @@ public class ItemStateChangedEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return String.format("%s changed from %s to %s", itemName, oldItemState, itemState);
+        return String.format("Item '%s' changed from %s to %s", itemName, oldItemState, itemState);
     }
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
@@ -72,7 +72,7 @@ public class ItemStateEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return String.format("%s updated to %s", itemName, itemState);
+        return String.format("Item '%s' updated to %s", itemName, itemState);
     }
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
@@ -29,7 +29,7 @@ import org.openhab.core.types.State;
 public class ItemStatePredictedEvent extends AbstractEvent {
 
     /**
-     * The item state changed event type.
+     * The item state predicted event type.
      */
     public static final String TYPE = ItemStatePredictedEvent.class.getSimpleName();
 
@@ -37,6 +37,15 @@ public class ItemStatePredictedEvent extends AbstractEvent {
     protected final State predictedState;
     protected final boolean isConfirmation;
 
+    /**
+     * Constructs a new item state predicted event.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param itemName the item name
+     * @param predictedState the predicted item state
+     * @param isConfirmation the confirmation of previous item state
+     */
     public ItemStatePredictedEvent(String topic, String payload, String itemName, State predictedState,
             boolean isConfirmation) {
         super(topic, payload, null);
@@ -50,21 +59,36 @@ public class ItemStatePredictedEvent extends AbstractEvent {
         return TYPE;
     }
 
+    /**
+     * Gets the item name.
+     *
+     * @return the item name
+     */
     public String getItemName() {
         return itemName;
     }
 
+    /**
+     * Gets the predicted item state.
+     *
+     * @return the predicted item state
+     */
     public State getPredictedState() {
         return predictedState;
     }
 
+    /**
+     * Gets the confirmation of previous item state.
+     *
+     * @return true, if previous item state is confirmed
+     */
     public boolean isConfirmation() {
         return isConfirmation;
     }
 
     @Override
     public String toString() {
-        return String.format("%s predicted to become %s", itemName, predictedState);
+        return String.format("Item '%s' predicted to become %s", itemName, predictedState);
     }
 
 }


### PR DESCRIPTION
- Streamline format of event outputs / Always prepend "Item" or "Thing" and put identifier between hyphens `'<ID>'`

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>