### PR TITLE
[oauthclient] Reduce log level to debug for successful token refresh

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -307,7 +307,7 @@ public class OAuthConnector {
             if (statusCode == HttpStatus.OK_200) {
                 AccessTokenResponse jsonResponse = gson.fromJson(content, AccessTokenResponse.class);
                 jsonResponse.setCreatedOn(LocalDateTime.now()); // this is not supplied by the response
-                logger.info("grant type {} to URL {} success", grantType, request.getURI());
+                logger.debug("grant type {} to URL {} success", grantType, request.getURI());
                 return jsonResponse;
             } else if (statusCode == HttpStatus.BAD_REQUEST_400) {
                 OAuthResponseException errorResponse = gson.fromJson(content, OAuthResponseException.class);


### PR DESCRIPTION
It seems unnecessary to log every successful token refresh at log level INFO, especially when the `expiresIn` is relatively short (e.g. hourly).

Signed-off-by: Mark Hilbush <mark@hilbush.com>
