### PR TITLE
Add filters to some REST getAll endpoints

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import javax.annotation.security.RolesAllowed;
@@ -25,11 +26,13 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Role;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
@@ -64,6 +67,7 @@ import io.swagger.annotations.ApiResponses;
  *
  * @author Chris Jackson - Initial contribution
  * @author Franck Dechavanne - Added DTOs to ApiResponses
+ * @author Yannick Schaus - Added filter to getAll
  */
 @Path(ChannelTypeResource.PATH_CHANNEL_TYPES)
 @RolesAllowed({ Role.ADMIN })
@@ -122,11 +126,21 @@ public class ChannelTypeResource implements RESTResource {
     @ApiOperation(value = "Gets all available channel types.", response = ChannelTypeDTO.class, responseContainer = "Set")
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = ChannelTypeDTO.class, responseContainer = "Set"))
     public Response getAll(
-            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = HttpHeaders.ACCEPT_LANGUAGE) String language) {
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = HttpHeaders.ACCEPT_LANGUAGE) String language,
+            @QueryParam("prefixes") @ApiParam(value = "filter UIDs by prefix (multiple comma-separated prefixes allowed, for example: 'system,mqtt')", required = false) @Nullable String prefixes) {
         Locale locale = localeService.getLocale(language);
 
         Stream<ChannelTypeDTO> channelStream = channelTypeRegistry.getChannelTypes(locale).stream()
                 .map(c -> convertToChannelTypeDTO(c, locale));
+
+        if (prefixes != null) {
+            Predicate<ChannelTypeDTO> filter = ct -> false;
+            for (String prefix : prefixes.split(",")) {
+                filter = filter.or(ct -> ct.UID.startsWith(prefix + ":"));
+            }
+            channelStream = channelStream.filter(filter);
+        }
+
         return Response.ok(new Stream2JSONInputStream(channelStream)).build();
     }
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -23,10 +23,12 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Role;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
@@ -76,6 +78,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  * @author Miki Jankov - Introducing StrippedThingTypeDTO
  * @author Franck Dechavanne - Added DTOs to ApiResponses
+ * @author Yannick Schaus - Added filter to getAll
  */
 @Path(ThingTypeResource.PATH_THINGS_TYPES)
 @Api(value = ThingTypeResource.PATH_THINGS_TYPES)
@@ -145,10 +148,16 @@ public class ThingTypeResource implements RESTResource {
     @ApiOperation(value = "Gets all available thing types without config description, channels and properties.", response = StrippedThingTypeDTO.class, responseContainer = "Set")
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = StrippedThingTypeDTO.class, responseContainer = "Set"))
     public Response getAll(
-            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = HttpHeaders.ACCEPT_LANGUAGE) String language) {
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = HttpHeaders.ACCEPT_LANGUAGE) String language,
+            @QueryParam("bindingId") @ApiParam(value = "filter by binding Id", required = false) @Nullable String bindingId) {
         Locale locale = localeService.getLocale(language);
         Stream<StrippedThingTypeDTO> typeStream = thingTypeRegistry.getThingTypes(locale).stream()
                 .map(t -> convertToStrippedThingTypeDTO(t, locale));
+
+        if (bindingId != null) {
+            typeStream = typeStream.filter(type -> type.UID.startsWith(bindingId + ':'));
+        }
+
         return Response.ok(new Stream2JSONInputStream(typeStream)).build();
     }
 

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
@@ -63,7 +63,7 @@ public class ChannelTypeResourceTest {
 
     @Test
     public void getAllShouldRetrieveAllChannelTypes() throws Exception {
-        channelTypeResource.getAll(null);
+        channelTypeResource.getAll(null, null);
         verify(channelTypeRegistry).getChannelTypes(any(Locale.class));
     }
 


### PR DESCRIPTION
These filters help reduce payloads for UIs which
retrieve ad-hoc information rather than maintain
a global state.

Signed-off-by: Yannick Schaus <github@schaus.net>