### PR TITLE
replaced Joda Time by Java Time

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -178,14 +178,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- Joda Time -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.2</version>
-      <scope>compile</scope>
-    </dependency>
-
     <!-- jUPnP -->
     <dependency>
       <groupId>org.jupnp</groupId>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -885,14 +885,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- Joda Time -->
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.9.2</version>
-      <scope>compile</scope>
-    </dependency>
-
     <!-- ... -->
     <dependency>
       <groupId>com.eclipsesource.jaxrs</groupId>

--- a/bundles/org.openhab.core.model.persistence/NOTICE
+++ b/bundles/org.openhab.core.model.persistence/NOTICE
@@ -13,13 +13,6 @@ https://www.eclipse.org/legal/epl-2.0/.
 https://github.com/openhab/openhab-core
 
 
-== Third-party Content
-
-org.joda.time Version: 2.9.2
-* License: Apache License, 2.0
-* Project: www.joda.org/joda-time/
-* Source: https://github.com/JodaOrg/joda-time/tree/v2.9.2
-
 == Third-party license(s)
 
 === Apache License, 2.0

--- a/bundles/org.openhab.core.model.persistence/bnd.bnd
+++ b/bundles/org.openhab.core.model.persistence/bnd.bnd
@@ -28,8 +28,7 @@ Import-Package: \
  org.eclipse.jdt.annotation;resolution:=optional,\
  org.eclipse.xtext.xbase.lib,\
  org.osgi.*,\
- org.slf4j.*,\
- org.joda.*
+ org.slf4j.*
 Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.codegen.ecore;resolution:=optional,\
  org.eclipse.emf.common,\

--- a/bundles/org.openhab.core.model.persistence/pom.xml
+++ b/bundles/org.openhab.core.model.persistence/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>org.openhab.core.reactor.bundles</artifactId>
     <version>3.0.0-SNAPSHOT</version>
   </parent>
-
+ 
   <artifactId>org.openhab.core.model.persistence</artifactId>
 
   <name>openHAB Core :: Bundles :: Model Persistence</name>

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/extensions/PersistenceExtensions.java
@@ -14,14 +14,13 @@ package org.openhab.core.model.persistence.extensions;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 
-import org.joda.time.DateTime;
-import org.joda.time.base.AbstractInstant;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.DecimalType;
@@ -139,7 +138,7 @@ public class PersistenceExtensions {
      *         the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static HistoricItem historicState(Item item, AbstractInstant timestamp) {
+    public static HistoricItem historicState(Item item, Instant timestamp) {
         return historicState(item, timestamp, getDefaultServiceId());
     }
 
@@ -154,12 +153,12 @@ public class PersistenceExtensions {
      *         if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static HistoricItem historicState(Item item, AbstractInstant timestamp, String serviceId) {
+    public static HistoricItem historicState(Item item, Instant timestamp, String serviceId) {
         PersistenceService service = getService(serviceId);
         if (service instanceof QueryablePersistenceService) {
             QueryablePersistenceService qService = (QueryablePersistenceService) service;
             FilterCriteria filter = new FilterCriteria();
-            filter.setEndDate(ZonedDateTime.ofInstant(timestamp.toDate().toInstant(), timeZoneProvider.getTimeZone()));
+            filter.setEndDate(ZonedDateTime.ofInstant(timestamp, timeZoneProvider.getTimeZone()));
             filter.setItemName(item.getName());
             filter.setPageSize(1);
             filter.setOrdering(Ordering.DESCENDING);
@@ -185,7 +184,7 @@ public class PersistenceExtensions {
      * @return <code>true</code> if item state has changed, <code>false</code> if it has not changed or if the default
      *         persistence service is not available or does not refer to a {@link QueryablePersistenceService}
      */
-    public static Boolean changedSince(Item item, AbstractInstant timestamp) {
+    public static Boolean changedSince(Item item, Instant timestamp) {
         return changedSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -199,7 +198,7 @@ public class PersistenceExtensions {
      * @return <code>true</code> if item state has changed, or <code>false</code> if it has not changed or if the
      *         provided <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
-    public static Boolean changedSince(Item item, AbstractInstant timestamp, String serviceId) {
+    public static Boolean changedSince(Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
         HistoricItem itemThen = historicState(item, timestamp);
@@ -212,7 +211,7 @@ public class PersistenceExtensions {
         State state = itemThen.getState();
         while (it.hasNext()) {
             HistoricItem hItem = it.next();
-            if (state != null && !hItem.getState().equals(state)) {
+            if (!hItem.getState().equals(state)) {
                 return true;
             }
             state = hItem.getState();
@@ -231,7 +230,7 @@ public class PersistenceExtensions {
      *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
      *         available
      */
-    public static Boolean updatedSince(Item item, AbstractInstant timestamp) {
+    public static Boolean updatedSince(Item item, Instant timestamp) {
         return updatedSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -246,7 +245,7 @@ public class PersistenceExtensions {
      *         since <code>timestamp</code> or if the given <code>serviceId</code> does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static Boolean updatedSince(Item item, AbstractInstant timestamp, String serviceId) {
+    public static Boolean updatedSince(Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         if (result.iterator().hasNext()) {
             return true;
@@ -265,7 +264,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code> if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static HistoricItem maximumSince(Item item, AbstractInstant timestamp) {
+    public static HistoricItem maximumSince(Item item, Instant timestamp) {
         return maximumSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -281,7 +280,7 @@ public class PersistenceExtensions {
      *         maximum value or if the given <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static HistoricItem maximumSince(final Item item, AbstractInstant timestamp, String serviceId) {
+    public static HistoricItem maximumSince(final Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
         HistoricItem maximumHistoricItem = null;
@@ -332,7 +331,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
      */
-    public static HistoricItem minimumSince(Item item, AbstractInstant timestamp) {
+    public static HistoricItem minimumSince(Item item, Instant timestamp) {
         return minimumSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -347,7 +346,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the given <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
-    public static HistoricItem minimumSince(final Item item, AbstractInstant timestamp, String serviceId) {
+    public static HistoricItem minimumSince(final Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
         HistoricItem minimumHistoricItem = null;
@@ -398,7 +397,7 @@ public class PersistenceExtensions {
      *         previous states could be found or if the default persistence service does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static DecimalType averageSince(Item item, AbstractInstant timestamp) {
+    public static DecimalType averageSince(Item item, Instant timestamp) {
         return averageSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -413,7 +412,7 @@ public class PersistenceExtensions {
      *         previous states could be found or if the persistence service given by <code>serviceId</code> does not
      *         refer to an available {@link QueryablePersistenceService}
      */
-    public static DecimalType averageSince(Item item, AbstractInstant timestamp, String serviceId) {
+    public static DecimalType averageSince(Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
 
@@ -431,7 +430,7 @@ public class PersistenceExtensions {
             if (state instanceof DecimalType) {
                 thisState = (DecimalType) state;
                 thisTimestamp = BigDecimal.valueOf(thisItem.getTimestamp().getTime());
-                if (firstTimestamp == null) {
+                if (firstTimestamp == null || lastState == null) {
                     firstTimestamp = thisTimestamp;
                 } else {
                     avgValue = (thisState.toBigDecimal().add(lastState.toBigDecimal())).divide(BigDecimal.valueOf(2),
@@ -447,7 +446,7 @@ public class PersistenceExtensions {
         if (lastState != null) {
             thisState = item.getStateAs(DecimalType.class);
             if (thisState != null) {
-                thisTimestamp = BigDecimal.valueOf((new DateTime()).getMillis());
+                thisTimestamp = BigDecimal.valueOf(Instant.now().toEpochMilli());
                 avgValue = (thisState.toBigDecimal().add(lastState.toBigDecimal())).divide(BigDecimal.valueOf(2),
                         MathContext.DECIMAL64);
                 timeSpan = thisTimestamp.subtract(lastTimestamp);
@@ -475,7 +474,7 @@ public class PersistenceExtensions {
      *         states could be found or if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static DecimalType sumSince(Item item, AbstractInstant timestamp) {
+    public static DecimalType sumSince(Item item, Instant timestamp) {
         return sumSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -490,7 +489,7 @@ public class PersistenceExtensions {
      *         states could be found for the <code>item</code> or if <code>serviceId</code> does no refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static DecimalType sumSince(Item item, AbstractInstant timestamp, String serviceId) {
+    public static DecimalType sumSince(Item item, Instant timestamp, String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
 
@@ -505,13 +504,12 @@ public class PersistenceExtensions {
         return new DecimalType(sum);
     }
 
-    private static Iterable<HistoricItem> getAllStatesSince(Item item, AbstractInstant timestamp, String serviceId) {
+    private static Iterable<HistoricItem> getAllStatesSince(Item item, Instant timestamp, String serviceId) {
         PersistenceService service = getService(serviceId);
         if (service instanceof QueryablePersistenceService) {
             QueryablePersistenceService qService = (QueryablePersistenceService) service;
             FilterCriteria filter = new FilterCriteria();
-            filter.setBeginDate(
-                    ZonedDateTime.ofInstant(timestamp.toDate().toInstant(), timeZoneProvider.getTimeZone()));
+            filter.setBeginDate(ZonedDateTime.ofInstant(timestamp, timeZoneProvider.getTimeZone()));
             filter.setItemName(item.getName());
             filter.setOrdering(Ordering.ASCENDING);
             return qService.query(filter);
@@ -530,7 +528,7 @@ public class PersistenceExtensions {
      *         persisted updates or the default persistence service is not available or a
      *         {@link QueryablePersistenceService}
      */
-    public static AbstractInstant lastUpdate(Item item) {
+    public static ZonedDateTime lastUpdate(Item item) {
         return lastUpdate(item, getDefaultServiceId());
     }
 
@@ -543,7 +541,7 @@ public class PersistenceExtensions {
      *         persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
      *         available {@link QueryablePersistenceService}
      */
-    public static AbstractInstant lastUpdate(Item item, String serviceId) {
+    public static ZonedDateTime lastUpdate(Item item, String serviceId) {
         PersistenceService service = getService(serviceId);
         if (service instanceof QueryablePersistenceService) {
             QueryablePersistenceService qService = (QueryablePersistenceService) service;
@@ -553,7 +551,8 @@ public class PersistenceExtensions {
             filter.setPageSize(1);
             Iterable<HistoricItem> result = qService.query(filter);
             if (result.iterator().hasNext()) {
-                return new DateTime(result.iterator().next().getTimestamp());
+                return ZonedDateTime.ofInstant(result.iterator().next().getTimestamp().toInstant(),
+                        timeZoneProvider.getTimeZone());
             } else {
                 return null;
             }
@@ -575,7 +574,7 @@ public class PersistenceExtensions {
      *         there is no persisted state for the given <code>item</code> at the given <code>timestamp</code> available
      *         in the default persistence service
      */
-    public static DecimalType deltaSince(Item item, AbstractInstant timestamp) {
+    public static DecimalType deltaSince(Item item, Instant timestamp) {
         return deltaSince(item, timestamp, getDefaultServiceId());
     }
 
@@ -591,13 +590,13 @@ public class PersistenceExtensions {
      *         <code>item</code> at the given <code>timestamp</code> using the persistence service named
      *         <code>serviceId</code>
      */
-    public static DecimalType deltaSince(Item item, AbstractInstant timestamp, String serviceId) {
+    public static DecimalType deltaSince(Item item, Instant timestamp, String serviceId) {
         HistoricItem itemThen = historicState(item, timestamp, serviceId);
         if (itemThen != null) {
             DecimalType valueThen = (DecimalType) itemThen.getState();
             DecimalType valueNow = item.getStateAs(DecimalType.class);
 
-            if ((valueThen != null) && (valueNow != null)) {
+            if (valueNow != null) {
                 return new DecimalType(valueNow.toBigDecimal().subtract(valueThen.toBigDecimal()));
             }
         }
@@ -617,7 +616,7 @@ public class PersistenceExtensions {
      *         the given <code>timestamp</code>, or if there is a state but it is zero (which would cause a
      *         divide-by-zero error)
      */
-    public static DecimalType evolutionRate(Item item, AbstractInstant timestamp) {
+    public static DecimalType evolutionRate(Item item, Instant timestamp) {
         return evolutionRate(item, timestamp, getDefaultServiceId());
     }
 
@@ -635,14 +634,13 @@ public class PersistenceExtensions {
      *         <code>serviceId</code>, or if there is a state but it is zero (which would cause a divide-by-zero
      *         error)
      */
-    public static DecimalType evolutionRate(Item item, AbstractInstant timestamp, String serviceId) {
+    public static DecimalType evolutionRate(Item item, Instant timestamp, String serviceId) {
         HistoricItem itemThen = historicState(item, timestamp, serviceId);
         if (itemThen != null) {
             DecimalType valueThen = (DecimalType) itemThen.getState();
             DecimalType valueNow = item.getStateAs(DecimalType.class);
 
-            if ((valueThen != null) && (valueThen.toBigDecimal().compareTo(BigDecimal.ZERO) != 0)
-                    && (valueNow != null)) {
+            if ((valueThen.toBigDecimal().compareTo(BigDecimal.ZERO) != 0) && (valueNow != null)) {
                 // ((now - then) / then) * 100
                 return new DecimalType(valueNow.toBigDecimal().subtract(valueThen.toBigDecimal())
                         .divide(valueThen.toBigDecimal(), MathContext.DECIMAL64).movePointRight(2));

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/extensions/PersistenceExtensions.java
@@ -528,7 +528,7 @@ public class PersistenceExtensions {
      *         persisted updates or the default persistence service is not available or a
      *         {@link QueryablePersistenceService}
      */
-    public static ZonedDateTime lastUpdate(Item item) {
+    public static Instant lastUpdate(Item item) {
         return lastUpdate(item, getDefaultServiceId());
     }
 
@@ -541,7 +541,7 @@ public class PersistenceExtensions {
      *         persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
      *         available {@link QueryablePersistenceService}
      */
-    public static ZonedDateTime lastUpdate(Item item, String serviceId) {
+    public static Instant lastUpdate(Item item, String serviceId) {
         PersistenceService service = getService(serviceId);
         if (service instanceof QueryablePersistenceService) {
             QueryablePersistenceService qService = (QueryablePersistenceService) service;
@@ -551,8 +551,7 @@ public class PersistenceExtensions {
             filter.setPageSize(1);
             Iterable<HistoricItem> result = qService.query(filter);
             if (result.iterator().hasNext()) {
-                return ZonedDateTime.ofInstant(result.iterator().next().getTimestamp().toInstant(),
-                        timeZoneProvider.getTimeZone());
+                return result.iterator().next().getTimestamp().toInstant();
             } else {
                 return null;
             }

--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -35,8 +35,6 @@ Import-Package: \
  org.apache.commons.lang,\
  org.eclipse.jdt.annotation;resolution:=optional,\
  org.eclipse.xtext.xbase.lib,\
- org.joda.time,\
- org.joda.time.base,\
  org.osgi.*,\
  org.quartz,\
  org.quartz.impl,\

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -47,7 +47,6 @@ Import-Package: \
  org.eclipse.jdt.annotation;resolution:=optional,\
  org.eclipse.jetty.http.*,\
  org.eclipse.xtext.xbase.lib,\
- org.joda.*,\
  org.osgi.*,\
  org.quartz.*,\
  org.slf4j.*

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -15,7 +15,13 @@ package org.openhab.core.model.script.actions;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import java.time.Instant;
+import java.util.Date;
+
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.xtext.xbase.XExpression;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.script.ScriptServiceUtil;
 import org.openhab.core.model.script.engine.Script;
@@ -23,10 +29,6 @@ import org.openhab.core.model.script.engine.ScriptEngine;
 import org.openhab.core.model.script.engine.ScriptExecutionException;
 import org.openhab.core.model.script.internal.actions.TimerExecutionJob;
 import org.openhab.core.model.script.internal.actions.TimerImpl;
-import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
-import org.joda.time.base.AbstractInstant;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
@@ -87,7 +89,7 @@ public class ScriptExecution {
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      * @throws ScriptExecutionException if an error occurs during the execution
      */
-    public static Timer createTimer(AbstractInstant instant, Procedure0 closure) {
+    public static Timer createTimer(Instant instant, Procedure0 closure) {
         JobDataMap dataMap = new JobDataMap();
         dataMap.put("procedure", closure);
         return makeTimer(instant, closure.toString(), dataMap);
@@ -103,7 +105,7 @@ public class ScriptExecution {
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      * @throws ScriptExecutionException if an error occurs during the execution
      */
-    public static Timer createTimerWithArgument(AbstractInstant instant, Object arg1, Procedure1<Object> closure) {
+    public static Timer createTimerWithArgument(Instant instant, Object arg1, Procedure1<Object> closure) {
         JobDataMap dataMap = new JobDataMap();
         dataMap.put("procedure1", closure);
         dataMap.put("argument1", arg1);
@@ -118,11 +120,11 @@ public class ScriptExecution {
      * @param dataMap job data map, preconfigured with arguments
      * @return
      */
-    private static Timer makeTimer(AbstractInstant instant, String closure, JobDataMap dataMap) {
+    private static Timer makeTimer(Instant instant, String closure, JobDataMap dataMap) {
 
         Logger logger = LoggerFactory.getLogger(ScriptExecution.class);
         JobKey jobKey = new JobKey(getTimerId() + " " + instant.toString() + ": " + closure.toString());
-        Trigger trigger = newTrigger().startAt(instant.toDate()).build();
+        Trigger trigger = newTrigger().startAt(Date.from(instant)).build();
         Timer timer = new TimerImpl(jobKey, trigger.getKey(), dataMap, instant);
         try {
             JobDetail job = newJob(TimerExecutionJob.class).withIdentity(jobKey).usingJobData(dataMap).build();

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.model.script.actions;
 
-import org.joda.time.base.AbstractInstant;
+import java.time.Instant;
 
 /**
  * A timer is a handle for a block of code that is scheduled for future execution. A timer
@@ -25,21 +25,21 @@ public interface Timer {
 
     /**
      * Cancels the timer
-     * 
+     *
      * @return true, if cancellation was successful
      */
     public boolean cancel();
 
     /**
      * Determines whether the scheduled code is currently executed.
-     * 
+     *
      * @return true, if the code is being executed, false otherwise
      */
     public boolean isRunning();
 
     /**
      * Determines whether the scheduled execution has already terminated.
-     * 
+     *
      * @return true, if the scheduled execution has already terminated, false otherwise
      */
     public boolean hasTerminated();
@@ -48,10 +48,10 @@ public interface Timer {
      * Reschedules a timer to a new starting time.
      * This can also be called after a timer has terminated, which will result in another
      * execution of the same code.
-     * 
+     *
      * @param newTime the new time to execute the code
      * @return true, if the rescheduling was done successful
      */
-    public boolean reschedule(AbstractInstant newTime);
+    public boolean reschedule(Instant newTime);
 
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
@@ -15,11 +15,10 @@ package org.openhab.core.model.script.internal.actions;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 
+import java.time.Instant;
 import java.util.Date;
 
 import org.openhab.core.model.script.actions.Timer;
-import org.joda.time.DateTime;
-import org.joda.time.base.AbstractInstant;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
@@ -56,12 +55,12 @@ public class TimerImpl implements Timer {
     private final JobKey jobKey;
     private TriggerKey triggerKey;
     private final JobDataMap dataMap;
-    private final AbstractInstant startTime;
+    private final Instant startTime;
 
     private boolean cancelled = false;
     private boolean terminated = false;
 
-    public TimerImpl(JobKey jobKey, TriggerKey triggerKey, JobDataMap dataMap, AbstractInstant startTime) {
+    public TimerImpl(JobKey jobKey, TriggerKey triggerKey, JobDataMap dataMap, Instant startTime) {
         this.jobKey = jobKey;
         this.triggerKey = triggerKey;
         this.dataMap = dataMap;
@@ -83,9 +82,9 @@ public class TimerImpl implements Timer {
     }
 
     @Override
-    public boolean reschedule(AbstractInstant newTime) {
+    public boolean reschedule(Instant newTime) {
         try {
-            Trigger trigger = newTrigger().startAt(newTime.toDate()).build();
+            Trigger trigger = newTrigger().startAt(Date.from(newTime)).build();
             Date nextTriggerTime = scheduler.rescheduleJob(triggerKey, trigger);
             if (nextTriggerTime == null) {
                 logger.debug("Scheduling a new job job '{}' because the original has already run", jobKey.toString());
@@ -114,7 +113,7 @@ public class TimerImpl implements Timer {
         } catch (SchedulerException e) {
             // fallback implementation
             logger.debug("An error occurred getting currently running jobs: {}", e.getMessage());
-            return DateTime.now().isAfter(startTime) && !terminated;
+            return Instant.now().isAfter(startTime) && !terminated;
         }
     }
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -15,12 +15,13 @@ package org.openhab.core.model.script.scoping;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URLEncoder;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.xtext.xbase.scoping.batch.ImplicitlyImportedFeatures;
-import org.joda.time.DateTime;
 import org.openhab.core.library.unit.BinaryPrefix;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.MetricPrefix;
@@ -108,8 +109,9 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(SmartHomeUnits.class);
         result.add(BinaryPrefix.class);
 
-        // jodatime static functions
-        result.add(DateTime.class);
+        // date time static functions
+        result.add(Instant.class);
+        result.add(ZonedDateTime.class);
 
         result.addAll(getActionClasses());
         return result;

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -20,17 +20,16 @@ import org.eclipse.xtext.xbase.scoping.XImportSectionNamespaceScopeProvider;
 
 public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNamespaceScopeProvider {
 
-    public static final QualifiedName CORE_LIBRARY_TYPES_PACKAGE = QualifiedName.create("org", "openhab",
-            "core", "library", "types");
-    public static final QualifiedName CORE_LIBRARY_ITEMS_PACKAGE = QualifiedName.create("org", "openhab",
-            "core", "library", "items");
-    public static final QualifiedName CORE_ITEMS_PACKAGE = QualifiedName.create("org", "openhab", "core",
-            "items");
-    public static final QualifiedName CORE_PERSISTENCE_PACKAGE = QualifiedName.create("org", "openhab",
-            "core", "persistence");
-    public static final QualifiedName MODEL_SCRIPT_ACTIONS_PACKAGE = QualifiedName.create("org", "openhab",
-            "core", "model", "script", "actions");
-    public static final QualifiedName JODA_TIME_PACKAGE = QualifiedName.create("org", "joda", "time");
+    public static final QualifiedName CORE_LIBRARY_TYPES_PACKAGE = QualifiedName.create("org", "openhab", "core",
+            "library", "types");
+    public static final QualifiedName CORE_LIBRARY_ITEMS_PACKAGE = QualifiedName.create("org", "openhab", "core",
+            "library", "items");
+    public static final QualifiedName CORE_ITEMS_PACKAGE = QualifiedName.create("org", "openhab", "core", "items");
+    public static final QualifiedName CORE_PERSISTENCE_PACKAGE = QualifiedName.create("org", "openhab", "core",
+            "persistence");
+    public static final QualifiedName MODEL_SCRIPT_ACTIONS_PACKAGE = QualifiedName.create("org", "openhab", "core",
+            "model", "script", "actions");
+    public static final QualifiedName TIME_PACKAGE = QualifiedName.create("java", "time");
 
     @Override
     protected List<ImportNormalizer> getImplicitImports(boolean ignoreCase) {
@@ -40,7 +39,7 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
         implicitImports.add(doCreateImportNormalizer(CORE_ITEMS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(MODEL_SCRIPT_ACTIONS_PACKAGE, true, false));
-        implicitImports.add(doCreateImportNormalizer(JODA_TIME_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(TIME_PACKAGE, true, false));
         return implicitImports;
     }
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -34,7 +34,6 @@
 
 		<!-- TODO: Unbundled libraries -->
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>
-		<bundle dependency="true">mvn:joda-time/joda-time/2.9.2</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -50,7 +50,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.xtext.util;version='[2.19.0,2.19.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.19.0,2.19.1)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	org.eclipse.xtext.common.types;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
 	jollyday;version='[0.5.8,0.5.9)',\

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -35,7 +35,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	osgi.enroute.hamcrest.wrapper;version='[1.3.0,1.3.1)',\
 	osgi.enroute.junit.wrapper;version='[4.12.0,4.12.1)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\

--- a/itests/org.openhab.core.model.persistence.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.persistence.tests/itest.bndrun
@@ -13,7 +13,6 @@ Fragment-Host: org.openhab.core.model.persistence
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.commons.io;version='[2.2.0,2.2.1)',\

--- a/itests/org.openhab.core.model.persistence.tests/src/main/java/org/openhab/core/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/itests/org.openhab.core.model.persistence.tests/src/main/java/org/openhab/core/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -14,14 +14,15 @@ package org.openhab.core.model.persistence.extensions;
 
 import static org.junit.Assert.*;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.joda.time.DateMidnight;
-import org.joda.time.DateTime;
-import org.joda.time.base.AbstractInstant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -98,53 +99,63 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testHistoricState() {
-        HistoricItem historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2012, 1, 1),
+        HistoricItem historicItem = PersistenceExtensions.historicState(item,
+                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2012", historicItem.getState().toString());
 
-        historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2011, 12, 31),
+        historicItem = PersistenceExtensions.historicState(item,
+                ZonedDateTime.of(2011, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2011", historicItem.getState().toString());
 
-        historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2011, 1, 1),
+        historicItem = PersistenceExtensions.historicState(item,
+                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2011", historicItem.getState().toString());
 
-        historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2000, 1, 1),
+        historicItem = PersistenceExtensions.historicState(item,
+                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2000", historicItem.getState().toString());
 
         // default persistence service
-        historicItem = PersistenceExtensions.historicState(item, new DateMidnight(2000, 1, 1));
+        historicItem = PersistenceExtensions.historicState(item,
+                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNull(historicItem);
     }
 
     @Test
     public void testMinimumSince() {
         item.setState(new QuantityType<>(5000, SIUnits.CELSIUS));
-        HistoricItem historicItem = PersistenceExtensions.minimumSince(item, new DateMidnight(1940, 1, 1),
+        HistoricItem historicItem = PersistenceExtensions.minimumSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("5000", historicItem.getState().toString());
 
         item.setState(new DecimalType(5000));
-        historicItem = PersistenceExtensions.minimumSince(item, new DateMidnight(1940, 1, 1),
+        historicItem = PersistenceExtensions.minimumSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("5000", historicItem.getState().toString());
 
-        historicItem = PersistenceExtensions.minimumSince(item, new DateMidnight(2005, 1, 1),
+        historicItem = PersistenceExtensions.minimumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2005", historicItem.getState().toString());
-        assertEquals(new DateMidnight(2005, 1, 1).toDate(), historicItem.getTimestamp());
+        assertEquals(Date.from(ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant()),
+                historicItem.getTimestamp());
 
         // default persistence service
-        historicItem = PersistenceExtensions.minimumSince(item, new DateMidnight(2005, 1, 1));
+        historicItem = PersistenceExtensions.minimumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNotNull(historicItem);
         assertEquals("5000", historicItem.getState().toString());
     }
@@ -152,25 +163,30 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMaximumSince() {
         item.setState(new QuantityType<>(1, SIUnits.CELSIUS));
-        HistoricItem historicItem = PersistenceExtensions.maximumSince(item, new DateMidnight(2012, 1, 1),
+        HistoricItem historicItem = PersistenceExtensions.maximumSince(item,
+                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("1", historicItem.getState().toString());
 
         item.setState(new DecimalType(1));
-        historicItem = PersistenceExtensions.maximumSince(item, new DateMidnight(2012, 1, 1),
+        historicItem = PersistenceExtensions.maximumSince(item,
+                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("1", historicItem.getState().toString());
 
-        historicItem = PersistenceExtensions.maximumSince(item, new DateMidnight(2005, 1, 1),
+        historicItem = PersistenceExtensions.maximumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertEquals("2012", historicItem.getState().toString());
-        assertEquals(new DateMidnight(2012, 1, 1).toDate(), historicItem.getTimestamp());
+        assertEquals(Date.from(ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant()),
+                historicItem.getTimestamp());
 
         // default persistence service
-        historicItem = PersistenceExtensions.maximumSince(item, new DateMidnight(2005, 1, 1));
+        historicItem = PersistenceExtensions.maximumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNotNull(historicItem);
         assertEquals("1", historicItem.getState().toString());
     }
@@ -178,14 +194,15 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSince() {
         item.setState(new DecimalType(3025));
-        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(1940, 1, 1),
+        DecimalType average = PersistenceExtensions.averageSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNull(average);
 
-        DateMidnight startStored = new DateMidnight(2003, 1, 1);
-        DateMidnight endStored = new DateMidnight(2012, 1, 1);
-        long storedInterval = endStored.getMillis() - startStored.getMillis();
-        long recentInterval = DateTime.now().getMillis() - endStored.getMillis();
+        Instant startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant();
+        Instant endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant();
+        long storedInterval = endStored.toEpochMilli() - startStored.toEpochMilli();
+        long recentInterval = Instant.now().toEpochMilli() - endStored.toEpochMilli();
         double expected = (2007.4994 * storedInterval + 2518.5 * recentInterval) / (storedInterval + recentInterval);
         average = PersistenceExtensions.averageSince(item, startStored, TestPersistenceService.ID);
         assertNotNull(average);
@@ -203,16 +220,21 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testSumSince() {
-        DecimalType sum = PersistenceExtensions.sumSince(item, new DateMidnight(1940, 1, 1), TestPersistenceService.ID);
+        DecimalType sum = PersistenceExtensions.sumSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(sum);
         assertEquals(0.0, sum.doubleValue(), 0.001);
 
-        sum = PersistenceExtensions.sumSince(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        sum = PersistenceExtensions.sumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(sum);
         assertEquals(IntStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012).sum(), sum.doubleValue(), 0.001);
 
         // default persistence service
-        sum = PersistenceExtensions.sumSince(item, new DateMidnight(2005, 1, 1));
+        sum = PersistenceExtensions.sumSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNotNull(sum);
         assertEquals(0.0, sum.doubleValue(), 0.001);
     }
@@ -220,9 +242,9 @@ public class PersistenceExtensionsTest {
     @Test
     public void testLastUpdate() {
         item.setState(new DecimalType(2005));
-        AbstractInstant lastUpdate = PersistenceExtensions.lastUpdate(item, TestPersistenceService.ID);
+        Instant lastUpdate = PersistenceExtensions.lastUpdate(item, TestPersistenceService.ID);
         assertNotNull(lastUpdate);
-        assertEquals(new DateMidnight(2012, 1, 1).toDate(), lastUpdate.toDate());
+        assertEquals(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(), lastUpdate);
 
         // default persistence service
         lastUpdate = PersistenceExtensions.lastUpdate(item);
@@ -232,44 +254,56 @@ public class PersistenceExtensionsTest {
     @Test
     public void testDeltaSince() {
         item.setState(new DecimalType(2012));
-        DecimalType delta = PersistenceExtensions.deltaSince(item, new DateMidnight(1940, 1, 1),
+        DecimalType delta = PersistenceExtensions.deltaSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNull(delta);
 
-        delta = PersistenceExtensions.deltaSince(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        delta = PersistenceExtensions.deltaSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(delta);
         assertEquals(7, delta.doubleValue(), 0.001);
 
         item.setState(new QuantityType<>(2012, SIUnits.CELSIUS));
-        delta = PersistenceExtensions.deltaSince(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        delta = PersistenceExtensions.deltaSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(delta);
         assertEquals(7, delta.doubleValue(), 0.001);
 
         // default persistence service
-        delta = PersistenceExtensions.deltaSince(item, new DateMidnight(2005, 1, 1));
+        delta = PersistenceExtensions.deltaSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNull(delta);
     }
 
     @Test
     public void testEvolutionRate() {
         item.setState(new DecimalType(2012));
-        DecimalType rate = PersistenceExtensions.evolutionRate(item, new DateMidnight(1940, 1, 1),
+        DecimalType rate = PersistenceExtensions.evolutionRate(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertNull(rate);
 
-        rate = PersistenceExtensions.evolutionRate(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        rate = PersistenceExtensions.evolutionRate(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(rate);
         // ((now - then) / then) * 100
         assertEquals(0.349127182, rate.doubleValue(), 0.001);
 
         item.setState(new QuantityType<>(2012, SIUnits.CELSIUS));
-        rate = PersistenceExtensions.evolutionRate(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        rate = PersistenceExtensions.evolutionRate(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertNotNull(rate);
         // ((now - then) / then) * 100
         assertEquals(0.349127182, rate.doubleValue(), 0.001);
 
         // default persistence service
-        rate = PersistenceExtensions.evolutionRate(item, new DateMidnight(2005, 1, 1));
+        rate = PersistenceExtensions.evolutionRate(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertNull(rate);
     }
 
@@ -304,29 +338,37 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testChangedSince() {
-        boolean changed = PersistenceExtensions.changedSince(item, new DateMidnight(1940, 1, 1),
+        boolean changed = PersistenceExtensions.changedSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertFalse(changed);
 
-        changed = PersistenceExtensions.changedSince(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        changed = PersistenceExtensions.changedSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertTrue(changed);
 
         // default persistence service
-        changed = PersistenceExtensions.changedSince(item, new DateMidnight(2005, 1, 1));
+        changed = PersistenceExtensions.changedSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertFalse(changed);
     }
 
     @Test
     public void testUpdatedSince() {
-        boolean updated = PersistenceExtensions.updatedSince(item, new DateMidnight(1940, 1, 1),
+        boolean updated = PersistenceExtensions.updatedSince(item,
+                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
                 TestPersistenceService.ID);
         assertFalse(updated);
 
-        updated = PersistenceExtensions.updatedSince(item, new DateMidnight(2005, 1, 1), TestPersistenceService.ID);
+        updated = PersistenceExtensions.updatedSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant(),
+                TestPersistenceService.ID);
         assertTrue(updated);
 
         // default persistence service
-        updated = PersistenceExtensions.updatedSince(item, new DateMidnight(2005, 1, 1));
+        updated = PersistenceExtensions.updatedSince(item,
+                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()).toInstant());
         assertFalse(updated);
     }
 }

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -13,7 +13,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -13,7 +13,6 @@ Fragment-Host: org.openhab.core.model.script
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\
@@ -97,3 +96,4 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.thing;version='[3.0.0,3.0.1)',\
 	org.openhab.core.transform;version='[3.0.0,3.0.1)',\
 	org.openhab.core.voice;version='[3.0.0,3.0.1)'
+	

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/actions/ScriptExecutionTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/actions/ScriptExecutionTest.java
@@ -13,8 +13,9 @@
 package org.openhab.core.model.script.actions;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.joda.time.Instant.now;
 import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,14 +49,14 @@ public class ScriptExecutionTest {
     }
 
     private Timer createTimer(MockClosure0 closure) {
-        Timer timer = ScriptExecution.createTimer(now(), closure);
+        Timer timer = ScriptExecution.createTimer(Instant.now(), closure);
         // The code in our mock closure needs access to the timer object
         closure.setTimer(timer);
         return timer;
     }
 
     private Timer createTimer(Object arg, MockClosure1 closure) {
-        Timer timer = ScriptExecution.createTimerWithArgument(now(), arg, closure);
+        Timer timer = ScriptExecution.createTimerWithArgument(Instant.now(), arg, closure);
         // The code in our mock closure needs access to the timer object
         closure.setTimer(timer);
         return timer;
@@ -113,7 +114,7 @@ public class ScriptExecutionTest {
         assertThat(t.hasTerminated(), is(equalTo(true)));
 
         // Now try to reschedule the Timer to run again after 10ms
-        boolean rescheduled = t.reschedule(now());
+        boolean rescheduled = t.reschedule(Instant.now());
         assertThat(rescheduled, is(equalTo(true)));
         assertThat(t.hasTerminated(), is(equalTo(false)));
         assertThat(scheduler.getPendingJobCount(), is(equalTo(1)));

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/scheduler/test/MockClosure.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/scheduler/test/MockClosure.java
@@ -13,8 +13,9 @@
 package org.openhab.core.model.script.scheduler.test;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.joda.time.Instant.now;
 import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
 
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
@@ -48,7 +49,7 @@ public class MockClosure {
 
             if (this.rescheduleCount > 0) {
                 this.rescheduleCount--;
-                boolean rescheduled = timer.reschedule(now());
+                boolean rescheduled = timer.reschedule(Instant.now());
                 assertThat(rescheduled, is(equalTo(true)));
             }
         }

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.model.thing
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
-	joda-time;version='[2.9.2,2.9.3)',\
 	log4j;version='[1.2.17,1.2.18)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.commons.exec;version='[1.1.0,1.1.1)',\


### PR DESCRIPTION
This PR finally gets rid off Joda Time.
As discussed in the past, this will break rules from users, but as the final rule format is anyhow still under discussion, it is clear that we will need some way or another for rule migration for the 3.0 release. This PR should hence not really have much additional weight.

Signed-off-by: Kai Kreuzer <kai@openhab.org>

Fixes #1250