### PR TITLE
[voice] Simplify lifecycle by using constructor injection

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioException;
@@ -83,7 +82,7 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
             switch (subCommand) {
                 case SUBCMD_PLAY:
                     if (args.length > 1) {
-                        play((String[]) ArrayUtils.subarray(args, 1, args.length), console);
+                        play(Arrays.copyOfRange(args, 1, args.length), console);
                     } else {
                         console.println(
                                 "Specify file to play, and optionally the sink(s) to use (e.g. 'play javasound hello.mp3')");
@@ -91,7 +90,7 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
                     return;
                 case SUBCMD_STREAM:
                     if (args.length > 1) {
-                        stream((String[]) ArrayUtils.subarray(args, 1, args.length), console);
+                        stream(Arrays.copyOfRange(args, 1, args.length), console);
                     } else {
                         console.println("Specify url to stream from, and optionally the sink(s) to use");
                     }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -62,6 +62,11 @@ public class AudioServlet extends SmartHomeServlet implements AudioHTTPServer {
     private final Map<String, Long> streamTimeouts = new ConcurrentHashMap<>();
 
     @Activate
+    public AudioServlet(final @Reference HttpService httpService) {
+        this.httpService = httpService;
+    }
+
+    @Activate
     protected void activate() {
         super.activate(SERVLET_NAME);
     }
@@ -69,17 +74,6 @@ public class AudioServlet extends SmartHomeServlet implements AudioHTTPServer {
     @Deactivate
     protected void deactivate() {
         super.deactivate(SERVLET_NAME);
-    }
-
-    @Override
-    @Reference
-    protected void setHttpService(HttpService httpService) {
-        super.setHttpService(httpService);
-    }
-
-    @Override
-    public void unsetHttpService(HttpService httpService) {
-        super.unsetHttpService(httpService);
     }
 
     private @Nullable InputStream prepareInputStream(final String streamId, final HttpServletResponse resp)

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.audio.internal;
 
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -30,6 +31,7 @@ import org.openhab.core.audio.FixedLengthAudioStream;
 import org.openhab.core.test.TestPortUtil;
 import org.openhab.core.test.TestServer;
 import org.openhab.core.test.java.JavaTest;
+import org.osgi.service.http.HttpService;
 
 /**
  * Base class for tests using the {@link AudioServlet}.
@@ -52,7 +54,7 @@ public abstract class AbstractAudioServletTest extends JavaTest {
 
     @Before
     public void setupServerAndClient() {
-        audioServlet = new AudioServlet();
+        audioServlet = new AudioServlet(mock(HttpService.class));
 
         ServletHolder servletHolder = new ServletHolder(audioServlet);
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.io.console.Console;
@@ -74,14 +73,14 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
             switch (subCommand) {
                 case SUBCMD_SAY:
                     if (args.length > 1) {
-                        say((String[]) ArrayUtils.subarray(args, 1, args.length), console);
+                        say(Arrays.copyOfRange(args, 1, args.length), console);
                     } else {
                         console.println("Specify text to say (e.g. 'say hello')");
                     }
                     return;
                 case SUBCMD_INTERPRET:
                     if (args.length > 1) {
-                        interpret((String[]) ArrayUtils.subarray(args, 1, args.length), console);
+                        interpret(Arrays.copyOfRange(args, 1, args.length), console);
                     } else {
                         console.println("Specify text to interpret (e.g. 'interpret turn all lights off')");
                     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -30,6 +30,7 @@ import org.openhab.core.voice.TTSService;
 import org.openhab.core.voice.Voice;
 import org.openhab.core.voice.VoiceManager;
 import org.openhab.core.voice.text.InterpretationException;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -46,12 +47,17 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
     private static final String SUBCMD_INTERPRET = "interpret";
     private static final String SUBCMD_VOICES = "voices";
 
-    private ItemRegistry itemRegistry;
-    private LocaleProvider localeProvider;
-    private VoiceManager voiceManager;
+    private final ItemRegistry itemRegistry;
+    private final VoiceManager voiceManager;
+    private final LocaleProvider localeProvider;
 
-    public VoiceConsoleCommandExtension() {
+    @Activate
+    public VoiceConsoleCommandExtension(final @Reference VoiceManager voiceManager,
+            final @Reference LocaleProvider localeProvider, final @Reference ItemRegistry itemRegistry) {
         super("voice", "Commands around voice enablement features.");
+        this.voiceManager = voiceManager;
+        this.localeProvider = localeProvider;
+        this.itemRegistry = itemRegistry;
     }
 
     @Override
@@ -150,33 +156,6 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
             msg.append(" ");
         }
         voiceManager.say(msg.toString());
-    }
-
-    @Reference
-    protected void setItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = itemRegistry;
-    }
-
-    protected void unsetItemRegistry(ItemRegistry itemRegistry) {
-        this.itemRegistry = null;
-    }
-
-    @Reference
-    protected void setLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = localeProvider;
-    }
-
-    protected void unsetLocaleProvider(LocaleProvider localeProvider) {
-        this.localeProvider = null;
-    }
-
-    @Reference
-    protected void setVoiceManager(VoiceManager voiceManager) {
-        this.voiceManager = voiceManager;
-    }
-
-    protected void unsetVoiceManager(VoiceManager voiceManager) {
-        this.voiceManager = null;
     }
 
 }

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/javavoicemanager/VoiceManagerTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/javavoicemanager/VoiceManagerTest.java
@@ -33,7 +33,6 @@ import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.voice.VoiceManager;
 import org.openhab.core.voice.internal.AudioManagerStub;
 import org.openhab.core.voice.internal.AudioSourceStub;
-import org.openhab.core.voice.internal.ConsoleStub;
 import org.openhab.core.voice.internal.HumanLanguageInterpreterStub;
 import org.openhab.core.voice.internal.KSServiceStub;
 import org.openhab.core.voice.internal.STTServiceStub;
@@ -59,8 +58,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
     private static final String CONFIG_DEFAULT_VOICE = "defaultVoice";
     private static final String CONFIG_DEFAULT_TTS = "defaultTTS";
     private static final String CONFIG_KEYWORD = "keyword";
-    private VoiceManagerImpl voiceManager = new VoiceManagerImpl();
-    private ConsoleStub stubConsole;
+    private VoiceManagerImpl voiceManager;
     private SinkStub sink;
     private TTSServiceStub ttsService;
     private VoiceStub voice;
@@ -134,7 +132,6 @@ public class VoiceManagerTest extends JavaOSGiTest {
 
     @Test
     public void interpretSomethingWithGivenHliIdWhenTheHliIsARegisteredService() throws InterpretationException {
-        stubConsole = new ConsoleStub();
         hliStub = new HumanLanguageInterpreterStub();
         registerService(hliStub);
 
@@ -144,7 +141,6 @@ public class VoiceManagerTest extends JavaOSGiTest {
 
     @Test
     public void interpretSomethingWithGivenHliIdEhenTheHliIsNotARegisteredService() throws InterpretationException {
-        stubConsole = new ConsoleStub();
         hliStub = new HumanLanguageInterpreterStub();
         String result;
         exception.expect(InterpretationException.class);
@@ -156,7 +152,6 @@ public class VoiceManagerTest extends JavaOSGiTest {
     @Test
     public void interpretSomethingWhenTheDefaultHliIsSetAndItIsARegisteredService()
             throws IOException, InterpretationException {
-        stubConsole = new ConsoleStub();
         hliStub = new HumanLanguageInterpreterStub();
         registerService(hliStub);
 


### PR DESCRIPTION
- Simplify lifecycle by using constructor injection
- Removed usage of `org.apache.commons.lang.ArrayUtils`
- Minor code improvements

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>