### PR TITLE
Reenable javadoc generation

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
@@ -63,7 +63,7 @@ public class ASTNode {
     }
 
     /**
-     * @return the value of this node as {@link String[]}
+     * @return the value of this node as {link String[]}
      */
     public String[] getValueAsStringArray() {
         Object[] objs = value instanceof Object[] ? (Object[]) value : new Object[] { value };
@@ -83,10 +83,10 @@ public class ASTNode {
 
     /**
      * Breadth searches this (sub-) tree/node for a node with the given name and returning its value as a
-     * {@link String[]}.
+     * {link String[]}.
      *
      * @param name the name of the named node to be found
-     * @return the value of the resulting node as {@link String[]} or null if not found
+     * @return the value of the resulting node as {link String[]} or null if not found
      */
     public String[] findValueAsStringArray(String name) {
         ASTNode node = findNode(name);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -422,7 +422,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a sequence expression. Matches, if all the given expressions match. They are tested in
-     * the provided order. The resulting nodes's value will be an {@link Object[]} that contains all values of the
+     * the provided order. The resulting nodes's value will be an {link Object[]} that contains all values of the
      * matching expressions.
      *
      * @param expressions the expressions (alternatives) that have to match in sequence
@@ -445,7 +445,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a repeating expression that will match the given expression as often as possible. Always succeeds. The
-     * resulting node's value will be an {@link Object[]} that contains all values of the
+     * resulting node's value will be an {link Object[]} that contains all values of the
      * matches.
      *
      * @param expression the repeating expression
@@ -457,7 +457,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a repeating expression that will match the given expression as often as possible. Only succeeds, if there
-     * is at least one match. The resulting node's value will be an {@link Object[]} that contains all values of the
+     * is at least one match. The resulting node's value will be an {link Object[]} that contains all values of the
      * matches.
      *
      * @param expression the repeating expression

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,13 @@ Import-Package: \\
           <version>2.10.3</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
+            <!-- Turn off doclint -->
+            <additionalparam>-Xdoclint:none</additionalparam>
+            <!-- Frames are deprecated and will disappear at some point -->
+            <additionalparam>--frames</additionalparam>
+            <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
+            <additionalJOption>--no-module-directories</additionalJOption>
+            <excludePackageNames>*.internal.*,nl.*</excludePackageNames>
           </configuration>
         </plugin>
 
@@ -739,5 +746,4 @@ Import-Package: \\
       </build>
     </profile>
   </profiles>
-
 </project>


### PR DESCRIPTION
@kaikreuzer This turned out to be a bit more involved than I expected.

I started with what was done in ESH, but immediately ran into problems trying to build the javadocs. It turns out there's an issue with javadoc in Java 11 that results in a nasty (and silent) ClassCastException. I traced it down to this construct `{@link SomeType[]}`. Fortunately, there were only 6 occurrences in the codebase, all of them in `org.openhab.core.voice`. Here's an example:
https://github.com/openhab/openhab-core/blob/master/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java#L66

In this PR, I simply removed the @ in those 6 occurrences until I get some direction on how best to handle these 6 occurrences, as well as how to prevent the offending construct from being reintroduced in the future. In hindsight, I suppose it might've been better to change it to something such as `{@link String array}`.

There's also an issue with the Java 11 javadoc that inserts "undefined" in the path name to the classes. This was breaking the search feature. I eventually found the parameter `--no-module-directories` option, which fixed that.

Finally, the "Frames" view of the javadoc is deprecated, and disabled by default. I reenabled it using the parameter `--frames`. Not sure if you want to keep the frames view (the search feature is supposed to be the better way to find things).

In any event, I've tested with the following 2 commands. The results look correct to me.
```
mvn javadoc:aggregate
mvn javadoc:aggregate-jar
```

Signed-off-by: Mark Hilbush <mark@hilbush.com>
