### PR TITLE
Units for reactive and apparent power

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
@@ -122,9 +122,11 @@ public final class SmartHomeUnits extends CustomUnits {
     public static final Unit<Energy> WATT_HOUR = addUnit(new ProductUnit<>(Units.WATT.multiply(Units.HOUR)));
     public static final Unit<Energy> KILOWATT_HOUR = addUnit(MetricPrefix.KILO(WATT_HOUR));
     public static final Unit<Energy> MEGAWATT_HOUR = addUnit(MetricPrefix.MEGA(WATT_HOUR));
-    public static final Unit<Power> KILOVAR = addUnit(MetricPrefix.KILO(new BaseUnit<Power>("var")));
-    public static final Unit<Energy> KILOVAR_HOUR = addUnit(new ProductUnit<>(KILOVAR.divide(Units.HOUR)),
+    public static final Unit<Power> VAR = addUnit(new AlternateUnit<Power>(Units.WATT, "var"));
+    public static final Unit<Power> KILOVAR = addUnit(MetricPrefix.KILO(VAR));
+    public static final Unit<Energy> VAR_HOUR = addUnit(new ProductUnit<>(VAR.multiply(Units.HOUR)),
             Energy.class);
+    public static final Unit<Energy> KILOVAR_HOUR = addUnit(MetricPrefix.KILO(VAR_HOUR));
     public static final Unit<Force> NEWTON = addUnit(Units.NEWTON);
     public static final Unit<Frequency> HERTZ = addUnit(Units.HERTZ);
     public static final Unit<Intensity> IRRADIANCE = addUnit(
@@ -238,6 +240,8 @@ public final class SmartHomeUnits extends CustomUnits {
         SimpleUnitFormat.getInstance().label(SIEMENS_PER_METRE, "S/m");
         SimpleUnitFormat.getInstance().label(TERABIT, "Tbit");
         SimpleUnitFormat.getInstance().label(TERABIT_PER_SECOND, "Tbit/s");
+        SimpleUnitFormat.getInstance().label(VAR, "var");
+        SimpleUnitFormat.getInstance().label(VAR_HOUR, "varh");
         SimpleUnitFormat.getInstance().label(WATT_HOUR, "Wh");
         SimpleUnitFormat.getInstance().label(WATT_SECOND, "Ws");
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
@@ -127,6 +127,9 @@ public final class SmartHomeUnits extends CustomUnits {
     public static final Unit<Energy> VAR_HOUR = addUnit(new ProductUnit<>(VAR.multiply(Units.HOUR)),
             Energy.class);
     public static final Unit<Energy> KILOVAR_HOUR = addUnit(MetricPrefix.KILO(VAR_HOUR));
+    public static final Unit<Power> VOLT_AMPERE = addUnit(new AlternateUnit<Power>(Units.WATT, "VA"));
+    public static final Unit<Energy> VOLT_AMPERE_HOUR = addUnit(new ProductUnit<>(VOLT_AMPERE.multiply(Units.HOUR)),
+            Energy.class);
     public static final Unit<Force> NEWTON = addUnit(Units.NEWTON);
     public static final Unit<Frequency> HERTZ = addUnit(Units.HERTZ);
     public static final Unit<Intensity> IRRADIANCE = addUnit(
@@ -242,6 +245,8 @@ public final class SmartHomeUnits extends CustomUnits {
         SimpleUnitFormat.getInstance().label(TERABIT_PER_SECOND, "Tbit/s");
         SimpleUnitFormat.getInstance().label(VAR, "var");
         SimpleUnitFormat.getInstance().label(VAR_HOUR, "varh");
+        SimpleUnitFormat.getInstance().label(VOLT_AMPERE, "VA");
+        SimpleUnitFormat.getInstance().label(VOLT_AMPERE_HOUR, "VAh");
         SimpleUnitFormat.getInstance().label(WATT_HOUR, "Wh");
         SimpleUnitFormat.getInstance().label(WATT_SECOND, "Ws");
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
@@ -168,6 +168,23 @@ public class SmartHomeUnitsTest {
         assertThat(SmartHomeUnits.KNOT.getSymbol(), is("kn"));
         assertThat(SmartHomeUnits.KNOT.toString(), is("kn"));
     }
+    
+    @Test
+    public void testVarUnitSymbol() {
+        assertThat(SmartHomeUnits.VAR.getSymbol(), is("var"));
+        assertThat(SmartHomeUnits.VAR_HOUR.toString(), is("varh"));
+    }
+    
+    @Test
+    public void testKVarUnitSymbol() {
+        assertThat(SmartHomeUnits.KILOVAR.toString(), is("kvar"));
+        assertThat(SmartHomeUnits.KILOVAR_HOUR.toString(), is("kvarh"));
+    }
+    
+    @Test
+    public void testKVarHFromString() {
+        assertThat(QuantityType.valueOf("2.60 kvarh").getUnit().toString(), is("kvarh"));
+    }
 
     @Test
     public void testCm2In() {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
@@ -172,6 +172,7 @@ public class SmartHomeUnitsTest {
     @Test
     public void testVarUnitSymbol() {
         assertThat(SmartHomeUnits.VAR.getSymbol(), is("var"));
+        assertThat(SmartHomeUnits.VAR.toString(), is("var"));
         assertThat(SmartHomeUnits.VAR_HOUR.toString(), is("varh"));
     }
     
@@ -184,6 +185,18 @@ public class SmartHomeUnitsTest {
     @Test
     public void testKVarHFromString() {
         assertThat(QuantityType.valueOf("2.60 kvarh").getUnit().toString(), is("kvarh"));
+    }
+    
+    @Test
+    public void testVoltAmpereUnitSymbol() {
+        assertThat(SmartHomeUnits.VOLT_AMPERE.toString(), is("VA"));
+        assertThat(SmartHomeUnits.VOLT_AMPERE.getSymbol(), is("VA"));
+        assertThat(SmartHomeUnits.VOLT_AMPERE_HOUR.toString(), is("VAh"));
+    }
+
+    @Test
+    public void testVoltAmpereHFromString() {
+        assertThat(QuantityType.valueOf("2.60 VAh").getUnit().toString(), is("VAh"));
     }
 
     @Test


### PR DESCRIPTION
Dear  openHAB developers,

this PR tries to fix some minor issues related to the units of reactive and apparent power.

kvar existed already but I believe it was incorrectly defined. Also var (1000 var = 1 kvar) was missing from the list of units.

Unit for apparent power (VA) and it's common derivates were missing entirely.

These units are used sometimes by smart electricity meters and solar inverters.

I hope you will like these changes.