### PR TITLE
Binding events concept

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEvent.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.binding.events;
+
+import org.eclipse.smarthome.core.events.AbstractEvent;
+
+/**
+ * Event for binding level user notifications
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public class BindingEvent extends AbstractEvent {
+    public final static String TYPE = BindingEvent.class.getSimpleName();
+
+    public BindingEvent(String topic, String binding, String payload) {
+        super(topic, payload, binding);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventDTO.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.binding.events;
+
+/**
+ * Base BindingEvent data transfer object
+ *
+ * This can be extended by bindings to add binding specific information, but provides basic information to allow the UI
+ * to render a message the user without having to implement any binding specific processor.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public class BindingEventDTO {
+    public BindingEventType type;
+    public String message;
+
+    /**
+     * Constructs a binding event with the minimal required information to be sent to the user
+     *
+     * @param type the {@link BindingEventType} providing general context and severity
+     * @param message the message to be provided to the user
+     */
+    public BindingEventDTO(BindingEventType type, String message) {
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventFactory.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.binding.events;
+
+import java.util.Set;
+
+import org.eclipse.smarthome.core.events.AbstractEventFactory;
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventFactory;
+import org.osgi.service.component.annotations.Component;
+
+import jersey.repackaged.com.google.common.collect.Sets;
+
+/**
+ * Event factory to create binding level user event notifications
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+@Component(service = EventFactory.class, immediate = true)
+public class BindingEventFactory extends AbstractEventFactory {
+    private static final String BINDING_EVENT_TOPIC = "smarthome/binding/{binding}/{entity}/{event}";
+
+    public BindingEventFactory(Set<String> supportedEventTypes) {
+        super(supportedEventTypes);
+    }
+
+    public BindingEventFactory() {
+        super(Sets.newHashSet(BindingEvent.TYPE));
+    }
+
+    @Override
+    protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
+        if (eventType.equals(BindingEvent.TYPE)) {
+            return new BindingEvent(topic, source, payload);
+        }
+        throw new IllegalArgumentException(
+                eventType + " not supported by " + BindingEventFactory.class.getSimpleName());
+    }
+
+    /**
+     * Creates a binding event. The event is to be sent on the event bus to advise users of binding status or other
+     * information required within the binding.
+     *
+     * @param binding a {@link String} with the binding name
+     * @param entity a {@link String} with binding entity information
+     * @param event a {@link String} with the event name
+     * @param dto a {@link BindingEventDTO} with the event information to be sent to the user application
+     * @return the {@link BindingEvent} to be sent
+     */
+    public static BindingEvent createBindingEvent(String binding, String entity, String event, BindingEventDTO dto) {
+        String topic = BINDING_EVENT_TOPIC;
+        topic = topic.replace("{binding}", binding);
+        topic = topic.replace("{entity}", entity);
+        topic = topic.replace("{event}", event);
+
+        String payload = serializePayload(dto);
+        return new BindingEvent(topic, binding, payload);
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventType.java
+++ b/bundles/org.openhab.core/src/main/java/org/eclipse/smarthome/core/binding/events/BindingEventType.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.binding.events;
+
+/**
+ * Binding event states for user notifications.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public enum BindingEventType {
+    SUCCESS,
+    WARNING,
+    INFO,
+    ERROR
+}


### PR DESCRIPTION
This introduces a binding event notification concept that was originally discussed [here](https://github.com/openhab/openhab-addons/pull/977). At the time there was discussion how this fits in with the imminent generic notification system (that then never appeared) and it was then suggested to move this to ESH, and then dropped as ESH maintainers did not require this.

I would like to introduce this again with a view to providing a standard way for bindings to provide information to users. This provides an event factory and standard event system that could be used within a UI to present feedback to users. This has been used in the ZWave binding since OH2.0 to provide feedback about things like exclusion or errors during inclusion.

The events provide a single Type (eg severity) and text information field that can present user feedback.

Currently this is based against the (now deleted) ```2.5.x``` branch, but before I do too much work I want to quickly see if this would now be accepted here, so would welcome any feedback.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>