### PR TITLE
[ThingManagerImpl] Prevent multiple handler inits on thing enabling

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -1201,8 +1201,8 @@ public class ThingManagerImpl
 
         if (enabled) {
             // Enable a thing
-            if (thing.getStatus().equals(ThingStatus.ONLINE)) {
-                logger.debug("Thing {} is already in the required state.", thingUID);
+            if (thing.isEnabled()) {
+                logger.debug("Thing {} is already enabled.", thingUID);
                 return;
             }
 
@@ -1222,7 +1222,7 @@ public class ThingManagerImpl
             }
         } else {
             if (!thing.isEnabled()) {
-                logger.debug("Thing {} is already in the required state.", thingUID);
+                logger.debug("Thing {} is already disabled.", thingUID);
                 return;
             }
 


### PR DESCRIPTION
When a thing is enabled, the `ThingManagerImpl` takes care of calling `ThingHandler#initialize()`.
That makes totally sense if the thing was disabled before. However, if `setEnabled(thingUID, true)` is called for a thing which was already enabled, it causes an additional initialization.
Since concurrent hanlder initializations may cause trouble, it is safer to prevent this. Therefore enabling a thing (including starting its thing handler) should only be performed if the thing is disabled.

Signed-off-by: Michael Reitler <github@madpage.de>