### PR TITLE
Ephemeris: isBankHoliday(offset, filename) now really uses the filename

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ephemeris.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ephemeris.java
@@ -77,7 +77,7 @@ public class Ephemeris {
 
     @ActionDoc(text = "checks if today plus or minus a given offset is bank holiday from a given userfile")
     public static boolean isBankHoliday(int offset, String filename) {
-        return isBankHoliday(ZonedDateTime.now().plusDays(offset));
+        return isBankHoliday(ZonedDateTime.now().plusDays(offset), filename);
     }
 
     @ActionDoc(text = "checks a given day is bank holiday from a given userfile")


### PR DESCRIPTION
isBankHoliday(offset, filename) in 2.5.0 and master throws away the filename instead of using it.  This little patch should fix this.

Closes: #1374