### PR TITLE
[DSL] Added implicit import for units to rule models

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -18,8 +18,13 @@ import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.scoping.impl.ImportNormalizer;
 import org.eclipse.xtext.xbase.scoping.XImportSectionNamespaceScopeProvider;
 
+/**
+ * @author Oliver Libutzki - Initial contribution
+ */
 public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNamespaceScopeProvider {
 
+    public static final QualifiedName CORE_LIBRARY_UNITS_PACKAGE = QualifiedName.create("org", "openhab", "core",
+            "library", "unit");
     public static final QualifiedName CORE_LIBRARY_TYPES_PACKAGE = QualifiedName.create("org", "openhab", "core",
             "library", "types");
     public static final QualifiedName CORE_LIBRARY_ITEMS_PACKAGE = QualifiedName.create("org", "openhab", "core",
@@ -34,6 +39,7 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
     @Override
     protected List<ImportNormalizer> getImplicitImports(boolean ignoreCase) {
         List<ImportNormalizer> implicitImports = super.getImplicitImports(ignoreCase);
+        implicitImports.add(doCreateImportNormalizer(CORE_LIBRARY_UNITS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_LIBRARY_TYPES_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_LIBRARY_ITEMS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(CORE_ITEMS_PACKAGE, true, false));


### PR DESCRIPTION
- Added implicit import for units to rule models

Related to #917

This fix takes care of working rules without using imports of unit classes like https://github.com/openhab/openhab-core/issues/917#issuecomment-520945885. `KILOMETRE_PER_HOUR` now can be used with or without `SIUnits` prefix. The validation issue still is shown while rules are refreshed.

```
rule "Test SIUnits"
when
 	Item EnConges received command
then
	logInfo("Test.rules","Test SIUnits " + SIUnits.KILOMETRE_PER_HOUR.toString)
	val QuantityType<Speed> speed = new QuantityType(25.0, SIUnits.KILOMETRE_PER_HOUR)
 	logInfo("Test.rules", "Test SIUnits speed = " + speed.toString)
end
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>