### PR TITLE
Fix NPE with uninitialized state trackers

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/ItemStatesSseBroadcaster.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/ItemStatesSseBroadcaster.java
@@ -128,8 +128,7 @@ public class ItemStatesSseBroadcaster extends SseBroadcaster {
         for (String itemName : itemNames) {
             try {
                 // Check that the item is tracked by at least one connection
-                if (itemRegistry != null
-                        && eventOutputs.values().stream().anyMatch(c -> c.getTrackedItems().contains(itemName))) {
+                if (eventOutputs.values().stream().anyMatch(c -> c.getTrackedItems().contains(itemName))) {
                     Item item = itemRegistry.getItem(itemName);
                     StateDTO stateDto = new StateDTO();
                     stateDto.state = item.getState().toString();

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseStateEventOutput.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseStateEventOutput.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.rest.sse.internal;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,7 +34,7 @@ import org.glassfish.jersey.media.sse.OutboundEvent;
 public class SseStateEventOutput extends EventOutput {
 
     private String connectionId;
-    private Collection<String> trackedItems;
+    private Collection<String> trackedItems = Collections.emptySet();
 
     public SseStateEventOutput() {
         super();


### PR DESCRIPTION
This fixes a NPE which occurs when a ItemStateChangedEvent
is broadcasted by the ItemStatesSseBroadcaster while some
SseStateEventOutputs haven't initialized their list of
tracked items.

Signed-off-by: Yannick Schaus <github@schaus.net>