### PR TITLE
[uom] Fixed intensity conversion from W/m² to µW/cm²

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SmartHomeUnits.java
@@ -134,7 +134,7 @@ public final class SmartHomeUnits extends CustomUnits {
     public static final Unit<Frequency> HERTZ = addUnit(Units.HERTZ);
     public static final Unit<Intensity> IRRADIANCE = addUnit(new ProductUnit<>(Units.WATT.divide(Units.SQUARE_METRE)));
     public static final Unit<Intensity> MICROWATT_PER_SQUARE_CENTIMETRE = addUnit(
-            new TransformedUnit<>(IRRADIANCE, new RationalConverter(BigInteger.valueOf(100), BigInteger.ONE)));
+            new TransformedUnit<>(IRRADIANCE, new RationalConverter(BigInteger.ONE, BigInteger.valueOf(100))));
     public static final Unit<Illuminance> LUX = addUnit(Units.LUX);
     public static final Unit<LuminousFlux> LUMEN = addUnit(Units.LUMEN);
     public static final Unit<LuminousIntensity> CANDELA = addUnit(Units.CANDELA);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
@@ -326,7 +326,7 @@ public class SmartHomeUnitsTest {
     public void testMicrowattPerSquareCentimetre2KilogramPerSquareCentiMetre() {
         Quantity<Intensity> oneMwCm2 = Quantities.getQuantity(BigDecimal.ONE, SmartHomeUnits.IRRADIANCE);
         Quantity<Intensity> converted = oneMwCm2.to(SmartHomeUnits.MICROWATT_PER_SQUARE_CENTIMETRE);
-        assertThat(converted.getValue().doubleValue(), is(closeTo(0.01, DEFAULT_ERROR)));
+        assertThat(converted.getValue().doubleValue(), is(100));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/SmartHomeUnitsTest.java
@@ -326,7 +326,7 @@ public class SmartHomeUnitsTest {
     public void testMicrowattPerSquareCentimetre2KilogramPerSquareCentiMetre() {
         Quantity<Intensity> oneMwCm2 = Quantities.getQuantity(BigDecimal.ONE, SmartHomeUnits.IRRADIANCE);
         Quantity<Intensity> converted = oneMwCm2.to(SmartHomeUnits.MICROWATT_PER_SQUARE_CENTIMETRE);
-        assertThat(converted.getValue().doubleValue(), is(100));
+        assertThat(converted.getValue().doubleValue(), is(100d));
     }
 
     @Test


### PR DESCRIPTION
- Fixed intensity conversion from `W/m²` to `µW/cm²`

IIRC conversion from W/m² to µW/cm² should be division by 1,000,000 / 10,000 = 100. Shouldn’t it?

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>