### PR TITLE
[thing] Dynamic state/command provider should not return original description 

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
@@ -89,9 +89,14 @@ public class ChannelCommandDescriptionProvider implements CommandDescriptionProv
             try {
                 CommandDescription dynamicCommandDescription = dynamicCommandDescriptionProvider
                         .getCommandDescription(channel, originalCommandDescription, locale);
-                if (dynamicCommandDescription != null
-                        && !dynamicCommandDescription.equals(originalCommandDescription)) {
-                    return dynamicCommandDescription;
+                if (dynamicCommandDescription != null) {
+                    if (dynamicCommandDescription.equals(originalCommandDescription)) {
+                        logger.error(
+                                "Dynamic command description matches original command description. DynamicCommandDescriptionProvider implementations must never return the original command description. {} has to be fixed.",
+                                dynamicCommandDescription.getClass());
+                    } else {
+                        return dynamicCommandDescription;
+                    }
                 }
             } catch (Exception e) {
                 logger.error("Error evaluating {}#getCommandDescription: {}",

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
@@ -89,7 +89,8 @@ public class ChannelCommandDescriptionProvider implements CommandDescriptionProv
             try {
                 CommandDescription dynamicCommandDescription = dynamicCommandDescriptionProvider
                         .getCommandDescription(channel, originalCommandDescription, locale);
-                if (dynamicCommandDescription != null) {
+                if (dynamicCommandDescription != null
+                        && !dynamicCommandDescription.equals(originalCommandDescription)) {
                     return dynamicCommandDescription;
                 }
             } catch (Exception e) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -132,8 +132,14 @@ public class ChannelStateDescriptionProvider implements StateDescriptionFragment
             @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
         for (DynamicStateDescriptionProvider provider : dynamicStateDescriptionProviders) {
             StateDescription stateDescription = provider.getStateDescription(channel, originalStateDescription, locale);
-            if (stateDescription != null && !stateDescription.equals(originalStateDescription)) {
-                return stateDescription;
+            if (stateDescription != null) {
+                if (stateDescription.equals(originalStateDescription)) {
+                    logger.error(
+                            "Dynamic state description matches original state description. DynamicStateDescriptionProvider implementations must never return the original state description. {} has to be fixed.",
+                            provider.getClass());
+                } else {
+                    return stateDescription;
+                }
             }
         }
         return null;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -132,7 +132,7 @@ public class ChannelStateDescriptionProvider implements StateDescriptionFragment
             @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
         for (DynamicStateDescriptionProvider provider : dynamicStateDescriptionProviders) {
             StateDescription stateDescription = provider.getStateDescription(channel, originalStateDescription, locale);
-            if (stateDescription != null) {
+            if (stateDescription != null && !stateDescription.equals(originalStateDescription)) {
                 return stateDescription;
             }
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicCommandDescriptionProvider.java
@@ -20,20 +20,23 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.types.CommandDescription;
 
 /**
- * Implementations may provide channel specific {@link CommandDescription}s. Therefore the provider must be registered
- * as OSGi service.
+ * Implementations may provide {@link Channel} specific {@link CommandDescription}s. Therefore the provider must be
+ * registered as OSGi service.
  *
  * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
 public interface DynamicCommandDescriptionProvider {
     /**
-     * For a given channel UID, return a {@link CommandDescription} that should be used for the channel, instead of the
-     * one defined statically in the {@link ChannelType}.
+     * For a given {@link Channel}, return a {@link CommandDescription} that should be used for the channel, instead of
+     * the one defined statically in the {@link ChannelType}.
      *
      * For a particular channel, there should be only one provider of the dynamic command description. When more than
      * one description is provided for the same channel (by different providers), only one will be used, from the
      * provider that registered first.
+     *
+     * If the given channel will not be managed by the provider null should be returned. You never must return the
+     * original command description in such case.
      *
      * @param channel channel
      * @param originalCommandDescription original command description retrieved from the channel type

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
@@ -29,15 +29,14 @@ import org.openhab.core.types.StateDescription;
 public interface DynamicStateDescriptionProvider {
     /**
      * For a given {@link Channel}, return a {@link StateDescription} that should be used for the channel, instead of
-     * the
-     * one defined statically in the {@link ChannelType}.
+     * the one defined statically in the {@link ChannelType}.
      *
      * For a particular channel, there should be only one provider of the dynamic state description. When more than one
      * description is provided for the same channel (by different providers), only one will be used, from the provider
      * that registered first.
      *
-     * If the given channel will not be managed by the provider null should be returned. You never must return the in
-     * such case.
+     * If the given channel will not be managed by the provider null should be returned. You never must return the
+     * original state description in such case.
      *
      * @param channel channel
      * @param originalStateDescription original state description retrieved from the channel type

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
@@ -20,20 +20,24 @@ import org.openhab.core.thing.Channel;
 import org.openhab.core.types.StateDescription;
 
 /**
- * The {@link DynamicStateDescriptionProvider} is responsible for providing {@link StateDescription} for a channel
- * dynamically in the runtime. Therefore the provider must be registered as OSGi service.
+ * The {@link DynamicStateDescriptionProvider} is responsible for providing {@link StateDescription} for a
+ * {@link Channel} dynamically in the runtime. Therefore the provider must be registered as OSGi service.
  *
  * @author Pawel Pieczul - Initial contribution
  */
 @NonNullByDefault
 public interface DynamicStateDescriptionProvider {
     /**
-     * For a given channel UID, return a {@link StateDescription} that should be used for the channel, instead of the
+     * For a given {@link Channel}, return a {@link StateDescription} that should be used for the channel, instead of
+     * the
      * one defined statically in the {@link ChannelType}.
      *
      * For a particular channel, there should be only one provider of the dynamic state description. When more than one
      * description is provided for the same channel (by different providers), only one will be used, from the provider
      * that registered first.
+     *
+     * If the given channel will not be managed by the provider null should be returned. You never must return the in
+     * such case.
      *
      * @param channel channel
      * @param originalStateDescription original state description retrieved from the channel type

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/CommandDescriptionImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/CommandDescriptionImpl.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandOption;
 
@@ -46,5 +47,33 @@ public class CommandDescriptionImpl implements CommandDescription {
     @Override
     public List<CommandOption> getCommandOptions() {
         return Collections.unmodifiableList(commandOptions);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + commandOptions.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CommandDescriptionImpl other = (CommandDescriptionImpl) obj;
+        return commandOptions.equals(other.commandOptions);
+    }
+
+    @Override
+    public String toString() {
+        return "CommandDescription [commandOptions=" + commandOptions + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -190,7 +190,45 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         if (this.options == null || this.options.isEmpty()) {
             this.options = fragment.getOptions();
         }
-
         return this;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (minimum != null ? minimum.hashCode() : 0);
+        result = prime * result + (maximum != null ? maximum.hashCode() : 0);
+        result = prime * result + (step != null ? step.hashCode() : 0);
+        result = prime * result + (pattern != null ? pattern.hashCode() : 0);
+        result = prime * result + (readOnly ? 1231 : 1237);
+        result = prime * result + (options != null ? options.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        StateDescriptionFragmentImpl other = (StateDescriptionFragmentImpl) obj;
+        return (minimum != null ? minimum.equals(other.minimum) : other.minimum == null)
+                && (maximum != null ? maximum.equals(other.maximum) : other.maximum == null)
+                && (step != null ? step.equals(other.step) : other.step == null)
+                && (pattern != null ? pattern.equals(other.pattern) : other.pattern == null)
+                && readOnly == other.readOnly //
+                && (options != null ? options.equals(other.options) : other.options == null);
+    }
+
+    @Override
+    public String toString() {
+        return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
+                + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
@@ -64,6 +64,30 @@ public class CommandOption {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + command.hashCode();
+        result = prime * result + (label != null ? label.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CommandOption other = (CommandOption) obj;
+        return command.equals(other.command) && (label != null ? label.equals(other.label) : other.label == null);
+    }
+
+    @Override
     public String toString() {
         return "CommandOption [command=" + command + ", label=" + label + "]";
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
@@ -20,8 +20,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * The {@link StateDescription} describes restrictions of an item state and gives information how to interpret
- * it.
+ * The {@link StateDescription} describes restrictions of an item state and gives information how to interpret it.
  *
  * @author Dennis Nobel - Initial contribution
  */
@@ -112,6 +111,39 @@ public class StateDescription {
      */
     public List<StateOption> getOptions() {
         return options;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (minimum != null ? minimum.hashCode() : 0);
+        result = prime * result + (maximum != null ? maximum.hashCode() : 0);
+        result = prime * result + (step != null ? step.hashCode() : 0);
+        result = prime * result + (pattern != null ? pattern.hashCode() : 0);
+        result = prime * result + (readOnly ? 1231 : 1237);
+        result = prime * result + options.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        StateDescription other = (StateDescription) obj;
+        return (minimum != null ? minimum.equals(other.minimum) : other.minimum == null)
+                && (maximum != null ? maximum.equals(other.maximum) : other.maximum == null)
+                && (step != null ? step.equals(other.step) : other.step == null)
+                && (pattern != null ? pattern.equals(other.pattern) : other.pattern == null)
+                && readOnly == other.readOnly //
+                && options.equals(other.options);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
@@ -56,6 +56,30 @@ public final class StateOption {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + value.hashCode();
+        result = prime * result + (label != null ? label.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        StateOption other = (StateOption) obj;
+        return value.equals(other.value) && (label != null ? label.equals(other.label) : other.label == null);
+    }
+
+    @Override
     public String toString() {
         return "StateOption [value=" + value + ", label=" + label + "]";
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -1,0 +1,396 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openhab.core.common.registry.ProviderChangeListener;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemProvider;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.test.SyntheticBundleInstaller;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ManagedThingProvider;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.BaseDynamicCommandDescriptionProvider;
+import org.openhab.core.thing.binding.BaseThingHandler;
+import org.openhab.core.thing.binding.BaseThingHandlerFactory;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerFactory;
+import org.openhab.core.thing.i18n.ThingStatusInfoI18nLocalizationService;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.thing.type.ChannelDefinition;
+import org.openhab.core.thing.type.ChannelDefinitionBuilder;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeProvider;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.openhab.core.thing.type.DynamicCommandDescriptionProvider;
+import org.openhab.core.thing.type.ThingTypeBuilder;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.CommandDescriptionBuilder;
+import org.openhab.core.types.CommandOption;
+import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
+import org.openhab.core.types.StateOption;
+import org.openhab.core.util.BundleResolver;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.ComponentContext;
+
+/**
+ * Tests for {@link ChannelCommandDescriptionProvider}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
+
+    private static final String TEST_BUNDLE_NAME = "thingStatusInfoI18nTest.bundle";
+    private static final ChannelTypeUID CHANNEL_TYPE_UID = new ChannelTypeUID("hue:dynamic");
+
+    private ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService;
+    private ItemRegistry itemRegistry;
+    private ItemChannelLinkRegistry linkRegistry;
+
+    @Mock
+    private ComponentContext componentContext;
+
+    private Bundle testBundle;
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+
+        Mockito.when(componentContext.getBundleContext()).thenReturn(bundleContext);
+
+        registerVolatileStorageService();
+
+        itemRegistry = getService(ItemRegistry.class);
+        assertNotNull(itemRegistry);
+
+        final TestThingHandlerFactory thingHandlerFactory = new TestThingHandlerFactory();
+        thingHandlerFactory.activate(componentContext);
+        registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
+
+        final StateDescription state = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
+                .withMaximum(BigDecimal.valueOf(100)).withStep(BigDecimal.TEN).withPattern("%d Peek").withReadOnly(true)
+                .withOption(new StateOption("SOUND", "My great sound.")).build().toStateDescription();
+        final CommandDescription command = CommandDescriptionBuilder.create()
+                .withCommandOption(new CommandOption("COMMAND", "My command.")).build();
+
+        final ChannelType channelType1 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:state-as-command"), " ", CoreItemFactory.NUMBER)
+                .withStateDescription(state).build();
+        final ChannelType channelType2 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:static"), " ", CoreItemFactory.STRING).withTag("Light")
+                .withCommandDescription(command).build();
+        final ChannelType channelType3 = ChannelTypeBuilder.state(CHANNEL_TYPE_UID, " ", CoreItemFactory.STRING)
+                .withTag("Light").build();
+
+        List<ChannelType> channelTypes = new ArrayList<>();
+        channelTypes.add(channelType1);
+        channelTypes.add(channelType2);
+        channelTypes.add(channelType3);
+
+        registerService(new ChannelTypeProvider() {
+            @Override
+            public Collection<ChannelType> getChannelTypes(Locale locale) {
+                return channelTypes;
+            }
+
+            @Override
+            public ChannelType getChannelType(ChannelTypeUID channelTypeUID, Locale locale) {
+                for (final ChannelType channelType : channelTypes) {
+                    if (channelType.getUID().equals(channelTypeUID)) {
+                        return channelType;
+                    }
+                }
+                return null;
+            }
+        });
+
+        testBundle = SyntheticBundleInstaller.install(bundleContext, TEST_BUNDLE_NAME);
+        assertThat(testBundle, is(notNullValue()));
+
+        thingStatusInfoI18nLocalizationService = getService(ThingStatusInfoI18nLocalizationService.class);
+        assertThat(thingStatusInfoI18nLocalizationService, is(notNullValue()));
+
+        thingStatusInfoI18nLocalizationService.setBundleResolver(new BundleResolverImpl());
+
+        List<ChannelDefinition> channelDefinitions = new ArrayList<>();
+        channelDefinitions.add(new ChannelDefinitionBuilder("1", channelType1.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("7_1", channelType2.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("7_2", channelType3.getUID()).build());
+
+        registerService(new SimpleThingTypeProvider(Collections.singleton(ThingTypeBuilder
+                .instance(new ThingTypeUID("hue:lamp"), "label").withChannelDefinitions(channelDefinitions).build())));
+
+        List<Item> items = new ArrayList<>();
+        items.add(new NumberItem("TestItem1"));
+        items.add(new NumberItem("TestItem7_1"));
+        items.add(new NumberItem("TestItem7_2"));
+        registerService(new TestItemProvider(items));
+
+        linkRegistry = getService(ItemChannelLinkRegistry.class);
+    }
+
+    @After
+    public void teardown() throws BundleException {
+        testBundle.uninstall();
+        ManagedThingProvider managedThingProvider = getService(ManagedThingProvider.class);
+        assertNotNull(managedThingProvider);
+        managedThingProvider.getAll().forEach(thing -> {
+            managedThingProvider.remove(thing.getUID());
+        });
+        linkRegistry.getAll().forEach(link -> {
+            linkRegistry.remove(link.getUID());
+        });
+    }
+
+    private static Channel getChannel(final Thing thing, final String channelId) {
+        final Channel channel = thing.getChannel(channelId);
+        if (channel == null) {
+            throw new IllegalArgumentException(String.format("The thing '%s' does not seems to contain a channel '%s'.",
+                    thing.getUID(), channelId));
+        } else {
+            return channel;
+        }
+    }
+
+    /**
+     * Assert that item's command description is present.
+     */
+    @Test
+    public void presentItemCommandDescription() throws ItemNotFoundException {
+        ThingRegistry thingRegistry = getService(ThingRegistry.class);
+        assertNotNull(thingRegistry);
+        ManagedThingProvider managedThingProvider = getService(ManagedThingProvider.class);
+        assertNotNull(managedThingProvider);
+
+        registerService(new TestDynamicCommandDescriptionProvider(), DynamicCommandDescriptionProvider.class.getName());
+
+        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
+                null, "test thing", new Configuration());
+        assertNotNull(thing);
+        managedThingProvider.add(thing);
+        ItemChannelLink link = new ItemChannelLink("TestItem1", getChannel(thing, "1").getUID());
+        linkRegistry.add(link);
+        link = new ItemChannelLink("TestItem7_1", getChannel(thing, "7_1").getUID());
+        linkRegistry.add(link);
+        link = new ItemChannelLink("TestItem7_2", getChannel(thing, "7_2").getUID());
+        linkRegistry.add(link);
+        //
+        final Collection<Item> items = itemRegistry.getItems();
+        assertEquals(false, items.isEmpty());
+
+        Item item = itemRegistry.getItem("TestItem1");
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
+
+        CommandDescription command = item.getCommandDescription();
+        assertNotNull(command);
+
+        List<CommandOption> opts = command.getCommandOptions();
+        assertNotNull(opts);
+        assertEquals(1, opts.size());
+        final CommandOption opt0 = opts.get(0);
+        assertNotNull(opt0);
+        assertEquals("SOUND", opt0.getCommand());
+        assertEquals("My great sound.", opt0.getLabel());
+
+        item = itemRegistry.getItem("TestItem7_1");
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
+
+        command = item.getCommandDescription();
+        assertNotNull(command);
+
+        opts = command.getCommandOptions();
+        assertNotNull(opts);
+        assertEquals(1, opts.size());
+        final CommandOption opt1 = opts.get(0);
+        assertNotNull(opt1);
+        assertEquals("COMMAND", opt1.getCommand());
+        assertEquals("My command.", opt1.getLabel());
+
+        item = itemRegistry.getItem("TestItem7_2");
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
+
+        command = item.getCommandDescription();
+        assertNotNull(command);
+
+        opts = command.getCommandOptions();
+        assertNotNull(opts);
+        assertEquals(1, opts.size());
+        final CommandOption opt2 = opts.get(0);
+        assertEquals("NEW COMMAND", opt2.getCommand());
+        assertEquals("My new command.", opt2.getLabel());
+    }
+
+    @Test
+    public void wrongItemCommandDescription() throws ItemNotFoundException {
+        ThingRegistry thingRegistry = getService(ThingRegistry.class);
+        assertNotNull(thingRegistry);
+        ManagedThingProvider managedThingProvider = getService(ManagedThingProvider.class);
+        assertNotNull(managedThingProvider);
+
+        registerService(new MalfunctioningDynamicCommandDescriptionProvider(),
+                DynamicCommandDescriptionProvider.class.getName());
+        registerService(new TestDynamicCommandDescriptionProvider(), DynamicCommandDescriptionProvider.class.getName());
+
+        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
+                null, "test thing", new Configuration());
+        assertNotNull(thing);
+        managedThingProvider.add(thing);
+        ItemChannelLink link = new ItemChannelLink("TestItem7_2", getChannel(thing, "7_2").getUID());
+        linkRegistry.add(link);
+        //
+        final Collection<Item> items = itemRegistry.getItems();
+        assertEquals(false, items.isEmpty());
+
+        Item item = itemRegistry.getItem("TestItem7_2");
+
+        CommandDescription command = item.getCommandDescription();
+        assertNotNull(command);
+
+        List<CommandOption> opts = command.getCommandOptions();
+        assertNotNull(opts);
+        assertEquals(1, opts.size());
+        final CommandOption opt2 = opts.get(0);
+        assertEquals("NEW COMMAND", opt2.getCommand());
+        assertEquals("My new command.", opt2.getLabel());
+    }
+
+    /*
+     * Helper
+     */
+    class TestDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+        final CommandDescription newCommand = CommandDescriptionBuilder.create()
+                .withCommandOption(new CommandOption("NEW COMMAND", "My new command.")).build();
+
+        @Override
+        public @Nullable CommandDescription getCommandDescription(Channel channel,
+                @Nullable CommandDescription originalCommandDescription, @Nullable Locale locale) {
+            String id = channel.getUID().getIdWithoutGroup();
+            if ("7_2".equals(id)) {
+                assertEquals(channel.getChannelTypeUID(), CHANNEL_TYPE_UID);
+                return newCommand;
+            }
+            return null;
+        }
+    }
+
+    class MalfunctioningDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+        @Override
+        public @Nullable CommandDescription getCommandDescription(Channel channel,
+                @Nullable CommandDescription originalCommandDescription, @Nullable Locale locale) {
+            return originalCommandDescription;
+        }
+    }
+
+    class TestThingHandlerFactory extends BaseThingHandlerFactory {
+
+        @Override
+        public void activate(final ComponentContext ctx) {
+            super.activate(ctx);
+        }
+
+        @Override
+        public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+            return true;
+        }
+
+        @Override
+        protected ThingHandler createHandler(Thing thing) {
+            return new AbstractThingHandler(thing) {
+                @Override
+                public void handleCommand(ChannelUID channelUID, Command command) {
+                    // do nothing
+                }
+
+                @Override
+                public void initialize() {
+                    updateStatus(ThingStatus.ONLINE);
+                }
+            };
+        }
+    }
+
+    class TestItemProvider implements ItemProvider {
+        private final Collection<Item> items;
+
+        TestItemProvider(Collection<Item> items) {
+            this.items = items;
+        }
+
+        @Override
+        public void addProviderChangeListener(ProviderChangeListener<Item> listener) {
+        }
+
+        @Override
+        public Collection<Item> getAll() {
+            return items;
+        }
+
+        @Override
+        public void removeProviderChangeListener(ProviderChangeListener<Item> listener) {
+        }
+    }
+
+    private abstract class AbstractThingHandler extends BaseThingHandler {
+        public AbstractThingHandler(Thing thing) {
+            super(thing);
+        }
+    }
+
+    /**
+     * Use this for simulating that the {@link AbstractThingHandler} class does come from another bundle than this test
+     * bundle.
+     */
+    private class BundleResolverImpl implements BundleResolver {
+        @Override
+        public Bundle resolveBundle(Class<?> clazz) {
+            if (clazz != null && clazz.equals(AbstractThingHandler.class)) {
+                return testBundle;
+            } else {
+                return FrameworkUtil.getBundle(clazz);
+            }
+        }
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -36,6 +36,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.items.ColorItem;
 import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.items.NumberItem;
@@ -118,20 +119,20 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         final StateDescription state2 = new StateDescription(BigDecimal.ZERO, BigDecimal.valueOf(256),
                 BigDecimal.valueOf(8), null, false, null);
 
-        final ChannelType channelType = new ChannelType(new ChannelTypeUID("hue:alarm"), false, "Number", " ", "", null,
-                null, state, null);
-        final ChannelType channelType2 = new ChannelType(new ChannelTypeUID("hue:num"), false, "Number", " ", "", null,
-                null, state2, null);
-        final ChannelType channelType3 = new ChannelType(new ChannelTypeUID("hue:info"), true, "String", " ", "", null,
-                null, (StateDescription) null, null);
-        final ChannelType channelType4 = new ChannelType(new ChannelTypeUID("hue:color"), false, "Color", "Color", "",
-                "ColorLight", null, (StateDescription) null, null);
-        final ChannelType channelType5 = new ChannelType(new ChannelTypeUID("hue:brightness"), false, "Dimmer",
-                "Brightness", "", "DimmableLight", null, (StateDescription) null, null);
-        final ChannelType channelType6 = new ChannelType(new ChannelTypeUID("hue:switch"), false, "Switch", "Switch",
-                "", "Light", null, (StateDescription) null, null);
-        final ChannelType channelType7 = new ChannelType(CHANNEL_TYPE_7_UID, false, "Number", " ", "", "Light", null,
-                state, null);
+        final ChannelType channelType = new ChannelType(new ChannelTypeUID("hue:alarm"), false, CoreItemFactory.NUMBER,
+                " ", "", null, null, state, null);
+        final ChannelType channelType2 = new ChannelType(new ChannelTypeUID("hue:num"), false, CoreItemFactory.NUMBER,
+                " ", "", null, null, state2, null);
+        final ChannelType channelType3 = new ChannelType(new ChannelTypeUID("hue:info"), true, CoreItemFactory.STRING,
+                " ", "", null, null, (StateDescription) null, null);
+        final ChannelType channelType4 = new ChannelType(new ChannelTypeUID("hue:color"), false, CoreItemFactory.COLOR,
+                "Color", "", "ColorLight", null, (StateDescription) null, null);
+        final ChannelType channelType5 = new ChannelType(new ChannelTypeUID("hue:brightness"), false,
+                CoreItemFactory.DIMMER, "Brightness", "", "DimmableLight", null, (StateDescription) null, null);
+        final ChannelType channelType6 = new ChannelType(new ChannelTypeUID("hue:switch"), false,
+                CoreItemFactory.SWITCH, "Switch", "", "Light", null, (StateDescription) null, null);
+        final ChannelType channelType7 = new ChannelType(CHANNEL_TYPE_7_UID, false, CoreItemFactory.NUMBER, " ", "",
+                "Light", null, state, null);
 
         List<ChannelType> channelTypes = new ArrayList<>();
         channelTypes.add(channelType);
@@ -254,7 +255,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(false, items.isEmpty());
 
         Item item = itemRegistry.getItem("TestItem");
-        assertEquals("Number", item.getType());
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
 
         StateDescription state = item.getStateDescription();
         assertNotNull(state);
@@ -271,7 +272,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals("My great sound.", opt.getLabel());
 
         item = itemRegistry.getItem("TestItem2");
-        assertEquals("Number", item.getType());
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
 
         state = item.getStateDescription();
         assertNotNull(state);
@@ -285,7 +286,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(0, opts.size());
 
         item = itemRegistry.getItem("TestItem3");
-        assertEquals("String", item.getType());
+        assertEquals(CoreItemFactory.STRING, item.getType());
 
         state = item.getStateDescription();
         assertNotNull(state);
@@ -299,25 +300,25 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(0, opts.size());
 
         item = itemRegistry.getItem("TestItem4");
-        assertEquals("Color", item.getType());
+        assertEquals(CoreItemFactory.COLOR, item.getType());
 
         state = item.getStateDescription();
         assertNull(state);
 
         item = itemRegistry.getItem("TestItem5");
-        assertEquals("Dimmer", item.getType());
+        assertEquals(CoreItemFactory.DIMMER, item.getType());
 
         state = item.getStateDescription();
         assertNull(state);
 
         item = itemRegistry.getItem("TestItem6");
-        assertEquals("Switch", item.getType());
+        assertEquals(CoreItemFactory.SWITCH, item.getType());
 
         state = item.getStateDescription();
         assertNull(state);
 
         item = itemRegistry.getItem("TestItem7_1");
-        assertEquals("Number", item.getType());
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
 
         state = item.getStateDescription();
         assertNotNull(state);
@@ -341,7 +342,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(opt1.getLabel(), "label1");
 
         item = itemRegistry.getItem("TestItem7_2");
-        assertEquals("Number", item.getType());
+        assertEquals(CoreItemFactory.NUMBER, item.getType());
 
         state = item.getStateDescription();
         assertNotNull(state);


### PR DESCRIPTION
- Dynamic state/command provider should not return original description
- Added integration test for `CommandDescriptionProvider`

See https://community.openhab.org/t/dynamic-state-options-not-showing-up/95625

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>