### PR TITLE
Replace unit placeholder in patterns if updated by DecimalType states

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -400,7 +400,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         // for DecimalTypes we don't want to risk format exceptions, if pattern contains unit
                         // placeholder
                         if (formatPattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
-                            formatPattern = formatPattern.replaceAll(UnitUtils.UNIT_PLACEHOLDER, "");
+                            formatPattern = formatPattern.replaceAll(UnitUtils.UNIT_PLACEHOLDER, "").stripTrailing();
                         }
                     } else if (state instanceof QuantityType) {
                         QuantityType<?> quantityState = (QuantityType<?>) state;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -357,9 +357,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         state = item.getStateAs(DecimalType.class);
                     }
 
-                    // for fraction digits in state we dont want to risk format exceptions,
+                    // for fraction digits in state we don't want to risk format exceptions,
                     // so treat everything as floats:
-                    formatPattern = formatPattern.replaceAll("\\%d", "%.0f");
+                    formatPattern = formatPattern.replaceAll("%d", "%.0f");
                 }
             }
         } catch (ItemNotFoundException e) {
@@ -396,7 +396,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         }
                     }
 
-                    if (state instanceof QuantityType) {
+                    if (state instanceof DecimalType) {
+                        // for DecimalTypes we don't want to risk format exceptions, if pattern contains unit
+                        // placeholder
+                        if (formatPattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
+                            formatPattern = formatPattern.replaceAll(UnitUtils.UNIT_PLACEHOLDER, "");
+                        }
+                    } else if (state instanceof QuantityType) {
                         QuantityType<?> quantityState = (QuantityType<?>) state;
                         // sanity convert current state to the item state description unit in case it was updated in the
                         // meantime. The item state is still in the "original" unit while the state description will

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -47,6 +47,7 @@ import org.openhab.core.model.sitemap.sitemap.Switch;
 import org.openhab.core.model.sitemap.sitemap.Widget;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.types.UnDefType;
 import org.openhab.core.types.util.UnitUtils;
@@ -126,6 +127,32 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
+    public void getLabelLabelWithoutPatterAndIntegerValue() {
+        String testLabel = "Label";
+
+        when(widget.getLabel()).thenReturn(testLabel);
+        when(item.getState()).thenReturn(new DecimalType(20));
+        when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20));
+        when(item.getStateDescription())
+                .thenReturn(StateDescriptionFragmentBuilder.create().withPattern("%d").build().toStateDescription());
+        String label = uiRegistry.getLabel(widget);
+        assertEquals("Label [20]", label);
+    }
+
+    @Test
+    public void getLabelLabelWithoutPatterAndFractionalDigitsValue() {
+        String testLabel = "Label";
+
+        when(widget.getLabel()).thenReturn(testLabel);
+        when(item.getState()).thenReturn(new DecimalType(20.5));
+        when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20.5));
+        when(item.getStateDescription())
+                .thenReturn(StateDescriptionFragmentBuilder.create().withPattern("%d").build().toStateDescription());
+        String label = uiRegistry.getLabel(widget);
+        assertEquals("Label [21]", label);
+    }
+
+    @Test
     public void getLabelLabelWithIntegerValue() {
         String testLabel = "Label [%d]";
 
@@ -134,6 +161,17 @@ public class ItemUIRegistryImplTest {
         when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20));
         String label = uiRegistry.getLabel(widget);
         assertEquals("Label [20]", label);
+    }
+
+    @Test
+    public void getLabelLabelWithFractionalDigitsValue() {
+        String testLabel = "Label [%d]";
+
+        when(widget.getLabel()).thenReturn(testLabel);
+        when(item.getState()).thenReturn(new DecimalType(20.5));
+        when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20.5));
+        String label = uiRegistry.getLabel(widget);
+        assertEquals("Label [21]", label);
     }
 
     @Test
@@ -170,13 +208,23 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabelLabelWithDecimalValueAndUnit() {
+    public void getLabelLabelWithDecimalValueAndUnitUpdatedWithQuantityType() {
         String testLabel = "Label [%.3f " + UnitUtils.UNIT_PLACEHOLDER + "]";
 
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new QuantityType<>("" + 10f / 3f + " °C"));
         String label = uiRegistry.getLabel(widget);
         assertEquals("Label [3" + SEP + "333 °C]", label);
+    }
+
+    @Test
+    public void getLabelLabelWithDecimalValueAndUnitUpdatedWithDecimalType() {
+        String testLabel = "Label [%.3f " + UnitUtils.UNIT_PLACEHOLDER + "]";
+
+        when(widget.getLabel()).thenReturn(testLabel);
+        when(item.getState()).thenReturn(new DecimalType(10f / 3f));
+        String label = uiRegistry.getLabel(widget);
+        assertEquals("Label [3" + SEP + "333 ]", label);
     }
 
     @Test
@@ -217,6 +265,16 @@ public class ItemUIRegistryImplTest {
         when(item.getState()).thenReturn(new QuantityType<>("33 %"));
         String label = uiRegistry.getLabel(widget);
         assertEquals("Label [33 %]", label);
+    }
+
+    @Test
+    public void getLabelLabelWithFractionalDigitsValueAndUnit5() {
+        String testLabel = "Label [%d " + UnitUtils.UNIT_PLACEHOLDER + "]";
+
+        when(widget.getLabel()).thenReturn(testLabel);
+        when(item.getState()).thenReturn(new QuantityType<>("" + 10f / 3f + " %"));
+        String label = uiRegistry.getLabel(widget);
+        assertEquals("Label [3 %]", label);
     }
 
     @Test

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -224,7 +224,7 @@ public class ItemUIRegistryImplTest {
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new DecimalType(10f / 3f));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3" + SEP + "333 ]", label);
+        assertEquals("Label [3" + SEP + "333]", label);
     }
 
     @Test


### PR DESCRIPTION
- Replace unit placeholder in patterns if updated by `DecimalType` states

Fixes #986

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>