### PR TITLE
[core] Fix UnsupportedOperationException in StateDescriptionFragmentBuilder

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
@@ -46,7 +46,7 @@ public class StateDescriptionFragmentBuilder {
         this.pattern = legacy.getPattern();
         this.readOnly = Boolean.valueOf(legacy.isReadOnly());
         if (!legacy.getOptions().isEmpty()) {
-            this.options = legacy.getOptions();
+            this.options = new ArrayList<>(legacy.getOptions());
         }
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
@@ -85,7 +85,8 @@ public class StateDescriptionFragmentBuilderTest {
     public void builderWithStateDescription() {
         StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern", true,
                 Collections.singletonList(new StateOption("value", "label")));
-        StateDescriptionFragment fragment = StateDescriptionFragmentBuilder.create(source).build();
+        StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create(source);
+        StateDescriptionFragment fragment = builder.build();
 
         assertThat(fragment.getMinimum(), is(source.getMinimum()));
         assertThat(fragment.getMaximum(), is(source.getMaximum()));
@@ -93,6 +94,8 @@ public class StateDescriptionFragmentBuilderTest {
         assertThat(fragment.getPattern(), is(source.getPattern()));
         assertThat(fragment.isReadOnly(), is(source.isReadOnly()));
         assertThat(fragment.getOptions(), is(source.getOptions()));
+
+        builder.withOption(new StateOption("NEW value", "NEW label"));
     }
 
     @Test


### PR DESCRIPTION
- Fix `UnsupportedOperationException` in `StateDescriptionFragmentBuilder` when copying a legacy `StateDescription` as `getOptions()` returns an immutable list.

https://github.com/openhab/openhab-core/blob/1f825fc529a107ba11bdab19992939e213abd99d/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java#L57

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>