### PR TITLE
Removed 'advanced' attribute from 'ChannelGroupType'

### DIFF
--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeConverter.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeConverter.java
@@ -34,24 +34,14 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  *
  * @author Michael Grammling - Initial contribution
  * @author Chris Jackson - Modified to support channel properties
+ * @author Christoph Weitkamp - Removed "advanced" attribute
  */
 public class ChannelGroupTypeConverter extends AbstractDescriptionTypeConverter<ChannelGroupTypeXmlResult> {
 
     public ChannelGroupTypeConverter() {
         super(ChannelGroupTypeXmlResult.class, "channel-group-type");
 
-        super.attributeMapValidator = new ConverterAttributeMapValidator(
-                new String[][] { { "id", "true" }, { "advanced", "false" } });
-    }
-
-    private boolean isAdvanced(Map<String, String> attributes, boolean defaultValue) {
-        Object advancedObj = attributes.get("advanced");
-
-        if (advancedObj != null) {
-            return Boolean.parseBoolean((String) advancedObj);
-        }
-
-        return defaultValue;
+        super.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "id", "true" } });
     }
 
     @SuppressWarnings("unchecked")
@@ -64,14 +54,12 @@ public class ChannelGroupTypeConverter extends AbstractDescriptionTypeConverter<
             Map<String, String> attributes, NodeIterator nodeIterator) throws ConversionException {
         ChannelGroupTypeUID channelGroupTypeUID = new ChannelGroupTypeUID(super.getUID(attributes, context));
 
-        boolean advanced = isAdvanced(attributes, false);
-
         String label = super.readLabel(nodeIterator);
         String description = super.readDescription(nodeIterator);
         String category = readCategory(nodeIterator);
         List<ChannelXmlResult> channelTypeDefinitions = readChannelTypeDefinitions(nodeIterator);
 
-        ChannelGroupTypeXmlResult groupChannelType = new ChannelGroupTypeXmlResult(channelGroupTypeUID, advanced, label,
+        ChannelGroupTypeXmlResult groupChannelType = new ChannelGroupTypeXmlResult(channelGroupTypeUID, label,
                 description, category, channelTypeDefinitions);
 
         return groupChannelType;
@@ -79,11 +67,7 @@ public class ChannelGroupTypeConverter extends AbstractDescriptionTypeConverter<
 
     private String readCategory(NodeIterator nodeIterator) {
         Object category = nodeIterator.nextValue("category", false);
-        if (category != null) {
-            return category.toString();
-        } else {
-            return null;
-        }
+        return category == null ? null : category.toString();
     }
 
 }

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
@@ -31,20 +31,19 @@ import com.thoughtworks.xstream.converters.ConversionException;
  *
  * @author Michael Grammling - Initial contribution
  * @author Chris Jackson - Updated to support channel properties
+ * @author Christoph Weitkamp - Removed "advanced" attribute
  */
 public class ChannelGroupTypeXmlResult {
 
     private final ChannelGroupTypeUID channelGroupTypeUID;
-    private final boolean advanced;
     private final String label;
     private final String description;
     private final String category;
     private final List<ChannelXmlResult> channelTypeReferences;
 
-    public ChannelGroupTypeXmlResult(ChannelGroupTypeUID channelGroupTypeUID, boolean advanced, String label,
-            String description, String category, List<ChannelXmlResult> channelTypeReferences) {
+    public ChannelGroupTypeXmlResult(ChannelGroupTypeUID channelGroupTypeUID, String label, String description,
+            String category, List<ChannelXmlResult> channelTypeReferences) {
         this.channelGroupTypeUID = channelGroupTypeUID;
-        this.advanced = advanced;
         this.label = label;
         this.description = description;
         this.category = category;
@@ -52,7 +51,7 @@ public class ChannelGroupTypeXmlResult {
     }
 
     public ChannelGroupTypeUID getUID() {
-        return this.channelGroupTypeUID;
+        return channelGroupTypeUID;
     }
 
     protected List<ChannelDefinition> toChannelDefinitions(List<ChannelXmlResult> channelTypeReferences)
@@ -61,10 +60,9 @@ public class ChannelGroupTypeXmlResult {
 
         if (channelTypeReferences != null && !channelTypeReferences.isEmpty()) {
             channelTypeDefinitions = new ArrayList<>(channelTypeReferences.size());
-
             for (ChannelXmlResult channelTypeReference : channelTypeReferences) {
                 channelTypeDefinitions
-                        .add(channelTypeReference.toChannelDefinition(this.channelGroupTypeUID.getBindingId()));
+                        .add(channelTypeReference.toChannelDefinition(channelGroupTypeUID.getBindingId()));
             }
         }
 
@@ -72,18 +70,25 @@ public class ChannelGroupTypeXmlResult {
     }
 
     public ChannelGroupType toChannelGroupType() throws ConversionException {
-        ChannelGroupType channelGroupType = ChannelGroupTypeBuilder.instance(this.channelGroupTypeUID, this.label)
-                .isAdvanced(this.advanced).withDescription(this.description).withCategory(this.category)
-                .withChannelDefinitions(toChannelDefinitions(this.channelTypeReferences)).build();
-
-        return channelGroupType;
+        ChannelGroupTypeBuilder builder = ChannelGroupTypeBuilder.instance(channelGroupTypeUID, label);
+        if (description != null) {
+            builder.withDescription(description);
+        }
+        if (category != null) {
+            builder.withCategory(category);
+        }
+        List<ChannelDefinition> channelDefinitions = toChannelDefinitions(channelTypeReferences);
+        if (channelDefinitions != null) {
+            builder.withChannelDefinitions(channelDefinitions);
+        }
+        return builder.build();
     }
 
     @Override
     public String toString() {
-        return "ChannelGroupTypeXmlResult [channelGroupTypeUID=" + channelGroupTypeUID + ", advanced=" + advanced
-                + ", label=" + label + ", description=" + description + ", category=" + category
-                + ", channelTypeReferences=" + channelTypeReferences + "]";
+        return "ChannelGroupTypeXmlResult [channelGroupTypeUID=" + channelGroupTypeUID + ", label=" + label
+                + ", description=" + description + ", category=" + category + ", channelTypeReferences="
+                + channelTypeReferences + "]";
     }
 
 }

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
@@ -28,7 +28,6 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeUID;
-import org.openhab.core.thing.type.StateChannelTypeBuilder;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.EventDescription;
 import org.openhab.core.types.StateDescription;
@@ -187,18 +186,23 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
 
         ChannelKind cKind = ChannelKind.parse(kind);
         URI configDescriptionURI = (URI) configDescriptionObjects[0];
-        ChannelType channelType = null;
+        final ChannelTypeBuilder<?> builder;
         if (cKind == ChannelKind.STATE) {
-            StateChannelTypeBuilder builder = ChannelTypeBuilder.state(channelTypeUID, label, itemType)
-                    .isAdvanced(advanced).withDescription(description).withCategory(category).withTags(tags)
-                    .withConfigDescriptionURI(configDescriptionURI).withStateDescription(stateDescription)
-                    .withAutoUpdatePolicy(autoUpdatePolicy).withCommandDescription(commandDescription);
-            channelType = builder.build();
+            builder = ChannelTypeBuilder.state(channelTypeUID, label, itemType).isAdvanced(advanced)
+                    .withCategory(category).withTags(tags).withConfigDescriptionURI(configDescriptionURI)
+                    .withStateDescription(stateDescription).withAutoUpdatePolicy(autoUpdatePolicy)
+                    .withCommandDescription(commandDescription);
         } else if (cKind == ChannelKind.TRIGGER) {
-            channelType = ChannelTypeBuilder.trigger(channelTypeUID, label).isAdvanced(advanced)
-                    .withDescription(description).withCategory(category).withTags(tags)
-                    .withConfigDescriptionURI(configDescriptionURI).withEventDescription(eventDescription).build();
+            builder = ChannelTypeBuilder.trigger(channelTypeUID, label).isAdvanced(advanced).withCategory(category)
+                    .withTags(tags).withConfigDescriptionURI(configDescriptionURI)
+                    .withEventDescription(eventDescription);
+        } else {
+            throw new IllegalArgumentException(String.format("Unknown channel kind: '%s'", cKind));
         }
+        if (description != null) {
+            builder.withDescription(description);
+        }
+        ChannelType channelType = builder.build();
 
         ChannelTypeXmlResult channelTypeXmlResult = new ChannelTypeXmlResult(channelType,
                 (ConfigDescription) configDescriptionObjects[1], system);

--- a/bundles/org.openhab.core.thing.xml/src/test/resources/example/example.xml
+++ b/bundles/org.openhab.core.thing.xml/src/test/resources/example/example.xml
@@ -94,7 +94,7 @@
 	</channel-type>
 
 	<!-- Alarm System Channel -->
-	<channel-group-type id="alarm_system" advanced="false">
+	<channel-group-type id="alarm_system">
 		<label>Alarm System</label>
 		<description>The alarm system.</description>
 		<channels>

--- a/bundles/org.openhab.core.thing.xml/thing-description-1.0.0.xsd
+++ b/bundles/org.openhab.core.thing.xml/thing-description-1.0.0.xsd
@@ -91,7 +91,6 @@
             <xs:element name="channels" type="thing-description:channels" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="id" type="config-description:idRestrictionPattern" use="required"/>
-        <xs:attribute name="advanced" type="xs:boolean" default="false" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="supportedBridgeTypeRefs">

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -39,6 +39,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Laurent Garnier - fix localized label and description for channel group definition
  * @author Christoph Weitkamp - factored out from {@link XmlChannelTypeProvider} and {@link XmlChannelGroupTypeProvider}
  * @author Henning Treu - factored out from {@link ThingTypeI18nLocalizationService}
+ * @author Christoph Weitkamp - Removed "advanced" attribute
  */
 @Component(service = ChannelGroupTypeI18nLocalizationService.class)
 @NonNullByDefault

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -73,8 +73,7 @@ public class ChannelGroupTypeI18nLocalizationService {
 
         ChannelGroupTypeBuilder builder = ChannelGroupTypeBuilder
                 .instance(channelGroupTypeUID, label == null ? defaultLabel : label)
-                .isAdvanced(channelGroupType.isAdvanced()).withCategory(channelGroupType.getCategory())
-                .withChannelDefinitions(localizedChannelDefinitions);
+                .withCategory(channelGroupType.getCategory()).withChannelDefinitions(localizedChannelDefinitions);
         if (description != null) {
             builder.withDescription(description);
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
@@ -12,22 +12,21 @@
  */
 package org.openhab.core.thing.type;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 /**
- * The {@link ChannelGroupType} contains a list of {@link ChannelDefinition}s and further
- * meta information such as label and description, which are generally used by user interfaces.
+ * The {@link ChannelGroupType} contains a list of {@link ChannelDefinition}s and further meta information such as label
+ * and description, which are generally used by user interfaces.
  * <p>
  * This type can be used for Things which offers multiple functionalities which belong all together.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Michael Grammling - Initial contribution
+ * @author Christoph Weitkamp - Removed "advanced" attribute
  */
 public class ChannelGroupType extends AbstractDescriptionType {
 
-    private final boolean advanced;
     private final List<ChannelDefinition> channelDefinitions;
     private final String category;
 
@@ -36,38 +35,6 @@ public class ChannelGroupType extends AbstractDescriptionType {
      *
      * @param uid the unique identifier which identifies this channel group type within the
      *            overall system (must neither be null, nor empty)
-     * @param advanced true if this channel group type contains advanced features, otherwise false
-     * @param label the human readable label for the according type
-     *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
-     *            (could be null or empty)
-     * @param channelDefinitions the channel definitions this channel group forms
-     *            (could be null or empty)
-     * @throws IllegalArgumentException if the UID is null, or the label is null or empty
-     *
-     * @deprecated Use the {@link ChannelGroupTypeBuilder} instead.
-     */
-    @Deprecated
-    public ChannelGroupType(ChannelGroupTypeUID uid, boolean advanced, String label, String description,
-            List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
-        super(uid, label, description);
-
-        this.advanced = advanced;
-        this.category = null;
-
-        if (channelDefinitions != null) {
-            this.channelDefinitions = Collections.unmodifiableList(channelDefinitions);
-        } else {
-            this.channelDefinitions = Collections.unmodifiableList(new ArrayList<>(0));
-        }
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @param uid the unique identifier which identifies this channel group type within the
-     *            overall system (must neither be null, nor empty)
-     * @param advanced true if this channel group type contains advanced features, otherwise false
      * @param label the human readable label for the according type
      *            (must neither be null nor empty)
      * @param description the human readable description for the according type
@@ -77,29 +44,13 @@ public class ChannelGroupType extends AbstractDescriptionType {
      *            (could be null or empty)
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
-    ChannelGroupType(ChannelGroupTypeUID uid, boolean advanced, String label, String description, String category,
+    ChannelGroupType(ChannelGroupTypeUID uid, String label, String description, String category,
             List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
         super(uid, label, description);
 
-        this.advanced = advanced;
         this.category = category;
-
-        if (channelDefinitions != null) {
-            this.channelDefinitions = Collections.unmodifiableList(channelDefinitions);
-        } else {
-            this.channelDefinitions = Collections.unmodifiableList(new ArrayList<>(0));
-        }
-    }
-
-    /**
-     * Returns {@code true} if this {@link ChannelGroupType} contains advanced functionalities
-     * which should be typically not shown in the basic view of user interfaces,
-     * otherwise {@code false}.
-     *
-     * @return true if this channel group contains advanced functionalities, otherwise false
-     */
-    public boolean isAdvanced() {
-        return advanced;
+        this.channelDefinitions = channelDefinitions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(channelDefinitions);
     }
 
     /**
@@ -114,7 +65,7 @@ public class ChannelGroupType extends AbstractDescriptionType {
     }
 
     public String getCategory() {
-        return this.category;
+        return category;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeBuilder.java
@@ -22,11 +22,11 @@ import org.eclipse.jdt.annotation.Nullable;
  * A {@link ChannelGroupType} builder.
  *
  * @author Christoph Weitkamp - Initial contribution
+ * @author Christoph Weitkamp - Removed "advanced" attribute
  */
 @NonNullByDefault
 public class ChannelGroupTypeBuilder {
 
-    private boolean advanced;
     private @Nullable List<ChannelDefinition> channelDefinitions;
     private @Nullable String category;
     private @Nullable String description;
@@ -64,18 +64,7 @@ public class ChannelGroupTypeBuilder {
      * @return the created {@link ChannelGroupType}
      */
     public ChannelGroupType build() {
-        return new ChannelGroupType(channelGroupTypeUID, advanced, label, description, category, channelDefinitions);
-    }
-
-    /**
-     * Specify whether this is an advanced {@link ChannelGroupType}, default is false
-     *
-     * @param advanced true if this is an advanced {@link ChannelGroupType}
-     * @return this Builder
-     */
-    public ChannelGroupTypeBuilder isAdvanced(boolean advanced) {
-        this.advanced = advanced;
-        return this;
+        return new ChannelGroupType(channelGroupTypeUID, label, description, category, channelDefinitions);
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelGroupTypeBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelGroupTypeBuilderTest.java
@@ -56,20 +56,6 @@ public class ChannelGroupTypeBuilderTest {
     }
 
     @Test
-    public void withDefaultAdvancedIsFalse() {
-        ChannelGroupType channelGroupType = builder.build();
-
-        assertFalse(channelGroupType.isAdvanced());
-    }
-
-    @Test
-    public void isAdvancedShouldSetAdvanced() {
-        ChannelGroupType channelGroupType = builder.isAdvanced(true).build();
-
-        assertTrue(channelGroupType.isAdvanced());
-    }
-
-    @Test
     public void withDescriptionShouldSetDescription() {
         ChannelGroupType channelGroupType = builder.withDescription(DESCRIPTION).build();
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -122,9 +122,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     private static final Pattern LABEL_PATTERN = Pattern.compile(".*?\\[.*? (.*?)\\]");
 
-    protected Set<ItemUIProvider> itemUIProviders = new HashSet<>();
+    protected final Set<ItemUIProvider> itemUIProviders = new HashSet<>();
 
-    protected @Nullable ItemRegistry itemRegistry;
+    private @Nullable ItemRegistry itemRegistry;
 
     private @Nullable ItemBuilderFactory itemBuilderFactory;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
@@ -274,13 +274,12 @@ public class ThingFactoryTest extends JavaOSGiTest {
         ChannelDefinition channelDef2 = new ChannelDefinitionBuilder("ch2", channelType2.getUID()).build();
 
         ChannelGroupType channelGroupType1 = ChannelGroupTypeBuilder
-                .instance(new ChannelGroupTypeUID("bindingid:groupTypeId1"), "label").isAdvanced(false)
-                .withDescription("description").withCategory("myCategory1")
+                .instance(new ChannelGroupTypeUID("bindingid:groupTypeId1"), "label").withDescription("description")
+                .withCategory("myCategory1")
                 .withChannelDefinitions(Stream.of(channelDef1, channelDef2).collect(toList())).build();
         ChannelGroupType channelGroupType2 = ChannelGroupTypeBuilder
-                .instance(new ChannelGroupTypeUID("bindingid:groupTypeId2"), "label").isAdvanced(false)
-                .withDescription("description").withCategory("myCategory2")
-                .withChannelDefinitions(singletonList(channelDef1)).build();
+                .instance(new ChannelGroupTypeUID("bindingid:groupTypeId2"), "label").withDescription("description")
+                .withCategory("myCategory2").withChannelDefinitions(singletonList(channelDef1)).build();
 
         ChannelGroupDefinition channelGroupDef1 = new ChannelGroupDefinition("group1", channelGroupType1.getUID());
         ChannelGroupDefinition channelGroupDef2 = new ChannelGroupDefinition("group2", channelGroupType2.getUID());

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/OH-INF/thing/thing-types.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ThingTypesTest.bundle/OH-INF/thing/thing-types.xml
@@ -141,7 +141,7 @@
 	</channel-type>
 
 	<!-- Channel Group -->
-	<channel-group-type id="lampgroup" advanced="true">
+	<channel-group-type id="lampgroup">
 		<label>Alarm System</label>
 		<description>The alarm system.</description>
 		<channels>
@@ -152,7 +152,7 @@
 	</channel-group-type>
 
 	<!-- Channel Group without channels -->
-	<channel-group-type id="lampgroup-without-channels" advanced="true">
+	<channel-group-type id="lampgroup-without-channels">
 		<label>Alarm System</label>
 		<description>The alarm system without channels.</description>
 	</channel-group-type>


### PR DESCRIPTION
- Removed 'advanced' attribute from `ChannelGroupType`

Resolves #1402 

@kaikreuzer What would be an appropriate versioning for the XSD file? 3.0.0? matching OHC version? If we change it we have to migrate all XML files in this repo.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>