### PR TITLE
Removed deprecated constructors and methods from Thing API

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.AbstractUID;
 import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -50,7 +51,6 @@ public class DiscoveryResultBuilder {
     private @Nullable ThingTypeUID thingTypeUID;
 
     private DiscoveryResultBuilder(ThingUID thingUID) {
-        this.thingTypeUID = thingUID.getThingTypeUID();
         this.thingUID = thingUID;
     };
 
@@ -155,6 +155,12 @@ public class DiscoveryResultBuilder {
             logger.warn(
                     "Representation property '{}' of discovery result for thing '{}' is missing in properties map. It has to be fixed by the bindings developer.\n{}",
                     representationProperty, thingUID, getStackTrace(Thread.currentThread()));
+        }
+        if (thingTypeUID == null) {
+            String[] segments = thingUID.getAsString().split(AbstractUID.SEPARATOR);
+            if (!segments[1].isEmpty()) {
+                thingTypeUID = new ThingTypeUID(thingUID.getBindingId(), segments[1]);
+            }
         }
         return new DiscoveryResultImpl(thingTypeUID, thingUID, bridgeUID, properties, representationProperty, label,
                 ttl);

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTO.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTO.java
@@ -32,7 +32,7 @@ public class DiscoveryResultDTO {
     public @Nullable String label;
     public @Nullable Map<String, Object> properties;
     public @Nullable String representationProperty;
-    public @Nullable String thingUID;
+    public @NonNullByDefault({}) String thingUID;
     public @Nullable String thingTypeUID;
 
     public DiscoveryResultDTO() {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.AbstractUID;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
@@ -101,7 +102,11 @@ public class DiscoveryResultImpl implements DiscoveryResult {
             return localThingTypeUID;
         } else {
             // fallback for discovery result which were created before the thingTypeUID field was added
-            return thingUID.getThingTypeUID();
+            String[] segments = thingUID.getAsString().split(AbstractUID.SEPARATOR);
+            if (!segments[1].isEmpty()) {
+                return new ThingTypeUID(thingUID.getBindingId(), segments[1]);
+            }
+            throw new IllegalArgumentException("ThingTypeUID of thing '" + thingUID.getAsString() + "' is null.");
         }
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
@@ -35,14 +35,12 @@ public class DiscoveryResultImplTest {
 
     private static final int DEFAULT_TTL = 60;
 
-    @SuppressWarnings("unused")
     @Test
     public void testInvalidConstructorForThingType() {
         assertThrows(IllegalArgumentException.class,
                 () -> new DiscoveryResultImpl(null, new ThingUID("aa"), null, null, null, null, DEFAULT_TTL));
     }
 
-    @SuppressWarnings("unused")
     @Test
     public void testInvalidConstructorForTTL() {
         ThingTypeUID thingTypeUID = new ThingTypeUID("bindingId", "thingType");

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -177,10 +177,9 @@ public class ProfileTypeResource implements RESTResource {
 
             Collection<String> supportedItemTypesOfChannelOnProfileType = stateProfileType
                     .getSupportedItemTypesOfChannel();
-            if (supportedItemTypesOfChannelOnProfileType.contains(ItemUtil.getMainItemType(channelType.getItemType()))
-                    || supportedItemTypesOfChannelOnProfileType.contains(channelType.getItemType())) {
-                return true;
-            }
+            String itemType = channelType.getItemType();
+            return itemType != null
+                    && supportedItemTypesOfChannelOnProfileType.contains(ItemUtil.getMainItemType(itemType));
         }
         return false;
     }

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
@@ -33,8 +33,8 @@ import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.io.rest.LocaleServiceImpl;
 import org.openhab.core.thing.profiles.ProfileTypeRegistry;
 import org.openhab.core.thing.profiles.TriggerProfileType;
-import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 
@@ -67,27 +67,22 @@ public class ChannelTypeResourceTest {
     @SuppressWarnings("unchecked")
     @Test
     public void returnLinkableItemTypesForTriggerChannelType() throws IOException {
-        ChannelType channelType = mockChannelType("ct");
-        ChannelTypeUID uid = channelType.getUID();
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID("binding", "ct");
+        ChannelType channelType = ChannelTypeBuilder.trigger(channelTypeUID, "Label").build();
 
-        when(channelTypeRegistry.getChannelType(uid)).thenReturn(channelType);
+        when(channelTypeRegistry.getChannelType(channelTypeUID)).thenReturn(channelType);
 
         TriggerProfileType profileType = mock(TriggerProfileType.class);
-        when(profileType.getSupportedChannelTypeUIDs()).thenReturn(List.of(uid));
+        when(profileType.getSupportedChannelTypeUIDs()).thenReturn(List.of(channelTypeUID));
         when(profileType.getSupportedItemTypes()).thenReturn(List.of("Switch", "Dimmer"));
 
         when(profileTypeRegistry.getProfileTypes()).thenReturn(List.of(profileType));
 
-        Response response = channelTypeResource.getLinkableItemTypes(uid.getAsString());
+        Response response = channelTypeResource.getLinkableItemTypes(channelTypeUID.getAsString());
 
-        verify(channelTypeRegistry).getChannelType(uid);
+        verify(channelTypeRegistry).getChannelType(channelTypeUID);
         verify(profileTypeRegistry).getProfileTypes();
         assertThat(response.getStatus(), is(200));
         assertThat((Set<String>) response.getEntity(), IsIterableContaining.hasItems("Switch", "Dimmer"));
-    }
-
-    private ChannelType mockChannelType(String channelId) {
-        return new ChannelType(new ChannelTypeUID("binding", channelId), false, null, ChannelKind.TRIGGER, "Label",
-                null, null, null, null, null, null);
     }
 }

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
@@ -55,7 +55,7 @@ class ThingValidator extends AbstractThingValidator {
 				val endOffset = thingIdFeature.endOffset
 				getMessageAcceptor().acceptError("Provide a thing UID in this format:\n <bindingId>:<thingTypeId>:<thingId>", thing, startOffset, endOffset - startOffset, null, null)
 			} else {
-				if (thing.id != null) {
+				if (thing.id !== null) {
 					try {
 						new ThingUID(thing.id)
 					} catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
@@ -190,18 +190,20 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
         final ChannelTypeBuilder<?> builder;
         if (cKind == ChannelKind.STATE) {
             builder = ChannelTypeBuilder.state(channelTypeUID, label, itemType).isAdvanced(advanced)
-                    .withCategory(category).withTags(tags).withConfigDescriptionURI(configDescriptionURI)
+                    .withCategory(category).withConfigDescriptionURI(configDescriptionURI)
                     .withStateDescription(stateDescription).withAutoUpdatePolicy(autoUpdatePolicy)
                     .withCommandDescription(commandDescription);
         } else if (cKind == ChannelKind.TRIGGER) {
             builder = ChannelTypeBuilder.trigger(channelTypeUID, label).isAdvanced(advanced).withCategory(category)
-                    .withTags(tags).withConfigDescriptionURI(configDescriptionURI)
-                    .withEventDescription(eventDescription);
+                    .withConfigDescriptionURI(configDescriptionURI).withEventDescription(eventDescription);
         } else {
             throw new IllegalArgumentException(String.format("Unknown channel kind: '%s'", cKind));
         }
         if (description != null) {
             builder.withDescription(description);
+        }
+        if (tags != null) {
+            builder.withTags(tags);
         }
         ChannelType channelType = builder.build();
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.thing;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -75,43 +74,6 @@ public class Channel {
      * @deprecated - use {@link ChannelBuilder} instead
      */
     @Deprecated
-    public Channel(ChannelUID uid, String acceptedItemType) {
-        this.uid = uid;
-        this.acceptedItemType = acceptedItemType;
-        this.kind = ChannelKind.STATE;
-        this.configuration = new Configuration();
-        this.properties = Map.of();
-    }
-
-    /**
-     * @deprecated - use {@link ChannelBuilder} instead
-     */
-    @Deprecated
-    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration) {
-        this(uid, null, acceptedItemType, ChannelKind.STATE, configuration, new HashSet<>(0), null, null, null, null);
-    }
-
-    /**
-     * @deprecated - use {@link ChannelBuilder} instead
-     */
-    @Deprecated
-    public Channel(ChannelUID uid, String acceptedItemType, Set<String> defaultTags) {
-        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, null, null, null, null);
-    }
-
-    /**
-     * @deprecated - use {@link ChannelBuilder} instead
-     */
-    @Deprecated
-    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags,
-            Map<String, String> properties) {
-        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, properties, null, null, null);
-    }
-
-    /**
-     * @deprecated - use ChannelBuilder instead
-     */
-    @Deprecated
     public Channel(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
             ChannelKind kind, @Nullable Configuration configuration, Set<String> defaultTags,
             @Nullable Map<String, String> properties, @Nullable String label, @Nullable String description,
@@ -134,7 +96,7 @@ public class Channel {
      * @return accepted item type
      */
     public @Nullable String getAcceptedItemType() {
-        return this.acceptedItemType;
+        return acceptedItemType;
     }
 
     /**
@@ -152,7 +114,7 @@ public class Channel {
      * @return unique id of the channel
      */
     public ChannelUID getUID() {
-        return this.uid;
+        return uid;
     }
 
     /**
@@ -171,7 +133,7 @@ public class Channel {
      * @return the label for the channel. Can be null.
      */
     public @Nullable String getLabel() {
-        return this.label;
+        return label;
     }
 
     /**
@@ -182,7 +144,7 @@ public class Channel {
      * @return the description for the channel. Can be null.
      */
     public @Nullable String getDescription() {
-        return this.description;
+        return description;
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
@@ -30,8 +30,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class ChannelUID extends UID {
 
-    private static final String CHANNEL_SEGMENT_PATTERN = "[\\w-]*|[\\w-]*#[\\w-]*";
-    private static final String CHANNEL_GROUP_SEPARATOR = "#";
+    public static final String CHANNEL_SEGMENT_PATTERN = "[\\w-]*|[\\w-]*#[\\w-]*";
+    public static final String CHANNEL_GROUP_SEPARATOR = "#";
 
     /**
      * Default constructor in package scope only. Will allow to instantiate this
@@ -45,7 +45,7 @@ public class ChannelUID extends UID {
      * Parses a {@link ChannelUID} for a given string. The UID must be in the format
      * 'bindingId:segment:segment:...'.
      *
-     * @param channelUid uid in form a string (must not be null)
+     * @param channelUid uid in form a string
      */
     public ChannelUID(String channelUid) {
         super(channelUid);
@@ -56,11 +56,6 @@ public class ChannelUID extends UID {
      * @param id the channel's id
      */
     public ChannelUID(ThingUID thingUID, String id) {
-        super(toSegments(thingUID, null, id));
-    }
-
-    @Deprecated
-    public ChannelUID(ThingTypeUID thingTypeUID, ThingUID thingUID, String id) {
         super(toSegments(thingUID, null, id));
     }
 
@@ -79,44 +74,6 @@ public class ChannelUID extends UID {
      */
     public ChannelUID(ThingUID thingUID, String groupId, String id) {
         super(toSegments(thingUID, groupId, id));
-    }
-
-    @Deprecated
-    public ChannelUID(ThingTypeUID thingTypeUID, ThingUID thingUID, String groupId, String id) {
-        super(toSegments(thingUID, groupId, id));
-    }
-
-    /**
-     * @param thingTypeUID the unique id of the thing's thingType
-     * @param thingId the id of the thing the channel belongs to
-     * @param id the channel's id
-     */
-    @Deprecated
-    public ChannelUID(ThingTypeUID thingTypeUID, String thingId, String id) {
-        this(thingTypeUID.getBindingId(), thingTypeUID.getId(), thingId, id);
-    }
-
-    /**
-     * @param bindingId the binding id of the thingType
-     * @param thingTypeId the thing type id of the thing's thingType
-     * @param thingId the id of the thing the channel belongs to
-     * @param id the channel's id
-     */
-    @Deprecated
-    public ChannelUID(String bindingId, String thingTypeId, String thingId, String id) {
-        super(bindingId, thingTypeId, thingId, id);
-    }
-
-    /**
-     * @param bindingId the binding id of the thingType
-     * @param thingTypeId the thing type id of the thing's thingType
-     * @param thingId the id of the thing the channel belongs to
-     * @param groupId the channel's group id
-     * @param id the channel's id
-     */
-    @Deprecated
-    public ChannelUID(String bindingId, String thingTypeId, String thingId, String groupId, String id) {
-        super(bindingId, thingTypeId, thingId, getChannelId(groupId, id));
     }
 
     private static List<String> toSegments(ThingUID thingUID, @Nullable String groupId, String id) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
@@ -40,22 +40,22 @@ import org.openhab.core.thing.binding.ThingHandler;
 public interface Thing extends Identifiable<ThingUID> {
 
     /** the key for the vendor property */
-    String PROPERTY_VENDOR = "vendor";
+    final String PROPERTY_VENDOR = "vendor";
 
     /** the key for the model ID property */
-    String PROPERTY_MODEL_ID = "modelId";
+    final String PROPERTY_MODEL_ID = "modelId";
 
     /** the key for the serial number property */
-    String PROPERTY_SERIAL_NUMBER = "serialNumber";
+    final String PROPERTY_SERIAL_NUMBER = "serialNumber";
 
     /** the key for the hardware version property */
-    String PROPERTY_HARDWARE_VERSION = "hardwareVersion";
+    final String PROPERTY_HARDWARE_VERSION = "hardwareVersion";
 
     /** the key for the firmware version property */
-    String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
+    final String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
 
     /** the key for the MAC address property */
-    String PROPERTY_MAC_ADDRESS = "macAddress";
+    final String PROPERTY_MAC_ADDRESS = "macAddress";
 
     /**
      * Returns the human readable label for this thing.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingUID.java
@@ -15,12 +15,16 @@ package org.openhab.core.thing;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * {@link ThingUID} represents a unique identifier for things.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Jochen Hiller - Bugfix 455434: added default constructor
  */
+@NonNullByDefault
 public class ThingUID extends UID {
 
     private static final String NO_THING_TYPE = "";
@@ -86,7 +90,7 @@ public class ThingUID extends UID {
         super(getArray(bindingId, NO_THING_TYPE, id, bridgeUID.getBridgeIds(), bridgeUID.getId()));
     }
 
-    private static String[] getArray(String bindingId, String thingTypeId, String id, String... bridgeIds) {
+    private static String[] getArray(String bindingId, String thingTypeId, String id, @Nullable String... bridgeIds) {
         if (bridgeIds == null || bridgeIds.length == 0) {
             return new String[] { bindingId, thingTypeId, id };
         }
@@ -129,42 +133,10 @@ public class ThingUID extends UID {
     /**
      * Instantiates a new thing UID.
      *
-     * @param segments segments (must not be null)
+     * @param segments segments
      */
     public ThingUID(String... segments) {
         super(segments);
-    }
-
-    /**
-     * Returns the thing type id.
-     *
-     * @return thing type id
-     * @deprecated use {@link Thing#getThingTypeUID()} instead.
-     */
-    @Deprecated
-    public String getThingTypeId() {
-        String thingType = getSegment(1);
-        if (NO_THING_TYPE.equals(thingType)) {
-            return null;
-        } else {
-            return thingType;
-        }
-    }
-
-    /**
-     * Returns the thing type uid.
-     *
-     * @return thing type uid
-     * @deprecated use {@link Thing#getThingTypeUID()} instead.
-     */
-    @Deprecated
-    public ThingTypeUID getThingTypeUID() {
-        String thingType = getSegment(1);
-        if (NO_THING_TYPE.equals(thingType)) {
-            return null;
-        } else {
-            return new ThingTypeUID(getSegment(0), getSegment(1));
-        }
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
@@ -42,7 +42,7 @@ public abstract class UID extends AbstractUID {
      * Parses a UID for a given string. The UID must be in the format
      * 'bindingId:segment:segment:...'.
      *
-     * @param uid uid in form a string (must not be null)
+     * @param uid uid in form a string
      */
     public UID(String uid) {
         super(uid);
@@ -51,7 +51,7 @@ public abstract class UID extends AbstractUID {
     /**
      * Creates a UID for list of segments.
      *
-     * @param segments segments (must not be null)
+     * @param segments segments
      */
     public UID(String... segments) {
         super(segments);
@@ -60,7 +60,7 @@ public abstract class UID extends AbstractUID {
     /**
      * Creates a UID for list of segments.
      *
-     * @param segments segments (must not be null)
+     * @param segments segments
      */
     protected UID(List<String> segments) {
         super(segments);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -74,9 +74,13 @@ public class ChannelGroupTypeI18nLocalizationService {
 
         ChannelGroupTypeBuilder builder = ChannelGroupTypeBuilder
                 .instance(channelGroupTypeUID, label == null ? defaultLabel : label)
-                .withCategory(channelGroupType.getCategory()).withChannelDefinitions(localizedChannelDefinitions);
+                .withChannelDefinitions(localizedChannelDefinitions);
         if (description != null) {
             builder.withDescription(description);
+        }
+        String category = channelGroupType.getCategory();
+        if (category != null) {
+            builder.withCategory(category);
         }
         return builder.build();
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/AbstractChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/AbstractChannelTypeBuilder.java
@@ -40,7 +40,7 @@ abstract class AbstractChannelTypeBuilder<T extends ChannelTypeBuilder<T>> imple
     protected final Set<String> tags = new HashSet<>();
     protected @Nullable URI configDescriptionURI;
 
-    public AbstractChannelTypeBuilder(ChannelTypeUID channelTypeUID, String label) {
+    protected AbstractChannelTypeBuilder(ChannelTypeUID channelTypeUID, String label) {
         if (channelTypeUID == null) {
             throw new IllegalArgumentException("ChannelTypeUID must be set.");
         }
@@ -79,9 +79,7 @@ abstract class AbstractChannelTypeBuilder<T extends ChannelTypeBuilder<T>> imple
 
     @Override
     public T withTags(Collection<String> tags) {
-        if (tags != null) {
-            this.tags.addAll(tags);
-        }
+        this.tags.addAll(tags);
         return (T) this;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
@@ -15,7 +15,6 @@ package org.openhab.core.thing.internal.type;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
-import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.StateChannelTypeBuilder;
@@ -75,15 +74,11 @@ public class StateChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<Stat
         return this;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public ChannelType build() {
-        if (stateDescriptionFragment != null) {
-            return new ChannelType(channelTypeUID, advanced, itemType, ChannelKind.STATE, label, description, category,
-                    tags.isEmpty() ? null : tags, stateDescriptionFragment.toStateDescription(), null,
-                    configDescriptionURI, autoUpdatePolicy);
-        }
-
-        return new ChannelType(channelTypeUID, advanced, itemType, label, description, category,
-                tags.isEmpty() ? null : tags, commandDescription, configDescriptionURI, autoUpdatePolicy);
+        return new ChannelType(channelTypeUID, advanced, itemType, label, description, category, tags,
+                stateDescriptionFragment != null ? stateDescriptionFragment.toStateDescription() : null,
+                commandDescription, configDescriptionURI, autoUpdatePolicy);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
@@ -14,7 +14,6 @@ package org.openhab.core.thing.internal.type;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.TriggerChannelTypeBuilder;
@@ -41,9 +40,10 @@ public class TriggerChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<Tr
         return this;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public ChannelType build() {
-        return new ChannelType(channelTypeUID, advanced, null, ChannelKind.TRIGGER, label, description, category,
-                tags.isEmpty() ? null : tags, null, eventDescription, configDescriptionURI, null);
+        return new ChannelType(channelTypeUID, advanced, label, description, category, tags, eventDescription,
+                configDescriptionURI);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
@@ -46,7 +46,7 @@ public abstract class AbstractDescriptionType implements Identifiable<UID> {
      */
     public AbstractDescriptionType(UID uid, String label, @Nullable String description)
             throws IllegalArgumentException {
-        if ((label == null) || (label.isEmpty())) {
+        if (label == null || label.isEmpty()) {
             throw new IllegalArgumentException("The label must neither be null nor empty!");
         }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/BridgeType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/BridgeType.java
@@ -37,66 +37,6 @@ import org.openhab.core.thing.ThingTypeUID;
 public class BridgeType extends ThingType {
 
     /**
-     * @deprecated Use {@link ThingTypeBuilder}.buildBridge() instead.
-     *
-     */
-    @Deprecated
-    public BridgeType(String bindingId, String thingTypeId, String label) throws IllegalArgumentException {
-        this(new ThingTypeUID(bindingId, thingTypeId), null, label, null, null, true, null, null, null, null, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use {@link ThingTypeBuilder}.buildBridge() instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty,
-     *             or the the meta information is null
-     */
-    @Deprecated
-    public BridgeType(ThingTypeUID uid, List<String> supportedBridgeTypeUIDs, String label, String description,
-            List<ChannelDefinition> channelDefinitions, List<ChannelGroupDefinition> channelGroupDefinitions,
-            Map<String, String> properties, URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, supportedBridgeTypeUIDs, label, description, null, true, null, channelDefinitions,
-                channelGroupDefinitions, properties, configDescriptionURI);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use {@link ThingTypeBuilder}.buildBridge() instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty,
-     *             or the the meta information is null
-     */
-    @Deprecated
-    public BridgeType(ThingTypeUID uid, List<String> supportedBridgeTypeUIDs, String label, String description,
-            String category, boolean listed, List<ChannelDefinition> channelDefinitions,
-            List<ChannelGroupDefinition> channelGroupDefinitions, Map<String, String> properties,
-            URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, supportedBridgeTypeUIDs, label, description, category, listed, null, channelDefinitions,
-                channelGroupDefinitions, properties, configDescriptionURI);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use {@link ThingTypeBuilder}.buildBridge() instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty,
-     *             or the the meta information is null
-     */
-    @Deprecated
-    public BridgeType(ThingTypeUID uid, @Nullable List<String> supportedBridgeTypeUIDs, String label,
-            @Nullable String description, @Nullable String category, boolean listed,
-            @Nullable String representationProperty, @Nullable List<ChannelDefinition> channelDefinitions,
-            @Nullable List<ChannelGroupDefinition> channelGroupDefinitions, @Nullable Map<String, String> properties,
-            @Nullable URI configDescriptionURI) throws IllegalArgumentException {
-        super(uid, supportedBridgeTypeUIDs, label, description, category, listed, representationProperty,
-                channelDefinitions, channelGroupDefinitions, properties, configDescriptionURI);
-    }
-
-    /**
      * A new instance of BridgeType.
      *
      * @see ThingType(uid, supportedBridgeTypeUIDs, label, description, category, listed, representationProperty,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinition.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinition.java
@@ -46,54 +46,16 @@ public class ChannelDefinition {
      *
      * @param id the identifier of the channel (must neither be null nor empty)
      * @param channelTypeUID the type UID of the channel (must not be null)
-     * @throws IllegalArgumentException if the ID is null or empty, or the type is null
-     * @deprecated use the builder
-     */
-    @Deprecated
-    public ChannelDefinition(String id, ChannelTypeUID channelTypeUID) throws IllegalArgumentException {
-        this(id, channelTypeUID, (String) null, (String) null, null, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @param id the identifier of the channel (must neither be null nor empty)
-     * @param channelTypeUID the type UID of the channel (must not be null)
-     * @param properties the properties this Channel provides (could be null)
-     * @param label the label for the channel to override channelType (could be null)
-     * @param description the description for the channel to override channelType (could be null)
-     * @throws IllegalArgumentException if the ID is null or empty, or the type is null
-     * @deprecated use the builder
-     */
-    @Deprecated
-    public ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable Map<String, String> properties,
-            @Nullable String label, @Nullable String description) throws IllegalArgumentException {
-        this(id, channelTypeUID, label, description, properties, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @param id the identifier of the channel (must neither be null nor empty)
-     * @param channelTypeUID the type UID of the channel (must not be null)
      * @param properties the properties this Channel provides (could be null)
      * @param label the label for the channel to override channelType (could be null)
      * @param description the description for the channel to override channelType (could be null)
      * @param autoUpdatePolicy the auto update policy for the channel to override from the thing type (could be null)
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
-     * @deprecated use the builder
      */
-    @Deprecated
-    public ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable Map<String, String> properties,
-            @Nullable String label, @Nullable String description, @Nullable AutoUpdatePolicy autoUpdatePolicy)
-            throws IllegalArgumentException {
-        this(id, channelTypeUID, label, description, properties, autoUpdatePolicy);
-    }
-
     ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable String label, @Nullable String description,
             @Nullable Map<String, String> properties, @Nullable AutoUpdatePolicy autoUpdatePolicy)
             throws IllegalArgumentException {
-        if ((id == null) || (id.isEmpty())) {
+        if (id == null || id.isEmpty()) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
         }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
@@ -15,6 +15,9 @@ package org.openhab.core.thing.type;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link ChannelGroupType} contains a list of {@link ChannelDefinition}s and further meta information such as label
  * and description, which are generally used by user interfaces.
@@ -25,27 +28,24 @@ import java.util.List;
  * @author Michael Grammling - Initial contribution
  * @author Christoph Weitkamp - Removed "advanced" attribute
  */
+@NonNullByDefault
 public class ChannelGroupType extends AbstractDescriptionType {
 
     private final List<ChannelDefinition> channelDefinitions;
-    private final String category;
+    private final @Nullable String category;
 
     /**
      * Creates a new instance of this class with the specified parameters.
      *
      * @param uid the unique identifier which identifies this channel group type within the
-     *            overall system (must neither be null, nor empty)
      * @param label the human readable label for the according type
-     *            (must neither be null nor empty)
      * @param description the human readable description for the according type
-     *            (could be null or empty)
-     * @param category the category of this channel group type, e.g. Temperature (could be null or empty)
+     * @param category the category of this channel group type, e.g. Temperature
      * @param channelDefinitions the channel definitions this channel group forms
-     *            (could be null or empty)
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
-    ChannelGroupType(ChannelGroupTypeUID uid, String label, String description, String category,
-            List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
+    ChannelGroupType(ChannelGroupTypeUID uid, String label, @Nullable String description, @Nullable String category,
+            @Nullable List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
         super(uid, label, description);
 
         this.category = category;
@@ -58,13 +58,13 @@ public class ChannelGroupType extends AbstractDescriptionType {
      * <p>
      * The returned list is immutable.
      *
-     * @return the channels this Thing type provides (not null, could be empty)
+     * @return the channels this Thing type provides
      */
     public List<ChannelDefinition> getChannelDefinitions() {
         return channelDefinitions;
     }
 
-    public String getCategory() {
+    public @Nullable String getCategory() {
         return category;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeUID.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.type;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.UID;
 
 /**
@@ -19,6 +20,7 @@ import org.openhab.core.thing.UID;
  *
  * @author Michael Grammling - Initial contribution.
  */
+@NonNullByDefault
 public class ChannelGroupTypeUID extends UID {
 
     /**
@@ -33,8 +35,8 @@ public class ChannelGroupTypeUID extends UID {
     /**
      * Creates a new instance of this class with the specified parameter.
      *
-     * @param bindingId the binding ID (must neither be null, nor empty)
-     * @param id the identifier of the channel group (must neither be null, nor empty)
+     * @param bindingId the binding ID
+     * @param id the identifier of the channel group
      */
     public ChannelGroupTypeUID(String bindingId, String id) {
         super(bindingId, id);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
@@ -15,6 +15,8 @@ package org.openhab.core.thing.type;
 import java.net.URI;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.types.CommandDescription;
@@ -31,66 +33,45 @@ import org.openhab.core.types.StateDescription;
  * @author Michael Grammling - Initial contribution
  * @author Henning Treu - add command options
  */
+@NonNullByDefault
 public class ChannelType extends AbstractDescriptionType {
 
     private final boolean advanced;
-    private final String itemType;
+    private final @Nullable String itemType;
     private final ChannelKind kind;
     private final Set<String> tags;
-    private final String category;
-    private final StateDescription state;
-    private final CommandDescription commandDescription;
-    private final EventDescription event;
-    private final URI configDescriptionURI;
-    private final AutoUpdatePolicy autoUpdatePolicy;
+    private final @Nullable String category;
+    private final @Nullable StateDescription state;
+    private final @Nullable CommandDescription commandDescription;
+    private final @Nullable EventDescription event;
+    private final @Nullable URI configDescriptionURI;
+    private final @Nullable AutoUpdatePolicy autoUpdatePolicy;
 
     /**
-     * @deprecated Use the {@link ChannelTypeBuilder} instead.
-     */
-    @Deprecated
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, String label, String description,
-            String category, Set<String> tags, StateDescription state, URI configDescriptionURI) {
-        this(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, state, null,
-                configDescriptionURI);
-    }
-
-    /**
-     * @deprecated Use the {@link ChannelTypeBuilder} instead.
-     */
-    @Deprecated
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, ChannelKind kind, String label,
-            String description, String category, Set<String> tags, StateDescription state, EventDescription event,
-            URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, advanced, itemType, kind, label, description, category, tags, state, event, configDescriptionURI,
-                null);
-    }
-
-    /**
-     * Creates a new instance of a "write-only" {@link ChannelType} with command options. The purpose of this
-     * {@link ChannelType} is to send command to a device without updating the state of the corresponding channel.
-     * E.g. activate a special device mode which is not represented as a definitive state.
+     * Creates a new instance of this class with the specified parameters.
      *
-     * @param uid the unique identifier which identifies this Channel type within
-     *            the overall system (must neither be null, nor empty)
-     * @param advanced true if this channel type contains advanced features, otherwise false
-     * @param itemType the item type of this Channel type, e.g. {@code ColorItem} (must neither be null nor empty)
-     * @param label the human readable label for the according type
-     *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
-     *            (could be null or empty)
-     * @param category the category of this Channel type, e.g. {@code TEMPERATURE} (could be null or empty)
-     * @param tags all tags of this {@link ChannelType}, e.g. {@code Alarm} (could be null or empty)
-     * @param commandDescription a {@link CommandDescription} which should be rendered as push-buttons. The command
-     *            values will be send to the channel from this {@link ChannelType}.
-     * @param configDescriptionURI the link to the concrete ConfigDescription (could be null)
-     * @param autoUpdatePolicy the {@link AutoUpdatePolicy} to use.
-     * @throws IllegalArgumentException if the UID or the item type is null or empty,
-     *             or the meta information is null
+     * @deprecated Use the {@link ChannelTypeBuilder#trigger(ChannelTypeUID, String)} instead.
      */
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, String label, String description,
-            String category, Set<String> tags, CommandDescription commandDescription, URI configDescriptionURI,
-            AutoUpdatePolicy autoUpdatePolicy) {
-        this(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, null, commandDescription,
+    @Deprecated
+    public ChannelType(ChannelTypeUID uid, boolean advanced, String label, @Nullable String description,
+            @Nullable String category, @Nullable Set<String> tags, @Nullable EventDescription event,
+            @Nullable URI configDescriptionURI) throws IllegalArgumentException {
+        this(uid, advanced, null, ChannelKind.TRIGGER, label, description, category, tags, null, null, event,
+                configDescriptionURI, null);
+    }
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @deprecated Use the {@link ChannelTypeBuilder#state(ChannelTypeUID, String, String)} instead.
+     */
+    @Deprecated
+    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, String label,
+            @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
+            @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
+            @Nullable URI configDescriptionURI, @Nullable AutoUpdatePolicy autoUpdatePolicy)
+            throws IllegalArgumentException {
+        this(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, state, commandDescription,
                 null, configDescriptionURI, autoUpdatePolicy);
     }
 
@@ -108,29 +89,20 @@ public class ChannelType extends AbstractDescriptionType {
      *            (could be null or empty)
      * @param category the category of this Channel type, e.g. {@code TEMPERATURE} (could be null or empty)
      * @param tags all tags of this {@link ChannelType}, e.g. {@code Alarm} (could be null or empty)
-     * @param state the restrictions of an item state which gives information how to interpret it
-     *            (could be null)
+     * @param state a {@link StateDescription} of an items state which gives information how to interpret it.
+     * @param commandDescription a {@link CommandDescription} which should be rendered as push-buttons. The command
+     *            values will be send to the channel from this {@link ChannelType}.
      * @param configDescriptionURI the link to the concrete ConfigDescription (could be null)
      * @param autoUpdatePolicy the {@link AutoUpdatePolicy} to use.
      * @throws IllegalArgumentException if the UID or the item type is null or empty,
      *             or the meta information is null
      */
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, ChannelKind kind, String label,
-            String description, String category, Set<String> tags, StateDescription state, EventDescription event,
-            URI configDescriptionURI, AutoUpdatePolicy autoUpdatePolicy) throws IllegalArgumentException {
-        this(uid, advanced, itemType, kind, label, description, category, tags, state, null, event,
-                configDescriptionURI, autoUpdatePolicy);
-    }
-
-    private ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, ChannelKind kind, String label,
-            String description, String category, Set<String> tags, StateDescription state,
-            CommandDescription commandDescription, EventDescription event, URI configDescriptionURI,
-            AutoUpdatePolicy autoUpdatePolicy) throws IllegalArgumentException {
+    ChannelType(ChannelTypeUID uid, boolean advanced, @Nullable String itemType, ChannelKind kind, String label,
+            @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
+            @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
+            @Nullable EventDescription event, @Nullable URI configDescriptionURI,
+            @Nullable AutoUpdatePolicy autoUpdatePolicy) throws IllegalArgumentException {
         super(uid, label, description);
-
-        if (kind == null) {
-            throw new IllegalArgumentException("Kind must not be null!");
-        }
 
         if (kind == ChannelKind.STATE && (itemType == null || itemType.isBlank())) {
             throw new IllegalArgumentException("If the kind is 'state', the item type must be set!");
@@ -143,12 +115,7 @@ public class ChannelType extends AbstractDescriptionType {
         this.kind = kind;
         this.configDescriptionURI = configDescriptionURI;
 
-        if (tags != null) {
-            this.tags = Set.copyOf(tags);
-        } else {
-            this.tags = Set.of();
-        }
-
+        this.tags = tags == null ? Set.of() : Set.copyOf(tags);
         this.advanced = advanced;
         this.category = category;
         this.state = state;
@@ -168,7 +135,7 @@ public class ChannelType extends AbstractDescriptionType {
      * @return the item type of this Channel type, e.g. {@code ColorItem}. Can be null if the channel is a trigger
      *         channel.
      */
-    public String getItemType() {
+    public @Nullable String getItemType() {
         return this.itemType;
     }
 
@@ -184,7 +151,7 @@ public class ChannelType extends AbstractDescriptionType {
     /**
      * Returns all tags of this {@link ChannelType}, e.g. {@code Alarm}.
      *
-     * @return all tags of this Channel type, e.g. {@code Alarm} (not null, could be empty)
+     * @return all tags of this Channel type, e.g. {@code Alarm}
      */
     public Set<String> getTags() {
         return this.tags;
@@ -198,29 +165,27 @@ public class ChannelType extends AbstractDescriptionType {
     /**
      * Returns the link to a concrete {@link ConfigDescription}.
      *
-     * @return the link to a concrete ConfigDescription (could be null)
+     * @return the link to a concrete ConfigDescription
      */
-    public URI getConfigDescriptionURI() {
+    public @Nullable URI getConfigDescriptionURI() {
         return this.configDescriptionURI;
     }
 
     /**
-     * Returns the restrictions of an item state which gives information how to interpret it.
+     * Returns the {@link StateDescription} of an items state which gives information how to interpret it.
      *
-     * @return the restriction of an item state which gives information how to interpret it
-     *         (could be null)
+     * @return the {@link StateDescription}
      */
-    public StateDescription getState() {
+    public @Nullable StateDescription getState() {
         return state;
     }
 
     /**
      * Returns informations about the supported events.
      *
-     * @return the event information
-     *         (could be null)
+     * @return the event information. Can be null if the channel is a state channel.
      */
-    public EventDescription getEvent() {
+    public @Nullable EventDescription getEvent() {
         return event;
     }
 
@@ -238,22 +203,28 @@ public class ChannelType extends AbstractDescriptionType {
     /**
      * Returns the category of this {@link ChannelType}, e.g. {@code TEMPERATURE}.
      *
-     * @return the category of this Channel type, e.g. {@code TEMPERATURE} (could be null or empty)
+     * @return the category of this Channel type, e.g. {@code TEMPERATURE}
      */
-    public String getCategory() {
+    public @Nullable String getCategory() {
         return category;
     }
 
     /**
      * Returns the {@link AutoUpdatePolicy} of for channels of this type.
      *
-     * @return the {@link AutoUpdatePolicy}
+     * @return the {@link AutoUpdatePolicy}. Can be null if the channel is a trigger
+     *         channel.
      */
-    public AutoUpdatePolicy getAutoUpdatePolicy() {
+    public @Nullable AutoUpdatePolicy getAutoUpdatePolicy() {
         return autoUpdatePolicy;
     }
 
-    public CommandDescription getCommandDescription() {
+    /**
+     * Returns the {@link CommandDescription} which should be rendered as push-buttons.
+     *
+     * @return the {@link CommandDescription}
+     */
+    public @Nullable CommandDescription getCommandDescription() {
         return commandDescription;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeProvider.java
@@ -13,7 +13,6 @@
 package org.openhab.core.thing.type;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -39,21 +38,4 @@ public interface ChannelTypeProvider {
      */
     @Nullable
     ChannelType getChannelType(ChannelTypeUID channelTypeUID, @Nullable Locale locale);
-
-    /**
-     * @deprecated The {@link ChannelGroupTypeProvider} is now to be implemented/used instead.
-     */
-    @Deprecated
-    default @Nullable ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID,
-            @Nullable Locale locale) {
-        return null;
-    }
-
-    /**
-     * @deprecated The {@link ChannelGroupTypeProvider} is now to be implemented/used instead.
-     */
-    @Deprecated
-    default Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
-        return Collections.emptyList();
-    }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeUID.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.type;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.UID;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.thing.UID;
  * @author Jochen Hiller - Bugfix 455434: added default constructor
  * @author Dennis Nobel - Javadoc added
  */
+@NonNullByDefault
 public class ChannelTypeUID extends UID {
 
     /**
@@ -43,8 +45,8 @@ public class ChannelTypeUID extends UID {
     /**
      * Creates a new instance of this class with the specified parameter.
      *
-     * @param bindingId the binding ID (must neither be null, nor empty)
-     * @param id the identifier of the channel (must neither be null, nor empty)
+     * @param bindingId the binding ID
+     * @param id the identifier of the channel
      */
     public ChannelTypeUID(String bindingId, String id) {
         super(bindingId, id);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
@@ -51,65 +51,6 @@ public class ThingType extends AbstractDescriptionType {
     private final @Nullable String category;
 
     /**
-     * @deprecated Use the {@link ThingTypeBuilder} instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty, or the the meta information is null
-     */
-    @Deprecated
-    public ThingType(String bindingId, String thingTypeId, String label) throws IllegalArgumentException {
-        this(new ThingTypeUID(bindingId, thingTypeId), null, label, null, null, true, null, null, null, null, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ThingTypeBuilder} instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty, or the the meta information is null
-     */
-    @Deprecated
-    public ThingType(ThingTypeUID uid, List<String> supportedBridgeTypeUIDs, String label, String description,
-            List<ChannelDefinition> channelDefinitions, List<ChannelGroupDefinition> channelGroupDefinitions,
-            Map<String, String> properties, URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, supportedBridgeTypeUIDs, label, description, null, true, null, channelDefinitions,
-                channelGroupDefinitions, properties, configDescriptionURI);
-    }
-
-    /**
-     *
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ThingTypeBuilder} instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty, or the the meta information is null
-     */
-    @Deprecated
-    public ThingType(ThingTypeUID uid, List<String> supportedBridgeTypeUIDs, String label, String description,
-            String category, boolean listed, List<ChannelDefinition> channelDefinitions,
-            List<ChannelGroupDefinition> channelGroupDefinitions, @Nullable Map<String, String> properties,
-            URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, supportedBridgeTypeUIDs, label, description, category, listed, null, channelDefinitions,
-                channelGroupDefinitions, properties, configDescriptionURI);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ThingTypeBuilder} instead.
-     *
-     * @throws IllegalArgumentException if the UID is null or empty, or the the meta information is null
-     */
-    @Deprecated
-    public ThingType(ThingTypeUID uid, @Nullable List<String> supportedBridgeTypeUIDs, String label,
-            @Nullable String description, @Nullable String category, boolean listed,
-            @Nullable String representationProperty, @Nullable List<ChannelDefinition> channelDefinitions,
-            @Nullable List<ChannelGroupDefinition> channelGroupDefinitions, @Nullable Map<String, String> properties,
-            @Nullable URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, supportedBridgeTypeUIDs, label, description, category, listed, representationProperty,
-                channelDefinitions, channelGroupDefinitions, properties, configDescriptionURI, null);
-    }
-
-    /**
      * Creates a new instance of this class with the specified parameters.
      *
      * @param uid the unique identifier which identifies this Thing type within the overall system
@@ -141,37 +82,15 @@ public class ThingType extends AbstractDescriptionType {
         this.category = category;
         this.listed = listed;
         this.representationProperty = representationProperty;
-
-        if (supportedBridgeTypeUIDs != null) {
-            this.supportedBridgeTypeUIDs = Collections.unmodifiableList(supportedBridgeTypeUIDs);
-        } else {
-            this.supportedBridgeTypeUIDs = Collections.emptyList();
-        }
-
-        if (channelDefinitions != null) {
-            this.channelDefinitions = Collections.unmodifiableList(channelDefinitions);
-        } else {
-            this.channelDefinitions = Collections.emptyList();
-        }
-
-        if (channelGroupDefinitions != null) {
-            this.channelGroupDefinitions = Collections.unmodifiableList(channelGroupDefinitions);
-        } else {
-            this.channelGroupDefinitions = Collections.emptyList();
-        }
-
-        if (extensibleChannelTypeIds != null) {
-            this.extensibleChannelTypeIds = Collections.unmodifiableList(extensibleChannelTypeIds);
-        } else {
-            this.extensibleChannelTypeIds = Collections.emptyList();
-        }
-
-        if (properties != null) {
-            this.properties = Collections.unmodifiableMap(properties);
-        } else {
-            this.properties = Collections.emptyMap();
-        }
-
+        this.supportedBridgeTypeUIDs = supportedBridgeTypeUIDs == null ? Collections.emptyList()
+                : Collections.unmodifiableList(supportedBridgeTypeUIDs);
+        this.channelDefinitions = channelDefinitions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(channelDefinitions);
+        this.channelGroupDefinitions = channelGroupDefinitions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(channelGroupDefinitions);
+        this.extensibleChannelTypeIds = extensibleChannelTypeIds == null ? Collections.emptyList()
+                : Collections.unmodifiableList(extensibleChannelTypeIds);
+        this.properties = properties == null ? Collections.emptyMap() : Collections.unmodifiableMap(properties);
         this.configDescriptionURI = configDescriptionURI;
     }
 
@@ -179,7 +98,6 @@ public class ThingType extends AbstractDescriptionType {
      * Returns the unique identifier which identifies this Thing type within the overall system.
      *
      * @return the unique identifier which identifies this Thing type within the overall system
-     *         (not null)
      */
     @Override
     public ThingTypeUID getUID() {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ThingUIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ThingUIDTest.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.core.thing;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,29 +26,31 @@ public class ThingUIDTest {
     @Test
     public void testThreeSegments() {
         ThingTypeUID thingType = new ThingTypeUID("fake", "type");
-        ThingUID t = new ThingUID(thingType, "gaga");
+        ThingUID subject = new ThingUID(thingType, "thing");
 
-        assertEquals("type", t.getThingTypeId());
-        assertEquals("gaga", t.getId());
-        assertEquals("fake:type:gaga", t.getAsString());
+        assertEquals("fake", subject.getBindingId());
+        assertEquals("thing", subject.getId());
+        assertThat(subject.getAllSegments(), hasSize(3));
+        assertEquals("fake:type:thing", subject.getAsString());
     }
 
     @Test
     public void testTwoSegments() {
-        ThingUID t = new ThingUID("fake", "gaga");
+        ThingUID subject = new ThingUID("fake", "thing");
 
-        assertNull(t.getThingTypeId());
-        assertEquals("gaga", t.getId());
-        assertEquals("fake::gaga", t.getAsString());
+        assertEquals("fake", subject.getBindingId());
+        assertEquals("thing", subject.getId());
+        assertThat(subject.getAllSegments(), hasSize(3));
+        assertEquals("fake::thing", subject.getAsString());
     }
 
     @Test
     public void testGetBridgeIds() {
         ThingTypeUID thingType = new ThingTypeUID("fake", "type");
-        ThingUID t = new ThingUID(thingType, new ThingUID("fake", "something", "bridge"), "thing");
+        ThingUID subject = new ThingUID(thingType, new ThingUID("fake", "something", "bridge"), "thing");
 
-        assertEquals("fake:type:bridge:thing", t.getAsString());
-        assertEquals(1, t.getBridgeIds().size());
-        assertEquals("bridge", t.getBridgeIds().get(0));
+        assertEquals("fake:type:bridge:thing", subject.getAsString());
+        assertThat(subject.getBridgeIds(), hasSize(1));
+        assertEquals("bridge", subject.getBridgeIds().get(0));
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public abstract class AbstractUID {
 
-    public static final String SEGMENT_PATTERN = "[A-Za-z0-9_-]*";
+    public static final String SEGMENT_PATTERN = "[\\w-]*";
     public static final String SEPARATOR = ":";
     private final List<String> segments;
 
@@ -43,7 +43,7 @@ public abstract class AbstractUID {
      * Parses a UID for a given string. The UID must be in the format
      * 'bindingId:segment:segment:...'.
      *
-     * @param uid uid in form a string (must not be null)
+     * @param uid uid in form a string
      */
     public AbstractUID(String uid) {
         this(splitToSegments(uid));
@@ -61,7 +61,7 @@ public abstract class AbstractUID {
     /**
      * Creates a UID for list of segments.
      *
-     * @param segments segments (must not be null)
+     * @param segments segments
      */
     public AbstractUID(List<String> segments) {
         int minNumberOfSegments = getMinimalNumberOfSegments();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -54,6 +53,7 @@ import org.openhab.core.thing.type.ChannelGroupType;
 import org.openhab.core.thing.type.ChannelGroupTypeProvider;
 import org.openhab.core.thing.type.ChannelGroupTypeUID;
 import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.ThingType;
@@ -425,9 +425,10 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
 
     private List<ChannelDefinition> getChannelDefinitions(ThingTypeUID thingTypeUID) throws URISyntaxException {
         ChannelTypeUID channelTypeUID = new ChannelTypeUID("test:" + thingTypeUID.getId());
-        ChannelType channelType = new ChannelType(channelTypeUID, false, "itemType", "channelLabel", "description",
-                "category", new HashSet<>(), null, new URI("scheme", "channelType:" + thingTypeUID.getId(), null));
-
+        ChannelType channelType = ChannelTypeBuilder.state(channelTypeUID, "channelLabel", "itemType")
+                .withDescription("description") //
+                .withCategory("category") //
+                .withConfigDescriptionURI(new URI("scheme", "channelType:" + thingTypeUID.getId(), null)).build();
         channelTypes.put(channelTypeUID, channelType);
 
         ChannelDefinition cd = new ChannelDefinitionBuilder("channel" + thingTypeUID.getId(), channelTypeUID).build();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -64,6 +64,7 @@ import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.type.ChannelDefinition;
 import org.openhab.core.thing.type.ChannelDefinitionBuilder;
 import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
 import org.openhab.core.thing.type.ChannelTypeProvider;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
@@ -121,20 +122,24 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         final StateDescription state2 = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                 .withMaximum(BigDecimal.valueOf(256)).withStep(BigDecimal.valueOf(8)).build().toStateDescription();
 
-        final ChannelType channelType = new ChannelType(new ChannelTypeUID("hue:alarm"), false, CoreItemFactory.NUMBER,
-                " ", "", null, null, state, null);
-        final ChannelType channelType2 = new ChannelType(new ChannelTypeUID("hue:num"), false, CoreItemFactory.NUMBER,
-                " ", "", null, null, state2, null);
-        final ChannelType channelType3 = new ChannelType(new ChannelTypeUID("hue:info"), true, CoreItemFactory.STRING,
-                " ", "", null, null, (StateDescription) null, null);
-        final ChannelType channelType4 = new ChannelType(new ChannelTypeUID("hue:color"), false, CoreItemFactory.COLOR,
-                "Color", "", "ColorLight", null, (StateDescription) null, null);
-        final ChannelType channelType5 = new ChannelType(new ChannelTypeUID("hue:brightness"), false,
-                CoreItemFactory.DIMMER, "Brightness", "", "DimmableLight", null, (StateDescription) null, null);
-        final ChannelType channelType6 = new ChannelType(new ChannelTypeUID("hue:switch"), false,
-                CoreItemFactory.SWITCH, "Switch", "", "Light", null, (StateDescription) null, null);
-        final ChannelType channelType7 = new ChannelType(CHANNEL_TYPE_7_UID, false, CoreItemFactory.NUMBER, " ", "",
-                "Light", null, state, null);
+        final ChannelType channelType = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:alarm"), " ", CoreItemFactory.NUMBER).withStateDescription(state)
+                .build();
+        final ChannelType channelType2 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:num"), " ", CoreItemFactory.NUMBER).withStateDescription(state2).build();
+        final ChannelType channelType3 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:info"), " ", CoreItemFactory.STRING).isAdvanced(true).build();
+        final ChannelType channelType4 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:color"), "Color", CoreItemFactory.COLOR).withCategory("ColorLight")
+                .build();
+        final ChannelType channelType5 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:brightness"), "Brightness", CoreItemFactory.DIMMER)
+                .withCategory("DimmableLight").build();
+        final ChannelType channelType6 = ChannelTypeBuilder
+                .state(new ChannelTypeUID("hue:switch"), "Switch", CoreItemFactory.SWITCH).withCategory("Light")
+                .build();
+        final ChannelType channelType7 = ChannelTypeBuilder.state(CHANNEL_TYPE_7_UID, " ", CoreItemFactory.NUMBER)
+                .withCategory("Light").withStateDescription(state).build();
 
         List<ChannelType> channelTypes = new ArrayList<>();
         channelTypes.add(channelType);


### PR DESCRIPTION
- Removed deprecated constructors and methods from Thing API
- Replaced deprecated constructors by related builder where possible

Relates to #1408

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

---

Depends on https://github.com/openhab/openhab-addons/pull/7352
Depends on https://github.com/openhab/openhab-addons/issues/7354
Depends on https://github.com/openhab/openhab-addons/issues/7402
Depends on https://github.com/openhab/org.openhab.binding.zwave/issues/1339