### PR TITLE
[transport.serial] New exception class for serial transport bundle

### DIFF
--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/NoSuchPortException.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/NoSuchPortException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.transport.serial;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Exception that marks that a port does not exist.
+ *
+ * @author Miika Jukka - Initial contribution
+ */
+@NonNullByDefault
+public class NoSuchPortException extends Exception {
+
+    private static final long serialVersionUID = 8908425854301014827L;
+
+    public NoSuchPortException() {
+        super();
+    }
+
+    public NoSuchPortException(String message) {
+        super(message);
+    }
+
+    public NoSuchPortException(Exception cause) {
+        super(cause);
+    }
+
+    public NoSuchPortException(String message, Exception cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Introduce new exception class for `transport.serial` package. Please see issue #1415 .

Signed-off-by: Miika Jukka <github@lantee.eu>