### PR TITLE
Use .equals() on constants and literals to prevent NPEs

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -319,7 +319,7 @@ public class AudioFormat {
             }
 
             // Prefer WAVE container
-            if (!currentAudioFormat.getContainer().equals("WAVE")) {
+            if (!CONTAINER_WAVE.equals(currentAudioFormat.getContainer())) {
                 continue;
             }
 
@@ -341,7 +341,7 @@ public class AudioFormat {
             }
 
             // Prefer WAVE container
-            if (!format.getContainer().equals(AudioFormat.CONTAINER_WAVE)) {
+            if (!CONTAINER_WAVE.equals(format.getContainer())) {
                 continue;
             }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -92,7 +92,7 @@ public class URLAudioStream extends AudioStream {
             }
             URL streamUrl = new URL(url);
             URLConnection connection = streamUrl.openConnection();
-            if (connection.getContentType().equals("unknown/unknown")) {
+            if ("unknown/unknown".equals(connection.getContentType())) {
                 // Java does not parse non-standard headers used by SHOUTCast
                 int port = streamUrl.getPort() > 0 ? streamUrl.getPort() : 80;
                 // Manipulate User-Agent to receive a stream

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -291,7 +291,7 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
 
     @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-        if (uri.toString().equals(CONFIG_URI)) {
+        if (CONFIG_URI.equals(uri.toString())) {
             final Locale safeLocale = locale != null ? locale : Locale.getDefault();
             if (CONFIG_DEFAULT_SOURCE.equals(param)) {
                 return audioSources.values().stream().sorted(comparing(s -> s.getLabel(safeLocale)))

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
@@ -282,7 +282,7 @@ public class OAuthStoreHandlerImpl implements OAuthStoreHandler {
                 }
 
                 // update last used when it is an access token
-                if (recordType.equals(ACCESS_TOKEN_RESPONSE)) {
+                if (ACCESS_TOKEN_RESPONSE.equals(recordType)) {
                     try {
                         AccessTokenResponse accessTokenResponse = gson.fromJson(value, AccessTokenResponse.class);
                         return accessTokenResponse;
@@ -293,7 +293,7 @@ public class OAuthStoreHandlerImpl implements OAuthStoreHandler {
                                 value, e);
                         return null;
                     }
-                } else if (recordType.equals(SERVICE_CONFIGURATION)) {
+                } else if (SERVICE_CONFIGURATION.equals(recordType)) {
                     try {
                         PersistedParams params = gson.fromJson(value, PersistedParams.class);
                         return params;
@@ -301,7 +301,7 @@ public class OAuthStoreHandlerImpl implements OAuthStoreHandler {
                         logger.error("Unable to deserialize json, discarding PersistedParams. json:\n{}", value, e);
                         return null;
                     }
-                } else if (recordType.equals(LAST_USED)) {
+                } else if (LAST_USED.equals(recordType)) {
                     try {
                         LocalDateTime lastUsedDate = gson.fromJson(value, LocalDateTime.class);
                         return lastUsedDate;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
@@ -165,7 +165,7 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
             return obj;
         }
 
-        if (type.equals(AUTOMATION_MANAGER) || type.equals(RULE_REGISTRY)) {
+        if (AUTOMATION_MANAGER.equals(type) || RULE_REGISTRY.equals(type)) {
             RuleSupportRuleRegistryDelegate ruleRegistryDelegate = new RuleSupportRuleRegistryDelegate(ruleRegistry,
                     ruleProvider);
             ScriptedAutomationManager automationManager = new ScriptedAutomationManager(ruleRegistryDelegate,
@@ -191,7 +191,7 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
             scopeValues.put(value, STATIC_TYPES.get(value));
         }
 
-        if (preset.equals(RULE_SUPPORT)) {
+        if (RULE_SUPPORT.equals(preset)) {
             Object automationManager = get(scriptIdentifier, AUTOMATION_MANAGER);
             if (automationManager != null) {
                 scopeValues.put(AUTOMATION_MANAGER, automationManager);

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcher.java
@@ -139,11 +139,11 @@ public class ScriptFileWatcher extends AbstractWatchService {
         if (!file.isHidden()) {
             try {
                 URL fileUrl = file.toURI().toURL();
-                if (kind.equals(ENTRY_DELETE)) {
+                if (ENTRY_DELETE.equals(kind)) {
                     this.removeFile(fileUrl);
                 }
 
-                if (file.canRead() && (kind.equals(ENTRY_CREATE) || kind.equals(ENTRY_MODIFY))) {
+                if (file.canRead() && (ENTRY_CREATE.equals(kind) || ENTRY_MODIFY.equals(kind))) {
                     this.importFile(fileUrl);
                 }
             } catch (MalformedURLException e) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
@@ -202,7 +202,7 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
 
     @Override
     public Map<String, Object> importPreset(String scriptIdentifier, String preset) {
-        if (preset.equals(PRESET_DEFAULT)) {
+        if (PRESET_DEFAULT.equals(preset)) {
             return Collections.unmodifiableMap(elements);
         }
         return Collections.emptyMap();

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
@@ -104,13 +104,13 @@ public class ModuleTypeResource implements RESTResource {
         final String[] tags = tagList != null ? tagList.split(",") : new String[0];
         final List<ModuleTypeDTO> modules = new ArrayList<>();
 
-        if (type == null || type.equals("trigger")) {
+        if (type == null || "trigger".equals(type)) {
             modules.addAll(TriggerTypeDTOMapper.map(moduleTypeRegistry.getTriggers(locale, tags)));
         }
-        if (type == null || type.equals("condition")) {
+        if (type == null || "condition".equals(type)) {
             modules.addAll(ConditionTypeDTOMapper.map(moduleTypeRegistry.getConditions(locale, tags)));
         }
-        if (type == null || type.equals("action")) {
+        if (type == null || "action".equals(type)) {
             modules.addAll(ActionTypeDTOMapper.map(moduleTypeRegistry.getActions(locale, tags)));
         }
         return Response.ok(modules).build();

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -452,11 +452,11 @@ public class RuleResource implements RESTResource {
     }
 
     protected Module getModule(Rule rule, String moduleCategory, String id) {
-        if (moduleCategory.equals("triggers")) {
+        if ("triggers".equals(moduleCategory)) {
             return getTrigger(rule, id);
-        } else if (moduleCategory.equals("conditions")) {
+        } else if ("conditions".equals(moduleCategory)) {
             return getCondition(rule, id);
-        } else if (moduleCategory.equals("actions")) {
+        } else if ("actions".equals(moduleCategory)) {
             return getAction(rule, id);
         } else {
             return null;
@@ -464,13 +464,13 @@ public class RuleResource implements RESTResource {
     }
 
     protected ModuleDTO getModuleDTO(Rule rule, String moduleCategory, String id) {
-        if (moduleCategory.equals("triggers")) {
+        if ("triggers".equals(moduleCategory)) {
             final Trigger trigger = getTrigger(rule, id);
             return trigger == null ? null : TriggerDTOMapper.map(trigger);
-        } else if (moduleCategory.equals("conditions")) {
+        } else if ("conditions".equals(moduleCategory)) {
             final Condition condition = getCondition(rule, id);
             return condition == null ? null : ConditionDTOMapper.map(condition);
-        } else if (moduleCategory.equals("actions")) {
+        } else if ("actions".equals(moduleCategory)) {
             final Action action = getAction(rule, id);
             return action == null ? null : ActionDTOMapper.map(action);
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConnectionValidator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConnectionValidator.java
@@ -264,7 +264,7 @@ public class ConnectionValidator {
         if (outputs != null && !outputs.isEmpty()) {
             for (Output output : outputs) {
                 if (output.getName().equals(outputName)) {
-                    if (input.getType().equals("*")) {
+                    if ("*".equals(input.getType())) {
                         return;
                     } else {
                         try {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -373,7 +373,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                 if (ruleStatus == null) {
                     continue;
                 }
-                if (ruleStatus.equals(RuleStatus.IDLE) || ruleStatus.equals(RuleStatus.RUNNING)) {
+                if (RuleStatus.IDLE.equals(ruleStatus) || RuleStatus.RUNNING.equals(ruleStatus)) {
                     unregister(getManagedRule(rUID), RuleStatusDetail.HANDLER_MISSING_ERROR,
                             "Update Module Type " + moduleType.getUID());
                     setStatus(rUID, new RuleStatusInfo(RuleStatus.INITIALIZING));
@@ -879,7 +879,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     @Override
     public @Nullable Boolean isEnabled(String ruleUID) {
         return getStatus(ruleUID) == null ? null
-                : !getStatusInfo(ruleUID).getStatusDetail().equals(RuleStatusDetail.DISABLED);
+                : !RuleStatusDetail.DISABLED.equals(getStatusInfo(ruleUID).getStatusDetail());
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
@@ -67,13 +67,13 @@ public class RuleEventFactory extends AbstractEventFactory {
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
         logger.trace("creating ruleEvent of type: {}", eventType);
-        if (eventType.equals(RuleAddedEvent.TYPE)) {
+        if (RuleAddedEvent.TYPE.equals(eventType)) {
             return createRuleAddedEvent(topic, payload, source);
-        } else if (eventType.equals(RuleRemovedEvent.TYPE)) {
+        } else if (RuleRemovedEvent.TYPE.equals(eventType)) {
             return createRuleRemovedEvent(topic, payload, source);
-        } else if (eventType.equals(RuleStatusInfoEvent.TYPE)) {
+        } else if (RuleStatusInfoEvent.TYPE.equals(eventType)) {
             return createRuleStatusInfoEvent(topic, payload, source);
-        } else if (eventType.equals(RuleUpdatedEvent.TYPE)) {
+        } else if (RuleUpdatedEvent.TYPE.equals(eventType)) {
             return createRuleUpdatedEvent(topic, payload, source);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandEnableRule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandEnableRule.java
@@ -65,7 +65,7 @@ public class AutomationCommandEnableRule extends AutomationCommand {
                 continue;
             }
             if (parameterValues[i].charAt(0) == '-') {
-                if (parameterValues[i].equals(OPTION_ST)) {
+                if (OPTION_ST.equals(parameterValues[i])) {
                     st = true;
                     continue;
                 }
@@ -93,10 +93,10 @@ public class AutomationCommandEnableRule extends AutomationCommand {
      * @param parameterValue is the value entered from command line.
      */
     private void getEnable(String parameterValue) {
-        if (parameterValue.equals("true")) {
+        if ("true".equals(parameterValue)) {
             enable = true;
             hasEnable = true;
-        } else if (parameterValue.equals("false")) {
+        } else if ("false".equals(parameterValue)) {
             enable = false;
             hasEnable = true;
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandExport.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandExport.java
@@ -163,9 +163,9 @@ public class AutomationCommandExport extends AutomationCommand {
             if (null == parameterValues[i]) {
                 continue;
             }
-            if (parameterValues[i].equals(OPTION_ST)) {
+            if (OPTION_ST.equals(parameterValues[i])) {
                 st = true;
-            } else if (parameterValues[i].equalsIgnoreCase(OPTION_P)) {
+            } else if (OPTION_P.equalsIgnoreCase(parameterValues[i])) {
                 i++;
                 if (i >= parameterValues.length) {
                     return String.format("The option [%s] should be followed by value for the parser type.", OPTION_P);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
@@ -136,9 +136,9 @@ public class AutomationCommandImport extends AutomationCommand {
             if (null == parameterValues[i]) {
                 continue;
             }
-            if (parameterValues[i].equals(OPTION_ST)) {
+            if (OPTION_ST.equals(parameterValues[i])) {
                 st = true;
-            } else if (parameterValues[i].equalsIgnoreCase(OPTION_P)) {
+            } else if (OPTION_P.equalsIgnoreCase(parameterValues[i])) {
                 i++;
                 if (i >= parameterValues.length) {
                     return String.format("The option [%s] should be followed by value for the parser type.", OPTION_P);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
@@ -114,7 +114,7 @@ public class AutomationCommandList extends AutomationCommand {
                 continue;
             }
             if (parameterValues[i].charAt(0) == '-') {
-                if (parameterValues[i].equals(OPTION_ST)) {
+                if (OPTION_ST.equals(parameterValues[i])) {
                     st = true;
                     continue;
                 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
@@ -138,7 +138,7 @@ public class AutomationCommandRemove extends AutomationCommand {
             if (null == parameterValues[i]) {
                 continue;
             }
-            if (parameterValues[i].equals(OPTION_ST)) {
+            if (OPTION_ST.equals(parameterValues[i])) {
                 st = true;
             } else if (parameterValues[i].charAt(0) == '-') {
                 return String.format("Unsupported option: %s", parameterValues[i]);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
@@ -331,46 +331,46 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
 
     @Override
     protected @Nullable AutomationCommand parseCommand(String command, String[] params) {
-        if (command.equalsIgnoreCase(IMPORT_MODULE_TYPES)) {
+        if (IMPORT_MODULE_TYPES.equalsIgnoreCase(command)) {
             return new AutomationCommandImport(IMPORT_MODULE_TYPES, params, MODULE_TYPE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(EXPORT_MODULE_TYPES)) {
+        if (EXPORT_MODULE_TYPES.equalsIgnoreCase(command)) {
             return new AutomationCommandExport(EXPORT_MODULE_TYPES, params, MODULE_TYPE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(LIST_MODULE_TYPES)) {
+        if (LIST_MODULE_TYPES.equalsIgnoreCase(command)) {
             return new AutomationCommandList(LIST_MODULE_TYPES, params, MODULE_TYPE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(IMPORT_TEMPLATES)) {
+        if (IMPORT_TEMPLATES.equalsIgnoreCase(command)) {
             return new AutomationCommandImport(IMPORT_TEMPLATES, params, TEMPLATE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(EXPORT_TEMPLATES)) {
+        if (EXPORT_TEMPLATES.equalsIgnoreCase(command)) {
             return new AutomationCommandExport(EXPORT_TEMPLATES, params, TEMPLATE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(LIST_TEMPLATES)) {
+        if (LIST_TEMPLATES.equalsIgnoreCase(command)) {
             return new AutomationCommandList(LIST_TEMPLATES, params, TEMPLATE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(IMPORT_RULES)) {
+        if (IMPORT_RULES.equalsIgnoreCase(command)) {
             return new AutomationCommandImport(IMPORT_RULES, params, RULE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(EXPORT_RULES)) {
+        if (EXPORT_RULES.equalsIgnoreCase(command)) {
             return new AutomationCommandExport(EXPORT_RULES, params, RULE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(LIST_RULES)) {
+        if (LIST_RULES.equalsIgnoreCase(command)) {
             return new AutomationCommandList(LIST_RULES, params, RULE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(REMOVE_TEMPLATES)) {
+        if (REMOVE_TEMPLATES.equalsIgnoreCase(command)) {
             return new AutomationCommandRemove(REMOVE_TEMPLATES, params, TEMPLATE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(REMOVE_MODULE_TYPES)) {
+        if (REMOVE_MODULE_TYPES.equalsIgnoreCase(command)) {
             return new AutomationCommandRemove(REMOVE_MODULE_TYPES, params, MODULE_TYPE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(REMOVE_RULE)) {
+        if (REMOVE_RULE.equalsIgnoreCase(command)) {
             return new AutomationCommandRemove(REMOVE_RULE, params, RULE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(REMOVE_RULES)) {
+        if (REMOVE_RULES.equalsIgnoreCase(command)) {
             return new AutomationCommandRemove(REMOVE_RULES, params, RULE_REGISTRY, this);
         }
-        if (command.equalsIgnoreCase(ENABLE_RULE)) {
+        if (ENABLE_RULE.equalsIgnoreCase(command)) {
             return new AutomationCommandEnableRule(ENABLE_RULE, params, RULE_REGISTRY, this);
         }
         return null;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
@@ -89,7 +89,7 @@ public class CommandlineModuleTypeProvider extends AbstractCommandProvider<Modul
      */
     @Override
     public @Nullable Object addingService(@SuppressWarnings("rawtypes") @Nullable ServiceReference reference) {
-        if (reference.getProperty(Parser.PARSER_TYPE).equals(Parser.PARSER_MODULE_TYPE)) {
+        if (reference != null && Parser.PARSER_MODULE_TYPE.equals(reference.getProperty(Parser.PARSER_TYPE))) {
             return super.addingService(reference);
         }
         return null;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
@@ -85,7 +85,7 @@ public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTem
      */
     @Override
     public @Nullable Object addingService(@SuppressWarnings("rawtypes") @Nullable ServiceReference reference) {
-        if (reference.getProperty(Parser.PARSER_TYPE).equals(Parser.PARSER_TEMPLATE)) {
+        if (reference != null && Parser.PARSER_TEMPLATE.equals(reference.getProperty(Parser.PARSER_TYPE))) {
             return super.addingService(reference);
         }
         return null;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
@@ -81,7 +81,7 @@ public class CompareConditionHandler extends BaseConditionModuleHandler {
                     case "EQUALS":
                         // EQUALS
                         if (toCompare == null) {
-                            if (rightOperandString.equals("null") || rightOperandString.equals("")) {
+                            if ("null".equals(rightOperandString) || "".equals(rightOperandString)) {
                                 return true;
                             } else {
                                 return false;
@@ -156,7 +156,7 @@ public class CompareConditionHandler extends BaseConditionModuleHandler {
     }
 
     private Object getRightOperandValue(String rightOperandString2, Object toCompare) {
-        if (rightOperandString2.equals("null")) {
+        if ("null".equals(rightOperandString2)) {
             return rightOperandString2;
         }
         if (toCompare instanceof State) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
@@ -45,7 +45,7 @@ public class GenericEventConditionHandler extends BaseConditionModuleHandler {
         Object mo = module.getConfiguration().get(keyParam);
         String configValue = mo != null && mo instanceof String ? (String) mo : null;
         if (configValue != null) {
-            if (keyParam.equals(PAYLOAD)) {
+            if (PAYLOAD.equals(keyParam)) {
                 // automatically adding wildcards only for payload matching
                 configValue = configValue.startsWith("*") ? configValue : ".*" + configValue;
                 configValue = configValue.endsWith("*") ? configValue : configValue + ".*";

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -306,15 +306,9 @@ public abstract class AbstractResourceBundleProvider<@NonNull E> {
      */
     protected String getParserType(URL url) {
         String fileName = url.getPath();
-        int fileExtensionStartIndex = fileName.lastIndexOf(".") + 1;
-        if (fileExtensionStartIndex == -1) {
-            return Parser.FORMAT_JSON;
-        }
-        String fileExtension = fileName.substring(fileExtensionStartIndex);
-        if ("txt".equals(fileExtension)) {
-            return Parser.FORMAT_JSON;
-        }
-        return fileExtension;
+        int index = fileName.lastIndexOf(".");
+        String extension = index != -1 ? fileName.substring(index + 1) : "";
+        return extension.isEmpty() || "txt".equals(extension) ? Parser.FORMAT_JSON : extension;
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -306,15 +306,15 @@ public abstract class AbstractResourceBundleProvider<@NonNull E> {
      */
     protected String getParserType(URL url) {
         String fileName = url.getPath();
-        int fileExtesionStartIndex = fileName.lastIndexOf(".") + 1;
-        if (fileExtesionStartIndex == -1) {
+        int fileExtensionStartIndex = fileName.lastIndexOf(".") + 1;
+        if (fileExtensionStartIndex == -1) {
             return Parser.FORMAT_JSON;
         }
-        String fileExtesion = fileName.substring(fileExtesionStartIndex);
-        if (fileExtesion.equals("txt")) {
+        String fileExtension = fileName.substring(fileExtensionStartIndex);
+        if ("txt".equals(fileExtension)) {
             return Parser.FORMAT_JSON;
         }
-        return fileExtesion;
+        return fileExtension;
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -313,13 +313,8 @@ public abstract class AbstractFileProvider<@NonNull E> implements Provider<E> {
 
     private String getParserType(URL url) {
         String fileName = url.getPath();
-        if (fileName.lastIndexOf(".") == -1) {
-            return Parser.FORMAT_JSON;
-        }
-        String fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        if ("txt".equals(fileExtension)) {
-            return Parser.FORMAT_JSON;
-        }
-        return fileExtension;
+        int index = fileName.lastIndexOf(".");
+        String extension = index != -1 ? fileName.substring(index + 1) : "";
+        return extension.isEmpty() || "txt".equals(extension) ? Parser.FORMAT_JSON : extension;
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -317,7 +317,7 @@ public abstract class AbstractFileProvider<@NonNull E> implements Provider<E> {
             return Parser.FORMAT_JSON;
         }
         String fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        if (fileExtension.equals("txt")) {
+        if ("txt".equals(fileExtension)) {
             return Parser.FORMAT_JSON;
         }
         return fileExtension;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AutomationWatchService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AutomationWatchService.java
@@ -53,7 +53,7 @@ public class AutomationWatchService extends AbstractWatchService {
     protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
         File file = path.toFile();
         if (!file.isHidden()) {
-            if (kind.equals(ENTRY_DELETE)) {
+            if (ENTRY_DELETE.equals(kind)) {
                 provider.removeResources(file);
             } else if (file.canRead()) {
                 provider.importResources(file);

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -129,11 +129,11 @@ public class ReferenceResolverUtilTest {
         Assert.assertTrue(ReferenceResolver.splitReferenceToTokens("").length == 0);
         final String[] referenceTokens = ReferenceResolver
                 .splitReferenceToTokens(".module.array[\".na[m}.\"e\"][1].values1");
-        Assert.assertTrue(referenceTokens[0].equals("module"));
-        Assert.assertTrue(referenceTokens[1].equals("array"));
-        Assert.assertTrue(referenceTokens[2].equals(".na[m}.\"e"));
-        Assert.assertTrue(referenceTokens[3].equals("1"));
-        Assert.assertTrue(referenceTokens[4].equals("values1"));
+        Assert.assertTrue("module".equals(referenceTokens[0]));
+        Assert.assertTrue("array".equals(referenceTokens[1]));
+        Assert.assertTrue(".na[m}.\"e".equals(referenceTokens[2]));
+        Assert.assertTrue("1".equals(referenceTokens[3]));
+        Assert.assertTrue("values1".equals(referenceTokens[4]));
     }
 
     @Test

--- a/bundles/org.openhab.core.boot/src/main/java/org/openhab/core/OpenHAB.java
+++ b/bundles/org.openhab.core.boot/src/main/java/org/openhab/core/OpenHAB.java
@@ -44,7 +44,7 @@ public class OpenHAB {
         // if the version string contains a "snapshot" qualifier, remove it!
         if (StringUtils.countMatches(versionString, ".") == 3) {
             String qualifier = StringUtils.substringAfterLast(versionString, ".");
-            if (StringUtils.isNumeric(qualifier) || qualifier.equals("qualifier")) {
+            if (StringUtils.isNumeric(qualifier) || "qualifier".equals(qualifier)) {
                 versionString = StringUtils.substringBeforeLast(versionString, ".");
             }
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -28,6 +28,8 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.internal.normalization.Normalizer;
 import org.openhab.core.config.core.internal.normalization.NormalizerFactory;
 import org.openhab.core.config.core.validation.ConfigDescriptionValidator;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.ComponentConstants;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -267,7 +269,8 @@ public class ConfigUtil {
      * @param name The configuration parameter name
      */
     private static boolean isOSGiConfigParameter(String name) {
-        return name.equals("objectClass") || name.equals("component.name") || name.equals("component.id");
+        return Constants.OBJECTCLASS.equals(name) || ComponentConstants.COMPONENT_NAME.equals(name)
+                || ComponentConstants.COMPONENT_ID.equals(name);
     }
 
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
@@ -131,33 +131,33 @@ public class ConfigMapper {
         // Handle the conversion case of BigDecimal to Float,Double,Long,Integer and the respective
         // primitive types
         String typeName = type.getSimpleName();
-        if (value instanceof BigDecimal && !type.equals(BigDecimal.class)) {
+        if (value instanceof BigDecimal && !BigDecimal.class.equals(type)) {
             BigDecimal bdValue = (BigDecimal) value;
-            if (type.equals(Float.class) || typeName.equals("float")) {
+            if (Float.class.equals(type) || "float".equals(typeName)) {
                 result = bdValue.floatValue();
-            } else if (type.equals(Double.class) || typeName.equals("double")) {
+            } else if (Double.class.equals(type) || "double".equals(typeName)) {
                 result = bdValue.doubleValue();
-            } else if (type.equals(Long.class) || typeName.equals("long")) {
+            } else if (Long.class.equals(type) || "long".equals(typeName)) {
                 result = bdValue.longValue();
-            } else if (type.equals(Integer.class) || typeName.equals("int")) {
+            } else if (Integer.class.equals(type) || "int".equals(typeName)) {
                 result = bdValue.intValue();
             }
         } else
         // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean and the respective
         // primitive types
-        if (value instanceof String && !type.equals(String.class)) {
+        if (value instanceof String && !String.class.equals(type)) {
             String bdValue = (String) value;
-            if (type.equals(Float.class) || typeName.equals("float")) {
+            if (Float.class.equals(type) || "float".equals(typeName)) {
                 result = Float.valueOf(bdValue);
-            } else if (type.equals(Double.class) || typeName.equals("double")) {
+            } else if (Double.class.equals(type) || "double".equals(typeName)) {
                 result = Double.valueOf(bdValue);
-            } else if (type.equals(Long.class) || typeName.equals("long")) {
+            } else if (Long.class.equals(type) || "long".equals(typeName)) {
                 result = Long.valueOf(bdValue);
-            } else if (type.equals(BigDecimal.class)) {
+            } else if (BigDecimal.class.equals(type)) {
                 result = new BigDecimal(bdValue);
-            } else if (type.equals(Integer.class) || typeName.equals("int")) {
+            } else if (Integer.class.equals(type) || "int".equals(typeName)) {
                 result = Integer.valueOf(bdValue);
-            } else if (type.equals(Boolean.class) || typeName.equals("boolean")) {
+            } else if (Boolean.class.equals(type) || "boolean".equals(typeName)) {
                 result = Boolean.valueOf(bdValue);
             } else if (type.isEnum()) {
                 @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ParameterOption;
 import org.osgi.service.component.annotations.Component;
@@ -33,6 +35,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Simon Kaufmann - Initial contribution
  * @author Erdoan Hadzhiyusein - Added time zone
  */
+@NonNullByDefault
 @Component(immediate = true)
 public class I18nConfigOptionsProvider implements ConfigOptionProvider {
 
@@ -41,15 +44,16 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
     private static final String POSITIVE_OFFSET_FORMAT = "(GMT+%d:%02d) %s";
 
     @Override
-    public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        if (uri.toString().equals("system:i18n")) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+        if ("system:i18n".equals(uri.toString())) {
             Locale translation = locale != null ? locale : Locale.getDefault();
             return processParamType(param, locale, translation);
         }
         return null;
     }
 
-    private Collection<ParameterOption> processParamType(String param, Locale locale, Locale translation) {
+    private @Nullable Collection<ParameterOption> processParamType(String param, @Nullable Locale locale,
+            Locale translation) {
         switch (param) {
             case "language":
                 return getAvailable(locale,
@@ -89,7 +93,8 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
         return result;
     }
 
-    private Collection<ParameterOption> getAvailable(Locale locale, Function<Locale, ParameterOption> mapFunction) {
+    private Collection<ParameterOption> getAvailable(@Nullable Locale locale,
+            Function<Locale, ParameterOption> mapFunction) {
         return Arrays.stream(Locale.getAvailableLocales()).map(l -> mapFunction.apply(l)).distinct()
                 .sorted(Comparator.comparing(a -> a.getLabel())).collect(Collectors.toList());
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.net.CidrAddress;
@@ -32,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 @Component
 public class NetworkConfigOptionProvider implements ConfigOptionProvider {
     static final URI CONFIG_URI = URI.create("system:network");
@@ -39,18 +42,18 @@ public class NetworkConfigOptionProvider implements ConfigOptionProvider {
     static final String PARAM_BROADCAST_ADDRESS = "broadcastAddress";
 
     @Override
-    public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        if (!uri.equals(CONFIG_URI)) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+        if (!CONFIG_URI.equals(uri)) {
             return null;
         }
 
-        if (param.equals(PARAM_PRIMARY_ADDRESS)) {
+        if (PARAM_PRIMARY_ADDRESS.equals(param)) {
             Stream<CidrAddress> ipv4Addresses = NetUtil.getAllInterfaceAddresses().stream()
                     .filter(a -> a.getAddress() instanceof Inet4Address);
             return ipv4Addresses.map(a -> new ParameterOption(a.toString(), a.toString())).collect(Collectors.toList());
         }
 
-        if (param.equals(PARAM_BROADCAST_ADDRESS)) {
+        if (PARAM_BROADCAST_ADDRESS.equals(param)) {
             List<String> broadcastAddrList = new ArrayList<>(NetUtil.getAllBroadcastAddresses());
             broadcastAddrList.add("255.255.255.255");
             return broadcastAddrList.stream().map(a -> new ParameterOption(a, a)).collect(Collectors.toList());

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
@@ -151,7 +151,7 @@ public class ConfigStatusServiceTest extends JavaTest {
         when(configStatusProvider.supportsEntity(anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(0).equals(entityId));
         when(configStatusProvider.getConfigStatus())
-                .thenAnswer(invocation -> entityId.equals(ENTITY_ID1) ? messagesEntity1 : messagesEntity2);
+                .thenAnswer(invocation -> ENTITY_ID1.equals(entityId) ? messagesEntity1 : messagesEntity2);
 
         return configStatusProvider;
     }
@@ -161,7 +161,7 @@ public class ConfigStatusServiceTest extends JavaTest {
         when(translationProvider.getText(any(), anyString(), eq(null), any(), any())).thenAnswer(invocation -> {
             String key = invocation.getArgument(1);
             Locale locale = invocation.getArgument(3);
-            if (locale.equals(LOCALE_DE)) {
+            if (LOCALE_DE.equals(locale)) {
                 if (key.endsWith(MSG_KEY1)) {
                     return MSG1_DE;
                 } else if (key.endsWith(MSG_KEY2)) {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactory.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactory.java
@@ -47,11 +47,11 @@ public class InboxEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        if (eventType.equals(InboxAddedEvent.TYPE)) {
+        if (InboxAddedEvent.TYPE.equals(eventType)) {
             return createAddedEvent(topic, payload);
-        } else if (eventType.equals(InboxRemovedEvent.TYPE)) {
+        } else if (InboxRemovedEvent.TYPE.equals(eventType)) {
             return createRemovedEvent(topic, payload);
-        } else if (eventType.equals(InboxUpdatedEvent.TYPE)) {
+        } else if (InboxUpdatedEvent.TYPE.equals(eventType)) {
             return createUpdatedEvent(topic, payload);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -128,9 +128,9 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
     protected void modified(@Nullable Map<String, @Nullable Object> properties) {
         if (properties != null) {
             Object value = properties.get(AUTO_IGNORE_CONFIG_PROPERTY);
-            autoIgnore = value == null || !value.toString().equals("false");
+            autoIgnore = value == null || !"false".equals(value.toString());
             value = properties.get(ALWAYS_AUTO_APPROVE_CONFIG_PROPERTY);
-            alwaysAutoApprove = value != null && value.toString().equals("true");
+            alwaysAutoApprove = value != null && "true".equals(value.toString());
             autoApproveInboxEntries();
         }
     }
@@ -261,7 +261,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
 
     private void autoApproveInboxEntries() {
         for (DiscoveryResult result : inbox.getAll()) {
-            if (result.getFlag().equals(DiscoveryResultFlag.NEW)) {
+            if (DiscoveryResultFlag.NEW.equals(result.getFlag())) {
                 if (alwaysAutoApprove || isToBeAutoApproved(result)) {
                     inbox.approve(result.getThingUID(), result.getLabel());
                 }
@@ -277,7 +277,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
     protected void addInboxAutoApprovePredicate(InboxAutoApprovePredicate inboxAutoApprovePredicate) {
         inboxAutoApprovePredicates.add(inboxAutoApprovePredicate);
         for (DiscoveryResult result : inbox.getAll()) {
-            if (result.getFlag().equals(DiscoveryResultFlag.NEW) && inboxAutoApprovePredicate.test(result)) {
+            if (DiscoveryResultFlag.NEW.equals(result.getFlag()) && inboxAutoApprovePredicate.test(result)) {
                 inbox.approve(result.getThingUID(), result.getLabel());
             }
         }

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -391,15 +391,15 @@ public class AutomaticInboxProcessorTest {
     @Test
     public void testAutomaticDiscoveryResultApprovalIfInboxEntriesAddedAfterApprovalPredicatesAreAdded() {
         automaticInboxProcessor.addInboxAutoApprovePredicate(
-                discoveryResult -> discoveryResult.getThingTypeUID().equals(THING_TYPE_UID));
+                discoveryResult -> THING_TYPE_UID.equals(discoveryResult.getThingTypeUID()));
 
         // The following discovery result is automatically approved, as it has matching thing type UID
         inbox.add(DiscoveryResultBuilder.create(THING_UID).build());
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID.equals(thing.getUID())));
 
         // The following discovery result is not automatically approved, as it does not have matching thing type UID
         inbox.add(DiscoveryResultBuilder.create(THING_UID3).build());
-        verify(thingRegistry, never()).add(argThat(thing -> thing.getUID().equals(THING_UID3)));
+        verify(thingRegistry, never()).add(argThat(thing -> THING_UID3.equals(thing.getUID())));
     }
 
     @Test
@@ -411,20 +411,20 @@ public class AutomaticInboxProcessorTest {
         // Adding this inboxAutoApprovePredicate will auto-approve the first two discovery results as they have matching
         // thing type UID.
         automaticInboxProcessor.addInboxAutoApprovePredicate(
-                discoveryResult -> discoveryResult.getThingTypeUID().equals(THING_TYPE_UID));
+                discoveryResult -> THING_TYPE_UID.equals(discoveryResult.getThingTypeUID()));
 
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID)));
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID2)));
-        verify(thingRegistry, never()).add(argThat(thing -> thing.getUID().equals(THING_UID3)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID.equals(thing.getUID())));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID2.equals(thing.getUID())));
+        verify(thingRegistry, never()).add(argThat(thing -> THING_UID3.equals(thing.getUID())));
 
         // Adding this inboxAutoApprovePredicate will auto-approve the third discovery results as it has matching
         // thing type UID.
         automaticInboxProcessor.addInboxAutoApprovePredicate(
-                discoveryResult -> discoveryResult.getThingTypeUID().equals(THING_TYPE_UID3));
+                discoveryResult -> THING_TYPE_UID3.equals(discoveryResult.getThingTypeUID()));
 
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID)));
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID2)));
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID3)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID.equals(thing.getUID())));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID2.equals(thing.getUID())));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID3.equals(thing.getUID())));
     }
 
     @Test
@@ -432,18 +432,18 @@ public class AutomaticInboxProcessorTest {
         // Before setting the always auto approve property, existing inbox results are not approved
         inbox.add(DiscoveryResultBuilder.create(THING_UID).build());
 
-        verify(thingRegistry, never()).add(argThat(thing -> thing.getUID().equals(THING_UID)));
+        verify(thingRegistry, never()).add(argThat(thing -> THING_UID.equals(thing.getUID())));
 
         // After setting the always auto approve property, all existing inbox results are approved.
         Map<String, Object> configProperties = new HashMap<>();
         configProperties.put(AutomaticInboxProcessor.ALWAYS_AUTO_APPROVE_CONFIG_PROPERTY, true);
         automaticInboxProcessor.activate(configProperties);
 
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID.equals(thing.getUID())));
 
         // Newly added inbox results are also approved.
         inbox.add(DiscoveryResultBuilder.create(THING_UID2).build());
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID2)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID2.equals(thing.getUID())));
     }
 
     @Test
@@ -453,14 +453,14 @@ public class AutomaticInboxProcessorTest {
             throw new RuntimeException("I am an evil inboxAutoApprovePredicate");
         });
         automaticInboxProcessor.addInboxAutoApprovePredicate(
-                discoveryResult -> discoveryResult.getThingTypeUID().equals(THING_TYPE_UID));
+                discoveryResult -> THING_TYPE_UID.equals(discoveryResult.getThingTypeUID()));
         automaticInboxProcessor.addInboxAutoApprovePredicate(discoveryResult -> {
             throw new RuntimeException("I am another evil inboxAutoApprovePredicate");
         });
 
         // The discovery result is auto-approved in the presence of the evil predicates
         inbox.add(DiscoveryResultBuilder.create(THING_UID).build());
-        verify(thingRegistry, times(1)).add(argThat(thing -> thing.getUID().equals(THING_UID)));
+        verify(thingRegistry, times(1)).add(argThat(thing -> THING_UID.equals(thing.getUID())));
     }
 
 }

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -113,7 +113,7 @@ public class CommandWrapper implements Command, Action {
     public Object execute() throws Exception {
         List<Command> commands = registry.getCommands();
         for (Command command : commands) {
-            if (command.getScope().equals(SCOPE) && command instanceof CommandWrapper) {
+            if (SCOPE.equals(command.getScope()) && command instanceof CommandWrapper) {
                 command.execute(null, Arrays.asList(new Object[] { "--help" }));
             }
         }

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -234,7 +234,7 @@ public class HttpUtil {
         }
 
         // add content if a valid method is given ...
-        if (content != null && (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))) {
+        if (content != null && (HttpMethod.POST.equals(method) || HttpMethod.PUT.equals(method))) {
             // Close this outmost stream again after use!
             try (final InputStreamContentProvider inputStreamContentProvider = new InputStreamContentProvider(
                     content)) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
@@ -169,7 +169,7 @@ public class ConfigurationService {
         Enumeration<String> keys = dictionary.keys();
         while (keys.hasMoreElements()) {
             String key = keys.nextElement();
-            if (!key.equals(Constants.SERVICE_PID)) {
+            if (!Constants.SERVICE_PID.equals(key)) {
                 properties.put(key, dictionary.get(key));
             }
         }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
@@ -78,7 +78,7 @@ public class MetadataSelectorMatcher {
             Collection<ConfigDescription> configDescriptions = configDescriptionRegistry.getConfigDescriptions(locale);
 
             Set<String> configNamespaces = configDescriptions.stream()
-                    .filter(cd -> cd.getUID().getScheme().equals(METADATA_SCHEME)).map(cd -> cd.getUID().toString())
+                    .filter(cd -> METADATA_SCHEME.equals(cd.getUID().getScheme())).map(cd -> cd.getUID().toString())
                     .filter(pattern.asPredicate()).map(uri -> uri.substring(METADATA_SCHEME_PREFIX.length()))
                     .collect(toSet());
 

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -60,21 +60,21 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(1));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> i.getType().equals(CoreItemFactory.NUMBER), URI.create(""), null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()), URI.create(""), null);
         assertThat(dto.members.length, is(1));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> i.getType().equals(CoreItemFactory.NUMBER) || i instanceof GroupItem, URI.create(""), null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, URI.create(""), null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(0));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> i.getType().equals(CoreItemFactory.NUMBER) || i instanceof GroupItem, URI.create(""), null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, URI.create(""), null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(0));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> i.getType().equals(CoreItemFactory.NUMBER) || i.getType().equals(CoreItemFactory.STRING)
+                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i.getType().equals(CoreItemFactory.STRING)
                         || i instanceof GroupItem,
                 URI.create(""), null);
         assertThat(dto.members.length, is(2));

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageChangeListener.java
@@ -237,7 +237,7 @@ public class PageChangeListener implements StateChangeListener {
                     String widgetTypeName = w.eClass().getInstanceTypeName()
                             .substring(w.eClass().getInstanceTypeName().lastIndexOf(".") + 1);
                     boolean drillDown = "mapview".equalsIgnoreCase(widgetTypeName);
-                    Predicate<Item> itemFilter = (i -> i.getType().equals(CoreItemFactory.LOCATION));
+                    Predicate<Item> itemFilter = (i -> CoreItemFactory.LOCATION.equals(i.getType()));
                     event.item = EnrichedItemDTOMapper.map(itemToBeSent, drillDown, itemFilter, null, null);
 
                     // event.state is an adjustment of the item state to the widget type.

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -490,7 +490,7 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
                 String widgetTypeName = widget.eClass().getInstanceTypeName()
                         .substring(widget.eClass().getInstanceTypeName().lastIndexOf(".") + 1);
                 boolean isMapview = "mapview".equalsIgnoreCase(widgetTypeName);
-                Predicate<Item> itemFilter = (i -> i.getType().equals(CoreItemFactory.LOCATION));
+                Predicate<Item> itemFilter = (i -> CoreItemFactory.LOCATION.equals(i.getType()));
                 bean.item = EnrichedItemDTOMapper.map(item, isMapview, itemFilter, UriBuilder.fromUri(uri).build(),
                         locale);
                 bean.state = itemUIRegistry.getState(widget).toFullString();

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -276,7 +276,7 @@ public class MqttBrokerConnectionTests extends JavaTest {
         assertNull(connection.getLastWill());
         assertNull(MqttWillAndTestament.fromString(""));
         connection.setLastWill(MqttWillAndTestament.fromString("topic:message:1:true"));
-        assertTrue(connection.getLastWill().getTopic().equals("topic"));
+        assertEquals("topic", connection.getLastWill().getTopic());
         assertEquals(1, connection.getLastWill().getQos());
         assertEquals(true, connection.getLastWill().isRetain());
         byte b[] = { 'm', 'e', 's', 's', 'a', 'g', 'e' };

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -390,8 +390,8 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
     private Service findService(Device device, String serviceID) {
         Service service = null;
         String namespace = device.getType().getNamespace();
-        if (namespace.equals(UDAServiceId.DEFAULT_NAMESPACE)
-                || namespace.equals(UDAServiceId.BROKEN_DEFAULT_NAMESPACE)) {
+        if (UDAServiceId.DEFAULT_NAMESPACE.equals(namespace)
+                || UDAServiceId.BROKEN_DEFAULT_NAMESPACE.equals(namespace)) {
             service = device.findService(new UDAServiceId(serviceID));
         } else {
             service = device.findService(new ServiceId(namespace, serviceID));

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -472,7 +472,7 @@ public class FeatureInstaller implements ConfigurationListener {
         if (packageName instanceof String) {
             currentPackage = (String) packageName;
             String fullName = PREFIX + PREFIX_PACKAGE + ((String) packageName).trim();
-            if (currentPackage.equals(MINIMAL_PACKAGE)) {
+            if (MINIMAL_PACKAGE.equals(currentPackage)) {
                 // no changes are done to the add-ons list, so the installer should proceed
                 configChanged = false;
             } else {
@@ -510,7 +510,7 @@ public class FeatureInstaller implements ConfigurationListener {
 
     @Override
     public void configurationEvent(ConfigurationEvent event) {
-        if (event.getPid().equals(PAX_URL_PID) && event.getType() == ConfigurationEvent.CM_UPDATED) {
+        if (PAX_URL_PID.equals(event.getPid()) && event.getType() == ConfigurationEvent.CM_UPDATED) {
             paxCfgUpdated = true;
         }
     }

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/valueconverter/ValueTypeToStringConverter.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/valueconverter/ValueTypeToStringConverter.java
@@ -39,7 +39,7 @@ public class ValueTypeToStringConverter implements IValueConverter<Object> {
                 throw new ValueConverterException(e.getMessage(), node, e);
             }
         }
-        if (string.equals("true") || string.equals("false")) {
+        if ("true".equals(string) || "false".equals(string)) {
             return Boolean.valueOf(string);
         }
         try {

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/engine/RuleTriggerManager.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/engine/RuleTriggerManager.java
@@ -29,11 +29,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.openhab.core.items.Item;
-import org.openhab.core.thing.ThingStatus;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
-import org.openhab.core.types.Type;
-import org.openhab.core.types.TypeParser;
 import org.openhab.core.model.rule.rules.ChangedEventTrigger;
 import org.openhab.core.model.rule.rules.CommandEventTrigger;
 import org.openhab.core.model.rule.rules.EventEmittedTrigger;
@@ -49,6 +44,11 @@ import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger;
 import org.openhab.core.model.rule.rules.ThingStateUpdateEventTrigger;
 import org.openhab.core.model.rule.rules.TimerTrigger;
 import org.openhab.core.model.rule.rules.UpdateEventTrigger;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.TypeParser;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.Job;
 import org.quartz.JobDetail;
@@ -781,9 +781,9 @@ public class RuleTriggerManager {
     private void createTimer(Rule rule, TimerTrigger trigger) throws SchedulerException {
         String cronExpression = trigger.getCron();
         if (trigger.getTime() != null) {
-            if (trigger.getTime().equals("noon")) {
+            if ("noon".equals(trigger.getTime())) {
                 cronExpression = "0 0 12 * * ?";
-            } else if (trigger.getTime().equals("midnight")) {
+            } else if ("midnight".equals(trigger.getTime())) {
                 cronExpression = "0 0 0 * * ?";
             } else {
                 logger.warn("Unrecognized time expression '{}' in rule '{}'", trigger.getTime(), rule.getName());

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
@@ -393,7 +393,7 @@ public class NumberExtensions {
     }
 
     private static boolean isAbstractUnitOne(QuantityType<?> left) {
-        return left.getUnit().equals(SmartHomeUnits.ONE);
+        return SmartHomeUnits.ONE.equals(left.getUnit());
     }
 
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -258,7 +258,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, Persi
     @SuppressWarnings("null")
     private void initialize(Item item) {
         // get the last persisted state from the persistence service if no state is yet set
-        if (item.getState().equals(UnDefType.NULL) && item instanceof GenericItem) {
+        if (UnDefType.NULL.equals(item.getState()) && item instanceof GenericItem) {
             for (Entry<String, @Nullable PersistenceServiceConfiguration> entry : persistenceServiceConfigs
                     .entrySet()) {
                 final String serviceName = entry.getKey();

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicBindingConstants.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicBindingConstants.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**
@@ -20,6 +21,7 @@ import org.openhab.core.thing.ThingTypeUID;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicBindingConstants {
 
     public static final String BINDING_ID = "magic";

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
@@ -14,6 +14,7 @@ package org.openhab.core.magic.binding;
 
 import java.net.URI;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.ConfigOptionProvider;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.config.core.ConfigOptionProvider;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public interface MagicService extends ConfigOptionProvider {
 
     static final URI CONFIG_URI = URI.create("test:magic");

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgeHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgeHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingStatus;
@@ -23,6 +24,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicBridgeHandler extends BaseBridgeHandler {
 
     public MagicBridgeHandler(Bridge thing) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgedThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgedThingHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -26,6 +27,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicBridgedThingHandler extends BaseThingHandler {
 
     public MagicBridgedThingHandler(Thing thing) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicColorLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicColorLightHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicColorLightHandler extends BaseThingHandler {
 
     public MagicColorLightHandler(Thing thing) {
@@ -32,9 +34,6 @@ public class MagicColorLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // process the command for the color channel here
-        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_COLOR)) {
-        // }
     }
 
     @Override

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicContactHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicContactHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicContactHandler extends BaseThingHandler {
 
     public MagicContactHandler(Thing thing) {
@@ -32,9 +34,6 @@ public class MagicContactHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // process the command for the contact channel here
-        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_CONTACT)) {
-        // }
     }
 
     @Override

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicDimmableLightHandler extends BaseThingHandler {
 
     public MagicDimmableLightHandler(Thing thing) {
@@ -32,9 +34,6 @@ public class MagicDimmableLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // process the command for the brightness channel here
-        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_BRIGHTNESS)) {
-        // }
     }
 
     @Override

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicImageHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicImageHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.net.http.HttpUtil;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.thing.ChannelUID;
@@ -28,9 +29,10 @@ import org.openhab.core.types.RefreshType;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicImageHandler extends BaseThingHandler {
 
-    private String url;
+    private @NonNullByDefault({}) String url;
 
     public MagicImageHandler(Thing thing) {
         super(thing);
@@ -48,7 +50,7 @@ public class MagicImageHandler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        this.url = (String) getConfig().get("url");
+        url = (String) getConfig().get("url");
         if (url == null || url.isEmpty()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "The URL must not be blank");
         }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicLocationThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicLocationThingHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicLocationThingHandler extends BaseThingHandler {
 
     public MagicLocationThingHandler(Thing thing) {
@@ -32,9 +34,6 @@ public class MagicLocationThingHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // process the command for the location channel here
-        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_LOCATION)) {
-        // }
     }
 
     @Override

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicOnOffLightHandler extends BaseThingHandler {
 
     public MagicOnOffLightHandler(Thing thing) {
@@ -32,9 +34,6 @@ public class MagicOnOffLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        // process the command for the switch channel here
-        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_SWITCH)) {
-        // }
     }
 
     @Override

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnlineOfflineHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnlineOfflineHandler.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -28,11 +29,12 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicOnlineOfflineHandler extends BaseThingHandler {
 
     private static final String TOGGLE_TIME = "toggleTime";
 
-    private ScheduledFuture<?> toggleJob;
+    private @NonNullByDefault({}) ScheduledFuture<?> toggleJob;
 
     public MagicOnlineOfflineHandler(Thing thing) {
         super(thing);

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicPlayerHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicPlayerHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicPlayerHandler extends BaseThingHandler {
 
     public MagicPlayerHandler(Thing thing) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicRolllershutterHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicRolllershutterHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.magic.binding.handler;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -24,6 +25,7 @@ import org.openhab.core.types.Command;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public class MagicRolllershutterHandler extends BaseThingHandler {
 
     public MagicRolllershutterHandler(Thing thing) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicThermostatThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicThermostatThingHandler.java
@@ -39,7 +39,7 @@ public class MagicThermostatThingHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_SET_TEMPERATURE)) {
+        if (CHANNEL_SET_TEMPERATURE.equals(channelUID.getId())) {
             if (command instanceof DecimalType || command instanceof QuantityType) {
                 String state = command.toFullString() + (command instanceof DecimalType ? " °C" : "");
                 scheduler.schedule(() -> {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
@@ -83,64 +83,65 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
     protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(THING_TYPE_EXTENSIBLE_THING)) {
+        if (THING_TYPE_EXTENSIBLE_THING.equals(thingTypeUID)) {
             return new MagicExtensibleThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_ON_OFF_LIGHT)) {
+        if (THING_TYPE_ON_OFF_LIGHT.equals(thingTypeUID)) {
             return new MagicOnOffLightHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_DIMMABLE_LIGHT)) {
+        if (THING_TYPE_DIMMABLE_LIGHT.equals(thingTypeUID)) {
             return new MagicDimmableLightHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_COLOR_LIGHT)) {
+        if (THING_TYPE_COLOR_LIGHT.equals(thingTypeUID)) {
             return new MagicColorLightHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_CONTACT_SENSOR)) {
+        if (THING_TYPE_CONTACT_SENSOR.equals(thingTypeUID)) {
             return new MagicContactHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_CONFIG_THING)) {
+        if (THING_TYPE_CONFIG_THING.equals(thingTypeUID)) {
             return new MagicConfigurableThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_DELAYED_THING)) {
+        if (THING_TYPE_DELAYED_THING.equals(thingTypeUID)) {
             return new MagicDelayedOnlineHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_LOCATION)) {
+        if (THING_TYPE_LOCATION.equals(thingTypeUID)) {
             return new MagicLocationThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_THERMOSTAT)) {
+        if (THING_TYPE_THERMOSTAT.equals(thingTypeUID)) {
             return new MagicThermostatThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_FIRMWARE_UPDATE)) {
+        if (THING_TYPE_FIRMWARE_UPDATE.equals(thingTypeUID)) {
             return new MagicFirmwareUpdateThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_BRIDGED_THING)) {
+        if (THING_TYPE_BRIDGED_THING.equals(thingTypeUID)) {
             return new MagicBridgedThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_CHATTY_THING)) {
+        if (THING_TYPE_CHATTY_THING.equals(thingTypeUID)) {
             return new MagicChattyThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_ROLLERSHUTTER)) {
+        if (THING_TYPE_ROLLERSHUTTER.equals(thingTypeUID)) {
             return new MagicRolllershutterHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_PLAYER)) {
+        if (THING_TYPE_PLAYER.equals(thingTypeUID)) {
             return new MagicPlayerHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_IMAGE)) {
+        if (THING_TYPE_IMAGE.equals(thingTypeUID)) {
             return new MagicImageHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_ACTION_MODULE)) {
+        if (THING_TYPE_ACTION_MODULE.equals(thingTypeUID)) {
             return new MagicActionModuleThingHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_DYNAMIC_STATE_DESCRIPTION)) {
+        if (THING_TYPE_DYNAMIC_STATE_DESCRIPTION.equals(thingTypeUID)) {
             return new MagicDynamicStateDescriptionThingHandler(thing, stateDescriptionProvider);
         }
-        if (thingTypeUID.equals(THING_TYPE_ONLINE_OFFLINE)) {
+        if (THING_TYPE_ONLINE_OFFLINE.equals(thingTypeUID)) {
             return new MagicOnlineOfflineHandler(thing);
         }
-        if (thingTypeUID.equals(THING_TYPE_BRIDGE_1) || thingTypeUID.equals(THING_TYPE_BRIDGE_2)) {
+        if (THING_TYPE_BRIDGE_1.equals(thingTypeUID) || THING_TYPE_BRIDGE_2.equals(thingTypeUID)) {
             return new MagicBridgeHandler((Bridge) thing);
         }
 
         return null;
     }
+
 }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -19,10 +19,14 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.magic.binding.MagicService;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -33,21 +37,24 @@ import org.slf4j.LoggerFactory;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 @Component(configurationPid = "org.openhab.magic", service = ConfigOptionProvider.class, immediate = true, property = {
-        "service.pid=org.openhab.core.magic", "service.config.description.uri=test:magic", "service.config.label=Magic",
-        "service.config.category=test" })
+        Constants.SERVICE_PID + "=org.openhab.core.magic",
+        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=test:magic",
+        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Magic",
+        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=test" })
 public class MagicServiceImpl implements MagicService {
     private final Logger logger = LoggerFactory.getLogger(MagicServiceImpl.class);
 
     static final String PARAMETER_BACKEND_DECIMAL = "select_decimal_limit";
 
     @Override
-    public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        if (!uri.equals(CONFIG_URI)) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+        if (!CONFIG_URI.equals(uri)) {
             return null;
         }
 
-        if (param.equals(PARAMETER_BACKEND_DECIMAL)) {
+        if (PARAMETER_BACKEND_DECIMAL.equals(param)) {
             return Arrays.asList(new ParameterOption(BigDecimal.ONE.toPlainString(), "1"),
                     new ParameterOption(BigDecimal.TEN.toPlainString(), "10"),
                     new ParameterOption(BigDecimal.valueOf(21d).toPlainString(), "21"));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
@@ -61,17 +61,17 @@ public class ThingEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        if (eventType.equals(ThingStatusInfoEvent.TYPE)) {
+        if (ThingStatusInfoEvent.TYPE.equals(eventType)) {
             return createStatusInfoEvent(topic, payload);
-        } else if (eventType.equals(ThingStatusInfoChangedEvent.TYPE)) {
+        } else if (ThingStatusInfoChangedEvent.TYPE.equals(eventType)) {
             return createStatusInfoChangedEvent(topic, payload);
-        } else if (eventType.equals(ThingAddedEvent.TYPE)) {
+        } else if (ThingAddedEvent.TYPE.equals(eventType)) {
             return createAddedEvent(topic, payload);
-        } else if (eventType.equals(ThingRemovedEvent.TYPE)) {
+        } else if (ThingRemovedEvent.TYPE.equals(eventType)) {
             return createRemovedEvent(topic, payload);
-        } else if (eventType.equals(ThingUpdatedEvent.TYPE)) {
+        } else if (ThingUpdatedEvent.TYPE.equals(eventType)) {
             return createUpdatedEvent(topic, payload);
-        } else if (eventType.equals(ChannelTriggeredEvent.TYPE)) {
+        } else if (ChannelTriggeredEvent.TYPE.equals(eventType)) {
             return createTriggerEvent(topic, payload, source);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -103,7 +103,7 @@ public class ChannelStateDescriptionProvider implements StateDescriptionFragment
                     if ((channelType.getItemType() != null)
                             && ((stateDescription == null) || (stateDescription.getPattern() == null))) {
                         String pattern = null;
-                        if (channelType.getItemType().equalsIgnoreCase(CoreItemFactory.STRING)) {
+                        if (CoreItemFactory.STRING.equalsIgnoreCase(channelType.getItemType())) {
                             pattern = "%s";
                         } else if (channelType.getItemType().startsWith(CoreItemFactory.NUMBER)) {
                             pattern = "%.0f";

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
@@ -105,7 +105,7 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 case SUBCMD_ENABLE:
                     if (args.length > 1) {
                         ThingUID thingUID = new ThingUID(args[1]);
-                        enableThing(console, thingUID, subCommand.equals(SUBCMD_ENABLE));
+                        enableThing(console, thingUID, SUBCMD_ENABLE.equals(subCommand));
                     } else {
                         console.println(
                                 "Command '" + subCommand + "' needs argument <thingUID> (e.g. \"hue:light:1\")");

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryImpl.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author Dimitar Ivanov - The firmwares are provided by thing and version
  */
 @Component(immediate = true, service = FirmwareRegistry.class)
-@NonNullByDefault()
+@NonNullByDefault
 public final class FirmwareRegistryImpl implements FirmwareRegistry {
 
     private final Logger logger = LoggerFactory.getLogger(FirmwareRegistryImpl.class);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -135,7 +135,7 @@ public class SystemOffsetProfile implements StateProfile {
                             state, offset);
                 }
                 // take care of temperatures because they start at offset -273°C = 0K
-                if (qtState.getUnit().getSystemUnit().equals(SmartHomeUnits.KELVIN)) {
+                if (SmartHomeUnits.KELVIN.equals(qtState.getUnit().getSystemUnit())) {
                     QuantityType<Temperature> tmp = handleTemperature(qtState, finalOffset);
                     if (tmp != null) {
                         result = tmp;
@@ -147,7 +147,7 @@ public class SystemOffsetProfile implements StateProfile {
             } catch (UnconvertibleException e) {
                 logger.warn("Cannot apply offset '{}' to state '{}' because types do not match.", finalOffset, qtState);
             }
-        } else if (state instanceof DecimalType && finalOffset.getUnit().equals(SmartHomeUnits.ONE)) {
+        } else if (state instanceof DecimalType && SmartHomeUnits.ONE.equals(finalOffset.getUnit())) {
             DecimalType decState = (DecimalType) state;
             result = new DecimalType(decState.doubleValue() + finalOffset.doubleValue());
         } else {
@@ -168,9 +168,9 @@ public class SystemOffsetProfile implements StateProfile {
         QuantityType<Temperature> kelvinState = qtState.toUnit(SmartHomeUnits.KELVIN);
         QuantityType<Temperature> kelvinOffset = offset.toUnit(SmartHomeUnits.KELVIN);
 
-        if (offset.getUnit().equals(SIUnits.CELSIUS)) {
+        if (SIUnits.CELSIUS.equals(offset.getUnit())) {
             finalOffset = kelvinOffset.add(ZERO_CELSIUS_IN_KELVIN.negate());
-        } else if (offset.getUnit().equals(ImperialUnits.FAHRENHEIT)) {
+        } else if (ImperialUnits.FAHRENHEIT.equals(offset.getUnit())) {
             finalOffset = kelvinOffset.add(ZERO_FAHRENHEIT_IN_KELVIN.negate());
         } else {
             // offset is already in kelvin

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
@@ -48,9 +48,9 @@ public class LinkEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        if (eventType.equals(ItemChannelLinkAddedEvent.TYPE)) {
+        if (ItemChannelLinkAddedEvent.TYPE.equals(eventType)) {
             return createItemChannelLinkAddedEvent(topic, payload);
-        } else if (eventType.equals(ItemChannelLinkRemovedEvent.TYPE)) {
+        } else if (ItemChannelLinkRemovedEvent.TYPE.equals(eventType)) {
             return createItemChannelLinkRemovedEvent(topic, payload);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
@@ -144,7 +144,7 @@ public class IconServlet extends SmartHomeServlet {
             return;
         }
 
-        if (format.equals(Format.SVG)) {
+        if (Format.SVG.equals(format)) {
             resp.setContentType("image/svg+xml");
         } else {
             resp.setContentType("image/png");

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
@@ -57,7 +57,7 @@ public class AbstractResourceIconProviderTest {
             protected boolean hasResource(String iconset, String resourceName) {
                 String state = StringUtils.substringAfterLast(resourceName, "-");
                 state = StringUtils.substringBeforeLast(state, ".");
-                return state.equals("30") || state.equals("y z");
+                return "30".equals(state) || "y z".equals(state);
             };
 
             @Override

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -186,8 +186,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         // e.g. the default widget of a rollerblind is "Switch".
         // We want to provide a dedicated default category for it
         // like "rollerblind".
-        if (itemType.equals(NumberItem.class) || itemType.equals(ContactItem.class)
-                || itemType.equals(RollershutterItem.class)) {
+        if (NumberItem.class.equals(itemType) || ContactItem.class.equals(itemType)
+                || RollershutterItem.class.equals(itemType)) {
             return itemType.getSimpleName().replace("Item", "").toLowerCase();
         }
         return null;
@@ -244,47 +244,47 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         boolean readOnly = isReadOnly(itemName);
         int nbOptions = getNbOptions(itemName);
 
-        if (itemType.equals(SwitchItem.class)) {
+        if (SwitchItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createSwitch();
         }
-        if (itemType.equals(GroupItem.class)) {
+        if (GroupItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createGroup();
         }
         if (NumberItem.class.isAssignableFrom(itemType)) {
             return (!readOnly && nbOptions > 0) ? SitemapFactory.eINSTANCE.createSelection()
                     : SitemapFactory.eINSTANCE.createText();
         }
-        if (itemType.equals(ContactItem.class)) {
+        if (ContactItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createText();
         }
-        if (itemType.equals(DateTimeItem.class)) {
+        if (DateTimeItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createText();
         }
-        if (itemType.equals(RollershutterItem.class)) {
+        if (RollershutterItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createSwitch();
         }
-        if (itemType.equals(StringItem.class)) {
+        if (StringItem.class.equals(itemType)) {
             return (!readOnly && nbOptions > 0) ? SitemapFactory.eINSTANCE.createSelection()
                     : SitemapFactory.eINSTANCE.createText();
         }
-        if (itemType.equals(LocationItem.class)) {
+        if (LocationItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createMapview();
         }
-        if (itemType.equals(CallItem.class)) {
+        if (CallItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createText();
         }
-        if (itemType.equals(DimmerItem.class)) {
+        if (DimmerItem.class.equals(itemType)) {
             Slider slider = SitemapFactory.eINSTANCE.createSlider();
             slider.setSwitchEnabled(true);
             return slider;
         }
-        if (itemType.equals(ColorItem.class)) {
+        if (ColorItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createColorpicker();
         }
-        if (itemType.equals(PlayerItem.class)) {
+        if (PlayerItem.class.equals(itemType)) {
             return createPlayerButtons();
         }
-        if (itemType.equals(ImageItem.class)) {
+        if (ImageItem.class.equals(itemType)) {
             return SitemapFactory.eINSTANCE.createImage();
         }
 
@@ -962,7 +962,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             }
         }
 
-        if (unquotedValue.equals(UnDefType.NULL.toString()) || unquotedValue.equals(UnDefType.UNDEF.toString())) {
+        if (UnDefType.NULL.toString().equals(unquotedValue) || UnDefType.UNDEF.toString().equals(unquotedValue)) {
             switch (condition) {
                 case EQUAL:
                     if (unquotedValue.equals(state.toString())) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -335,7 +335,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
             }
 
             // Prefer WAVE container
-            if (!currentAudioFormat.getContainer().equals("WAVE")) {
+            if (!AudioFormat.CONTAINER_WAVE.equals(currentAudioFormat.getContainer())) {
                 continue;
             }
 
@@ -357,7 +357,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
             }
 
             // Prefer WAVE container
-            if (!format.getContainer().equals(AudioFormat.CONTAINER_WAVE)) {
+            if (!AudioFormat.CONTAINER_WAVE.equals(format.getContainer())) {
                 continue;
             }
 
@@ -671,7 +671,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
 
     @Override
     public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        if (uri.toString().equals(CONFIG_URI)) {
+        if (CONFIG_URI.equals(uri.toString())) {
             if (CONFIG_DEFAULT_HLI.equals(param)) {
                 return humanLanguageInterpreters.values().stream()
                         .sorted((hli1, hli2) -> hli1.getLabel(locale).compareToIgnoreCase(hli2.getLabel(locale)))

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -588,7 +588,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             return parts;
         }
         String[] split;
-        if (localeSafe.getLanguage().equalsIgnoreCase(Locale.FRENCH.getLanguage())) {
+        if (Locale.FRENCH.getLanguage().equalsIgnoreCase(localeSafe.getLanguage())) {
             split = text.toLowerCase(localeSafe).replaceAll("[\\']", " ").replaceAll("[^\\w\\sàâäçéèêëîïôùûü]", " ")
                     .split("\\s");
         } else {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -23,6 +23,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.openhab.core.internal.common.WrappedScheduledExecutorService;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,8 +75,8 @@ public class ThreadPoolManager {
 
     protected void modified(Map<String, Object> properties) {
         for (Entry<String, Object> entry : properties.entrySet()) {
-            if (entry.getKey().equals("service.pid") || entry.getKey().equals("component.id")
-                    || entry.getKey().equals("component.name")) {
+            if (Constants.SERVICE_PID.equals(entry.getKey()) || ComponentConstants.COMPONENT_ID.equals(entry.getKey())
+                    || ComponentConstants.COMPONENT_NAME.equals(entry.getKey())) {
                 continue;
             }
             String poolName = entry.getKey();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronAdjuster.java
@@ -78,7 +78,7 @@ class CronAdjuster implements SchedulerTemporalAdjuster {
 
         String cronExpression = entries[entries.length - 1].trim();
 
-        reboot = cronExpression.equals("@reboot");
+        reboot = "@reboot".equals(cronExpression);
 
         if (cronExpression.startsWith("@")) {
             cronExpression = preDeclared(cronExpression);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
@@ -73,21 +73,21 @@ public class ItemEventFactory extends AbstractEventFactory {
 
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
-        if (eventType.equals(ItemCommandEvent.TYPE)) {
+        if (ItemCommandEvent.TYPE.equals(eventType)) {
             return createCommandEvent(topic, payload, source);
-        } else if (eventType.equals(ItemStateEvent.TYPE)) {
+        } else if (ItemStateEvent.TYPE.equals(eventType)) {
             return createStateEvent(topic, payload, source);
-        } else if (eventType.equals(ItemStatePredictedEvent.TYPE)) {
+        } else if (ItemStatePredictedEvent.TYPE.equals(eventType)) {
             return createStatePredictedEvent(topic, payload, source);
-        } else if (eventType.equals(ItemStateChangedEvent.TYPE)) {
+        } else if (ItemStateChangedEvent.TYPE.equals(eventType)) {
             return createStateChangedEvent(topic, payload);
-        } else if (eventType.equals(ItemAddedEvent.TYPE)) {
+        } else if (ItemAddedEvent.TYPE.equals(eventType)) {
             return createAddedEvent(topic, payload);
-        } else if (eventType.equals(ItemUpdatedEvent.TYPE)) {
+        } else if (ItemUpdatedEvent.TYPE.equals(eventType)) {
             return createUpdatedEvent(topic, payload);
-        } else if (eventType.equals(ItemRemovedEvent.TYPE)) {
+        } else if (ItemRemovedEvent.TYPE.equals(eventType)) {
             return createRemovedEvent(topic, payload);
-        } else if (eventType.equals(GroupItemStateChangedEvent.TYPE)) {
+        } else if (GroupItemStateChangedEvent.TYPE.equals(eventType)) {
             return createGroupStateChangedEvent(topic, payload);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/HSBType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/HSBType.java
@@ -385,7 +385,7 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == OnOffType.class) {
             // if brightness is not completely off, we consider the state to be on
-            return target.cast(getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON);
+            return target.cast(PercentType.ZERO.equals(getBrightness()) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == DecimalType.class) {
             return target.cast(new DecimalType(
                     getBrightness().toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP)));

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PointType.java
@@ -179,7 +179,7 @@ public class PointType implements ComplexType, Command, State {
         StringBuilder sb = new StringBuilder(latitude.toPlainString());
         sb.append(',');
         sb.append(longitude.toPlainString());
-        if (!altitude.equals(BigDecimal.ZERO)) {
+        if (!BigDecimal.ZERO.equals(altitude)) {
             sb.append(',');
             sb.append(altitude.toPlainString());
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -232,7 +232,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
         final String formatPattern;
 
         if (pattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
-            String unitSymbol = getUnit().equals(SmartHomeUnits.PERCENT) ? "%%" : getUnit().toString();
+            String unitSymbol = SmartHomeUnits.PERCENT.equals(getUnit()) ? "%%" : getUnit().toString();
             formatPattern = pattern.replace(UnitUtils.UNIT_PLACEHOLDER, unitSymbol);
         } else {
             formatPattern = pattern;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
@@ -154,7 +154,7 @@ public class UnitUtils {
             unitSymbol = pattern.substring(lastBlankIndex).trim();
         }
 
-        if (StringUtils.isNotBlank(unitSymbol) && !unitSymbol.equals(UNIT_PLACEHOLDER)) {
+        if (StringUtils.isNotBlank(unitSymbol) && !UNIT_PLACEHOLDER.equals(unitSymbol)) {
             if (UNIT_PERCENT_FORMAT_STRING.equals(unitSymbol)) {
                 return SmartHomeUnits.PERCENT;
             }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
@@ -103,7 +103,7 @@ public class StateUtil {
         for (State s : getAllStates()) {
             item.setState(s);
             if (item.isAcceptedState(item.getAcceptedDataTypes(), s)) {
-                if (s.equals(UnDefType.NULL)) {
+                if (UnDefType.NULL.equals(s)) {
                     // if we set null, the item should stay null
                     assertEquals(UnDefType.NULL, item.getState());
                 } else {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -135,7 +135,7 @@ public class QuantityTypeTest {
     public void testConvertionOnSameUnit() {
         QuantityType<?> dt2 = QuantityType.valueOf("2 m");
         QuantityType<?> dt3 = dt2.toUnit("m");
-        assertTrue(dt3.getUnit().toString().equalsIgnoreCase("m"));
+        assertTrue("m".equalsIgnoreCase(dt3.getUnit().toString()));
     }
 
     @Test

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -194,25 +194,25 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
 
             assertThat(moduleType1.getOutputs(), is(notNullValue()));
             Optional<Output> output1 = moduleType1.getOutputs().stream()
-                    .filter(o -> o.getName().equals("customTriggerOutput1")).findFirst();
+                    .filter(o -> "customTriggerOutput1".equals(o.getName())).findFirst();
             assertThat(output1.isPresent(), is(true));
             assertThat(output1.get().getDefaultValue(), is("true"));
 
             assertThat(moduleType2.getOutputs(), is(notNullValue()));
             Optional<Output> output2 = moduleType2.getOutputs().stream()
-                    .filter(o -> o.getName().equals("customTriggerOutput2")).findFirst();
+                    .filter(o -> "customTriggerOutput2".equals(o.getName())).findFirst();
             assertThat(output2.isPresent(), is(true));
             assertThat(output2.get().getDefaultValue(), is("event"));
 
             assertThat(moduleType4.getInputs(), is(notNullValue()));
             Optional<Input> input = moduleType4.getInputs().stream()
-                    .filter(o -> o.getName().equals("customActionInput")).findFirst();
+                    .filter(o -> "customActionInput".equals(o.getName())).findFirst();
             assertThat(input.isPresent(), is(true));
             assertThat(input.get().getDefaultValue(), is("5"));
 
             assertThat(moduleType3.getOutputs(), is(notNullValue()));
             Optional<Output> output3 = moduleType3.getOutputs().stream()
-                    .filter(o -> o.getName().equals("customActionOutput3")).findFirst();
+                    .filter(o -> "customActionOutput3".equals(o.getName())).findFirst();
             assertThat(output3.isPresent(), is(true));
             assertThat(output3.get().getDefaultValue(), is("{\"command\":\"OFF\"}"));
         }, 10000, 200);
@@ -243,14 +243,14 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         assertTrue(rule.getTags().contains("item"));
         assertTrue(rule.getTags().contains("rule"));
         Optional<? extends Trigger> trigger = rule.getTriggers().stream()
-                .filter(t -> t.getId().equals("ItemStateChangeTriggerID")).findFirst();
+                .filter(t -> "ItemStateChangeTriggerID".equals(t.getId())).findFirst();
         assertThat(trigger.isPresent(), is(true));
         assertThat(trigger.get().getTypeUID(), is("core.GenericEventTrigger"));
         assertThat(trigger.get().getConfiguration().get("eventSource"), is("myMotionItem"));
         assertThat(trigger.get().getConfiguration().get("eventTopic"), is("smarthome/items/*"));
         assertThat(trigger.get().getConfiguration().get("eventTypes"), is("ItemStateEvent"));
         Optional<? extends Action> action = rule.getActions().stream()
-                .filter(a -> a.getId().equals("ItemPostCommandActionID")).findFirst();
+                .filter(a -> "ItemPostCommandActionID".equals(a.getId())).findFirst();
         assertThat(action.isPresent(), is(true));
         assertThat(action.get().getTypeUID(), is("core.ItemCommandAction"));
         assertThat(action.get().getConfiguration().get("itemName"), is("myLampItem"));
@@ -283,13 +283,13 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         assertTrue(rule.getTags().contains("rule"));
         assertTrue(rule.getTags().contains("references"));
         Optional<? extends Trigger> trigger = rule.getTriggers().stream()
-                .filter(t -> t.getId().equals("ItemStateChangeTriggerID")).findFirst();
+                .filter(t -> "ItemStateChangeTriggerID".equals(t.getId())).findFirst();
         assertThat(trigger.isPresent(), is(true));
         assertThat(trigger.get().getTypeUID(), is("core.GenericEventTrigger"));
         assertThat(trigger.get().getConfiguration().get("eventTopic"), is("smarthome/items/*"));
         assertThat(trigger.get().getConfiguration().get("eventTypes"), is("ItemStateEvent"));
         Optional<? extends Action> action = rule.getActions().stream()
-                .filter(a -> a.getId().equals("ItemPostCommandActionID")).findFirst();
+                .filter(a -> "ItemPostCommandActionID".equals(a.getId())).findFirst();
         assertThat(action.isPresent(), is(true));
         assertThat(action.get().getTypeUID(), is("core.ItemCommandAction"));
         assertThat(action.get().getConfiguration().get("command"), is("ON"));
@@ -365,7 +365,7 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
             @Override
             public void receive(Event e) {
                 logger.info("Event: {}", e.getTopic());
-                if (e.getTopic().equals("smarthome/items/myLampItem/command")) {
+                if ("smarthome/items/myLampItem/command".equals(e.getTopic())) {
                     itemEvent = e;
                 }
             }

--- a/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/ScriptRuleTest.java
+++ b/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/ScriptRuleTest.java
@@ -126,7 +126,7 @@ public class ScriptRuleTest extends JavaOSGiTest {
         Rule rule = ruleRegistry.get("javascript.rule1");
         assertThat(rule, is(notNullValue()));
         assertThat(rule.getName(), is("DemoScriptRule"));
-        Optional<? extends Trigger> trigger = rule.getTriggers().stream().filter(t -> t.getId().equals("trigger"))
+        Optional<? extends Trigger> trigger = rule.getTriggers().stream().filter(t -> "trigger".equals(t.getId()))
                 .findFirst();
         assertThat(trigger.isPresent(), is(true));
         assertThat(trigger.get().getTypeUID(), is("core.GenericEventTrigger"));
@@ -134,12 +134,12 @@ public class ScriptRuleTest extends JavaOSGiTest {
         assertThat(trigger.get().getConfiguration().get("eventTopic"), is("smarthome/items/MyTrigger/state"));
         assertThat(trigger.get().getConfiguration().get("eventTypes"), is("ItemStateEvent"));
         Optional<? extends Condition> condition1 = rule.getConditions().stream()
-                .filter(c -> c.getId().equals("condition")).findFirst();
+                .filter(c -> "condition".equals(c.getId())).findFirst();
         assertThat(condition1.isPresent(), is(true));
         assertThat(condition1.get().getTypeUID(), is("script.ScriptCondition"));
         assertThat(condition1.get().getConfiguration().get("type"), is("application/javascript"));
         assertThat(condition1.get().getConfiguration().get("script"), is("event.itemState==ON"));
-        Optional<? extends Action> action = rule.getActions().stream().filter(a -> a.getId().equals("action"))
+        Optional<? extends Action> action = rule.getActions().stream().filter(a -> "action".equals(a.getId()))
                 .findFirst();
         assertThat(action.isPresent(), is(true));
         assertThat(action.get().getTypeUID(), is("script.ScriptAction"));

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -130,8 +130,8 @@ public class RuntimeRuleTest extends JavaOSGiTest {
                 final RuleStatusInfo ruleStatus = ruleEngine.getStatusInfo(rule.getUID());
                 logger.info("Rule status (should be IDLE or RUNNING): {}", ruleStatus);
                 boolean allFine;
-                if (ruleStatus.getStatus().equals(RuleStatus.IDLE)
-                        || ruleStatus.getStatus().equals(RuleStatus.RUNNING)) {
+                if (RuleStatus.IDLE.equals(ruleStatus.getStatus())
+                        || RuleStatus.RUNNING.equals(ruleStatus.getStatus())) {
                     allFine = true;
                 } else {
                     allFine = false;

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
@@ -196,11 +196,11 @@ public class RuleEventTest extends JavaOSGiTest {
         assertThat(itemEvent.getTopic(), is(equalTo("smarthome/items/myLampItem2/command")));
         assertThat(((ItemCommandEvent) itemEvent).getItemCommand(), is(OnOffType.ON));
         assertThat(ruleEvents.size(), is(not(0)));
-        assertThat(ruleEvents.stream().filter(e -> e.getTopic().equals("smarthome/rules/myRule21/added")).findFirst()
+        assertThat(ruleEvents.stream().filter(e -> "smarthome/rules/myRule21/added".equals(e.getTopic())).findFirst()
                 .isPresent(), is(true));
-        assertThat(ruleEvents.stream().filter(e -> e.getTopic().equals("smarthome/rules/myRule21/state")).findFirst()
+        assertThat(ruleEvents.stream().filter(e -> "smarthome/rules/myRule21/state".equals(e.getTopic())).findFirst()
                 .isPresent(), is(true));
-        List<Event> stateEvents = ruleEvents.stream().filter(e -> e.getTopic().equals("smarthome/rules/myRule21/state"))
+        List<Event> stateEvents = ruleEvents.stream().filter(e -> "smarthome/rules/myRule21/state".equals(e.getTopic()))
                 .collect(Collectors.toList());
         assertThat(stateEvents, is(notNullValue()));
         Optional<Event> runningEvent = stateEvents.stream()

--- a/itests/org.openhab.core.binding.xml.tests/src/main/java/org/openhab/core/binding/xml/test/BindingInfoTest.java
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/java/org/openhab/core/binding/xml/test/BindingInfoTest.java
@@ -90,14 +90,14 @@ public class BindingInfoTest extends JavaOSGiTest {
             List<ConfigDescriptionParameter> parameters = configDescription.getParameters();
             assertThat(parameters.size(), is(2));
 
-            ConfigDescriptionParameter listParameter = parameters.stream().filter(p -> p.getName().equals("list"))
+            ConfigDescriptionParameter listParameter = parameters.stream().filter(p -> "list".equals(p.getName()))
                     .findFirst().get();
             assertThat(listParameter, is(notNullValue()));
             assertThat(listParameter.getOptions().stream().map(p -> p.toString()).collect(Collectors.joining(", ")), is(
                     "ParameterOption [value=\"key1\", label=\"label1\"], ParameterOption [value=\"key2\", label=\"label2\"]"));
 
             ConfigDescriptionParameter lightParameter = parameters.stream()
-                    .filter(p -> p.getName().equals("color-alarming-light")).findFirst().get();
+                    .filter(p -> "color-alarming-light".equals(p.getName())).findFirst().get();
             assertThat(lightParameter, is(notNullValue()));
             assertThat(
                     lightParameter.getFilterCriteria().stream().map(p -> p.toString())

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
@@ -146,7 +146,7 @@ public class GenericThingProviderTest extends JavaOSGiTest {
         assertThat(bulb3, isA(Thing.class));
         assertThat(bulb3.getChannels().size(), is(3));
         Channel firstChannel = bulb3.getChannels().stream()
-                .filter(c -> c.getUID().toString().equals("hue:LCT001:bulb3:notification")).findFirst().get();
+                .filter(c -> "hue:LCT001:bulb3:notification".equals(c.getUID().toString())).findFirst().get();
         assertThat(firstChannel.getUID().toString(), is("hue:LCT001:bulb3:notification"));
         assertThat(firstChannel.getAcceptedItemType(), is("Switch"));
         assertThat(firstChannel.getConfiguration().values().size(), is(1));

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
@@ -128,7 +128,7 @@ public class GenericThingProviderTest3 extends JavaOSGiTest {
 
         ChannelTypeProvider channelTypeProvider = mock(ChannelTypeProvider.class);
         when(channelTypeProvider.getChannelType(any(), nullable(Locale.class))).thenAnswer(invocation -> {
-            if (channelType1.getUID().getId().equals("channel1")) {
+            if ("channel1".equals(channelType1.getUID().getId())) {
                 return channelType1;
             }
             return null;

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -287,7 +287,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         Set<Item> members = rootGroupItem.getMembers(i -> i instanceof GroupItem);
         assertThat(members.size(), is(1));
 
-        members = rootGroupItem.getMembers(i -> i.getLabel().equals("mem1"));
+        members = rootGroupItem.getMembers(i -> "mem1".equals(i.getLabel()));
         assertThat(members.size(), is(2));
     }
 
@@ -447,12 +447,12 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(changes.size(), is(1));
 
         GroupItemStateChangedEvent change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
-        assertTrue(change.getMemberName().equals(member.getName()));
-        assertTrue(change.getTopic().equals(groupitemStateChangedEventTopic.replace("{memberName}", member.getName())
+        assertThat(change.getItemName(), is(groupItem.getName()));
+        assertThat(change.getMemberName(), is(member.getName()));
+        assertThat(change.getTopic(), is(groupitemStateChangedEventTopic.replace("{memberName}", member.getName())
                 .replace("{itemName}", groupItem.getName())));
-        assertTrue(change.getItemState().equals(groupItem.getState()));
-        assertTrue(change.getOldItemState().equals(oldGroupState));
+        assertThat(change.getItemState(), is(groupItem.getState()));
+        assertThat(change.getOldItemState(), is(oldGroupState));
 
         events.clear();
 
@@ -558,11 +558,11 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(changes, hasSize(1));
 
         GroupItemStateChangedEvent change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
+        assertThat(change.getItemName(), is(groupItem.getName()));
 
         // we expect that the group should now have status "ON"
-        assertTrue(change.getOldItemState().equals(UnDefType.NULL));
-        assertTrue(change.getItemState().equals(OnOffType.ON));
+        assertThat(change.getOldItemState(), is(UnDefType.NULL));
+        assertThat(change.getItemState(), is(OnOffType.ON));
 
         assertThat(groupItem.getState(), is(OnOffType.ON));
 
@@ -578,7 +578,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
 
         assertThat(events, hasSize(0));
 
-        assertTrue(groupItem.getState().equals(OnOffType.ON));
+        assertThat(groupItem.getState(), is(OnOffType.ON));
     }
 
     @Test
@@ -605,11 +605,11 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(changes, hasSize(1));
 
         GroupItemStateChangedEvent change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
+        assertThat(change.getItemName(), is(groupItem.getName()));
 
         // we expect that the group should now have status "OFF"
-        assertTrue(change.getOldItemState().equals(UnDefType.NULL));
-        assertTrue(change.getItemState().equals(OnOffType.OFF));
+        assertThat(change.getOldItemState(), is(UnDefType.NULL));
+        assertThat(change.getItemState(), is(OnOffType.OFF));
 
         assertThat(groupItem.getState(), is(OnOffType.OFF));
 
@@ -624,13 +624,13 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(changes, hasSize(1));
 
         change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
+        assertThat(change.getItemName(), is(groupItem.getName()));
 
         // we expect that the group should now have status "ON"
-        assertTrue(change.getOldItemState().equals(OnOffType.OFF));
-        assertTrue(change.getItemState().equals(OnOffType.ON));
+        assertThat(change.getOldItemState(), is(OnOffType.OFF));
+        assertThat(change.getItemState(), is(OnOffType.ON));
 
-        assertTrue(groupItem.getState().equals(OnOffType.ON));
+        assertThat(groupItem.getState(), is(OnOffType.ON));
     }
 
     @SuppressWarnings("deprecation")
@@ -653,7 +653,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
 
         assertThat(events.size(), is(0));
 
-        assertTrue(groupItem.getState().equals(oldGroupState));
+        assertThat(groupItem.getState(), is(oldGroupState));
     }
 
     @Test
@@ -665,7 +665,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         State groupStateAsOnOff = groupItem.getStateAs(OnOffType.class);
 
         // any value >0 means on, so 50% means the group state should be ON
-        assertTrue(OnOffType.ON.equals(groupStateAsOnOff));
+        assertThat(groupStateAsOnOff, is(OnOffType.ON));
     }
 
     @Test
@@ -682,7 +682,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         groupStateAsOnOff = groupItem.getStateAs(OnOffType.class);
 
         // any value >0 means on, so 50% means the group state should be ON
-        assertTrue(OnOffType.ON.equals(groupStateAsOnOff));
+        assertThat(groupStateAsOnOff, is(OnOffType.ON));
     }
 
     @Test
@@ -738,7 +738,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         List<Event> changes = events.stream().filter(it -> it instanceof GroupItemStateChangedEvent)
                 .collect(Collectors.toList());
         GroupItemStateChangedEvent change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
+        assertThat(change.getItemName(), is(groupItem.getName()));
 
         State newEventState = change.getItemState();
         assertTrue(newEventState instanceof PercentType);
@@ -758,7 +758,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(changes.size(), is(1));
 
         change = (GroupItemStateChangedEvent) changes.get(0);
-        assertTrue(change.getItemName().equals(groupItem.getName()));
+        assertThat(change.getItemName(), is(groupItem.getName()));
 
         newEventState = change.getItemState();
         assertTrue(newEventState instanceof PercentType);

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/service/AbstractWatchServiceTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/service/AbstractWatchServiceTest.java
@@ -239,7 +239,7 @@ public class AbstractWatchServiceTest extends JavaTest {
         waitForAssert(() -> assertThat(watchService.allFullEvents.size() >= 1, is(true)), DFL_TIMEOUT * 2,
                 DFL_SLEEP_TIME);
 
-        if (osSpecific && kind.equals(ENTRY_DELETE)) {
+        if (osSpecific && ENTRY_DELETE.equals(kind)) {
             // There is possibility that one more modify event is triggered on some OS
             // so sleep a bit extra time
             Thread.sleep(500);
@@ -272,7 +272,7 @@ public class AbstractWatchServiceTest extends JavaTest {
         // Related discussion in StackOverflow:
         // http://stackoverflow.com/questions/28201283/watchservice-windows-7-when-deleting-a-file-it-fires-both-entry-modify-and-e
         boolean isDeletedWithPrecedingModify = watchService.allFullEvents.size() == 2
-                && watchService.allFullEvents.get(0).eventKind.equals(ENTRY_MODIFY);
+                && ENTRY_MODIFY.equals(watchService.allFullEvents.get(0).eventKind);
         if (isDeletedWithPrecedingModify) {
             // Remove the ENTRY_MODIFY element as it is not needed
             watchService.allFullEvents.remove(0);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -185,10 +185,10 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
 
         @Override
         protected ThingHandler createHandler(Thing thing) {
-            if (thing.getThingTypeUID().equals(THING_TYPE_GENERIC_UID)) {
+            if (THING_TYPE_GENERIC_UID.equals(thing.getThingTypeUID())) {
                 return new GenericThingHandler(thing);
             }
-            if (thing.getThingTypeUID().equals(THING_TYPE_SPECIFIC_UID)) {
+            if (THING_TYPE_SPECIFIC_UID.equals(thing.getThingTypeUID())) {
                 return new SpecificThingHandler(thing);
             }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
@@ -259,7 +259,7 @@ public class FirmwareTest extends JavaOSGiTest {
     @Test
     public void firmwareRestrictedFirmwareIsNotSuitable() {
         Firmware firmware = FirmwareBuilder.create(THING_TYPE_UID, "1.2.3")
-                .withFirmwareRestriction(thing -> thing.getLabel().equals("label")).build();
+                .withFirmwareRestriction(thing -> "label".equals(thing.getLabel())).build();
 
         Thing thing = ThingBuilder.create(THING_TYPE_UID, "thing").withLabel("invalid_label").build();
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
@@ -12,12 +12,10 @@
  */
 package org.openhab.core.thing.firmware;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -70,8 +68,8 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
 
     @Test
     public void firmwareRestrictionExactFirmwareVersion() {
-        FirmwareRestriction firmwareRestrictionFunction = t -> t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION)
-                .equals(FIRMWARE_VERSION_1);
+        FirmwareRestriction firmwareRestrictionFunction = t -> FIRMWARE_VERSION_1
+                .equals(t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         Firmware firmware = FirmwareBuilder.create(thingTypeUID, FIRMWARE_VERSION_2)
                 .withFirmwareRestriction(firmwareRestrictionFunction).build();
@@ -83,8 +81,8 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
 
     @Test
     public void firmwareRestrictionExactHardwareVersion() {
-        FirmwareRestriction hardwareRestrictionFunction = t -> t.getProperties().get(Thing.PROPERTY_HARDWARE_VERSION)
-                .equals(HARDWARE_VERSION_A);
+        FirmwareRestriction hardwareRestrictionFunction = t -> HARDWARE_VERSION_A
+                .equals(t.getProperties().get(Thing.PROPERTY_HARDWARE_VERSION));
 
         Firmware firmware = FirmwareBuilder.create(thingTypeUID, FIRMWARE_VERSION_2)
                 .withFirmwareRestriction(hardwareRestrictionFunction).build();
@@ -97,9 +95,9 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
 
     @Test
     public void firmwareRestrictionExactFirmwareAndHardwareVersion() {
-        FirmwareRestriction fwAndHwRestrictionFunction = t -> t.getProperties().get(Thing.PROPERTY_HARDWARE_VERSION)
-                .equals(HARDWARE_VERSION_A)
-                && t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION).equals(FIRMWARE_VERSION_1);
+        FirmwareRestriction fwAndHwRestrictionFunction = t -> HARDWARE_VERSION_A
+                .equals(t.getProperties().get(Thing.PROPERTY_HARDWARE_VERSION))
+                && FIRMWARE_VERSION_1.equals(t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         Firmware firmware = FirmwareBuilder.create(thingTypeUID, FIRMWARE_VERSION_2)
                 .withFirmwareRestriction(fwAndHwRestrictionFunction).build();
@@ -112,8 +110,8 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
 
     @Test
     public void firmwareRestrictionAndRestrictedModel() {
-        FirmwareRestriction firmwareRestrictionFunction = t -> t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION)
-                .equals(FIRMWARE_VERSION_1);
+        FirmwareRestriction firmwareRestrictionFunction = t -> FIRMWARE_VERSION_1
+                .equals(t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         Firmware firmware = FirmwareBuilder.create(thingTypeUID, FIRMWARE_VERSION_2).withModelRestricted(true)
                 .withModel(TEST_MODEL).withFirmwareRestriction(firmwareRestrictionFunction).build();
@@ -125,8 +123,8 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
 
     @Test
     public void firmwareRestrictionAndPrerequisiteVersion() {
-        FirmwareRestriction firmwareRestrictionFunction = t -> t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION)
-                .equals(FIRMWARE_VERSION_1);
+        FirmwareRestriction firmwareRestrictionFunction = t -> FIRMWARE_VERSION_1
+                .equals(t.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         Firmware firmware = FirmwareBuilder.create(thingTypeUID, FIRMWARE_VERSION_2).withPrerequisiteVersion("0.0.5")
                 .withFirmwareRestriction(firmwareRestrictionFunction).build();
@@ -153,11 +151,11 @@ public class FirmwareUpdateServiceFirmwareRestrictionTest extends JavaOSGiTest {
         // Define restrictions for the hardware versions
         FirmwareRestriction hwVersion1Restriction = thg -> Integer
                 .parseInt(thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION)) < 14
-                || thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION).equals(FW_VERSION_32);
+                || FW_VERSION_32.equals(thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         FirmwareRestriction hwVersion2Restriction = thg -> Integer
                 .parseInt(thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION)) >= 14
-                && !thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION).equals(FW_VERSION_32);
+                && !FW_VERSION_32.equals(thg.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION));
 
         // Build firmwares
         Firmware fw38 = FirmwareBuilder.create(thingTypeUID, FW_VERSION_38)

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -91,14 +91,12 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
     private static final String TEST_BUNDLE_NAME = "thingStatusInfoI18nTest.bundle";
     private static final ChannelTypeUID CHANNEL_TYPE_7_UID = new ChannelTypeUID("hue:num-dynamic");
 
-    private @NonNullByDefault({}) ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService;
+    private @Mock @NonNullByDefault({}) ComponentContext componentContext;
+
     private @NonNullByDefault({}) ItemRegistry itemRegistry;
     private @NonNullByDefault({}) ItemChannelLinkRegistry linkRegistry;
-
-    @Mock
-    private @NonNullByDefault({}) ComponentContext componentContext;
-
     private @NonNullByDefault({}) Bundle testBundle;
+    private @NonNullByDefault({}) ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService;
 
     @Before
     public void setup() throws Exception {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryOSGiTest.java
@@ -141,13 +141,13 @@ public class FirmwareRegistryOSGiTest extends JavaOSGiTest {
 
         @Override
         public @Nullable Set<Firmware> getFirmwares(Thing thing, @Nullable Locale locale) {
-            if (thing.getThingTypeUID().equals(THING_TYPE_UID1)) {
+            if (THING_TYPE_UID1.equals(thing.getThingTypeUID())) {
                 if (Locale.ENGLISH.equals(locale)) {
                     return Collections.singleton(FW111_FIX_EN);
                 } else {
                     return Collections.singleton(FW111_FIX_DE);
                 }
-            } else if (thing.getThingTypeUID().equals(THING_TYPE_UID2)) {
+            } else if (THING_TYPE_UID2.equals(thing.getThingTypeUID())) {
                 if (Locale.ENGLISH.equals(locale)) {
                     return Stream.of(FWALPHA_EN, FWBETA_EN, FWGAMMA_EN).collect(Collectors.toSet());
                 } else {

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
@@ -69,7 +69,7 @@ public class ChannelTypesI18nTest extends JavaOSGiTest {
 
             ChannelType channelType1 = waitForAssert(() -> {
                 final Optional<ChannelType> opt = channelTypeProvider.getChannelTypes(null).stream()
-                        .filter(c -> c.getUID().toString().equals("somebinding:channel-with-i18n")).findFirst();
+                        .filter(c -> "somebinding:channel-with-i18n".equals(c.getUID().toString())).findFirst();
                 assertTrue(opt.isPresent());
                 return opt.get();
             });
@@ -83,7 +83,7 @@ public class ChannelTypesI18nTest extends JavaOSGiTest {
 
             Collection<ChannelGroupType> channelGroupTypes = channelGroupTypeProvider.getChannelGroupTypes(null);
             ChannelGroupType channelGroupType = channelGroupTypes.stream()
-                    .filter(c -> c.getUID().toString().equals("somebinding:channelgroup-with-i18n")).findFirst().get();
+                    .filter(c -> "somebinding:channelgroup-with-i18n".equals(c.getUID().toString())).findFirst().get();
             assertThat(channelGroupType, is(not(nullValue())));
             assertThat(channelGroupType.getLabel(), is(equalTo("Channel Group Label")));
             assertThat(channelGroupType.getDescription(), is(equalTo("Channel Group Description")));
@@ -98,7 +98,7 @@ public class ChannelTypesI18nTest extends JavaOSGiTest {
 
             ThingType thingType = waitForAssert(() -> {
                 Optional<ThingType> thingTypeOpt = thingTypeProvider.getThingTypes(null).stream()
-                        .filter(it -> it.getUID().toString().equals("somebinding:something")).findFirst();
+                        .filter(it -> "somebinding:something".equals(it.getUID().toString())).findFirst();
                 Assert.assertTrue(thingTypeOpt.isPresent());
                 final ThingType thingTypeTmp = thingTypeOpt.get();
                 // assertThat(thingTypeTmp, is(notNullValue()));
@@ -107,12 +107,12 @@ public class ChannelTypesI18nTest extends JavaOSGiTest {
             });
 
             ChannelDefinition channelDefinition1 = thingType.getChannelDefinitions().stream()
-                    .filter(it -> it.getId().equals("channelPlain")).findFirst().get();
+                    .filter(it -> "channelPlain".equals(it.getId())).findFirst().get();
             assertThat(channelDefinition1.getLabel(), is(equalTo("Channel Plain Label")));
             assertThat(channelDefinition1.getDescription(), is(equalTo("Channel Plain Description")));
 
             ChannelDefinition channelDefinition2 = thingType.getChannelDefinitions().stream()
-                    .filter(it -> it.getId().equals("channelInplace")).findFirst().get();
+                    .filter(it -> "channelInplace".equals(it.getId())).findFirst().get();
             assertThat(channelDefinition2.getLabel(), is(equalTo("Channel Inplace Label")));
             assertThat(channelDefinition2.getDescription(), is(equalTo("Channel Inplace Description")));
         }

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
@@ -68,11 +68,11 @@ public class ChannelTypesTest extends JavaOSGiTest {
             });
 
             ChannelType channelType1 = channelTypes.stream()
-                    .filter(it -> it.getUID().toString().equals("somebinding:channel1")).findFirst().get();
+                    .filter(it -> "somebinding:channel1".equals(it.getUID().toString())).findFirst().get();
             assertThat(channelType1, is(not(nullValue())));
 
             ChannelType channelType2 = channelTypes.stream()
-                    .filter(it -> it.getUID().toString().equals("somebinding:channel-without-reference")).findFirst()
+                    .filter(it -> "somebinding:channel-without-reference".equals(it.getUID().toString())).findFirst()
                     .get();
             assertThat(channelType2, is(not(nullValue())));
 
@@ -83,7 +83,7 @@ public class ChannelTypesTest extends JavaOSGiTest {
             });
 
             ChannelGroupType channelGroupType = channelGroupTypes.stream()
-                    .filter(it -> it.getUID().toString().equals("somebinding:channelgroup")).findFirst().get();
+                    .filter(it -> "somebinding:channelgroup".equals(it.getUID().toString())).findFirst().get();
             assertThat(channelGroupType, is(not(nullValue())));
             assertThat(channelGroupType.getCategory(), is("Temperature"));
         }

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
@@ -64,7 +64,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
             Collection<ConfigDescriptionParameter> parameters = bridgeConfigDescription.getParameters();
             assertThat(parameters.size(), is(2));
 
-            ConfigDescriptionParameter ipParameter = parameters.stream().filter(it -> it.getName().equals("ip"))
+            ConfigDescriptionParameter ipParameter = parameters.stream().filter(it -> "ip".equals(it.getName()))
                     .findFirst().get();
             assertThat(ipParameter, is(notNullValue()));
             assertThat(ipParameter.getType(), is(Type.TEXT));
@@ -74,7 +74,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
             assertThat(ipParameter.isRequired(), is(true));
 
             ConfigDescriptionParameter userNameParameter = parameters.stream()
-                    .filter(it -> it.getName().equals("username")).findFirst().get();
+                    .filter(it -> "username".equals(it.getName())).findFirst().get();
             assertThat(userNameParameter, is(notNullValue()));
 
             assertThat(userNameParameter.isAdvanced(), is(true));
@@ -95,14 +95,14 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
             assertThat(parameters.size(), is(1));
 
             ConfigDescriptionParameter lastDimValueParameter = parameters.stream()
-                    .filter(it -> it.getName().equals("lastDimValue")).findFirst().get();
+                    .filter(it -> "lastDimValue".equals(it.getName())).findFirst().get();
             assertThat(lastDimValueParameter, is(notNullValue()));
             assertThat(lastDimValueParameter.getType(), is(Type.BOOLEAN));
 
             Collection<ConfigDescriptionParameterGroup> groups = bridgeConfigDescription.getParameterGroups();
             assertThat(groups.size(), is(2));
 
-            ConfigDescriptionParameterGroup group1 = groups.stream().filter(it -> it.getName().equals("group1"))
+            ConfigDescriptionParameterGroup group1 = groups.stream().filter(it -> "group1".equals(it.getName()))
                     .findFirst().get();
             assertThat(group1, is(notNullValue()));
             assertThat(group1.getContext(), is("Group1-context"));
@@ -122,14 +122,14 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
             Collection<ConfigDescriptionParameter> parameters = bridgeConfigDescription.getParameters();
             assertThat(parameters.size(), is(2));
 
-            ConfigDescriptionParameter unitParameter = parameters.stream().filter(it -> it.getName().equals("unit"))
+            ConfigDescriptionParameter unitParameter = parameters.stream().filter(it -> "unit".equals(it.getName()))
                     .findFirst().get();
             assertThat(unitParameter, is(notNullValue()));
             assertThat(join(unitParameter.getOptions(), ","), is(
                     "ParameterOption [value=\"us\", label=\"US\"],ParameterOption [value=\"metric\", label=\"Metric\"]"));
 
             ConfigDescriptionParameter lightParameter = parameters.stream()
-                    .filter(it -> it.getName().equals("color-alarming-light")).findFirst().get();
+                    .filter(it -> "color-alarming-light".equals(it.getName())).findFirst().get();
             assertThat(lightParameter, is(notNullValue()));
             assertThat(join(lightParameter.getFilterCriteria(), ","), is(
                     "FilterCriteria [name=\"tags\", value=\"alarm, light\"],FilterCriteria [name=\"type\", value=\"color\"],FilterCriteria [name=\"binding-id\", value=\"hue\"]"));

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/SystemChannelsInChannelGroupsTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/SystemChannelsInChannelGroupsTest.java
@@ -66,7 +66,7 @@ public class SystemChannelsInChannelGroupsTest extends JavaOSGiTest {
     public void thingTypesWithSystemChannelsInChannelsGoupsShouldHavePorperChannelDefinitions() throws Exception {
         try (final AutoCloseable unused = loadedTestBundle()) {
             List<ThingType> thingTypes = thingTypeProvider.getThingTypes(null).stream()
-                    .filter(it -> it.getUID().getId().equals("wireless-router")).collect(Collectors.toList());
+                    .filter(it -> "wireless-router".equals(it.getUID().getId())).collect(Collectors.toList());
             assertThat(thingTypes.size(), is(1));
 
             List<ChannelGroupType> channelGroupTypes = channelGroupTypeRegistry.getChannelGroupTypes();
@@ -79,17 +79,17 @@ public class SystemChannelsInChannelGroupsTest extends JavaOSGiTest {
             List<ChannelDefinition> channelDefs = channelGroup.getChannelDefinitions();
 
             List<ChannelDefinition> myChannel = channelDefs.stream().filter(
-                    it -> it.getId().equals("test") && it.getChannelTypeUID().getAsString().equals("system:my-channel"))
+                    it -> "test".equals(it.getId()) && "system:my-channel".equals(it.getChannelTypeUID().getAsString()))
                     .collect(Collectors.toList());
 
             List<ChannelDefinition> sigStr = channelDefs.stream()
-                    .filter(it -> it.getId().equals("sigstr")
-                            && it.getChannelTypeUID().getAsString().equals("system:signal-strength"))
+                    .filter(it -> "sigstr".equals(it.getId())
+                            && "system:signal-strength".equals(it.getChannelTypeUID().getAsString()))
                     .collect(Collectors.toList());
 
             List<ChannelDefinition> lowBat = channelDefs.stream()
-                    .filter(it -> it.getId().equals("lowbat")
-                            && it.getChannelTypeUID().getAsString().equals("system:low-battery"))
+                    .filter(it -> "lowbat".equals(it.getId())
+                            && "system:low-battery".equals(it.getChannelTypeUID().getAsString()))
                     .collect(Collectors.toList());
 
             assertThat(myChannel.size(), is(1));

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/SystemWideChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/SystemWideChannelTypesTest.java
@@ -86,23 +86,23 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
     public void thingTyoesShouldHaveProperChannelDefinitions() throws Exception {
         try (final AutoCloseable unused = loadedSystemChannelsBundle()) {
             ThingType wirelessRouterType = thingTypeProvider.getThingTypes(null).stream()
-                    .filter(it -> it.getUID().getAsString().equals("SystemChannels:wireless-router")).findFirst().get();
+                    .filter(it -> "SystemChannels:wireless-router".equals(it.getUID().getAsString())).findFirst().get();
             assertThat(wirelessRouterType, is(notNullValue()));
 
             Collection<ChannelDefinition> channelDefs = wirelessRouterType.getChannelDefinitions();
             assertThat(channelDefs.size(), is(3));
 
             ChannelDefinition myChannel = channelDefs.stream().filter(
-                    it -> it.getId().equals("test") && it.getChannelTypeUID().getAsString().equals("system:my-channel"))
+                    it -> "test".equals(it.getId()) && "system:my-channel".equals(it.getChannelTypeUID().getAsString()))
                     .findFirst().get();
             assertThat(myChannel, is(notNullValue()));
 
-            ChannelDefinition sigStr = channelDefs.stream().filter(it -> it.getId().equals("sigstr")
-                    && it.getChannelTypeUID().getAsString().equals("system:signal-strength")).findFirst().get();
+            ChannelDefinition sigStr = channelDefs.stream().filter(it -> "sigstr".equals(it.getId())
+                    && "system:signal-strength".equals(it.getChannelTypeUID().getAsString())).findFirst().get();
             assertThat(sigStr, is(notNullValue()));
 
-            ChannelDefinition lowBat = channelDefs.stream().filter(it -> it.getId().equals("lowbat")
-                    && it.getChannelTypeUID().getAsString().equals("system:low-battery")).findFirst().get();
+            ChannelDefinition lowBat = channelDefs.stream().filter(it -> "lowbat".equals(it.getId())
+                    && "system:low-battery".equals(it.getChannelTypeUID().getAsString())).findFirst().get();
             assertThat(lowBat, is(notNullValue()));
         }
     }
@@ -119,23 +119,23 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
             ThingType wirelessRouterType = thingTypes.stream()
-                    .filter(it -> it.getUID().getAsString().equals("SystemChannels:wireless-router")).findFirst().get();
+                    .filter(it -> "SystemChannels:wireless-router".equals(it.getUID().getAsString())).findFirst().get();
             assertNotNull(wirelessRouterType);
 
             List<ChannelDefinition> channelDefs = wirelessRouterType.getChannelDefinitions();
             assertEquals(3, channelDefs.size());
 
             ChannelDefinition myChannel = channelDefs.stream().filter(
-                    it -> it.getId().equals("test") && it.getChannelTypeUID().getAsString().equals("system:my-channel"))
+                    it -> "test".equals(it.getId()) && "system:my-channel".equals(it.getChannelTypeUID().getAsString()))
                     .findFirst().get();
             assertNotNull(myChannel);
 
-            ChannelDefinition sigStr = channelDefs.stream().filter(it -> it.getId().equals("sigstr")
-                    && it.getChannelTypeUID().getAsString().equals("system:signal-strength")).findFirst().get();
+            ChannelDefinition sigStr = channelDefs.stream().filter(it -> "sigstr".equals(it.getId())
+                    && "system:signal-strength".equals(it.getChannelTypeUID().getAsString())).findFirst().get();
             assertNotNull(sigStr);
 
-            ChannelDefinition lowBat = channelDefs.stream().filter(it -> it.getId().equals("lowbat")
-                    && it.getChannelTypeUID().getAsString().equals("system:low-battery")).findFirst().get();
+            ChannelDefinition lowBat = channelDefs.stream().filter(it -> "lowbat".equals(it.getId())
+                    && "system:low-battery".equals(it.getChannelTypeUID().getAsString())).findFirst().get();
             assertNotNull(lowBat);
 
             ChannelType lowBatType = systemChannelTypeProvider.getChannelType(lowBat.getChannelTypeUID(),

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypeI18nTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypeI18nTest.java
@@ -62,7 +62,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
         try (final AutoCloseable unused = loadedTestBundle()) {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
-            ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
+            ThingType weatherType = thingTypes.stream().filter(it -> "yahooweather:weather".equals(it.toString()))
                     .findFirst().get();
             assertNotNull(weatherType);
 
@@ -78,7 +78,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
             ThingType weatherGroupType = thingTypes.stream()
-                    .filter(it -> it.toString().equals("yahooweather:weather-with-group")).findFirst().get();
+                    .filter(it -> "yahooweather:weather-with-group".equals(it.toString())).findFirst().get();
             assertNotNull(weatherGroupType);
 
             ChannelGroupType channelGroupType = channelGroupTypeRegistry.getChannelGroupType(
@@ -96,12 +96,12 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
             ThingType weatherGroupType = thingTypes.stream()
-                    .filter(it -> it.toString().equals("yahooweather:weather-with-group")).findFirst().get();
+                    .filter(it -> "yahooweather:weather-with-group".equals(it.toString())).findFirst().get();
             assertNotNull(weatherGroupType);
             assertThat(weatherGroupType.getChannelGroupDefinitions().size(), is(2));
 
             ChannelGroupDefinition forecastTodayChannelGroupDefinition = weatherGroupType.getChannelGroupDefinitions()
-                    .stream().filter(it -> it.getId().equals("forecastToday")).findFirst().get();
+                    .stream().filter(it -> "forecastToday".equals(it.getId())).findFirst().get();
             assertNotNull(forecastTodayChannelGroupDefinition);
 
             assertThat(forecastTodayChannelGroupDefinition.getLabel(), is("Wettervorhersage heute"));
@@ -109,7 +109,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
                     is("Wettervorhersage für den heutigen Tag."));
 
             ChannelGroupDefinition forecastTomorrowChannelGroupDefinition = weatherGroupType
-                    .getChannelGroupDefinitions().stream().filter(it -> it.getId().equals("forecastTomorrow"))
+                    .getChannelGroupDefinitions().stream().filter(it -> "forecastTomorrow".equals(it.getId()))
                     .findFirst().get();
             assertNotNull(forecastTomorrowChannelGroupDefinition);
 
@@ -125,12 +125,12 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
             ThingType weatherGroupType = thingTypes.stream()
-                    .filter(it -> it.toString().equals("yahooweather:weather-with-group")).findFirst().get();
+                    .filter(it -> "yahooweather:weather-with-group".equals(it.toString())).findFirst().get();
             assertNotNull(weatherGroupType);
             assertEquals(2, weatherGroupType.getChannelGroupDefinitions().size());
 
             ChannelGroupDefinition forecastTodayChannelGroupDefinition = weatherGroupType.getChannelGroupDefinitions()
-                    .stream().filter(it -> it.getId().equals("forecastToday")).findFirst().get();
+                    .stream().filter(it -> "forecastToday".equals(it.getId())).findFirst().get();
             assertNotNull(forecastTodayChannelGroupDefinition);
 
             ChannelGroupType forecastTodayChannelGroupType = channelGroupTypeRegistry
@@ -139,7 +139,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
             assertEquals(3, forecastTodayChannelGroupType.getChannelDefinitions().size());
 
             ChannelDefinition temperatureChannelDefinition = forecastTodayChannelGroupType.getChannelDefinitions()
-                    .stream().filter(it -> it.getId().equals("temperature")).findFirst().get();
+                    .stream().filter(it -> "temperature".equals(it.getId())).findFirst().get();
             assertNotNull(temperatureChannelDefinition);
 
             assertEquals("Temperatur", temperatureChannelDefinition.getLabel());
@@ -147,7 +147,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
                     temperatureChannelDefinition.getDescription());
 
             ChannelDefinition minTemperatureChannelDefinition = forecastTodayChannelGroupType.getChannelDefinitions()
-                    .stream().filter(it -> it.getId().equals("minTemperature")).findFirst().get();
+                    .stream().filter(it -> "minTemperature".equals(it.getId())).findFirst().get();
             assertNotNull(minTemperatureChannelDefinition);
 
             assertEquals("Min. Temperatur", minTemperatureChannelDefinition.getLabel());
@@ -155,7 +155,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
                     minTemperatureChannelDefinition.getDescription());
 
             ChannelDefinition maxTemperatureChannelDefinition = forecastTodayChannelGroupType.getChannelDefinitions()
-                    .stream().filter(it -> it.getId().equals("maxTemperature")).findFirst().get();
+                    .stream().filter(it -> "maxTemperature".equals(it.getId())).findFirst().get();
             assertNotNull(maxTemperatureChannelDefinition);
 
             assertEquals("Max. Temperatur", maxTemperatureChannelDefinition.getLabel());
@@ -169,13 +169,13 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
         try (final AutoCloseable unused = loadedTestBundle()) {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
-            ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
+            ThingType weatherType = thingTypes.stream().filter(it -> "yahooweather:weather".equals(it.toString()))
                     .findFirst().get();
             assertNotNull(weatherType);
             assertThat(weatherType.getChannelDefinitions().size(), is(2));
 
             ChannelType temperatureChannelType = channelTypeRegistry.getChannelType(weatherType.getChannelDefinitions()
-                    .stream().filter(it -> it.getId().equals("temperature")).findFirst().get().getChannelTypeUID(),
+                    .stream().filter(it -> "temperature".equals(it.getId())).findFirst().get().getChannelTypeUID(),
                     Locale.GERMAN);
             assertNotNull(temperatureChannelType);
 
@@ -192,13 +192,13 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
         try (final AutoCloseable unused = loadedTestBundle()) {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
 
-            ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
+            ThingType weatherType = thingTypes.stream().filter(it -> "yahooweather:weather".equals(it.toString()))
                     .findFirst().get();
             assertNotNull(weatherType);
             assertThat(weatherType.getChannelDefinitions().size(), is(2));
 
             ChannelDefinition temperatureChannelDefinition = weatherType.getChannelDefinitions().stream()
-                    .filter(it -> it.getId().equals("temperature")).findFirst().get();
+                    .filter(it -> "temperature".equals(it.getId())).findFirst().get();
             assertNotNull(temperatureChannelDefinition);
 
             assertThat(temperatureChannelDefinition.getLabel(), is("Temperatur"));
@@ -206,7 +206,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
                     is("Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial)."));
 
             ChannelDefinition minTemperatureChannelDefinition = weatherType.getChannelDefinitions().stream()
-                    .filter(it -> it.getId().equals("minTemperature")).findFirst().get();
+                    .filter(it -> "minTemperature".equals(it.getId())).findFirst().get();
             assertNotNull(minTemperatureChannelDefinition);
 
             assertThat(minTemperatureChannelDefinition.getLabel(), is("Min. Temperatur"));

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
@@ -68,7 +68,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(null);
 
             // HUE Bridge
-            BridgeType bridgeType = (BridgeType) thingTypes.stream().filter(it -> it.toString().equals("hue:bridge"))
+            BridgeType bridgeType = (BridgeType) thingTypes.stream().filter(it -> "hue:bridge".equals(it.toString()))
                     .findFirst().get();
             assertThat(bridgeType, is(notNullValue()));
             assertThat(bridgeType.getCategory(), is("NetworkAppliance"));
@@ -80,7 +80,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(bridgeType.getRepresentationProperty(), is("serialNumber"));
 
             // HUE Lamp
-            ThingType thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp")).findFirst().get();
+            ThingType thingType = thingTypes.stream().filter(it -> "hue:lamp".equals(it.toString())).findFirst().get();
 
             assertThat(thingType, is(notNullValue()));
             assertThat(thingType.getCategory(), is("Lightbulb"));
@@ -98,7 +98,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             List<ChannelDefinition> channelDefinitions = thingType.getChannelDefinitions();
 
             assertThat(channelDefinitions.size(), is(3));
-            ChannelDefinition colorChannel = channelDefinitions.stream().filter(it -> it.getId().equals("color"))
+            ChannelDefinition colorChannel = channelDefinitions.stream().filter(it -> "color".equals(it.getId()))
                     .findFirst().get();
             assertThat(colorChannel, is(notNullValue()));
 
@@ -122,7 +122,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(tags.contains("AlarmSystem"), is(false));
 
             ChannelDefinition colorTemperatureChannel = channelDefinitions.stream()
-                    .filter(it -> it.getId().equals("color_temperature")).findFirst().get();
+                    .filter(it -> "color_temperature".equals(it.getId())).findFirst().get();
 
             assertThat(colorTemperatureChannel, is(notNullValue()));
             assertThat(colorTemperatureChannel.getProperties().size(), is(0));
@@ -143,7 +143,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(tags.contains("ColorLamp"), is(false));
             assertThat(tags.contains("AlarmSystem"), is(false));
 
-            ChannelDefinition alarmChannel = channelDefinitions.stream().filter(it -> it.getId().equals("alarm"))
+            ChannelDefinition alarmChannel = channelDefinitions.stream().filter(it -> "alarm".equals(it.getId()))
                     .findFirst().get();
             assertThat(alarmChannel, is(notNullValue()));
             ChannelType alarmChannelType = channelTypeRegistry.getChannelType(alarmChannel.getChannelTypeUID());
@@ -173,7 +173,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(state.getOptions().get(0).getLabel(), is(equalTo("My great sound.")));
 
             // HUE Lamp with group
-            thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-with-group")).findFirst().get();
+            thingType = thingTypes.stream().filter(it -> "hue:lamp-with-group".equals(it.toString())).findFirst().get();
             assertThat(thingType, is(notNullValue()));
             assertThat(thingType.getProperties().size(), is(0));
             assertThat(thingType.getCategory(), is(nullValue()));
@@ -185,7 +185,7 @@ public class ThingTypesTest extends JavaOSGiTest {
 
             // Channel Group
             ChannelGroupDefinition channelGroupDefinition = channelGroupDefinitions.stream()
-                    .filter(it -> it.getId().equals("lampgroup")).findFirst().get();
+                    .filter(it -> "lampgroup".equals(it.getId())).findFirst().get();
             assertThat(channelGroupDefinition, is(notNullValue()));
             ChannelGroupType channelGroupType = channelGroupTypeRegistry
                     .getChannelGroupType(channelGroupDefinition.getTypeUID());
@@ -195,7 +195,7 @@ public class ThingTypesTest extends JavaOSGiTest {
 
             // Channel Group without channels
             channelGroupDefinition = channelGroupDefinitions.stream()
-                    .filter(it -> it.getId().equals("lampgroup-without-channels")).findFirst().get();
+                    .filter(it -> "lampgroup-without-channels".equals(it.getId())).findFirst().get();
             assertThat(channelGroupDefinition, is(notNullValue()));
             channelGroupType = channelGroupTypeRegistry.getChannelGroupType(channelGroupDefinition.getTypeUID());
             assertThat(channelGroupType, is(notNullValue()));
@@ -203,7 +203,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(channelDefinitions.size(), is(0));
 
             // HUE Lamp without channels
-            thingType = thingTypes.stream().filter(it -> it.toString().equals("hue:lamp-without-channels")).findFirst()
+            thingType = thingTypes.stream().filter(it -> "hue:lamp-without-channels".equals(it.toString())).findFirst()
                     .get();
             assertThat(thingType, is(notNullValue()));
             channelDefinitions = thingType.getChannelDefinitions();


### PR DESCRIPTION
This should replace all such cases where possible so we don't have to spend time on this anymore when creating/reviewing other PRs.