### PR TITLE
Model refactoring, Memory Leak prevention, UTF-8 encoding

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepository.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepository.java
@@ -16,6 +16,8 @@ import java.io.InputStream;
 import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The model repository stores the configuration files (EMF models).
@@ -25,6 +27,7 @@ import org.eclipse.emf.ecore.EObject;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public interface ModelRepository {
 
     /**
@@ -33,7 +36,8 @@ public interface ModelRepository {
      * @param name name of the requested model
      * @return the model or null, if not found
      */
-    public EObject getModel(String name);
+    @Nullable
+    EObject getModel(String name);
 
     /**
      * Adds a model to the repository or refreshes it if it already exists
@@ -42,7 +46,7 @@ public interface ModelRepository {
      * @param inputStream an input stream with the model's content, optional if the file already exists
      * @return true, if it was successfully processed, false otherwise
      */
-    public boolean addOrRefreshModel(String name, InputStream inputStream);
+    boolean addOrRefreshModel(String name, InputStream inputStream);
 
     /**
      * Removes a model from the repository
@@ -50,7 +54,7 @@ public interface ModelRepository {
      * @param name the name of the model to remove
      * @return true, if model was removed, false, if it did not exist
      */
-    public boolean removeModel(String name);
+    boolean removeModel(String name);
 
     /**
      * Returns all names of models of a given type (file extension)
@@ -58,14 +62,14 @@ public interface ModelRepository {
      * @param modelType the model type to get the names for
      * @return all names of available models
      */
-    public Iterable<String> getAllModelNamesOfType(String modelType);
+    Iterable<String> getAllModelNamesOfType(String modelType);
 
     /**
      * Reload and parse all models of the given type
      *
      * @param modelType the model type to reload
      */
-    public void reloadAllModelsOfType(final String modelType);
+    void reloadAllModelsOfType(final String modelType);
 
     /**
      * Remove all models of the given type
@@ -73,19 +77,19 @@ public interface ModelRepository {
      * @param modelType the model type to remove
      * @return all names of the removed models
      */
-    public Set<String> removeAllModelsOfType(final String modelType);
+    Set<String> removeAllModelsOfType(final String modelType);
 
     /**
      * Adds a change listener
      *
      * @param listener the listener to add
      */
-    public void addModelRepositoryChangeListener(ModelRepositoryChangeListener listener);
+    void addModelRepositoryChangeListener(ModelRepositoryChangeListener listener);
 
     /**
      * Removes a change listener
      *
      * @param listener the listener to remove
      */
-    public void removeModelRepositoryChangeListener(ModelRepositoryChangeListener listener);
+    void removeModelRepositoryChangeListener(ModelRepositoryChangeListener listener);
 }

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -58,12 +58,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 @Component(name = "org.openhab.core.folder", immediate = true, configurationPid = "org.openhab.folder", configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class FolderObserver extends AbstractWatchService {
 
-    public FolderObserver() {
-        super(ConfigConstants.getConfigFolder());
-    }
-
     /* the model repository is provided as a service */
-    private ModelRepository modelRepo = null;
+    private final ModelRepository modelRepository;
 
     /* map that stores a list of valid file extensions for each folder */
     private final Map<String, String[]> folderFileExtMap = new ConcurrentHashMap<>();
@@ -75,13 +71,11 @@ public class FolderObserver extends AbstractWatchService {
     private final Set<File> ignoredFiles = new HashSet<>();
     private final Map<String, File> nameFileMap = new HashMap<>();
 
-    @Reference
-    public void setModelRepository(ModelRepository modelRepo) {
-        this.modelRepo = modelRepo;
-    }
+    @Activate
+    public FolderObserver(final @Reference ModelRepository modelRepo) {
+        super(ConfigConstants.getConfigFolder());
 
-    public void unsetModelRepository(ModelRepository modelRepo) {
-        this.modelRepo = null;
+        this.modelRepository = modelRepo;
     }
 
     @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
@@ -95,10 +89,8 @@ public class FolderObserver extends AbstractWatchService {
     protected void removeModelParser(ModelParser modelParser) {
         parsers.remove(modelParser.getExtension());
 
-        if (modelRepo != null) {
-            Set<String> removed = modelRepo.removeAllModelsOfType(modelParser.getExtension());
-            ignoredFiles.addAll(removed.stream().map(name -> nameFileMap.get(name)).collect(Collectors.toSet()));
-        }
+        Set<String> removed = modelRepository.removeAllModelsOfType(modelParser.getExtension());
+        ignoredFiles.addAll(removed.stream().map(name -> nameFileMap.get(name)).collect(Collectors.toSet()));
     }
 
     @Activate
@@ -145,7 +137,7 @@ public class FolderObserver extends AbstractWatchService {
         Set<File> clonedSet = new HashSet<>(this.ignoredFiles);
         for (File file : clonedSet) {
             if (extension.equals(getExtension(file.getPath()))) {
-                checkFile(modelRepo, file, ENTRY_CREATE);
+                checkFile(modelRepository, file, ENTRY_CREATE);
                 this.ignoredFiles.remove(file);
             }
         }
@@ -190,7 +182,7 @@ public class FolderObserver extends AbstractWatchService {
                         for (File file : files) {
                             // we omit parsing of hidden files possibly created by editors or operating systems
                             if (!file.isHidden()) {
-                                checkFile(modelRepo, file, ENTRY_CREATE);
+                                checkFile(modelRepository, file, ENTRY_CREATE);
                             }
                         }
                     }
@@ -202,12 +194,10 @@ public class FolderObserver extends AbstractWatchService {
     private void deleteModelsFromRepo() {
         Set<String> folders = folderFileExtMap.keySet();
         for (String folder : folders) {
-            Iterable<String> models = modelRepo.getAllModelNamesOfType(folder);
-            if (models != null) {
-                for (String model : models) {
-                    logger.debug("Removing file {} from the model repo.", model);
-                    modelRepo.removeModel(model);
-                }
+            Iterable<String> models = modelRepository.getAllModelNamesOfType(folder);
+            for (String model : models) {
+                logger.debug("Removing file {} from the model repo.", model);
+                modelRepository.removeModel(model);
             }
         }
     }
@@ -229,21 +219,20 @@ public class FolderObserver extends AbstractWatchService {
                     }
                 }
             }
-
             return false;
         }
     }
 
     @SuppressWarnings("rawtypes")
-    private void checkFile(final ModelRepository modelRepo, final File file, final Kind kind) {
-        if (modelRepo != null && file != null) {
+    private void checkFile(final ModelRepository modelRepository, final File file, final Kind kind) {
+        if (file != null) {
             try {
                 synchronized (FolderObserver.class) {
                     if ((kind == ENTRY_CREATE || kind == ENTRY_MODIFY)) {
                         if (parsers.contains(getExtension(file.getName()))) {
                             try (InputStream inputStream = Files.newInputStream(file.toPath())) {
                                 nameFileMap.put(file.getName(), file);
-                                modelRepo.addOrRefreshModel(file.getName(), inputStream);
+                                modelRepository.addOrRefreshModel(file.getName(), inputStream);
                             } catch (IOException e) {
                                 logger.warn("Error while opening file during update: {}", file.getAbsolutePath());
                             }
@@ -251,7 +240,7 @@ public class FolderObserver extends AbstractWatchService {
                             ignoredFiles.add(file);
                         }
                     } else if (kind == ENTRY_DELETE) {
-                        modelRepo.removeModel(file.getName());
+                        modelRepository.removeModel(file.getName());
                         nameFileMap.remove(file.getName());
                     }
                 }
@@ -306,7 +295,7 @@ public class FolderObserver extends AbstractWatchService {
     protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
         File toCheck = getFileByFileExtMap(folderFileExtMap, path.getFileName().toString());
         if (toCheck != null && !toCheck.isHidden()) {
-            checkFile(modelRepo, toCheck, kind);
+            checkFile(modelRepository, toCheck, kind);
         }
     }
 }

--- a/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
+++ b/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -123,8 +124,7 @@ public class FolderObserverTest extends JavaOSGiTest {
 
         modelRepo = new ModelRepoDummy();
 
-        folderObserver = new FolderObserver();
-        folderObserver.setModelRepository(modelRepo);
+        folderObserver = new FolderObserver(modelRepo);
         folderObserver.addModelParser(modelParser);
     }
 
@@ -348,11 +348,12 @@ public class FolderObserverTest extends JavaOSGiTest {
                 throw new RuntimeException("intentional failure.");
             }
         };
-        folderObserver.setModelRepository(modelRepo);
+        FolderObserver localFolderObserver = new FolderObserver(modelRepo);
+        localFolderObserver.addModelParser(modelParser);
 
         String validExtension = "java";
         configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg," + validExtension);
-        folderObserver.activate(context);
+        localFolderObserver.activate(context);
 
         File mockFileWithValidExt = new File(EXISTING_SUBDIR_PATH, "MockFileForModification." + validExtension);
         mockFileWithValidExt.createNewFile();
@@ -469,7 +470,7 @@ public class FolderObserverTest extends JavaOSGiTest {
         }
 
         @Override
-        public EObject getModel(String name) {
+        public @Nullable EObject getModel(String name) {
             return null;
         }
 
@@ -482,7 +483,7 @@ public class FolderObserverTest extends JavaOSGiTest {
 
         @Override
         public Set<String> removeAllModelsOfType(String modelType) {
-            return null;
+            return Collections.emptySet();
         }
     }
 }


### PR DESCRIPTION
- Model refactoring, Memory Leak prevention, UTF-8 encoding

Beside our basic improvements (nullness annotations and constructor injection) this draft tries to address two other issues - I will link them, when I find them - eventually they are placed in old ESH repository. First one is a potential memory leak in the `ModelRepositoryÌmpl` where we did not close the copied `InputStream`s (e.g. for validation). Second one is a potential encoding issue - I added `XtextResource.OPTION_ENCODING = "UTF-8"` in all places where the resources are loaded.

What do you think about that? I am fine with splitting this PR into smaller pieces.

But there might be a bigger problem related to the internal `resourceSet` (`SynchronizedXtextResourceSet`). Today I faced a system crash and luckily I could save the heap dump. @wborn I would like to share it with you for deeper analysis.

![grafik](https://user-images.githubusercontent.com/5131747/79274655-2e513900-7ea5-11ea-861e-1310452cc492.png)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>