### PR TITLE
Update nrjavaserial to 3.20.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -240,7 +240,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.14.0</version>
+      <version>3.20.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -466,14 +466,9 @@
 
     <!-- All serial transports -->
     <dependency>
-      <groupId>org.openhab</groupId>
+      <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <!-- Use "no liblockdev" version -->
-      <!-- See: https://github.com/openhab/openhab-core/pull/761 -->
-      <!-- See: https://github.com/openhab/openhab-core/issues/750 -->
-      <!-- <groupId>com.neuronrobotics</groupId> -->
-      <!-- <version>3.15.0</version> -->
-      <version>3.15.0.OH2</version>
+      <version>3.20.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -214,12 +214,7 @@
 
 	<feature name="openhab.tp-serial-rxtx" version="${project.version}">
 		<capability>openhab.tp;feature=serial;impl=rxtx</capability>
-
-		<!-- Use "no liblockdev" version -->
-		<!-- See: https://github.com/openhab/openhab-core/pull/761 -->
-		<!-- See: https://github.com/openhab/openhab-core/issues/750 -->
-		<!-- <bundle>mvn:com.neuronrobotics/nrjavaserial/3.15.0</bundle> -->
-		<bundle>mvn:org.openhab/nrjavaserial/3.15.0.OH2</bundle>
+		<bundle>mvn:com.neuronrobotics/nrjavaserial/3.20.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy"


### PR DESCRIPTION
Updates nrjavaserial to the official 3.20.0 release (compatible with Java 8/11).
With the upgraded version the library will no longer crash the Java 11 VM on Windows.
The native libraries now use the built in RXTX lockfiles instead of the previously used (OS dependent) liblockdev whereas the OH build didn't use any lockfiles at all.
It also has a fix for errors being printed when scanning for serial ports whenever a serial port is locked (NeuronRobotics/nrjavaserial#166).
With the new version RXTX threads also have proper names and there is a fix for an IllegalMonitorStateException that might occur when closing ports.

Fixes #1384