### PR TITLE
Fixed failing 'ChannelTypesI18nTest' because of invalid XML

### DIFF
--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/OH-INF/thing/thing-types.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/OH-INF/thing/thing-types.xml
@@ -33,9 +33,19 @@
 	</channel-type>
 
 	<channel-group-type id="channelgroup-with-i18n">
+
 		<label>@text/channelGroupLabel</label>
 		<description>@text/channelGroupDescription</description>
+
 		<channels>
+			<channel id="channelPlain" typeId="string">
+				<label>Channel Plain Label</label>
+				<description>Channel Plain Description</description>
+			</channel>
+			<channel id="channelInplace" typeId="channel-with-i18n">
+				<label>@text/channelInplaceLabel</label>
+				<description>@text/channelInplaceDescription</description>
+			</channel>
 		</channels>
 	</channel-group-type>
 


### PR DESCRIPTION
- Fixed failing `ChannelTypesI18nTest` because of invalid XML - it is not allowed to have an empty channels-tag

That was never really noticeable because the related test allows to throw an `Exception` which does not look comfortable. The `Exception` has to be handled because it could be thrown by the `SyntheticBundleInstaller.install()` method.

https://github.com/openhab/openhab-core/blob/778c72eabbce798271edf189b356975c8a54569f/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java#L65-L67

https://github.com/openhab/openhab-core/blob/778c72eabbce798271edf189b356975c8a54569f/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java#L94-L96

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>