### PR TITLE
Removed deprecated constructor for 'DiscoveryResultImpl'

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
-import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.i18n.I18nUtil;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
@@ -268,9 +267,11 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
             String label = this.i18nProvider.getText(bundle, key, defaultLabel, this.localeProvider.getLocale());
 
-            discoveryResultNew = new DiscoveryResultImpl(discoveryResult.getThingTypeUID(),
-                    discoveryResult.getThingUID(), discoveryResult.getBridgeUID(), discoveryResult.getProperties(),
-                    discoveryResult.getRepresentationProperty(), label, discoveryResult.getTimeToLive());
+            discoveryResultNew = DiscoveryResultBuilder.create(discoveryResult.getThingUID())
+                    .withThingType(discoveryResult.getThingTypeUID()).withBridge(discoveryResult.getBridgeUID())
+                    .withProperties(discoveryResult.getProperties())
+                    .withRepresentationProperty(discoveryResult.getRepresentationProperty()).withLabel(label)
+                    .withTTL(discoveryResult.getTimeToLive()).build();
         } else {
             discoveryResultNew = discoveryResult;
         }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -48,7 +49,7 @@ public interface DiscoveryResult {
      * discovered again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the serial
      * number. It's usually <i>not</i> a product number.
      *
-     * @return the Thing ID of this result object
+     * @return the Thing ID
      */
     public ThingUID getThingUID();
 
@@ -58,7 +59,7 @@ public interface DiscoveryResult {
      * A {@code Thing} type ID could be a product number which identifies the same type of {@link Thing}s. It's usually
      * <i>not</i> a serial number.
      *
-     * @return the unique Thing type of this result object
+     * @return the unique Thing type
      */
     public ThingTypeUID getThingTypeUID();
 
@@ -67,7 +68,7 @@ public interface DiscoveryResult {
      * <p>
      * The binding ID is extracted from the unique {@code Thing} ID.
      *
-     * @return the binding ID of this result object
+     * @return the binding ID
      */
     public String getBindingId();
 
@@ -77,7 +78,7 @@ public interface DiscoveryResult {
      * <p>
      * <b>Hint:</b> The returned properties are immutable.
      *
-     * @return the properties of this result object (could be empty)
+     * @return the properties (could be empty)
      */
     public Map<String, Object> getProperties();
 
@@ -89,7 +90,7 @@ public interface DiscoveryResult {
      * identifiers are typically the <code>ipAddress</code>, the <code>macAddress</code> or the
      * <code>serialNumber</code> of the discovered thing.
      *
-     * @return the representation property of this result object
+     * @return the representation property
      */
     public @Nullable String getRepresentationProperty();
 
@@ -100,33 +101,33 @@ public interface DiscoveryResult {
      * case the result object should be regarded as known by the system so that
      * further processing should be skipped.
      *
-     * @return the flag of this result object
+     * @return the flag
      */
     public DiscoveryResultFlag getFlag();
 
     /**
      * Returns the human readable label for this result object.
      *
-     * @return the human readable label for this result object (could be empty)
+     * @return the human readable label (could be empty)
      */
     public String getLabel();
 
     /**
-     * Returns the unique bridge ID of the {@link DiscoveryResult}.
+     * Returns the unique {@link Bridge} ID of this result object.
      *
-     * @return the unique bridge ID
+     * @return the unique Bridge ID
      */
     public @Nullable ThingUID getBridgeUID();
 
     /**
-     * Get the timestamp of this {@link DiscoveryResult}.
+     * Returns the timestamp of this result object.
      *
      * @return timestamp as long
      */
     public long getTimestamp();
 
     /**
-     * Get the time to live in seconds for this entry.
+     * Returns the time to live in seconds for this entry.
      *
      * @return time to live in seconds
      */

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -48,7 +48,7 @@ public interface DiscoveryResult {
      * discovered again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the serial
      * number. It's usually <i>not</i> a product number.
      *
-     * @return the Thing ID of this result object (not null, not empty)
+     * @return the Thing ID of this result object
      */
     public ThingUID getThingUID();
 
@@ -58,7 +58,7 @@ public interface DiscoveryResult {
      * A {@code Thing} type ID could be a product number which identifies the same type of {@link Thing}s. It's usually
      * <i>not</i> a serial number.
      *
-     * @return the unique Thing type of this result object (not null, not empty)
+     * @return the unique Thing type of this result object
      */
     public ThingTypeUID getThingTypeUID();
 
@@ -67,7 +67,7 @@ public interface DiscoveryResult {
      * <p>
      * The binding ID is extracted from the unique {@code Thing} ID.
      *
-     * @return the binding ID of this result object (not null, not empty)
+     * @return the binding ID of this result object
      */
     public String getBindingId();
 
@@ -77,7 +77,7 @@ public interface DiscoveryResult {
      * <p>
      * <b>Hint:</b> The returned properties are immutable.
      *
-     * @return the properties of this result object (not null, could be empty)
+     * @return the properties of this result object (could be empty)
      */
     public Map<String, Object> getProperties();
 
@@ -89,7 +89,7 @@ public interface DiscoveryResult {
      * identifiers are typically the <code>ipAddress</code>, the <code>macAddress</code> or the
      * <code>serialNumber</code> of the discovered thing.
      *
-     * @return the representation property of this result object (could be null)
+     * @return the representation property of this result object
      */
     public @Nullable String getRepresentationProperty();
 
@@ -100,21 +100,21 @@ public interface DiscoveryResult {
      * case the result object should be regarded as known by the system so that
      * further processing should be skipped.
      *
-     * @return the flag of this result object (not null)
+     * @return the flag of this result object
      */
     public DiscoveryResultFlag getFlag();
 
     /**
      * Returns the human readable label for this result object.
      *
-     * @return the human readable label for this result object (not null, could be empty)
+     * @return the human readable label for this result object (could be empty)
      */
     public String getLabel();
 
     /**
      * Returns the unique bridge ID of the {@link DiscoveryResult}.
      *
-     * @return the unique bridge ID (could be null)
+     * @return the unique bridge ID
      */
     public @Nullable ThingUID getBridgeUID();
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
@@ -141,6 +141,7 @@ public class DiscoveryResultBuilder {
      *
      * @return the desired result
      */
+    @SuppressWarnings("deprecation")
     public DiscoveryResult build() {
         return new DiscoveryResultImpl(thingTypeUID, thingUID, bridgeUID, properties, representationProperty, label,
                 ttl);

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -14,9 +14,10 @@ package org.openhab.core.config.discovery.internal;
 
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
@@ -27,16 +28,17 @@ import org.openhab.core.thing.ThingUID;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class DiscoveryResultImpl implements DiscoveryResult {
 
-    private ThingUID bridgeUID;
-    private ThingUID thingUID;
-    private ThingTypeUID thingTypeUID;
+    private @Nullable ThingUID bridgeUID;
+    private @NonNullByDefault({}) ThingUID thingUID;
+    private @Nullable ThingTypeUID thingTypeUID;
 
-    private Map<String, Object> properties;
-    private String representationProperty;
-    private DiscoveryResultFlag flag;
-    private String label;
+    private Map<String, Object> properties = Collections.emptyMap();
+    private @Nullable String representationProperty;
+    private @NonNullByDefault({}) DiscoveryResultFlag flag;
+    private @NonNullByDefault({}) String label;
     private long timestamp;
     private long timeToLive = TTL_UNLIMITED;
 
@@ -50,22 +52,22 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * Creates a new instance of this class with the specified parameters.
      *
      * @param thingTypeUID the {@link ThingTypeUID}
-     * @param thingUID the {@link ThingUID} to be set (must not be null). If a {@code Thing} disappears and is
+     * @param thingUID the {@link ThingUID} to be set. If a {@code Thing} disappears and is
      *            discovered again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the
      *            serial number. It's usually <i>not</i> a product name.
      * @param bridgeUID the unique bridge ID to be set
-     * @param properties the properties to be set (could be null or empty)
-     * @param representationProperty the representationProperty to be set (could be null or empty)
-     * @param label the human readable label to set (could be null or empty)
+     * @param properties the properties to be set
+     * @param representationProperty the representationProperty to be set
+     * @param label the human readable label to set
      * @param timeToLive time to live in seconds
      *
      * @throws IllegalArgumentException if the Thing type UID or the Thing UID is null
      * @deprecated use {@link DiscoveryResultBuilder} instead.
      */
     @Deprecated
-    public DiscoveryResultImpl(ThingTypeUID thingTypeUID, ThingUID thingUID, ThingUID bridgeUID,
-            Map<String, Object> properties, String representationProperty, String label, long timeToLive)
-            throws IllegalArgumentException {
+    public DiscoveryResultImpl(@Nullable ThingTypeUID thingTypeUID, ThingUID thingUID, @Nullable ThingUID bridgeUID,
+            @Nullable Map<String, Object> properties, @Nullable String representationProperty, @Nullable String label,
+            long timeToLive) throws IllegalArgumentException {
         if (thingUID == null) {
             throw new IllegalArgumentException("The thing UID must not be null!");
         }
@@ -76,8 +78,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         this.thingUID = thingUID;
         this.thingTypeUID = thingTypeUID;
         this.bridgeUID = bridgeUID;
-        this.properties = Collections
-                .unmodifiableMap((properties != null) ? new HashMap<>(properties) : new HashMap<>());
+        this.properties = properties == null ? Collections.emptyMap() : Collections.unmodifiableMap(properties);
         this.representationProperty = representationProperty;
         this.label = label == null ? "" : label;
 
@@ -94,45 +95,42 @@ public class DiscoveryResultImpl implements DiscoveryResult {
 
     @Override
     public ThingTypeUID getThingTypeUID() {
-        if (this.thingTypeUID != null) {
-            return this.thingTypeUID;
+        ThingTypeUID localThingTypeUID = thingTypeUID;
+        if (localThingTypeUID != null) {
+            return localThingTypeUID;
         } else {
             // fallback for discovery result which were created before the thingTypeUID field was added
-            return this.thingUID.getThingTypeUID();
+            return thingUID.getThingTypeUID();
         }
     }
 
     @Override
     public String getBindingId() {
-        ThingUID thingId = this.thingUID;
-        if (thingId != null) {
-            return thingId.getBindingId();
-        }
-        return "";
+        return thingUID.getBindingId();
     }
 
     @Override
     public Map<String, Object> getProperties() {
-        return this.properties;
+        return properties;
     }
 
     @Override
-    public String getRepresentationProperty() {
-        return this.representationProperty;
+    public @Nullable String getRepresentationProperty() {
+        return representationProperty;
     }
 
     @Override
     public DiscoveryResultFlag getFlag() {
-        return this.flag;
+        return flag;
     }
 
     @Override
     public String getLabel() {
-        return this.label;
+        return label;
     }
 
     @Override
-    public ThingUID getBridgeUID() {
+    public @Nullable ThingUID getBridgeUID() {
         return bridgeUID;
     }
 
@@ -146,8 +144,8 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      *
      * @param sourceResult the discovery result which is used as source for the merge
      */
-    public void synchronize(DiscoveryResult sourceResult) {
-        if ((sourceResult != null) && (sourceResult.getThingUID().equals(this.thingUID))) {
+    public void synchronize(@Nullable DiscoveryResult sourceResult) {
+        if (sourceResult != null && thingUID.equals(sourceResult.getThingUID())) {
             this.properties = sourceResult.getProperties();
             this.representationProperty = sourceResult.getRepresentationProperty();
             this.label = sourceResult.getLabel();
@@ -165,29 +163,23 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * <p>
      * If the specified flag is {@code null}, {@link DiscoveryResultFlag.NEW} is set by default.
      *
-     * @param flag the flag of this result object to be set (could be null)
+     * @param flag the flag of this result object to be set
      */
-    public void setFlag(DiscoveryResultFlag flag) {
-        this.flag = (flag == null) ? DiscoveryResultFlag.NEW : flag;
+    public void setFlag(@Nullable DiscoveryResultFlag flag) {
+        this.flag = flag == null ? DiscoveryResultFlag.NEW : flag;
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((thingUID == null) ? 0 : thingUID.hashCode());
-        return result;
+        return 31 + thingUID.hashCode();
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
         DiscoveryResultImpl other = (DiscoveryResultImpl) obj;

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -60,7 +60,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * @param timeToLive time to live in seconds
      *
      * @throws IllegalArgumentException if the Thing type UID or the Thing UID is null
-     * @deprecated use {@link DiscoveryResultBuilder} instead
+     * @deprecated use {@link DiscoveryResultBuilder} instead.
      */
     @Deprecated
     public DiscoveryResultImpl(ThingTypeUID thingTypeUID, ThingUID thingUID, ThingUID bridgeUID,

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -48,44 +49,20 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     /**
      * Creates a new instance of this class with the specified parameters.
      *
-     * @param thingUID
-     *            the Thing UID to be set (must not be null). If a {@code Thing} disappears and is discovered again, the
-     *            same {@code Thing} ID
-     *            must be created. A typical {@code Thing} ID could be the
+     * @param thingTypeUID the {@link ThingTypeUID}
+     * @param thingUID the {@link ThingUID} to be set (must not be null). If a {@code Thing} disappears and is
+     *            discovered again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the
      *            serial number. It's usually <i>not</i> a product name.
+     * @param bridgeUID the unique bridge ID to be set
      * @param properties the properties to be set (could be null or empty)
      * @param representationProperty the representationProperty to be set (could be null or empty)
      * @param label the human readable label to set (could be null or empty)
-     * @param bridgeUID the unique bridge ID to be set
      * @param timeToLive time to live in seconds
      *
-     * @throws IllegalArgumentException
-     *             if the Thing type UID or the Thing UID is null
-     * @deprecated use {@link #DiscoveryResultImpl(ThingUID, ThingTypeUID, ThingUID, Map, String, String, long)}
-     *             instead.
+     * @throws IllegalArgumentException if the Thing type UID or the Thing UID is null
+     * @deprecated use {@link DiscoveryResultBuilder} instead
      */
     @Deprecated
-    public DiscoveryResultImpl(ThingUID thingUID, ThingUID bridgeUID, Map<String, Object> properties,
-            String representationProperty, String label, long timeToLive) throws IllegalArgumentException {
-        this(thingUID.getThingTypeUID(), thingUID, bridgeUID, properties, representationProperty, label, timeToLive);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @param thingTypeUID the {@link ThingTypeUID}
-     * @param thingUID the Thing UID to be set (must not be null). If a {@code Thing} disappears and is discovered
-     *            again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the serial
-     *            number. It's usually <i>not</i> a product name.
-     * @param properties the properties to be set (could be null or empty)
-     * @param representationProperty the representationProperty to be set (could be null or empty)
-     * @param label the human readable label to set (could be null or empty)
-     * @param bridgeUID the unique bridge ID to be set
-     * @param timeToLive time to live in seconds
-     *
-     * @throws IllegalArgumentException
-     *             if the Thing type UID or the Thing UID is null
-     */
     public DiscoveryResultImpl(ThingTypeUID thingTypeUID, ThingUID thingUID, ThingUID bridgeUID,
             Map<String, Object> properties, String representationProperty, String label, long timeToLive)
             throws IllegalArgumentException {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
+import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 
@@ -52,16 +53,16 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * Creates a new instance of this class with the specified parameters.
      *
      * @param thingTypeUID the {@link ThingTypeUID}
-     * @param thingUID the {@link ThingUID} to be set. If a {@code Thing} disappears and is
-     *            discovered again, the same {@code Thing} ID must be created. A typical {@code Thing} ID could be the
-     *            serial number. It's usually <i>not</i> a product name.
-     * @param bridgeUID the unique bridge ID to be set
+     * @param thingUID the {@link ThingUID} to be set. If a {@code Thing} disappears and is discovered again, the same
+     *            {@code Thing} ID must be created. A typical {@code Thing} ID could be the serial number. It's usually
+     *            <i>not</i> a product name.
+     * @param bridgeUID the unique {@link Bridge} ID to be set
      * @param properties the properties to be set
      * @param representationProperty the representationProperty to be set
      * @param label the human readable label to set
      * @param timeToLive time to live in seconds
      *
-     * @throws IllegalArgumentException if the Thing type UID or the Thing UID is null
+     * @throws IllegalArgumentException if the {@link ThingUID} is null or the time to live is less than 1
      * @deprecated use {@link DiscoveryResultBuilder} instead.
      */
     @Deprecated

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
@@ -68,15 +68,13 @@ public class InboxPredicatesTest {
 
     private static final List<DiscoveryResult> RESULTS = Arrays.asList(
             DiscoveryResultBuilder.create(THING_UID11).withThingType(THING_TYPE_UID11).withProperties(PROPS1)
-                    .withRepresentationProperty(PROP1).withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED)
-                    .build(),
+                    .withRepresentationProperty(PROP1).withLabel("label").build(),
             DiscoveryResultBuilder.create(THING_UID12).withThingType(THING_TYPE_UID11).withProperties(PROPS1)
-                    .withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED).build(),
+                    .withLabel("label").build(),
             DiscoveryResultBuilder.create(THING_UID12).withThingType(THING_TYPE_UID12).withProperties(PROPS2)
-                    .withRepresentationProperty(PROP2).withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED)
-                    .build(),
+                    .withRepresentationProperty(PROP2).withLabel("label").build(),
             DiscoveryResultBuilder.create(THING_UID22).withThingType(THING_TYPE_UID21).withProperties(PROPS2)
-                    .withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED).build());
+                    .withLabel("label").build());
 
     @Before
     public void setUp() throws Exception {

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryResultFlag;
 import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.thing.ThingTypeUID;
@@ -65,19 +66,21 @@ public class InboxPredicatesTest {
                     .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
     private static final Map<String, Object> PROPS2 = Collections.singletonMap(PROP2, PROP_VAL2);
 
-    private static final List<DiscoveryResultImpl> RESULTS = Arrays.asList(
-            new DiscoveryResultImpl(THING_TYPE_UID11, THING_UID11, null, PROPS1, PROP1, "label",
-                    DiscoveryResult.TTL_UNLIMITED),
-            new DiscoveryResultImpl(THING_TYPE_UID11, THING_UID12, null, PROPS1, null, "label",
-                    DiscoveryResult.TTL_UNLIMITED),
-            new DiscoveryResultImpl(THING_TYPE_UID12, THING_UID12, null, PROPS2, PROP2, "label",
-                    DiscoveryResult.TTL_UNLIMITED),
-            new DiscoveryResultImpl(THING_TYPE_UID21, THING_UID22, null, PROPS2, null, "label",
-                    DiscoveryResult.TTL_UNLIMITED));
+    private static final List<DiscoveryResult> RESULTS = Arrays.asList(
+            DiscoveryResultBuilder.create(THING_UID11).withThingType(THING_TYPE_UID11).withProperties(PROPS1)
+                    .withRepresentationProperty(PROP1).withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED)
+                    .build(),
+            DiscoveryResultBuilder.create(THING_UID12).withThingType(THING_TYPE_UID11).withProperties(PROPS1)
+                    .withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED).build(),
+            DiscoveryResultBuilder.create(THING_UID12).withThingType(THING_TYPE_UID12).withProperties(PROPS2)
+                    .withRepresentationProperty(PROP2).withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED)
+                    .build(),
+            DiscoveryResultBuilder.create(THING_UID22).withThingType(THING_TYPE_UID21).withProperties(PROPS2)
+                    .withLabel("label").withTTL(DiscoveryResult.TTL_UNLIMITED).build());
 
     @Before
     public void setUp() throws Exception {
-        RESULTS.get(3).setFlag(DiscoveryResultFlag.IGNORED);
+        ((DiscoveryResultImpl) RESULTS.get(3)).setFlag(DiscoveryResultFlag.IGNORED);
     }
 
     @Test

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.dto.DiscoveryResultDTOMapper;
-import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.events.Event;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
@@ -36,8 +36,8 @@ public class InboxEventFactoryTest {
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding", "type");
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
 
-    private static final DiscoveryResult DISCOVERY_RESULT = new DiscoveryResultImpl(THING_TYPE_UID, THING_UID, null,
-            null, null, null, 60);
+    private static final DiscoveryResult DISCOVERY_RESULT = DiscoveryResultBuilder.create(THING_UID)
+            .withThingType(THING_TYPE_UID).withTTL(60).build();
 
     private static final String INBOX_ADDED_EVENT_TYPE = InboxAddedEvent.TYPE;
 

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
@@ -38,7 +38,7 @@ public class DiscoveryResultImplTest {
     @SuppressWarnings("unused")
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidConstructorForThingType() {
-        new DiscoveryResultImpl(new ThingUID("aa"), null, null, null, null, DEFAULT_TTL);
+        new DiscoveryResultImpl(null, new ThingUID("aa"), null, null, null, null, DEFAULT_TTL);
     }
 
     @SuppressWarnings("unused")

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMock.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMock.java
@@ -15,7 +15,6 @@ package org.openhab.core.config.discovery;
 import java.util.Collections;
 import java.util.Random;
 
-import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 
@@ -52,8 +51,8 @@ public class DiscoveryServiceMock extends AbstractDiscoveryService {
         if (faulty) {
             throw new RuntimeException();
         }
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "test" + new Random().nextInt(999999999)), null,
-                null, null, null, DEFAULT_TTL));
+        thingDiscovered(DiscoveryResultBuilder.create(new ThingUID(thingType, "test" + new Random().nextInt(999999999)))
+                .withTTL(DEFAULT_TTL).build());
     }
 
 }

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMockOfBridge.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMockOfBridge.java
@@ -14,7 +14,6 @@ package org.openhab.core.config.discovery;
 
 import java.util.Random;
 
-import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 
@@ -23,21 +22,21 @@ import org.openhab.core.thing.ThingUID;
  */
 public class DiscoveryServiceMockOfBridge extends DiscoveryServiceMock {
 
-    ThingUID bridge;
+    final ThingUID bridgeUID;
 
-    public DiscoveryServiceMockOfBridge(ThingTypeUID thingType, int timeout, ThingUID bridge) {
+    public DiscoveryServiceMockOfBridge(ThingTypeUID thingType, int timeout, ThingUID bridgeUID) {
         super(thingType, timeout);
-        this.bridge = bridge;
+        this.bridgeUID = bridgeUID;
     }
 
     @Override
     public void startScan() {
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "test" + new Random().nextInt(999999999)),
-                bridge, null, null, null, DEFAULT_TTL));
+        thingDiscovered(DiscoveryResultBuilder.create(new ThingUID(thingType, "test" + new Random().nextInt(999999999)))
+                .withBridge(bridgeUID).withTTL(DEFAULT_TTL).build());
     }
 
     public ThingUID getBridge() {
-        return bridge;
+        return bridgeUID;
     }
 
 }

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
@@ -16,16 +16,14 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Collections;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.core.config.discovery.DiscoveryResult;
+import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
-import org.openhab.core.config.discovery.internal.DiscoveryResultImpl;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
@@ -137,8 +135,9 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
         });
         callback.statusUpdated(thing, ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build());
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_TYPE_UID, THING_UID, null,
-                Collections.singletonMap(cfgIpAddressKey, cfgIpAddressValue), "DummyRepr", "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(THING_UID).withThingType(THING_TYPE_UID)
+                .withProperty(cfgIpAddressKey, cfgIpAddressValue).withRepresentationProperty("DummyRepr")
+                .withLabel("DummyLabel1").withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 
@@ -156,8 +155,8 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
     public void assertNotNUpdatedWithSameConfig() {
         managedThingProvider.add(ThingBuilder.create(THING_TYPE_UID, THING_ID).build());
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_TYPE_UID, THING_UID, null,
-                Collections.emptyMap(), null, "DummyLabel", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(THING_UID).withThingType(THING_TYPE_UID)
+                .withLabel("DummyLabel").withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 
@@ -169,8 +168,8 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
     public void assertAdded() {
         managedThingProvider.add(ThingBuilder.create(THING_TYPE_UID, THING_ID).build());
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_TYPE_UID, THING_UID2, null,
-                Collections.emptyMap(), null, "DummyLabel", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(THING_UID2).withThingType(THING_TYPE_UID)
+                .withLabel("DummyLabel").withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -112,17 +112,22 @@ public class InboxOSGiTest extends JavaOSGiTest {
 
     private static final ThingUID BRIDGE_THING_UID = new ThingUID(BRIDGE_THING_TYPE_UID, "bridgeId");
 
-    private static final DiscoveryResult BRIDGE = new DiscoveryResultImpl(BRIDGE_THING_TYPE_UID, BRIDGE_THING_UID, null,
-            null, "Bridge", "bridge", DEFAULT_TTL);
-    private static final DiscoveryResult THING1_WITH_BRIDGE = new DiscoveryResultImpl(THING_TYPE_UID,
-            new ThingUID(THING_TYPE_UID, "id1"), BRIDGE_THING_UID, null, "Thing1", "thing1", DEFAULT_TTL);
-    private static final DiscoveryResult THING2_WITH_BRIDGE = new DiscoveryResultImpl(THING_TYPE_UID,
-            new ThingUID(THING_TYPE_UID, "id2"), BRIDGE_THING_UID, null, "Thing2", "thing2", DEFAULT_TTL);
-    private static final DiscoveryResult THING_WITHOUT_BRIDGE = new DiscoveryResultImpl(THING_TYPE_UID,
-            new ThingUID(THING_TYPE_UID, "id3"), null, null, "Thing3", "thing3", DEFAULT_TTL);
-    private static final DiscoveryResult THING_WITH_OTHER_BRIDGE = new DiscoveryResultImpl(THING_TYPE_UID,
-            new ThingUID(THING_TYPE_UID, "id4"), new ThingUID(THING_TYPE_UID, "id5"), null, "Thing4", "thing4",
-            DEFAULT_TTL);
+    private static final DiscoveryResult BRIDGE = DiscoveryResultBuilder.create(BRIDGE_THING_UID)
+            .withThingType(BRIDGE_THING_TYPE_UID).withRepresentationProperty("Bridge1").withLabel("bridge")
+            .withTTL(DEFAULT_TTL).build();
+    private static final DiscoveryResult THING1_WITH_BRIDGE = DiscoveryResultBuilder
+            .create(new ThingUID(THING_TYPE_UID, "id1")).withThingType(THING_TYPE_UID).withBridge(BRIDGE_THING_UID)
+            .withRepresentationProperty("Thing1").withLabel("thing1").withTTL(DEFAULT_TTL).build();
+    private static final DiscoveryResult THING2_WITH_BRIDGE = DiscoveryResultBuilder
+            .create(new ThingUID(THING_TYPE_UID, "id2")).withThingType(THING_TYPE_UID).withBridge(BRIDGE_THING_UID)
+            .withRepresentationProperty("Thing2").withLabel("thing2").withTTL(DEFAULT_TTL).build();
+    private static final DiscoveryResult THING_WITHOUT_BRIDGE = DiscoveryResultBuilder
+            .create(new ThingUID(THING_TYPE_UID, "id3")).withThingType(THING_TYPE_UID)
+            .withRepresentationProperty("Thing3").withLabel("thing3").withTTL(DEFAULT_TTL).build();
+    private static final DiscoveryResult THING_WITH_OTHER_BRIDGE = DiscoveryResultBuilder
+            .create(new ThingUID(THING_TYPE_UID, "id4")).withThingType(THING_TYPE_UID)
+            .withBridge(new ThingUID(THING_TYPE_UID, "id5")).withRepresentationProperty("Thing4").withLabel("thing4")
+            .withTTL(DEFAULT_TTL).build();
 
     private final URI testURI = createURI("http:dummy");
     private final String testThingLabel = "dummy_thing";
@@ -227,12 +232,6 @@ public class InboxOSGiTest extends JavaOSGiTest {
         // inboxListeners.add(inboxListener)
     }
 
-    private void removeInboxListener(InboxListener inboxListener) {
-        inbox.removeInboxListener(inboxListener);
-        // TODO: the test fails if this line is used
-        // inboxListeners.remove(inboxListener)
-    }
-
     @Test
     public void assertThatGetAllIncludesPreviouslyAddedDiscoveryResult() {
         ThingTypeUID thingTypeUID = new ThingTypeUID("dummyBindingId", "dummyThingType");
@@ -245,8 +244,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
 
         assertTrue(addDiscoveryResult(discoveryResult));
 
@@ -277,16 +277,17 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
         assertTrue(addDiscoveryResult(discoveryResult));
 
         props.clear();
         props.put("property2", "property2value2");
         props.put("property3", "property3value1");
 
-        discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property3", "DummyLabel2",
-                DEFAULT_TTL);
+        discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID).withProperties(props)
+                .withRepresentationProperty("property3").withLabel("DummyLabel2").withTTL(DEFAULT_TTL).build();
 
         assertTrue(addDiscoveryResult(discoveryResult));
 
@@ -313,14 +314,14 @@ public class InboxOSGiTest extends JavaOSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.getAll();
         assertThat(allDiscoveryResults.size(), is(0));
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, null, null,
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withLabel("DummyLabel1").withTTL(DEFAULT_TTL).build();
 
         assertTrue(addDiscoveryResult(discoveryResult));
 
         ThingUID thingUID2 = new ThingUID(thingTypeUID, "dummyThingId2");
-        discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID2, null, null, null, "DummyLabel2",
-                DEFAULT_TTL);
+        discoveryResult = DiscoveryResultBuilder.create(thingUID2).withThingType(thingTypeUID).withLabel("DummyLabel2")
+                .withTTL(DEFAULT_TTL).build();
 
         addDiscoveryResult(discoveryResult);
 
@@ -340,8 +341,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
         assertTrue(addDiscoveryResult(discoveryResult));
 
         allDiscoveryResults = inbox.getAll();
@@ -365,8 +367,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
         assertTrue(addDiscoveryResult(discoveryResult));
 
         allDiscoveryResults = inbox.getAll();
@@ -376,8 +379,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property2", "property2value2");
         props.put("property3", "property3value1");
 
-        DiscoveryResult discoveryResultUpdate = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props,
-                "property3", "DummyLabel2", DEFAULT_TTL);
+        DiscoveryResult discoveryResultUpdate = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property3").withLabel("DummyLabel2")
+                .withTTL(DEFAULT_TTL).build();
 
         assertTrue(addDiscoveryResult(discoveryResultUpdate));
 
@@ -402,8 +406,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<>();
         AsyncResultWrapper<DiscoveryResult> updatedDiscoveryResultWrapper = new AsyncResultWrapper<>();
@@ -466,16 +471,17 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
         assertTrue(addDiscoveryResult(discoveryResult));
 
         props.clear();
         props.put("property2", "property2value2");
         props.put("property3", "property3value1");
 
-        discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property3", "DummyLabel2",
-                DEFAULT_TTL);
+        discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID).withProperties(props)
+                .withRepresentationProperty("property3").withLabel("DummyLabel2").withTTL(DEFAULT_TTL).build();
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<>();
         AsyncResultWrapper<DiscoveryResult> updatedDiscoveryResultWrapper = new AsyncResultWrapper<>();
@@ -537,8 +543,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
         assertTrue(addDiscoveryResult(discoveryResult));
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<>();
@@ -601,8 +608,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, props, "property1",
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withProperties(props).withRepresentationProperty("property1").withLabel("DummyLabel1")
+                .withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 
@@ -626,8 +634,8 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, null, null,
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withLabel("DummyLabel1").withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 
@@ -647,8 +655,8 @@ public class InboxOSGiTest extends JavaOSGiTest {
         props.put("property1", "property1value1");
         props.put("property2", "property2value1");
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, null, null,
-                "DummyLabel1", DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withLabel("DummyLabel1").withTTL(DEFAULT_TTL).build();
 
         inbox.add(discoveryResult);
 
@@ -688,15 +696,16 @@ public class InboxOSGiTest extends JavaOSGiTest {
         registerService(inboxEventSubscriber);
 
         // add discovery result
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, null, null, null,
-                DEFAULT_TTL);
+        DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)
+                .withTTL(DEFAULT_TTL).build();
         addDiscoveryResult(discoveryResult);
         waitForAssert(() -> assertThat(receivedEvent.getWrappedObject(), not(nullValue())));
         assertThat(receivedEvent.getWrappedObject(), is(instanceOf(InboxAddedEvent.class)));
         receivedEvent.reset();
 
         // update discovery result
-        discoveryResult = new DiscoveryResultImpl(thingTypeUID, thingUID, null, null, null, null, DEFAULT_TTL);
+        discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID).withTTL(DEFAULT_TTL)
+                .build();
         addDiscoveryResult(discoveryResult);
         waitForAssert(() -> assertThat(receivedEvent.getWrappedObject(), not(nullValue())));
         assertThat(receivedEvent.getWrappedObject(), is(instanceOf(InboxUpdatedEvent.class)));


### PR DESCRIPTION
- Removed deprecated constructor for `DiscoveryResultImpl`
- Replaced `DiscoveryResultImpl` by `DiscoveryResultBuilder`

Related to #1408

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>