### PR TITLE
Removed deprecated 'newItemBuilder' method

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -38,7 +38,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
-import org.openhab.core.items.ItemBuilder;
 import org.openhab.core.items.ItemBuilderFactory;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemNotUniqueException;
@@ -1385,24 +1384,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
 
         return null;
-    }
-
-    @Override
-    public ItemBuilder newItemBuilder(Item item) {
-        if (itemBuilderFactory != null) {
-            return itemBuilderFactory.newItemBuilder(item);
-        } else {
-            throw new IllegalStateException("Cannot create an item builder without the item registry");
-        }
-    }
-
-    @Override
-    public ItemBuilder newItemBuilder(String itemType, String itemName) {
-        if (itemBuilderFactory != null) {
-            return itemBuilderFactory.newItemBuilder(itemType, itemName);
-        } else {
-            throw new IllegalStateException("Cannot create an item builder without the item registry");
-        }
     }
 
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
@@ -13,14 +13,10 @@
 package org.openhab.core.items;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.Registry;
-import org.openhab.core.internal.items.ItemBuilderImpl;
-import org.openhab.core.library.CoreItemFactory;
-import org.slf4j.LoggerFactory;
 
 /**
  * The ItemRegistry is the central place, where items are kept in memory and their state
@@ -122,36 +118,5 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @param hook
      */
     void removeRegistryHook(RegistryHook<Item> hook);
-
-    /**
-     * Create a new {@link ItemBuilder}, which is initialized by the given item.
-     *
-     * @param item the template to initialize the builder with
-     * @return an ItemBuilder instance
-     *
-     * @deprecated Use the {@link ItemBuilderFactory} service instead.
-     */
-    @Deprecated
-    default ItemBuilder newItemBuilder(Item item) {
-        LoggerFactory.getLogger(ItemRegistry.class)
-                .warn("Deprecation: You are using a deprecated API. Please use the ItemBuilder OSGi service instead.");
-        return new ItemBuilderImpl(Collections.singleton(new CoreItemFactory()), item);
-    }
-
-    /**
-     * Create a new {@link ItemBuilder}, which is initialized by the given item.
-     *
-     * @param itemType the item type to create
-     * @param itemName the name of the item to create
-     * @return an ItemBuilder instance
-     *
-     * @deprecated Use the {@link ItemBuilderFactory} service instead.
-     */
-    @Deprecated
-    default ItemBuilder newItemBuilder(String itemType, String itemName) {
-        LoggerFactory.getLogger(ItemRegistry.class)
-                .warn("Deprecation: You are using a deprecated API. Please use the ItemBuilder OSGi service instead.");
-        return new ItemBuilderImpl(Collections.singleton(new CoreItemFactory()), itemType, itemName);
-    }
 
 }


### PR DESCRIPTION
- Removed deprecated `newItemBuilder` method

Related to #1408

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>