### PR TITLE
Removed deprecated constructors and methods from Config API

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -32,7 +32,7 @@ import org.openhab.core.automation.type.Input;
 import org.openhab.core.automation.type.ModuleType;
 import org.openhab.core.automation.type.Output;
 import org.openhab.core.automation.type.TriggerType;
-import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.i18n.ConfigI18nLocalizationService;
 import org.openhab.core.i18n.TranslationProvider;
@@ -109,8 +109,8 @@ public class ModuleTypeI18nServiceImpl implements ModuleTypeI18nService {
             @Nullable Locale locale) {
         try {
             return configI18nService
-                    .getLocalizedConfigDescription(bundle,
-                            new ConfigDescription(new URI(prefix + ":" + uid + ".name"), parameters), locale)
+                    .getLocalizedConfigDescription(bundle, ConfigDescriptionBuilder
+                            .create(new URI(prefix + ":" + uid + ".name")).withParameters(parameters).build(), locale)
                     .getParameters();
         } catch (URISyntaxException e) {
             logger.error("Constructed invalid uri '{}:{}.name'", prefix, uid, e);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescription.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescription.java
@@ -52,48 +52,16 @@ public class ConfigDescription implements Identifiable<URI> {
     private final List<ConfigDescriptionParameterGroup> parameterGroups;
 
     /**
-     * Creates a new instance of this class with the specified parameter.
-     *
-     * @deprecated Use the {@link ConfigDescriptionBuilder} instead.
+     * Creates a new instance of this class with the specified parameters.
      *
      * @param uri the URI of this description within the {@link ConfigDescriptionRegistry}
-     * @throws IllegalArgumentException if the URI is null or invalid
-     */
-    @Deprecated
-    public ConfigDescription(URI uri) throws IllegalArgumentException {
-        this(uri, null, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ConfigDescriptionBuilder} instead.
-     *
-     * @param uri the URI of this description within the {@link ConfigDescriptionRegistry} (must neither be null nor
-     *            empty)
      * @param parameters the list of configuration parameters that belong to the given URI
-     *            (could be null or empty)
-     * @throws IllegalArgumentException if the URI is null or invalid
-     */
-    @Deprecated
-    public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters) {
-        this(uri, parameters, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ConfigDescriptionBuilder} instead.
-     *
-     * @param uri the URI of this description within the {@link ConfigDescriptionRegistry} (must neither be null nor
-     *            empty)
-     * @param parameters the list of configuration parameters that belong to the given URI
-     *            (could be null or empty)
      * @param groups the list of groups associated with the parameters
      * @throws IllegalArgumentException if the URI is null or invalid
+     * @deprecated Use the {@link ConfigDescriptionBuilder} instead.
      */
     @Deprecated
-    public ConfigDescription(@Nullable URI uri, @Nullable List<ConfigDescriptionParameter> parameters,
+    ConfigDescription(URI uri, @Nullable List<ConfigDescriptionParameter> parameters,
             @Nullable List<ConfigDescriptionParameterGroup> groups) {
         if (uri == null) {
             throw new IllegalArgumentException("The URI must not be null!");
@@ -106,25 +74,15 @@ public class ConfigDescription implements Identifiable<URI> {
         }
 
         this.uri = uri;
-
-        if (parameters != null) {
-            this.parameters = Collections.unmodifiableList(parameters);
-        } else {
-            this.parameters = Collections.emptyList();
-        }
-
-        if (groups != null) {
-            this.parameterGroups = Collections.unmodifiableList(groups);
-        } else {
-            this.parameterGroups = Collections.emptyList();
-        }
+        this.parameters = parameters == null ? Collections.emptyList() : Collections.unmodifiableList(parameters);
+        this.parameterGroups = groups == null ? Collections.emptyList() : Collections.unmodifiableList(groups);
     }
 
     /**
      * Returns the URI of this description within the {@link ConfigDescriptionRegistry}.
      * The URI follows the syntax {@code '<scheme>:<token>[:<token>]'} (e.g. {@code "binding:hue:bridge"}).
      *
-     * @return the URI of this description (not null)
+     * @return the URI of this description
      */
     @Override
     public URI getUID() {
@@ -136,7 +94,7 @@ public class ConfigDescription implements Identifiable<URI> {
      * <p>
      * The returned list is immutable.
      *
-     * @return the corresponding configuration description parameters (not null, could be empty)
+     * @return the corresponding configuration description parameters (could be empty)
      */
     public List<ConfigDescriptionParameter> getParameters() {
         return parameters;
@@ -147,7 +105,7 @@ public class ConfigDescription implements Identifiable<URI> {
      * parameter as key and the parameter as value.
      *
      * @return the unmodifiable map of configuration description parameters which uses the name as key and the parameter
-     *         as value (not null, could be empty)
+     *         as value (could be empty)
      */
     public Map<String, ConfigDescriptionParameter> toParametersMap() {
         Map<String, ConfigDescriptionParameter> map = new HashMap<>();
@@ -162,7 +120,7 @@ public class ConfigDescription implements Identifiable<URI> {
      * <p>
      * The returned list is immutable.
      *
-     * @return the list of parameter groups parameter (not null, could be empty)
+     * @return the list of parameter groups parameter (could be empty)
      */
     public List<ConfigDescriptionParameterGroup> getParameterGroups() {
         return parameterGroups;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
@@ -121,20 +121,6 @@ public class ConfigDescriptionParameter {
      *
      * @param name the name of the configuration parameter (must neither be null
      *            nor empty)
-     * @param type the data type of the configuration parameter (must not be
-     *            null)
-     * @throws IllegalArgumentException if the name is null or empty, or the type is null
-     */
-    public ConfigDescriptionParameter(String name, Type type) throws IllegalArgumentException {
-        this(name, type, null, null, null, null, false, false, false, null, null, null, null, null, null, null, false,
-                true, null, null, null, false);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @param name the name of the configuration parameter (must neither be null
-     *            nor empty)
      * @param type the data type of the configuration parameter (nullable)
      * @param minimum the minimal value for numeric types, or the minimal length of
      *            strings, or the minimal number of selected options (nullable)
@@ -180,7 +166,9 @@ public class ConfigDescriptionParameter {
      *             https://openhab.org/documentation/development/bindings/xml-reference.html for the list
      *             of valid units)</li>
      *             </ul>
+     * @deprecated Use {@link ConfigDescriptionParameterBuilder} instead.
      */
+    @Deprecated
     ConfigDescriptionParameter(String name, Type type, BigDecimal minimum, BigDecimal maximum, BigDecimal stepsize,
             String pattern, Boolean required, Boolean readOnly, Boolean multiple, String context, String defaultValue,
             String label, String description, List<ParameterOption> options, List<FilterCriteria> filterCriteria,

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
@@ -294,6 +294,7 @@ public class ConfigDescriptionParameterBuilder {
      *
      * @return the desired result
      */
+    @SuppressWarnings("deprecation")
     public ConfigDescriptionParameter build() throws IllegalArgumentException {
         return new ConfigDescriptionParameter(name, type, min, max, step, pattern, required, readOnly, multiple,
                 context, defaultValue, label, description, options, filterCriteria, groupName, advanced, limitToOptions,

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionRegistry.java
@@ -105,7 +105,7 @@ public class ConfigDescriptionRegistry {
      * @return all config descriptions or an empty collection if no config
      *         description exists
      */
-    public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
+    public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
         Map<URI, ConfigDescription> configMap = new HashMap<>();
 
         // Loop over all providers
@@ -126,7 +126,8 @@ public class ConfigDescriptionRegistry {
 
                     // And add the combined configuration to the map
                     configMap.put(configDescription.getUID(),
-                            new ConfigDescription(configDescription.getUID(), parameters, parameterGroups));
+                            ConfigDescriptionBuilder.create(configDescription.getUID()).withParameters(parameters)
+                                    .withParameterGroups(parameterGroups).build());
                 } else {
                     // No - Just add the new configuration to the map
                     configMap.put(configDescription.getUID(), configDescription);
@@ -169,7 +170,7 @@ public class ConfigDescriptionRegistry {
      * @return config description or null if no config description exists for
      *         the given name
      */
-    public @Nullable ConfigDescription getConfigDescription(URI uri, Locale locale) {
+    public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
         List<ConfigDescriptionParameter> parameters = new ArrayList<>();
         List<ConfigDescriptionParameterGroup> parameterGroups = new ArrayList<>();
 
@@ -189,7 +190,8 @@ public class ConfigDescriptionRegistry {
             }
 
             // Return the new configuration description
-            return new ConfigDescription(uri, parametersWithOptions, parameterGroups);
+            return ConfigDescriptionBuilder.create(uri).withParameters(parametersWithOptions)
+                    .withParameterGroups(parameterGroups).build();
         } else {
             // Otherwise null
             return null;
@@ -207,7 +209,7 @@ public class ConfigDescriptionRegistry {
         return ret;
     }
 
-    private boolean fillFromProviders(URI uri, Locale locale, List<ConfigDescriptionParameter> parameters,
+    private boolean fillFromProviders(URI uri, @Nullable Locale locale, List<ConfigDescriptionParameter> parameters,
             List<ConfigDescriptionParameterGroup> parameterGroups) {
         boolean found = false;
         for (ConfigDescriptionProvider configDescriptionProvider : this.configDescriptionProviders) {
@@ -271,20 +273,35 @@ public class ConfigDescriptionRegistry {
 
         if (found) {
             // Return the new parameter
-            return new ConfigDescriptionParameter(parameter.getName(), parameter.getType(), parameter.getMinimum(),
-                    parameter.getMaximum(), parameter.getStepSize(), parameter.getPattern(), parameter.isRequired(),
-                    parameter.isReadOnly(), parameter.isMultiple(), parameter.getContext(), parameter.getDefault(),
-                    parameter.getLabel(), parameter.getDescription(), options, parameter.getFilterCriteria(),
-                    parameter.getGroupName(), parameter.isAdvanced(), parameter.getLimitToOptions(),
-                    parameter.getMultipleLimit(), parameter.getUnit(), parameter.getUnitLabel(),
-                    parameter.isVerifyable());
+            return ConfigDescriptionParameterBuilder.create(parameter.getName(), parameter.getType()) //
+                    .withMinimum(parameter.getMinimum()) //
+                    .withMaximum(parameter.getMaximum()) //
+                    .withStepSize(parameter.getStepSize()) //
+                    .withPattern(parameter.getPattern()) //
+                    .withRequired(parameter.isRequired()) //
+                    .withReadOnly(parameter.isReadOnly()) //
+                    .withMultiple(parameter.isMultiple()) //
+                    .withContext(parameter.getContext()) //
+                    .withDefault(parameter.getDefault()) //
+                    .withLabel(parameter.getLabel()) //
+                    .withDescription(parameter.getDescription()) //
+                    .withOptions(options) //
+                    .withFilterCriteria(parameter.getFilterCriteria()) //
+                    .withGroupName(parameter.getGroupName()) //
+                    .withAdvanced(parameter.isAdvanced()) //
+                    .withLimitToOptions(parameter.getLimitToOptions()) //
+                    .withMultipleLimit(parameter.getMultipleLimit()) //
+                    .withUnit(parameter.getUnit()) //
+                    .withUnitLabel(parameter.getUnitLabel()) //
+                    .withVerify(parameter.isVerifyable()) //
+                    .build();
         } else {
             // Otherwise return the original parameter
             return parameter;
         }
     }
 
-    private boolean fillFromProviders(URI alias, ConfigDescriptionParameter parameter, Locale locale,
+    private boolean fillFromProviders(URI alias, ConfigDescriptionParameter parameter, @Nullable Locale locale,
             List<ParameterOption> options) {
         boolean found = false;
         for (ConfigOptionProvider configOptionProvider : this.configOptionProviders) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -13,6 +13,7 @@
 package org.openhab.core.config.core;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -76,7 +77,7 @@ public class ConfigUtil {
                         LoggerFactory.getLogger(ConfigUtil.class).warn(
                                 "Default value for parameter '{}' of type 'INTEGER' seems not to be an integer value: {}",
                                 parameterName, defaultValue);
-                        return value.setScale(0, BigDecimal.ROUND_DOWN);
+                        return value.setScale(0, RoundingMode.DOWN);
                     }
                     return value;
                 case DECIMAL:

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
@@ -82,8 +83,9 @@ public class ConfigI18nLocalizationService {
                     bundle, configDescription, configDescriptionParameterGroup, locale);
             localizedConfigDescriptionGroups.add(localizedConfigDescriptionGroup);
         }
-        return new ConfigDescription(configDescription.getUID(), localizedConfigDescriptionParameters,
-                localizedConfigDescriptionGroups);
+        return ConfigDescriptionBuilder.create(configDescription.getUID())
+                .withParameters(localizedConfigDescriptionParameters)
+                .withParameterGroups(localizedConfigDescriptionGroups).build();
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImpl.java
@@ -14,7 +14,6 @@ package org.openhab.core.config.core.internal.metadata;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -23,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
@@ -121,7 +121,7 @@ public class MetadataConfigDescriptionProviderImpl implements ConfigDescriptionP
         builder.withDescription(description != null ? description : namespace);
         ConfigDescriptionParameter parameter = builder.build();
 
-        return new ConfigDescription(uri, Collections.singletonList(parameter));
+        return ConfigDescriptionBuilder.create(uri).withParameter(parameter).build();
     }
 
     private @Nullable ConfigDescription createParamConfigDescription(MetadataConfigDescriptionProvider provider,
@@ -132,7 +132,7 @@ public class MetadataConfigDescriptionProviderImpl implements ConfigDescriptionP
         if (parameters == null || parameters.isEmpty()) {
             return null;
         }
-        return new ConfigDescription(uri, parameters);
+        return ConfigDescriptionBuilder.create(uri).withParameters(parameters).build();
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
@@ -51,7 +51,7 @@ public class ConfigDescriptionParameterBuilderTest {
         String groupName = "groupName";
         boolean advanced = false;
         boolean limitToOptions = true;
-        Integer multipleLimit = new Integer(17);
+        Integer multipleLimit = Integer.valueOf(17);
 
         //@formatter:off
         ConfigDescriptionParameter param = ConfigDescriptionParameterBuilder.create(name, type)
@@ -152,8 +152,8 @@ public class ConfigDescriptionParameterBuilderTest {
         assertFalse(param.isMultiple());
         assertFalse(param.isAdvanced());
         assertTrue(param.getLimitToOptions());
-        ConfigDescriptionParameter param2 = new ConfigDescriptionParameter("Dummy", Type.BOOLEAN, null, null, null,
-                null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+
+        ConfigDescriptionParameter param2 = ConfigDescriptionParameterBuilder.create("Dummy", Type.BOOLEAN).build();
         assertFalse(param2.isRequired());
         assertFalse(param2.isReadOnly());
         assertFalse(param2.isMultiple());

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionRegistryTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionRegistryTest.java
@@ -61,33 +61,30 @@ public class ConfigDescriptionRegistryTest extends JavaTest {
         uriAliases = new URI("config:Aliased");
 
         configDescriptionRegistry = new ConfigDescriptionRegistry();
-        ConfigDescriptionParameter param1 = new ConfigDescriptionParameter("param1",
-                ConfigDescriptionParameter.Type.INTEGER);
-        List<ConfigDescriptionParameter> pList1 = new ArrayList<>();
-        pList1.add(param1);
+        ConfigDescriptionParameter param1 = ConfigDescriptionParameterBuilder
+                .create("param1", ConfigDescriptionParameter.Type.INTEGER).build();
 
-        configDescription = new ConfigDescription(uriDummy, pList1);
+        configDescription = ConfigDescriptionBuilder.create(uriDummy).withParameter(param1).build();
         when(configDescriptionProviderMock.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription));
         when(configDescriptionProviderMock.getConfigDescription(eq(uriDummy), any())).thenReturn(configDescription);
 
-        configDescription1 = new ConfigDescription(uriDummy1);
+        configDescription1 = ConfigDescriptionBuilder.create(uriDummy1).build();
         when(configDescriptionProviderMock1.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription1));
         when(configDescriptionProviderMock1.getConfigDescription(eq(uriDummy1), any())).thenReturn(configDescription1);
 
-        configDescriptionAliased = new ConfigDescription(uriAliases, Collections
-                .singletonList(new ConfigDescriptionParameter("instanceId", ConfigDescriptionParameter.Type.INTEGER)));
+        configDescriptionAliased = ConfigDescriptionBuilder.create(uriAliases).withParameter(
+                ConfigDescriptionParameterBuilder.create("instanceId", ConfigDescriptionParameter.Type.INTEGER).build())
+                .build();
         when(configDescriptionProviderAliased.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescriptionAliased));
         when(configDescriptionProviderAliased.getConfigDescription(eq(uriAliases), any()))
                 .thenReturn(configDescriptionAliased);
 
-        ConfigDescriptionParameter param2 = new ConfigDescriptionParameter("param2",
-                ConfigDescriptionParameter.Type.INTEGER);
-        List<ConfigDescriptionParameter> pList2 = new ArrayList<>();
-        pList2.add(param2);
-        configDescription2 = new ConfigDescription(uriDummy, pList2);
+        ConfigDescriptionParameter param2 = ConfigDescriptionParameterBuilder
+                .create("param2", ConfigDescriptionParameter.Type.INTEGER).build();
+        configDescription2 = ConfigDescriptionBuilder.create(uriDummy).withParameter(param2).build();
         when(configDescriptionProviderMock2.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription2));
         when(configDescriptionProviderMock2.getConfigDescription(eq(uriDummy), any())).thenReturn(configDescription2);

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -108,8 +108,8 @@ public class ConfigUtilTest {
     @Test
     public void verifyApplyDefaultConfigurationReturnsNullIfNotSet() {
         Configuration configuration = new Configuration();
-        ConfigDescription configDescription = new ConfigDescription(configUri,
-                Collections.singletonList(configDescriptionParameterBuilder2.build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configUri)
+                .withParameter(configDescriptionParameterBuilder2.build()).build();
 
         ConfigUtil.applyDefaultConfiguration(configuration, configDescription);
         assertThat(configuration.get("p2"), is(nullValue()));
@@ -120,8 +120,8 @@ public class ConfigUtilTest {
         configDescriptionParameterBuilder1.withDefault("2.5");
 
         Configuration configuration = new Configuration();
-        ConfigDescription configDescription = new ConfigDescription(configUri,
-                Collections.singletonList(configDescriptionParameterBuilder1.build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configUri)
+                .withParameter(configDescriptionParameterBuilder1.build()).build();
 
         ConfigUtil.applyDefaultConfiguration(configuration, configDescription);
         verifyValuesOfConfiguration(configuration.get("p1"), 1, Collections.singletonList(new BigDecimal("2.5")));
@@ -132,8 +132,8 @@ public class ConfigUtilTest {
         configDescriptionParameterBuilder1.withDefault("2.3,2.4,2.5");
 
         Configuration configuration = new Configuration();
-        ConfigDescription configDescription = new ConfigDescription(configUri,
-                Collections.singletonList(configDescriptionParameterBuilder1.build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configUri)
+                .withParameter(configDescriptionParameterBuilder1.build()).build();
 
         ConfigUtil.applyDefaultConfiguration(configuration, configDescription);
         verifyValuesOfConfiguration(configuration.get("p1"), 3,
@@ -145,8 +145,8 @@ public class ConfigUtilTest {
         configDescriptionParameterBuilder1.withDefault("2.3,2.4,foo,2.5");
 
         Configuration configuration = new Configuration();
-        ConfigDescription configDescription = new ConfigDescription(configUri,
-                Collections.singletonList(configDescriptionParameterBuilder1.build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configUri)
+                .withParameter(configDescriptionParameterBuilder1.build()).build();
 
         ConfigUtil.applyDefaultConfiguration(configuration, configDescription);
         verifyValuesOfConfiguration(configuration.get("p1"), 3,
@@ -158,8 +158,8 @@ public class ConfigUtilTest {
         configDescriptionParameterBuilder2.withDefault("first value,  second value  ,third value,,,");
 
         Configuration configuration = new Configuration();
-        ConfigDescription configDescription = new ConfigDescription(configUri,
-                Collections.singletonList(configDescriptionParameterBuilder2.build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configUri)
+                .withParameter(configDescriptionParameterBuilder2.build()).build();
 
         ConfigUtil.applyDefaultConfiguration(configuration, configDescription);
         verifyValuesOfConfiguration(configuration.get("p2"), 3,
@@ -175,11 +175,11 @@ public class ConfigUtilTest {
 
     @Test
     public void firstDesciptionWinsForNormalization() throws URISyntaxException {
-        ConfigDescription configDescriptionInteger = new ConfigDescription(new URI("thing:fooThing"),
-                Arrays.asList(new ConfigDescriptionParameter("foo", INTEGER)));
+        ConfigDescription configDescriptionInteger = ConfigDescriptionBuilder.create(new URI("thing:fooThing"))
+                .withParameter(ConfigDescriptionParameterBuilder.create("foo", INTEGER).build()).build();
 
-        ConfigDescription configDescriptionString = new ConfigDescription(new URI("thingType:fooThing"),
-                Arrays.asList(new ConfigDescriptionParameter("foo", TEXT)));
+        ConfigDescription configDescriptionString = ConfigDescriptionBuilder.create(new URI("thingType:fooThing"))
+                .withParameter(ConfigDescriptionParameterBuilder.create("foo", TEXT).build()).build();
 
         assertThat(
                 ConfigUtil.normalizeTypes(Collections.singletonMap("foo", "1"), Arrays.asList(configDescriptionInteger))

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/normalization/NormalizerTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/normalization/NormalizerTest.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
-import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 
 /**
  * @author Simon Kaufmann - Initial contribution
@@ -33,15 +33,16 @@ public class NormalizerTest {
 
     @Test
     public void testBooleanNormalizer() {
-        Normalizer normalizer = NormalizerFactory.getNormalizer(new ConfigDescriptionParameter("test", Type.BOOLEAN));
+        Normalizer normalizer = NormalizerFactory.getNormalizer(
+                ConfigDescriptionParameterBuilder.create("test", ConfigDescriptionParameter.Type.BOOLEAN).build());
 
         assertThat(normalizer.normalize(null), is(nullValue()));
         assertThat(normalizer.normalize(true), is(equalTo(true)));
         assertThat(normalizer.normalize(1), is(equalTo(true)));
         assertThat(normalizer.normalize(false), is(equalTo(false)));
         assertThat(normalizer.normalize(0), is(equalTo(false)));
-        assertThat(normalizer.normalize(new Boolean(true)), is(equalTo(true)));
-        assertThat(normalizer.normalize(new Boolean(false)), is(equalTo(false)));
+        assertThat(normalizer.normalize(Boolean.TRUE), is(equalTo(true)));
+        assertThat(normalizer.normalize(Boolean.FALSE), is(equalTo(false)));
         assertThat(normalizer.normalize("true"), is(equalTo(true)));
         assertThat(normalizer.normalize("false"), is(equalTo(false)));
         assertThat(normalizer.normalize("yes"), is(equalTo(true)));
@@ -67,7 +68,8 @@ public class NormalizerTest {
 
     @Test
     public void testIntNormalizer() {
-        Normalizer normalizer = NormalizerFactory.getNormalizer(new ConfigDescriptionParameter("test", Type.INTEGER));
+        Normalizer normalizer = NormalizerFactory.getNormalizer(
+                ConfigDescriptionParameterBuilder.create("test", ConfigDescriptionParameter.Type.INTEGER).build());
 
         assertThat(normalizer.normalize(null), is(nullValue()));
         assertThat(normalizer.normalize(42), is(equalTo(new BigDecimal(42))));
@@ -93,7 +95,8 @@ public class NormalizerTest {
 
     @Test
     public void testDecimalNormalizer() {
-        Normalizer normalizer = NormalizerFactory.getNormalizer(new ConfigDescriptionParameter("test", Type.DECIMAL));
+        Normalizer normalizer = NormalizerFactory.getNormalizer(
+                ConfigDescriptionParameterBuilder.create("test", ConfigDescriptionParameter.Type.DECIMAL).build());
 
         assertThat(normalizer.normalize(null), is(nullValue()));
         assertThat(normalizer.normalize(42), is(equalTo(new BigDecimal("42.0"))));
@@ -121,7 +124,8 @@ public class NormalizerTest {
 
     @Test
     public void testTextNormalizer() {
-        Normalizer normalizer = NormalizerFactory.getNormalizer(new ConfigDescriptionParameter("test", Type.TEXT));
+        Normalizer normalizer = NormalizerFactory.getNormalizer(
+                ConfigDescriptionParameterBuilder.create("test", ConfigDescriptionParameter.Type.TEXT).build());
 
         assertThat(normalizer.normalize(null), is(nullValue()));
         assertThat(normalizer.normalize(""), is(equalTo("")));
@@ -142,17 +146,8 @@ public class NormalizerTest {
 
     @Test
     public void testListNormalizer() {
-        Normalizer normalizer = NormalizerFactory.getNormalizer(new ConfigDescriptionParameter() {
-            @Override
-            public Type getType() {
-                return Type.BOOLEAN;
-            };
-
-            @Override
-            public Boolean isMultiple() {
-                return true;
-            };
-        });
+        Normalizer normalizer = NormalizerFactory.getNormalizer(ConfigDescriptionParameterBuilder
+                .create("test", ConfigDescriptionParameter.Type.BOOLEAN).withMultiple(true).build());
 
         assertThat(normalizer.normalize(null), is(nullValue()));
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
@@ -135,11 +136,13 @@ public class ConfigDescriptionValidatorTest {
         }
     }
 
-    private static final ConfigDescription CONFIG_DESCRIPTION = new ConfigDescription(CONFIG_DESCRIPTION_URI,
-            Stream.of(BOOL_PARAM, BOOL_REQUIRED_PARAM, TXT_PARAM, TXT_REQUIRED_PARAM, TXT_MIN_PARAM, TXT_MAX_PARAM,
-                    TXT_PATTERN_PARAM, TXT_MAX_PATTERN_PARAM, INT_PARAM, INT_REQUIRED_PARAM, INT_MIN_PARAM,
-                    INT_MAX_PARAM, DECIMAL_PARAM, DECIMAL_REQUIRED_PARAM, DECIMAL_MIN_PARAM, DECIMAL_MAX_PARAM)
-                    .collect(toList()));
+    private static final ConfigDescription CONFIG_DESCRIPTION = ConfigDescriptionBuilder.create(CONFIG_DESCRIPTION_URI)
+            .withParameters(Stream
+                    .of(BOOL_PARAM, BOOL_REQUIRED_PARAM, TXT_PARAM, TXT_REQUIRED_PARAM, TXT_MIN_PARAM, TXT_MAX_PARAM,
+                            TXT_PATTERN_PARAM, TXT_MAX_PATTERN_PARAM, INT_PARAM, INT_REQUIRED_PARAM, INT_MIN_PARAM,
+                            INT_MAX_PARAM, DECIMAL_PARAM, DECIMAL_REQUIRED_PARAM, DECIMAL_MIN_PARAM, DECIMAL_MAX_PARAM)
+                    .collect(toList()))
+            .build();
 
     private Map<String, Object> params;
     private ConfigDescriptionValidatorImpl configDescriptionValidator;
@@ -499,6 +502,7 @@ public class ConfigDescriptionValidatorTest {
         configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI);
     }
 
+    @SuppressWarnings("unchecked")
     private static List<ConfigValidationMessage> getConfigValidationMessages(ConfigValidationException cve) {
         try {
             Field field = cve.getClass().getDeclaredField("configValidationMessages");

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openhab.core.config.core.ConfigDescription;
-import org.openhab.core.config.core.ConfigDescriptionParameter;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
@@ -203,8 +203,8 @@ public class PersistentInboxTest {
         URI configDescriptionURI = new URI("thing-type:test:test");
         ThingType thingType = ThingTypeBuilder.instance(THING_TYPE_UID, "Test")
                 .withConfigDescriptionURI(configDescriptionURI).build();
-        ConfigDescriptionParameter param = ConfigDescriptionParameterBuilder.create(paramName, type).build();
-        ConfigDescription configDesc = new ConfigDescription(configDescriptionURI, Collections.singletonList(param));
+        ConfigDescription configDesc = ConfigDescriptionBuilder.create(configDescriptionURI)
+                .withParameter(ConfigDescriptionParameterBuilder.create(paramName, type).build()).build();
 
         when(thingTypeRegistry.getThingType(THING_TYPE_UID)).thenReturn(thingType);
         when(configDescriptionRegistry.getConfigDescription(eq(configDescriptionURI))).thenReturn(configDesc);

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionConverter.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionConverter.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
 import org.openhab.core.config.xml.util.ConverterAssertion;
@@ -98,9 +99,7 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
 
         ConverterAssertion.assertEndOfType(reader);
 
-        // create object
-        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups);
-
-        return configDescription;
+        return ConfigDescriptionBuilder.create(uri).withParameters(configDescriptionParams)
+                .withParameterGroups(configDescriptionGroups).build();
     }
 }

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionParameterConverter.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionParameterConverter.java
@@ -81,7 +81,7 @@ public class ConfigDescriptionParameterConverter extends GenericUnmarshaller<Con
         if (val == null) {
             return null;
         }
-        return new Boolean(val);
+        return Boolean.valueOf(val);
     }
 
     private Boolean falseIfNull(Boolean b) {

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
@@ -40,8 +41,8 @@ public class EnrichedConfigDescriptionDTOMapperTest {
     public void testThatDefaultValuesAreEmptyIfMultipleIsTrue() {
         ConfigDescriptionParameter configDescriptionParameter = ConfigDescriptionParameterBuilder
                 .create(CONFIG_PARAMETER_NAME, Type.TEXT).withMultiple(true).build();
-        ConfigDescription configDescription = new ConfigDescription(CONFIG_URI,
-                Arrays.asList(configDescriptionParameter));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(CONFIG_URI)
+                .withParameter(configDescriptionParameter).build();
 
         ConfigDescriptionDTO cddto = EnrichedConfigDescriptionDTOMapper.map(configDescription);
         assertThat(cddto.parameters, hasSize(1));
@@ -57,8 +58,8 @@ public class EnrichedConfigDescriptionDTOMapperTest {
     public void testThatDefaultValueIsNotAList() {
         ConfigDescriptionParameter configDescriptionParameter = ConfigDescriptionParameterBuilder
                 .create(CONFIG_PARAMETER_NAME, Type.TEXT).withDefault(CONFIG_PARAMETER_DEFAULT_VALUE).build();
-        ConfigDescription configDescription = new ConfigDescription(CONFIG_URI,
-                Arrays.asList(configDescriptionParameter));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(CONFIG_URI)
+                .withParameter(configDescriptionParameter).build();
 
         ConfigDescriptionDTO cddto = EnrichedConfigDescriptionDTOMapper.map(configDescription);
         assertThat(cddto.parameters, hasSize(1));
@@ -76,8 +77,8 @@ public class EnrichedConfigDescriptionDTOMapperTest {
         ConfigDescriptionParameter configDescriptionParameter = ConfigDescriptionParameterBuilder
                 .create(CONFIG_PARAMETER_NAME, Type.TEXT).withDefault(CONFIG_PARAMETER_DEFAULT_VALUE).withMultiple(true)
                 .build();
-        ConfigDescription configDescription = new ConfigDescription(CONFIG_URI,
-                Arrays.asList(configDescriptionParameter));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(CONFIG_URI)
+                .withParameter(configDescriptionParameter).build();
 
         ConfigDescriptionDTO cddto = EnrichedConfigDescriptionDTOMapper.map(configDescription);
         assertThat(cddto.parameters, hasSize(1));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
@@ -84,7 +85,7 @@ public class ItemChannelLinkConfigDescriptionProvider implements ConfigDescripti
             ConfigDescriptionParameter paramProfile = ConfigDescriptionParameterBuilder.create(PARAM_PROFILE, Type.TEXT)
                     .withLabel("Profile").withDescription("the profile to use").withRequired(false)
                     .withLimitToOptions(true).withOptions(getOptions(link, item, channel, locale)).build();
-            return new ConfigDescription(uri, Collections.singletonList(paramProfile));
+            return ConfigDescriptionBuilder.create(uri).withParameter(paramProfile).build();
         }
         return null;
     }

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -61,6 +61,7 @@ import org.openhab.core.automation.util.ModuleBuilder;
 import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
@@ -810,8 +811,8 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         List<Trigger> templateTriggers = Collections.emptyList();
         List<Condition> templateConditions = Collections.emptyList();
         List<Action> templateActions = Collections.emptyList();
-        List<ConfigDescriptionParameter> templateConfigDescriptionParameters = Collections
-                .singletonList(new ConfigDescriptionParameter("param", ConfigDescriptionParameter.Type.TEXT));
+        List<ConfigDescriptionParameter> templateConfigDescriptionParameters = Collections.singletonList(
+                ConfigDescriptionParameterBuilder.create("param", ConfigDescriptionParameter.Type.TEXT).build());
         RuleTemplate template = new RuleTemplate(templateUID, "Test template Label", "Test template description", tags,
                 templateTriggers, templateConditions, templateActions, templateConfigDescriptionParameters,
                 Visibility.VISIBLE);

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -42,8 +42,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionBuilder;
-import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.config.core.Configuration;
@@ -154,9 +154,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
     private final ThingType testThingType = ThingTypeBuilder.instance(testTypeUID, "label")
             .withConfigDescriptionURI(testURI).build();
     private final ConfigDescription testConfigDescription = ConfigDescriptionBuilder.create(testURI)
-            .withParameters(Stream
-                    .of(new ConfigDescriptionParameter(discoveryResultPropertyKeys.get(0), Type.TEXT),
-                            new ConfigDescriptionParameter(discoveryResultPropertyKeys.get(1), Type.INTEGER))
+            .withParameters(Stream.of(
+                    ConfigDescriptionParameterBuilder.create(discoveryResultPropertyKeys.get(0), Type.TEXT).build(),
+                    ConfigDescriptionParameterBuilder.create(discoveryResultPropertyKeys.get(1), Type.INTEGER).build())
                     .collect(toList()))
             .build();
     private final String[] keysInConfigDescription = new String[] { discoveryResultPropertyKeys.get(0),
@@ -868,9 +868,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         discoveryResultProperties.keySet().forEach(key -> {
             String thingProperty = addedThing.getProperties().get(key);
             String descResultParam = String.valueOf(discoveryResultProperties.get(key));
-            assertFalse(thingProperty == null);
-            assertFalse(descResultParam == null);
-            assertTrue(thingProperty.equals(descResultParam));
+            assertThat(thingProperty, is(notNullValue()));
+            assertThat(descResultParam, is(notNullValue()));
+            assertThat(thingProperty, is(descResultParam));
         });
     }
 

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
@@ -87,13 +88,14 @@ public class GenericThingProviderTest3 extends JavaOSGiTest {
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
         registerService(dumbThingHandlerFactory, ThingHandlerFactory.class.getName());
 
-        ConfigDescription configDescription = new ConfigDescription(new URI("test:test"),
-                Stream.of(
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(new URI("test:test"))
+                .withParameters(Stream.of(
                         ConfigDescriptionParameterBuilder.create("testAdditional", ConfigDescriptionParameter.Type.TEXT)
                                 .withRequired(false).withDefault("hello world").build(),
                         ConfigDescriptionParameterBuilder.create("testConf", ConfigDescriptionParameter.Type.TEXT)
                                 .withRequired(false).withDefault("bar").build())
-                        .collect(toList()));
+                        .collect(toList()))
+                .build();
 
         ConfigDescriptionProvider configDescriptionProvider = mock(ConfigDescriptionProvider.class);
         when(configDescriptionProvider.getConfigDescription(any(), nullable(Locale.class)))

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
@@ -22,8 +22,10 @@ import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.osgi.service.component.annotations.Component;
 
@@ -43,19 +45,12 @@ public class TestHueConfigDescriptionProvider implements ConfigDescriptionProvid
     @Override
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
         if (uri.equals(createURI("hue:LCT001:color"))) {
-            ConfigDescriptionParameter paramDefault = new ConfigDescriptionParameter("defaultConfig", Type.TEXT) {
-                @Override
-                public String getDefault() {
-                    return "defaultValue";
-                };
-            };
-            ConfigDescriptionParameter paramCustom = new ConfigDescriptionParameter("customConfig", Type.TEXT) {
-                @Override
-                public String getDefault() {
-                    return "none";
-                };
-            };
-            return new ConfigDescription(uri, Stream.of(paramDefault, paramCustom).collect(toList()));
+            ConfigDescriptionParameter paramDefault = ConfigDescriptionParameterBuilder
+                    .create("defaultConfig", Type.TEXT).withDefault("defaultValue").build();
+            ConfigDescriptionParameter paramCustom = ConfigDescriptionParameterBuilder.create("customConfig", Type.TEXT)
+                    .withDefault("none").build();
+            return ConfigDescriptionBuilder.create(uri)
+                    .withParameters(Stream.of(paramDefault, paramCustom).collect(toList())).build();
         }
         return null;
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
@@ -700,9 +701,10 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
     private void registerThingTypeAndConfigDescription() {
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID(BINDING_ID, THING_TYPE_ID), "label")
                 .withConfigDescriptionURI(configDescriptionUri()).build();
-        ConfigDescription configDescription = new ConfigDescription(configDescriptionUri(),
-                singletonList(ConfigDescriptionParameterBuilder
-                        .create("parameter", ConfigDescriptionParameter.Type.TEXT).withRequired(true).build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+                .withParameter(ConfigDescriptionParameterBuilder
+                        .create("parameter", ConfigDescriptionParameter.Type.TEXT).withRequired(true).build())
+                .build();
 
         ThingTypeProvider thingTypeProvider = mock(ThingTypeProvider.class);
         when(thingTypeProvider.getThingType(ArgumentMatchers.any(ThingTypeUID.class),
@@ -734,10 +736,11 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
     }
 
     private void registerConfigDescriptionProvider(boolean withRequiredParameter) {
-        ConfigDescription configDescription = new ConfigDescription(configDescriptionUri(),
-                singletonList(
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+                .withParameter(
                         ConfigDescriptionParameterBuilder.create("parameter", ConfigDescriptionParameter.Type.TEXT)
-                                .withRequired(withRequiredParameter).build()));
+                                .withRequired(withRequiredParameter).build())
+                .build();
 
         ConfigDescriptionProvider configDescriptionProvider = mock(ConfigDescriptionProvider.class);
         when(configDescriptionProvider.getConfigDescription(ArgumentMatchers.any(URI.class),

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
@@ -409,14 +410,17 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
         ThingType thingType = ThingTypeBuilder.instance(thingTypeUID, "label")
                 .withChannelDefinitions(getChannelDefinitions(thingTypeUID))
                 .withConfigDescriptionURI(configDescriptionUri).withProperties(thingTypeProperties).build();
-        ConfigDescription configDescription = new ConfigDescription(configDescriptionUri,
-                Arrays.asList(
-                        ConfigDescriptionParameterBuilder
-                                .create("parameter" + thingTypeUID.getId(), ConfigDescriptionParameter.Type.TEXT)
-                                .withRequired(false).withDefault("default" + thingTypeUID.getId()).build(),
-                        ConfigDescriptionParameterBuilder
-                                .create("provided" + thingTypeUID.getId(), ConfigDescriptionParameter.Type.TEXT)
-                                .withRequired(false).build()));
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri)
+                .withParameters(
+                        Arrays.asList(
+                                ConfigDescriptionParameterBuilder
+                                        .create("parameter" + thingTypeUID.getId(),
+                                                ConfigDescriptionParameter.Type.TEXT)
+                                        .withRequired(false).withDefault("default" + thingTypeUID.getId()).build(),
+                                ConfigDescriptionParameterBuilder
+                                        .create("provided" + thingTypeUID.getId(), ConfigDescriptionParameter.Type.TEXT)
+                                        .withRequired(false).build()))
+                .build();
 
         thingTypes.put(thingTypeUID, thingType);
         configDescriptions.put(configDescriptionUri, configDescription);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
@@ -138,11 +139,10 @@ public class ThingFactoryTest extends JavaOSGiTest {
                     @Override
                     public ConfigDescription answer(InvocationOnMock invocation) throws Throwable {
                         URI uri = (URI) invocation.getArgument(0);
-                        List<ConfigDescriptionParameter> parameters = singletonList(ConfigDescriptionParameterBuilder
+                        return ConfigDescriptionBuilder.create(uri).withParameter(ConfigDescriptionParameterBuilder
                                 .create("testProperty", ConfigDescriptionParameter.Type.TEXT).withContext("context")
-                                .withDefault("default").withDescription("description").withLimitToOptions(true)
-                                .build());
-                        return new ConfigDescription(uri, parameters);
+                                .withDefault("default").withDescription("description").withLimitToOptions(true).build())
+                                .build();
                     }
                 });
 
@@ -200,10 +200,8 @@ public class ThingFactoryTest extends JavaOSGiTest {
                                 .withDefault("2.3,2.4,2.5").withLabel("label").withDescription("description")
                                 .withMultiple(true).withLimitToOptions(true).build();
 
-                        List<ConfigDescriptionParameter> parameters = Stream.of(p1, p2, p3, p4, p5, p6)
-                                .collect(toList());
-
-                        return new ConfigDescription(uri, parameters);
+                        return ConfigDescriptionBuilder.create(uri)
+                                .withParameters(Stream.of(p1, p2, p3, p4, p5, p6).collect(toList())).build();
                     }
                 });
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -33,7 +33,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.openhab.core.common.SafeCaller;
-import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
@@ -324,20 +324,19 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         });
 
         ConfigDescriptionProvider mockConfigDescriptionProvider = mock(ConfigDescriptionProvider.class);
-        List<ConfigDescriptionParameter> parameters = Collections.singletonList( //
-                ConfigDescriptionParameterBuilder.create(CONFIG_PARAM_NAME, Type.TEXT).withRequired(true).build() //
-        );
+        ConfigDescriptionParameter parameter = ConfigDescriptionParameterBuilder.create(CONFIG_PARAM_NAME, Type.TEXT)
+                .withRequired(true).build();
         registerService(mockConfigDescriptionProvider, ConfigDescriptionProvider.class.getName());
 
         // verify a missing mandatory thing config prevents it from getting initialized
         when(mockConfigDescriptionProvider.getConfigDescription(eq(configDescriptionThing), any()))
-                .thenReturn(new ConfigDescription(configDescriptionThing, parameters));
+                .thenReturn(ConfigDescriptionBuilder.create(configDescriptionThing).withParameter(parameter).build());
         assertThingStatus(Collections.emptyMap(), Collections.emptyMap(), ThingStatus.UNINITIALIZED,
                 ThingStatusDetail.HANDLER_CONFIGURATION_PENDING);
 
         // verify a missing mandatory channel config prevents it from getting initialized
         when(mockConfigDescriptionProvider.getConfigDescription(eq(configDescriptionChannel), any()))
-                .thenReturn(new ConfigDescription(configDescriptionChannel, parameters));
+                .thenReturn(ConfigDescriptionBuilder.create(configDescriptionChannel).withParameter(parameter).build());
         assertThingStatus(Collections.singletonMap(CONFIG_PARAM_NAME, "value"), Collections.emptyMap(),
                 ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_CONFIGURATION_PENDING);
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -39,6 +39,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
@@ -1994,10 +1995,11 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
     }
 
     private void registerConfigDescriptionProvider(boolean withRequiredParameter) {
-        ConfigDescription configDescription = new ConfigDescription(configDescriptionUri(),
-                singletonList(
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+                .withParameter(
                         ConfigDescriptionParameterBuilder.create("parameter", ConfigDescriptionParameter.Type.TEXT)
-                                .withRequired(withRequiredParameter).build()));
+                                .withRequired(withRequiredParameter).build())
+                .build();
 
         ConfigDescriptionProvider configDescriptionProvider = mock(ConfigDescriptionProvider.class);
         when(configDescriptionProvider.getConfigDescription(any(URI.class), nullable(Locale.class)))


### PR DESCRIPTION
- Removed deprecated constructors and methods from Config API
- Replaced deprecated constructors by related builder where possible

Relates to #1408

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>