### PR TITLE
[config] Added builder for 'ConfigDescriptionParameterGroup'

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
@@ -26,6 +26,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
  * @author Thomas Höfer - Added unit
  */
 public class ConfigDescriptionParameterBuilder {
+
     private String name;
     private Type type;
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
@@ -45,7 +45,9 @@ public class ConfigDescriptionParameterGroup {
      * @param advanced a flag that is set to true if this group contains advanced settings
      * @param label the human readable group label
      * @param description a description that can be provided to the user
+     * @deprecated use {@link ConfigDescriptionParameterGroupBuilder} instead.
      */
+    @Deprecated
     public ConfigDescriptionParameterGroup(String name, @Nullable String context, Boolean advanced,
             @Nullable String label, @Nullable String description) {
         this.name = name;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilder.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ConfigDescriptionParameterGroupBuilder} class provides a builder for the
+ * {@link ConfigDescriptionParameterGroup} class.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigDescriptionParameterGroupBuilder {
+
+    private String name;
+    private @Nullable String context;
+    private @Nullable Boolean advanced;
+    private @Nullable String label;
+    private @Nullable String description;
+
+    private ConfigDescriptionParameterGroupBuilder(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Creates a parameter group builder
+     *
+     * @param name configuration parameter name
+     * @return parameter group builder
+     */
+    public static ConfigDescriptionParameterGroupBuilder create(String name) {
+        return new ConfigDescriptionParameterGroupBuilder(name);
+    }
+
+    /**
+     * Set. the context of the group.
+     *
+     * @param context group context as a string
+     * @return the updated builder instance
+     */
+    public ConfigDescriptionParameterGroupBuilder withContext(@Nullable String context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Sets the advanced flag for this group.
+     *
+     * @param advanced - true if the group contains advanced properties
+     * @return the updated builder instance
+     */
+    public ConfigDescriptionParameterGroupBuilder withAdvanced(@Nullable Boolean advanced) {
+        this.advanced = advanced;
+        return this;
+    }
+
+    /**
+     * Sets the human readable label of the group.
+     *
+     * @param label as a string
+     * @return the updated builder instance
+     */
+    public ConfigDescriptionParameterGroupBuilder withLabel(@Nullable String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Sets the human readable description of the parameter group.
+     *
+     * @param description as a string
+     * @return the updated builder instance
+     */
+    public ConfigDescriptionParameterGroupBuilder withDescription(@Nullable String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Builds a result with the settings of this builder.
+     *
+     * @return the desired result
+     */
+    @SuppressWarnings("deprecation")
+    public ConfigDescriptionParameterGroup build() throws IllegalArgumentException {
+        return new ConfigDescriptionParameterGroup(name, context, advanced != null ? advanced : false, label,
+                description);
+    }
+}

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
@@ -23,6 +23,7 @@ import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroupBuilder;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.config.core.internal.i18n.ConfigDescriptionGroupI18nUtil;
 import org.openhab.core.config.core.internal.i18n.ConfigDescriptionI18nUtil;
@@ -181,8 +182,9 @@ public class ConfigI18nLocalizationService {
         final String description = configDescriptionGroupI18nUtil.getGroupDescription(bundle, configDescriptionURI,
                 name, group.getDescription(), locale);
 
-        return new ConfigDescriptionParameterGroup(name, group.getContext(), group.isAdvanced(),
-                label == null ? group.getLabel() : label, description == null ? group.getDescription() : description);
+        return ConfigDescriptionParameterGroupBuilder.create(name).withContext(group.getContext())
+                .withAdvanced(group.isAdvanced()).withLabel(label != null ? label : group.getLabel())
+                .withDescription(description != null ? description : group.getDescription()).build();
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionBuilderTest.java
@@ -36,10 +36,10 @@ public class ConfigDescriptionBuilderTest {
             .create("TEST PARAM 1", Type.TEXT).build();
     private static final ConfigDescriptionParameter PARAM2 = ConfigDescriptionParameterBuilder
             .create("TEST PARAM 2", Type.INTEGER).build();
-    private static final ConfigDescriptionParameterGroup GROUP1 = new ConfigDescriptionParameterGroup("TEST GROUP 1",
-            null, false, "Test Group 1", null);
-    private static final ConfigDescriptionParameterGroup GROUP2 = new ConfigDescriptionParameterGroup("TEST GROUP 2",
-            null, true, "Test Group 2", null);
+    private static final ConfigDescriptionParameterGroup GROUP1 = ConfigDescriptionParameterGroupBuilder
+            .create("TEST GROUP 1").withLabel("Test Group 1").build();
+    private static final ConfigDescriptionParameterGroup GROUP2 = ConfigDescriptionParameterGroupBuilder
+            .create("TEST GROUP 2").withAdvanced(Boolean.TRUE).withLabel("Test Group 2").build();
     private ConfigDescriptionBuilder builder;
 
     @Before

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilderTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ConfigDescriptionParameterGroupBuilder) class.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigDescriptionParameterGroupBuilderTest {
+
+    private @NonNullByDefault({}) ConfigDescriptionParameterGroupBuilder builder;
+
+    @Before
+    public void setup() {
+        builder = ConfigDescriptionParameterGroupBuilder.create("test") //
+                .withContext("My Context") //
+                .withAdvanced(Boolean.TRUE) //
+                .withLabel("My Label") //
+                .withDescription("My Description");
+    }
+
+    @Test
+    public void testConfigDescriptionParameterGroupBuilder() {
+        ConfigDescriptionParameterGroup group = builder.build();
+        assertThat(group.getName(), is("test"));
+        assertThat(group.getContext(), is("My Context"));
+        assertThat(group.isAdvanced(), is(true));
+        assertThat(group.getLabel(), is("My Label"));
+        assertThat(group.getDescription(), is("My Description"));
+    }
+
+    @Test
+    public void subsequentBuildsCreateIndependentConfigDescriptionParameterGroups() {
+        ConfigDescriptionParameterGroup group = builder.build();
+        ConfigDescriptionParameterGroup otherGroup = builder.withContext("My Second Context") //
+                .withAdvanced(Boolean.FALSE) //
+                .withLabel("My Second Label") //
+                .withDescription("My Second Description") //
+                .build();
+
+        assertThat(otherGroup.getName(), is(group.getName()));
+        assertThat(otherGroup.getContext(), is(not(group.getContext())));
+        assertThat(otherGroup.isAdvanced(), is(not(group.isAdvanced())));
+        assertThat(otherGroup.getLabel(), is(not(group.getLabel())));
+        assertThat(otherGroup.getDescription(), is(not(group.getDescription())));
+    }
+}

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionParameterGroupConverter.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigDescriptionParameterGroupConverter.java
@@ -13,6 +13,7 @@
 package org.openhab.core.config.xml;
 
 import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroupBuilder;
 import org.openhab.core.config.xml.util.ConverterValueMap;
 import org.openhab.core.config.xml.util.GenericUnmarshaller;
 
@@ -44,6 +45,11 @@ public class ConfigDescriptionParameterGroupConverter extends GenericUnmarshalle
         String label = valueMap.getString("label");
         Boolean advanced = valueMap.getBoolean("advanced", false);
 
-        return new ConfigDescriptionParameterGroup(name, context, advanced, label, description);
+        return ConfigDescriptionParameterGroupBuilder.create(name) //
+                .withContext(context) //
+                .withAdvanced(advanced) //
+                .withLabel(label) //
+                .withDescription(description) //
+                .build();
     }
 }


### PR DESCRIPTION
- Added builder for `ConfigDescriptionParameterGroup`

We already have builder for `ConfigDescription`s and `ConfigDescriptionParameter`s. To improve and streamline the API I added a `ConfigDescriptionParameterGroupBuilder`.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>