### PR TITLE
[timer] Add Timer::isActive()

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
@@ -31,6 +31,13 @@ public interface Timer {
     public boolean cancel();
 
     /**
+     * Determines whether the scheduled execution is yet to happen.
+     *
+     * @return true, if the code is still scheduled to execute, false otherwise
+     */
+    public boolean isActive();
+
+    /**
      * Determines whether the scheduled code is currently executed.
      *
      * @return true, if the code is being executed, false otherwise

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
@@ -102,6 +102,11 @@ public class TimerImpl implements Timer {
     }
 
     @Override
+    public boolean isActive() {
+        return !terminated && !cancelled; 
+    }
+
+    @Override
     public boolean isRunning() {
         try {
             for (JobExecutionContext context : scheduler.getCurrentlyExecutingJobs()) {


### PR DESCRIPTION
The following is referring to org.eclipse.smarthome.model.script.actions.Timer

There seems to be no way to programmatically tell whether a timer is no longer "active" e.g. because it was cancelled.

There's Timer::hasTerminated() but that will only return true if the timer has finished executing. It will not return true if timer.cancel() was called before the scheduled execution occurred. 

Then there's Timer::isRunning() but that will only return true if the timer has reached its time and is actually still executing and not yet finished.

Example code to illustrate:
```
@rule("test1")
@when("System started")
def test(event):  
    timer = ScriptExecution.createTimer(DateTime.now().plusSeconds(5), lambda: test.log.info("Timer executing. isRunning(): {}".format(timer.isRunning())))
    test.log.info("timer.hasTerminated(): {}, isRunning(): {}".format(timer.hasTerminated(), timer.isRunning())) // will log as "timer.hasTerminated(): 0, isRunning(): 0"
    timer.cancel()
    test.log.info("timer.hasTerminated(): {}, isRunning(): {}".format(timer.hasTerminated(), timer.isRunning())) // will log as "timer.hasTerminated(): 0, isRunning(): 0"
```

As a result of this, people have been resorting to assigning the timer instance to null when the timer got cancelled and also when it has terminated following the completion. Then they would check whether the timer variable is null or not to know whether the timer is still active. People have gotten so used to doing it this way it seems. However, this complicates the code unnecessarily. 

I understand that in some, and perhaps most cases, knowing whether a timer has been cancelled or terminated is not required by the code, but in other cases, it is.

I would propose adding Timer::isActive() to the core to return true when a timer is still in progress, i.e. it has not been cancelled nor finished.

This would greatly simply scripting logic involving timers.

