### PR TITLE
Add commons-fileupload back to runtime BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -349,6 +349,12 @@
 
     <!-- Apache Commons -->
     <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>1.3.3</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.2</version>


### PR DESCRIPTION
Fixes resolving bundles in the Demo App.
It's a dependency of [org.apache.felix.webconsole](https://github.com/openhab/openhab-distro/blob/5e0d51c4c40593ca7720fcc4cb2f746e3a9ae2de/launch/app/app.bndrun#L8-L9)

Caused by: #1436

---

It's probably best to always check that bundles can still be resolved in the Demo App when changing this BOM.