### PR TITLE
Update nrjavaserial in TP to 5.0.2 and define import version range

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -223,8 +223,6 @@
     </dependency>
 
     <!-- Serial Communication -->
-    <!-- <dependency> <groupId>org.eclipse.kura</groupId> <artifactId>org.eclipse.soda.dk.comm</artifactId> <version>1.2.201</version>
-      <scope>compile</scope> </dependency> -->
     <dependency>
       <groupId>org.vesalainen.comm</groupId>
       <artifactId>javaxcomm</artifactId>
@@ -234,7 +232,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.20.0</version>
+      <version>3.12.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -462,7 +462,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.20.0</version>
+      <version>5.0.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/bnd.bnd
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/bnd.bnd
@@ -1,0 +1,5 @@
+Bundle-SymbolicName: ${project.artifactId}
+Import-Package: \
+  gnu.io;version="[3.12,6)",\
+  gnu.io.rfc2217;version="[3.12,6)",\
+  *

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/bnd.bnd
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-SymbolicName: ${project.artifactId}
+Import-Package: \
+  gnu.io;version="[3.12,6)",\
+  *

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -212,7 +212,7 @@
 
 	<feature name="openhab.tp-serial-rxtx" version="${project.version}">
 		<capability>openhab.tp;feature=serial;impl=rxtx</capability>
-		<bundle>mvn:com.neuronrobotics/nrjavaserial/3.20.0</bundle>
+		<bundle>mvn:com.neuronrobotics/nrjavaserial/5.0.2</bundle>
 	</feature>
 
 	<feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">


### PR DESCRIPTION
The first version of nrjavaserial with OSGi manifest entries is 3.12.0.
The interface has not changed and is still the same with nrjavaserial 5.x.
So using 3.12.0 as compile time dependency and defining a [3.12,6) version range using bnd.bnd files allows for maximum flexibility.