### PR TITLE
[config] Use field from calling method to check superclass hierarchy for writing fields in 'ConfigMapper'

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
@@ -98,33 +98,13 @@ public class ConfigMapper {
                 value = objectConvert(value, type);
                 LOGGER.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
                         value, fieldName, configurationClass.getName());
-                writeField(configuration, fieldName, value, true);
+                field.setAccessible(true);
+                field.set(configuration, value);
             } catch (SecurityException | IllegalArgumentException | IllegalAccessException ex) {
                 LOGGER.warn("Could not set field value for field '{}': {}", fieldName, ex.getMessage(), ex);
             }
         }
         return configuration;
-    }
-
-    /**
-     * Writes a field. Superclasses will be considered.
-     *
-     * @param target the object to reflect
-     * @param fieldName the field name to obtain
-     * @param value to set
-     * @param forceAccess whether to break scope restrictions using the <code>setAccessible</code> method.
-     */
-    private static void writeField(Object target, String fieldName, Object value, boolean forceAccess)
-            throws SecurityException, IllegalArgumentException, IllegalAccessException {
-        for (Class<?> superclazz = target.getClass(); superclazz != null; superclazz = superclazz.getSuperclass()) {
-            try {
-                Field field = superclazz.getDeclaredField(fieldName);
-                field.setAccessible(forceAccess);
-                field.set(target, value);
-            } catch (NoSuchFieldException e) {
-                // ignore
-            }
-        }
     }
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/ConfigMapper.java
@@ -75,7 +75,6 @@ public class ConfigMapper {
             Class<?> type = field.getType();
 
             Object value = properties.get(configKey);
-
             // Consider RequiredField annotations
             if (value == null) {
                 LOGGER.trace("Skipping field '{}', because config has no entry for {}", fieldName, configKey);
@@ -104,10 +103,17 @@ public class ConfigMapper {
                 LOGGER.warn("Could not set field value for field '{}': {}", fieldName, ex.getMessage(), ex);
             }
         }
-
         return configuration;
     }
 
+    /**
+     * Writes a field. Superclasses will be considered.
+     *
+     * @param target the object to reflect
+     * @param fieldName the field name to obtain
+     * @param value to set
+     * @param forceAccess whether to break scope restrictions using the <code>setAccessible</code> method.
+     */
     private static void writeField(Object target, String fieldName, Object value, boolean forceAccess)
             throws SecurityException, IllegalArgumentException, IllegalAccessException {
         for (Class<?> superclazz = target.getClass(); superclazz != null; superclazz = superclazz.getSuperclass()) {
@@ -129,13 +135,9 @@ public class ConfigMapper {
      */
     private static List<Field> getAllFields(Class<?> clazz) {
         List<Field> fields = new ArrayList<>();
-
-        Class<?> currentClass = clazz;
-        while (currentClass != null) {
-            fields.addAll(Arrays.asList(currentClass.getDeclaredFields()));
-            currentClass = currentClass.getSuperclass();
+        for (Class<?> superclazz = clazz; superclazz != null; superclazz = superclazz.getSuperclass()) {
+            fields.addAll(Arrays.asList(superclazz.getDeclaredFields()));
         }
-
         return fields;
     }
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -52,6 +52,7 @@ public class ConfigurationTest {
 
     public static class ExtendedConfigClass extends ConfigClass {
         public int additionalIntField;
+        public String listField;
     }
 
     @Test
@@ -78,11 +79,14 @@ public class ConfigurationTest {
         Configuration configuration = new Configuration();
         configuration.put("intField", 1);
         configuration.put("additionalIntField", 5);
+        configuration.put("listField", "one, two, three");
 
         ExtendedConfigClass extendedConfigClass = configuration.as(ExtendedConfigClass.class);
 
         assertThat(extendedConfigClass.intField, is(1));
+        assertThat(extendedConfigClass.stringField, is("somedefault"));
         assertThat(extendedConfigClass.additionalIntField, is(5));
+        assertThat(extendedConfigClass.listField, is("one, two, three"));
     }
 
     @Test

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class ConfigurationTest {
 
-    public static final class ConfigClass {
+    public static class ConfigClass {
         public enum MyEnum {
             ON,
             OFF,
@@ -48,6 +48,10 @@ public class ConfigurationTest {
         public List<String> listField;
         @SuppressWarnings("unused")
         private static final String CONSTANT = "SOME_CONSTANT";
+    }
+
+    public static class ExtendedConfigClass extends ConfigClass {
+        public int additionalIntField;
     }
 
     @Test
@@ -67,6 +71,18 @@ public class ConfigurationTest {
         assertThat(configClass.stringField, is("test"));
         assertThat(configClass.enumField, is(ConfigClass.MyEnum.ON));
         assertThat(configClass.listField, is(hasItems("one", "two", "three")));
+    }
+
+    @Test
+    public void assertGetConfigAsWorksWithSuperclass() {
+        Configuration configuration = new Configuration();
+        configuration.put("intField", 1);
+        configuration.put("additionalIntField", 5);
+
+        ExtendedConfigClass extendedConfigClass = configuration.as(ExtendedConfigClass.class);
+
+        assertThat(extendedConfigClass.intField, is(1));
+        assertThat(extendedConfigClass.additionalIntField, is(5));
     }
 
     @Test


### PR DESCRIPTION
- Use field from calling method to check superclass hierarchy for writing fields in `ConfigMapper`

Fixes #1473

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>