### PR TITLE
Give the missing channel group type

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -202,6 +202,10 @@ public class ThingTypeResource implements RESTResource {
             String id = channelGroupDefinition.getId();
             ChannelGroupType channelGroupType = channelGroupTypeRegistry
                     .getChannelGroupType(channelGroupDefinition.getTypeUID(), locale);
+            if (channelGroupType == null) {
+                logger.warn("Cannot find channel group type: {}", channelGroupDefinition.getTypeUID());
+                return null;
+            }
 
             // Default to the channelGroupDefinition label/description to override the channelGroupType
             String label = channelGroupDefinition.getLabel();

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -161,7 +161,7 @@ public class ThingTypeResource implements RESTResource {
         }
     }
 
-    private @Nullable ThingTypeDTO convertToThingTypeDTO(ThingType thingType, Locale locale) {
+    private ThingTypeDTO convertToThingTypeDTO(ThingType thingType, Locale locale) {
         final ConfigDescription configDescription;
         if (thingType.getConfigDescriptionURI() != null) {
             configDescription = this.configDescriptionRegistry.getConfigDescription(thingType.getConfigDescriptionURI(),

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -184,9 +184,6 @@ public class ThingTypeResource implements RESTResource {
 
         final List<ChannelDefinitionDTO> channelDefinitions = convertToChannelDefinitionDTOs(
                 thingType.getChannelDefinitions(), locale);
-        if (channelDefinitions == null) {
-            return null;
-        }
 
         return new ThingTypeDTO(thingType.getUID().toString(), thingType.getLabel(), thingType.getDescription(),
                 thingType.getCategory(), thingType.isListed(), parameters, channelDefinitions,
@@ -202,17 +199,15 @@ public class ThingTypeResource implements RESTResource {
             String id = channelGroupDefinition.getId();
             ChannelGroupType channelGroupType = channelGroupTypeRegistry
                     .getChannelGroupType(channelGroupDefinition.getTypeUID(), locale);
-            if (channelGroupType == null) {
-                logger.warn("Cannot find channel group type: {}", channelGroupDefinition.getTypeUID());
-                return null;
-            }
 
             // Default to the channelGroupDefinition label/description to override the channelGroupType
             String label = channelGroupDefinition.getLabel();
             String description = channelGroupDefinition.getDescription();
             List<ChannelDefinition> channelDefinitions = Collections.emptyList();
 
-            if (channelGroupType != null) {
+            if (channelGroupType == null) {
+                logger.warn("Cannot find channel group type: {}", channelGroupDefinition.getTypeUID());
+            } else {
                 if (label == null) {
                     label = channelGroupType.getLabel();
                 }
@@ -231,35 +226,35 @@ public class ThingTypeResource implements RESTResource {
         return channelGroupDefinitionDTOs;
     }
 
-    private @Nullable List<ChannelDefinitionDTO> convertToChannelDefinitionDTOs(
-            List<ChannelDefinition> channelDefinitions, Locale locale) {
+    private List<ChannelDefinitionDTO> convertToChannelDefinitionDTOs(List<ChannelDefinition> channelDefinitions,
+            Locale locale) {
         List<ChannelDefinitionDTO> channelDefinitionDTOs = new ArrayList<>();
         for (ChannelDefinition channelDefinition : channelDefinitions) {
             ChannelType channelType = channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID(), locale);
+
             if (channelType == null) {
                 logger.warn("Cannot find channel type: {}", channelDefinition.getChannelTypeUID());
-                return null;
-            }
+            } else {
+                // Default to the channelDefinition label to override the
+                // channelType
+                String label = channelDefinition.getLabel();
+                if (label == null) {
+                    label = channelType.getLabel();
+                }
 
-            // Default to the channelDefinition label to override the
-            // channelType
-            String label = channelDefinition.getLabel();
-            if (label == null) {
-                label = channelType.getLabel();
-            }
+                // Default to the channelDefinition description to override the
+                // channelType
+                String description = channelDefinition.getDescription();
+                if (description == null) {
+                    description = channelType.getDescription();
+                }
 
-            // Default to the channelDefinition description to override the
-            // channelType
-            String description = channelDefinition.getDescription();
-            if (description == null) {
-                description = channelType.getDescription();
+                ChannelDefinitionDTO channelDefinitionDTO = new ChannelDefinitionDTO(channelDefinition.getId(),
+                        channelDefinition.getChannelTypeUID().toString(), label, description, channelType.getTags(),
+                        channelType.getCategory(), channelType.getState(), channelType.isAdvanced(),
+                        channelDefinition.getProperties());
+                channelDefinitionDTOs.add(channelDefinitionDTO);
             }
-
-            ChannelDefinitionDTO channelDefinitionDTO = new ChannelDefinitionDTO(channelDefinition.getId(),
-                    channelDefinition.getChannelTypeUID().toString(), label, description, channelType.getTags(),
-                    channelType.getCategory(), channelType.getState(), channelType.isAdvanced(),
-                    channelDefinition.getProperties());
-            channelDefinitionDTOs.add(channelDefinitionDTO);
         }
         return channelDefinitionDTOs;
     }


### PR DESCRIPTION
A nullpointer exception is thrown when it cannot find the channel group type. This happens during development of bindings when you made a typo. This add a helpful message to the logs to help the binding developer. 