### PR TITLE
Avoid UnsupportedEncodingException & use const from StandardCharsets

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -249,7 +249,7 @@ public class OAuthConnector {
     private Request getMethod(HttpClient httpClient, String tokenUrl) {
         Request request = httpClient.newRequest(tokenUrl).method(HttpMethod.POST);
         request.header(HttpHeader.ACCEPT, "application/json");
-        request.header(HttpHeader.ACCEPT_CHARSET, "UTF-8");
+        request.header(HttpHeader.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
         return request;
     }
 

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -15,7 +15,6 @@ package org.openhab.core.auth.oauth2client.internal;
 import static org.openhab.core.auth.oauth2client.internal.Keyword.*;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
@@ -94,23 +93,18 @@ public class OAuthConnector {
             authorizationUrl.append('&');
         }
 
-        try {
-            authorizationUrl.append("response_type=code");
-            authorizationUrl.append("&client_id=").append(URLEncoder.encode(clientId, StandardCharsets.UTF_8.name()));
-            if (state != null) {
-                authorizationUrl.append("&state=").append(URLEncoder.encode(state, StandardCharsets.UTF_8.name()));
-            }
-            if (redirectURI != null) {
-                authorizationUrl.append("&redirect_uri=")
-                        .append(URLEncoder.encode(redirectURI, StandardCharsets.UTF_8.name()));
-            }
-            if (scope != null) {
-                authorizationUrl.append("&scope=").append(URLEncoder.encode(scope, StandardCharsets.UTF_8.name()));
-            }
-        } catch (UnsupportedEncodingException e) {
-            // never happens
-            logger.error("Unknown encoding {}", e.getMessage(), e);
+        authorizationUrl.append("response_type=code");
+        authorizationUrl.append("&client_id=").append(URLEncoder.encode(clientId, StandardCharsets.UTF_8));
+        if (state != null) {
+            authorizationUrl.append("&state=").append(URLEncoder.encode(state, StandardCharsets.UTF_8));
         }
+        if (redirectURI != null) {
+            authorizationUrl.append("&redirect_uri=").append(URLEncoder.encode(redirectURI, StandardCharsets.UTF_8));
+        }
+        if (scope != null) {
+            authorizationUrl.append("&scope=").append(URLEncoder.encode(scope, StandardCharsets.UTF_8));
+        }
+
         return authorizationUrl.toString();
     }
 

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -16,6 +16,7 @@ import static org.openhab.core.automation.RulePredicates.*;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -159,7 +160,7 @@ public class RuleResource implements RESTResource {
         try {
             final Rule newRule = ruleRegistry.add(RuleDTOMapper.map(rule));
             return Response.status(Status.CREATED)
-                    .header("Location", "rules/" + URLEncoder.encode(newRule.getUID(), "UTF-8")).build();
+                    .header("Location", "rules/" + URLEncoder.encode(newRule.getUID(), StandardCharsets.UTF_8)).build();
         } catch (IllegalArgumentException e) {
             String errMessage = "Creation of the rule is refused: " + e.getMessage();
             logger.warn("{}", errMessage);

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -154,7 +155,8 @@ public class HttpUtil {
             String proxyPassword, String nonProxyHosts) throws IOException {
         ContentResponse response = executeUrlAndGetReponse(httpMethod, url, httpHeaders, content, contentType, timeout,
                 proxyHost, proxyPort, proxyUser, proxyPassword, nonProxyHosts);
-        String encoding = response.getEncoding() != null ? response.getEncoding().replaceAll("\"", "").trim() : "UTF-8";
+        String encoding = response.getEncoding() != null ? response.getEncoding().replaceAll("\"", "").trim()
+                : StandardCharsets.UTF_8.name();
         String responseBody;
         try {
             responseBody = new String(response.getContent(), encoding);

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -15,6 +15,7 @@ package org.openhab.core.model.core.internal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -121,7 +122,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                         if (resource != null) {
                             logger.info("Loading model '{}'", name);
                             Map<String, String> options = new HashMap<>();
-                            options.put(XtextResource.OPTION_ENCODING, "UTF-8");
+                            options.put(XtextResource.OPTION_ENCODING, StandardCharsets.UTF_8.name());
                             if (inputStream == null) {
                                 logger.warn(
                                         "Resource '{}' not found. You have to pass an inputStream to create the resource.",

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
@@ -13,7 +13,6 @@
 package org.openhab.core.storage.json.internal;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -148,13 +147,7 @@ public class JsonStorageService implements StorageService {
      * @return url-encoded string or the original string if UTF-8 is not supported on the system
      */
     protected String urlEscapeUnwantedChars(String s) {
-        String result;
-        try {
-            result = URLEncoder.encode(s, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            logger.warn("Encoding UTF-8 is not supported, might generate invalid filenames.");
-            result = s;
-        }
+        String result = URLEncoder.encode(s, StandardCharsets.UTF_8);
         int length = Math.min(result.length(), MAX_FILENAME_LENGTH);
         return result.substring(0, length);
     }

--- a/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/JsonStorageServiceOSGiTest.java
+++ b/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/JsonStorageServiceOSGiTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
@@ -65,7 +64,7 @@ public class JsonStorageServiceOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testOnlyAlphanumericCharsInFileName() throws UnsupportedEncodingException {
+    public void testOnlyAlphanumericCharsInFileName() {
         JsonStorageService st = (JsonStorageService) storageService;
 
         String escaped = st.urlEscapeUnwantedChars("Strange:File-Name~with#Chars");


### PR DESCRIPTION
- Avoid `UnsupportedEncodingException`
- Use const from StandardCharsets

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>