### PR TITLE
Add OAuth2 information to Swagger API description

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -250,6 +250,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <version>1.5.5</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>de.maggu2810.jaxrswb.bundles</groupId>
       <artifactId>jaxrswb-swagger1-gen</artifactId>
       <version>0.0.4</version>

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -82,6 +82,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 import io.swagger.annotations.ResponseHeader;
 
 /**
@@ -97,7 +99,8 @@ import io.swagger.annotations.ResponseHeader;
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(RuleResource.PATH_RULES)
-@Api(RuleResource.PATH_RULES)
+@Api(value = RuleResource.PATH_RULES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @RolesAllowed({ Role.ADMIN })
 @NonNullByDefault
 public class RuleResource implements RESTResource {

--- a/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
+++ b/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
@@ -34,6 +34,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for accessing the UUID of the instance
@@ -46,7 +48,8 @@ import io.swagger.annotations.ApiResponses;
 @JaxrsName(UUIDResource.PATH_UUID)
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @Path(UUIDResource.PATH_UUID)
-@Api(UUIDResource.PATH_UUID)
+@Api(value = UUIDResource.PATH_UUID, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @RolesAllowed({ Role.ADMIN })
 @NonNullByDefault
 public class UUIDResource implements RESTResource {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
@@ -63,6 +63,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for bindings and is registered with the
@@ -109,7 +111,9 @@ public class BindingResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get all bindings.", response = BindingInfoDTO.class, responseContainer = "Set")
+    @ApiOperation(value = "Get all bindings.", response = BindingInfoDTO.class, responseContainer = "Set", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = BindingInfoDTO.class, responseContainer = "Set") })
     public Response getAll(

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
@@ -83,7 +83,8 @@ import io.swagger.annotations.AuthorizationScope;
 @JSONRequired
 @Path(BindingResource.PATH_BINDINGS)
 @RolesAllowed({ Role.ADMIN })
-@Api(BindingResource.PATH_BINDINGS)
+@Api(value = BindingResource.PATH_BINDINGS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class BindingResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
@@ -67,6 +67,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * Provides access to ChannelType via REST.
@@ -83,7 +85,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ChannelTypeResource.PATH_CHANNEL_TYPES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ChannelTypeResource.PATH_CHANNEL_TYPES)
+@Api(value = ChannelTypeResource.PATH_CHANNEL_TYPES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ChannelTypeResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -54,6 +54,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * {@link ConfigDescriptionResource} provides access to {@link ConfigDescription}s via REST.
@@ -70,7 +72,9 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
 @RolesAllowed({ Role.ADMIN })
-@Api(ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
+@Api(value = ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS, authorizations = {
+        @Authorization(value = "oauth2", scopes = {
+                @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ConfigDescriptionResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
@@ -47,6 +47,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for discovery and is registered with the
@@ -66,7 +68,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(DiscoveryResource.PATH_DISCOVERY)
 @RolesAllowed({ Role.ADMIN })
-@Api(DiscoveryResource.PATH_DISCOVERY)
+@Api(value = DiscoveryResource.PATH_DISCOVERY, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class DiscoveryResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
@@ -57,6 +57,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for the inbox and is registered with the
@@ -76,7 +78,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(InboxResource.PATH_INBOX)
 @RolesAllowed({ Role.ADMIN })
-@Api(InboxResource.PATH_INBOX)
+@Api(value = InboxResource.PATH_INBOX, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class InboxResource implements RESTResource {
     private final Logger logger = LoggerFactory.getLogger(InboxResource.class);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/extensions/ExtensionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/extensions/ExtensionResource.java
@@ -68,6 +68,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for extensions and provides methods to install and uninstall them.
@@ -83,7 +85,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ExtensionResource.PATH_EXTENSIONS)
 @RolesAllowed({ Role.ADMIN })
-@Api(ExtensionResource.PATH_EXTENSIONS)
+@Api(value = ExtensionResource.PATH_EXTENSIONS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ExtensionResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -97,6 +97,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * <p>
@@ -353,7 +355,9 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName: [a-zA-Z_0-9]+}/members/{memberItemName: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Adds a new member to a group item.")
+    @ApiOperation(value = "Adds a new member to a group item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item or member item not found or item is not of type group item."),
             @ApiResponse(code = 405, message = "Member item is not editable.") })
@@ -391,7 +395,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName: [a-zA-Z_0-9]+}/members/{memberItemName: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Removes an existing member from a group item.")
+    @ApiOperation(value = "Removes an existing member from a group item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item or member item not found or item is not of type group item."),
             @ApiResponse(code = 405, message = "Member item is not editable.") })
@@ -429,7 +435,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Removes an item from the registry.")
+    @ApiOperation(value = "Removes an item from the registry.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found or item is not editable.") })
     public Response removeItem(@PathParam("itemname") @ApiParam(value = "item name") String itemname) {
@@ -442,7 +450,8 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/tags/{tag}")
-    @ApiOperation(value = "Adds a tag to an item.")
+    @ApiOperation(value = "Adds a tag to an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Item not editable.") })
@@ -467,7 +476,8 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/tags/{tag}")
-    @ApiOperation(value = "Removes a tag from an item.")
+    @ApiOperation(value = "Removes a tag from an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Item not editable.") })
@@ -493,7 +503,8 @@ public class ItemResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/metadata/{namespace}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds metadata to an item.")
+    @ApiOperation(value = "Adds metadata to an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { //
             @ApiResponse(code = 200, message = "OK"), //
             @ApiResponse(code = 201, message = "Created"), //
@@ -528,7 +539,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/metadata/{namespace}")
-    @ApiOperation(value = "Removes metadata from an item.")
+    @ApiOperation(value = "Removes metadata from an item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Meta data not editable.") })
@@ -563,7 +576,9 @@ public class ItemResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds a new item to the registry or updates the existing item.")
+    @ApiOperation(value = "Adds a new item to the registry or updates the existing item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 201, message = "Item created."), @ApiResponse(code = 400, message = "Item null."),
             @ApiResponse(code = 404, message = "Item not found."),
@@ -614,7 +629,9 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds a list of items to the registry or updates the existing items.")
+    @ApiOperation(value = "Adds a list of items to the registry or updates the existing items.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 400, message = "Item list is null.") })
     public Response createOrUpdateItems(

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -55,6 +55,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for links.
@@ -73,7 +75,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ItemChannelLinkResource.PATH_LINKS)
 @RolesAllowed({ Role.ADMIN })
-@Api(ItemChannelLinkResource.PATH_LINKS)
+@Api(value = ItemChannelLinkResource.PATH_LINKS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ItemChannelLinkResource implements RESTResource {
 
@@ -129,7 +132,8 @@ public class ItemChannelLinkResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName}/{channelUID}")
-    @ApiOperation(value = "Links item to a channel.")
+    @ApiOperation(value = "Links item to a channel.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 400, message = "Content does not match the path"),
             @ApiResponse(code = 405, message = "Link is not editable") })
@@ -162,7 +166,8 @@ public class ItemChannelLinkResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName}/{channelUID}")
-    @ApiOperation(value = "Unlinks item from a channel.")
+    @ApiOperation(value = "Unlinks item from a channel.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Link not found."),
             @ApiResponse(code = 405, message = "Link not editable.") })

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -76,6 +76,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for history data and provides different methods to interact with the persistence
@@ -127,7 +129,9 @@ public class PersistenceResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.ADMIN })
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Gets a list of persistence services.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Gets a list of persistence services.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"))
     public Response httpGetPersistenceServices(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = "language") @Nullable String language) {
@@ -141,7 +145,9 @@ public class PersistenceResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/items")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Gets a list of items available via a specific persistence service.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Gets a list of items available via a specific persistence service.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"))
     public Response httpGetPersistenceServiceItems(@Context HttpHeaders headers,
             @ApiParam(value = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId) {
@@ -173,7 +179,9 @@ public class PersistenceResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/items/{itemname: [a-zA-Z_0-9]+}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Delete item data from a specific persistence service.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Delete item data from a specific persistence service.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
             @ApiResponse(code = 400, message = "Invalid filter parameters"),

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -58,6 +58,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * REST resource to obtain profile-types
@@ -72,7 +74,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ProfileTypeResource.PATH_PROFILE_TYPES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ProfileTypeResource.PATH_PROFILE_TYPES)
+@Api(value = ProfileTypeResource.PATH_PROFILE_TYPES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ProfileTypeResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -70,6 +70,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * {@link ConfigurableServiceResource} provides access to configurable services. It lists the available services and
@@ -86,7 +88,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ConfigurableServiceResource.PATH_SERVICES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ConfigurableServiceResource.PATH_SERVICES)
+@Api(value = ConfigurableServiceResource.PATH_SERVICES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ConfigurableServiceResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -112,6 +112,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for things and is registered with the
@@ -209,7 +211,9 @@ public class ThingResource implements RESTResource {
     @POST
     @RolesAllowed({ Role.ADMIN })
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Creates a new thing and adds it to the registry.")
+    @ApiOperation(value = "Creates a new thing and adds it to the registry.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Created", response = String.class),
             @ApiResponse(code = 400, message = "A uid must be provided, if no binding can create a thing of this type."),
             @ApiResponse(code = 409, message = "A thing with the same uid already exists.") })
@@ -297,7 +301,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing by UID.")
+    @ApiOperation(value = "Gets thing by UID.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getByUID(
@@ -327,7 +332,9 @@ public class ThingResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
-    @ApiOperation(value = "Removes a thing from the registry. Set \'force\' to __true__ if you want the thing te be removed immediately.")
+    @ApiOperation(value = "Removes a thing from the registry. Set \'force\' to __true__ if you want the thing te be removed immediately.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK, was deleted."),
             @ApiResponse(code = 202, message = "ACCEPTED for asynchronous deletion."),
             @ApiResponse(code = 404, message = "Thing not found."),
@@ -385,7 +392,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Updates a thing.")
+    @ApiOperation(value = "Updates a thing.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 404, message = "Thing not found."),
             @ApiResponse(code = 409, message = "Thing could not be updated as it is not editable.") })
@@ -444,7 +452,9 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/config")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Updates thing's configuration.")
+    @ApiOperation(value = "Updates thing's configuration.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 400, message = "Configuration of the thing is not valid."),
             @ApiResponse(code = 404, message = "Thing not found"),
@@ -500,7 +510,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{thingUID}/status")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing's status.")
+    @ApiOperation(value = "Gets thing status.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getStatus(
@@ -522,9 +533,11 @@ public class ThingResource implements RESTResource {
     }
 
     @PUT
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/enable")
-    @ApiOperation(value = "Sets the thing enabled status.")
+    @ApiOperation(value = "Sets the thing enabled status.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response setEnabled(
@@ -550,10 +563,11 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/config/status")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing's config status.")
+    @ApiOperation(value = "Gets thing config status.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getConfigStatus(
@@ -577,9 +591,11 @@ public class ThingResource implements RESTResource {
     }
 
     @PUT
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmware/{firmwareVersion}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Update thing firmware.")
+    @ApiOperation(value = "Update thing firmware.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 400, message = "Firmware update preconditions not satisfied."),
             @ApiResponse(code = 404, message = "Thing not found.") })
@@ -612,8 +628,11 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmware/status")
-    @ApiOperation(value = "Gets thing's firmware status.")
+    @ApiOperation(value = "Gets thing's firmware status.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 204, message = "No firmware status provided by this Thing.") })
     public Response getFirmwareStatus(
@@ -629,9 +648,12 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmwares")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get all available firmwares for provided thing UID", response = StrippedThingTypeDTO.class, responseContainer = "Set")
+    @ApiOperation(value = "Get all available firmwares for provided thing UID", response = StrippedThingTypeDTO.class, responseContainer = "Set", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 204, message = "No firmwares found.") })
     public Response getFirmwares(@PathParam("thingUID") @ApiParam(value = "thingUID") String thingUID,

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/RESTResource.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/RESTResource.java
@@ -33,8 +33,6 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.maggu2810.jaxrswb.swagger1.gen.JaxRsWhiteboardSwaggerGenerator;
-
 /**
  * An endpoint to generate and provide a Swagger 1 description.
  *
@@ -49,7 +47,7 @@ import de.maggu2810.jaxrswb.swagger1.gen.JaxRsWhiteboardSwaggerGenerator;
 public class RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(RESTResource.class);
-    private final JaxRsWhiteboardSwaggerGenerator generator;
+    private final SwaggerGenerator generator;
 
     /**
      * Creates a new instance.
@@ -57,7 +55,7 @@ public class RESTResource {
      * @param generator the generator
      */
     @Activate
-    public RESTResource(final @Reference JaxRsWhiteboardSwaggerGenerator generator) {
+    public RESTResource(final @Reference SwaggerGenerator generator) {
         this.generator = generator;
     }
 

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.core.io.rest.swagger.impl;
 
 import java.io.IOException;
@@ -29,8 +41,7 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.util.Json;
 
 /**
- * An JAX-RS Whiteboard Swagger 1 generator implementation.
- *
+ * A JAX-RS Whiteboard Swagger 1 generator implementation.
  *
  * @author Markus Rathgeb - Initial contribution
  * @author Yannick Schaus - adapt to provide OAuth2 security definitions

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
@@ -1,0 +1,122 @@
+package org.openhab.core.io.rest.swagger.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.openhab.core.io.rest.internal.resources.beans.RootBean;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.maggu2810.jaxrswb.gen.JaxRsWhiteboardGeneratorConfig;
+import de.maggu2810.jaxrswb.swagger1.gen.JaxRsWhiteboardSwaggerSpecialGenerator;
+import de.maggu2810.jaxrswb.utils.JaxRsHelper;
+import io.swagger.jaxrs.Reader;
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
+import io.swagger.models.auth.OAuth2Definition;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.util.Json;
+
+/**
+ * An JAX-RS Whiteboard Swagger 1 generator implementation.
+ *
+ *
+ * @author Markus Rathgeb - Initial contribution
+ * @author Yannick Schaus - adapt to provide OAuth2 security definitions
+ */
+@Component(service = SwaggerGenerator.class)
+public class SwaggerGenerator implements JaxRsWhiteboardSwaggerSpecialGenerator {
+
+    public static final String API_TITLE = "openHAB REST API";
+    public static final String API_VERSION = new RootBean().version;
+    public static final String OAUTH_AUTHORIZE_ENDPOINT = "/auth/authorize";
+    public static final String OAUTH_TOKEN_ENDPOINT = "/rest/auth/token";
+
+    @SuppressWarnings("all")
+    private static final TypeReference<Map<String, Object>> TYPEREF_MAP_STR_OBJ = new TypeReference<Map<String, Object>>() {
+    };
+
+    private static class SwaggerReader extends Reader {
+        public SwaggerReader(final Swagger swagger) {
+            super(swagger);
+        }
+
+        @Override
+        public Swagger read(final Class<?> cls, final String parentPath, final String parentMethod,
+                final boolean isSubresource, final String[] parentConsumes, final String[] parentProduces,
+                final Map<String, Tag> parentTags, final List<Parameter> parentParameters) {
+            return super.read(cls, parentPath, parentMethod, isSubresource, parentConsumes, parentProduces, parentTags,
+                    parentParameters);
+        }
+    }
+
+    private final BundleContext bc;
+    private final JaxRsWhiteboardGeneratorConfig config;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bc the bundle context
+     * @param config the configuration
+     */
+    @Activate
+    public SwaggerGenerator(final BundleContext bc) {
+        this.bc = bc;
+        this.config = null;
+    }
+
+    @Override
+    public Swagger generate() {
+        final Swagger swagger = new Swagger();
+
+        Info info = new Info();
+        info.setTitle(API_TITLE);
+        info.setVersion(API_VERSION);
+        swagger.setInfo(info);
+
+        // Add OAuth2 security definition
+        SecuritySchemeDefinition oauth2Definition = new OAuth2Definition()
+                .accessCode(OAUTH_AUTHORIZE_ENDPOINT, OAUTH_TOKEN_ENDPOINT).scope("admin", "Administration operations");
+        Map<String, SecuritySchemeDefinition> securityDefinitions = new HashMap<>();
+        securityDefinitions.put("oauth2", oauth2Definition);
+        swagger.setSecurityDefinitions(securityDefinitions);
+
+        final SwaggerReader reader = new SwaggerReader(swagger);
+
+        final JaxRsHelper jaxRsHelper = new JaxRsHelper(bc);
+        final Map<String, Set<Class<?>>> basePathAndClasses = jaxRsHelper.getBasePathAndClasses();
+        basePathAndClasses.forEach((basePath, classes) -> {
+            classes.forEach(clazz -> {
+                final String parentPath = basePath.startsWith("/") ? basePath : "/" + basePath;
+                reader.read(clazz, parentPath, null, false, new String[0], new String[0],
+                        new LinkedHashMap<String, Tag>(), new ArrayList<Parameter>());
+            });
+        });
+
+        return reader.getSwagger();
+    }
+
+    @Override
+    public String toJSON(final Swagger info) throws IOException {
+        final ObjectMapper mapper = Json.mapper();
+        return mapper.writeValueAsString(info);
+    }
+
+    @Override
+    public Map<String, Object> toMap(final Swagger info) throws IOException {
+        final ObjectMapper mapper = Json.mapper();
+        final String jsonString = mapper.writeValueAsString(info);
+        return mapper.readValue(jsonString, TYPEREF_MAP_STR_OBJ);
+    }
+}

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerGenerator.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.openhab.core.io.rest.internal.resources.beans.RootBean;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -50,7 +49,7 @@ import io.swagger.util.Json;
 public class SwaggerGenerator implements JaxRsWhiteboardSwaggerSpecialGenerator {
 
     public static final String API_TITLE = "openHAB REST API";
-    public static final String API_VERSION = new RootBean().version;
+    public static final String API_VERSION = "3";
     public static final String OAUTH_AUTHORIZE_ENDPOINT = "/auth/authorize";
     public static final String OAUTH_TOKEN_ENDPOINT = "/rest/auth/token";
 

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
@@ -51,6 +51,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for the UI resources and is registered with the
@@ -123,7 +125,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Add an UI component in the specified namespace.")
+    @ApiOperation(value = "Add an UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class) })
     public Response addComponent(@PathParam("namespace") String namespace, RootUIComponent component) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
@@ -136,7 +140,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}/{componentUID}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Update a specific UI component in the specified namespace.")
+    @ApiOperation(value = "Update a specific UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class),
             @ApiResponse(code = 404, message = "Component not found", response = Tile.class) })
     public Response updateComponent(@PathParam("namespace") String namespace,
@@ -159,7 +165,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}/{componentUID}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Remove a specific UI component in the specified namespace.")
+    @ApiOperation(value = "Remove a specific UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class),
             @ApiResponse(code = 404, message = "Component not found", response = Tile.class) })
     public Response deleteComponent(@PathParam("namespace") String namespace,


### PR DESCRIPTION
As discussed in https://github.com/openhab/openhab-core/pull/1482#issuecomment-630458832.

This allows the REST docs client to perform the OAuth2 flow
to let the user try operations requiring an authorization.

Requires a small change on the client-side (Swagger UI)
to set the client ID properly.

Required authorization scopes should be added to all
API operations requiring authorization using annotations.

Signed-off-by: Yannick Schaus <github@schaus.net>