### PR TITLE
Use ConfigurableService as ComponentPropertyType

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -63,12 +63,9 @@ import org.slf4j.LoggerFactory;
  * @author Wouter Born - Sort audio sink and source options
  */
 @NonNullByDefault
-@Component(immediate = true, configurationPid = "org.openhab.audio", property = { //
-        Constants.SERVICE_PID + "=org.openhab.audio", //
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system", //
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + AudioManagerImpl.CONFIG_URI, //
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Audio" //
-})
+@Component(immediate = true, configurationPid = "org.openhab.audio", //
+        property = Constants.SERVICE_PID + "=org.openhab.audio")
+@ConfigurableService(category = "system", label = "Audio", description_uri = AudioManagerImpl.CONFIG_URI)
 public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
 
     // constants for the configuration properties

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
@@ -12,8 +12,14 @@
  */
 package org.openhab.core.config.core;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentConstants;
+import org.osgi.service.component.annotations.ComponentPropertyType;
 
 /**
  * <p>
@@ -30,26 +36,64 @@ import org.osgi.service.component.ComponentConstants;
  * {@link ComponentConstants#COMPONENT_NAME} property will be used as fallback.
  *
  * @author Dennis Nobel - Initial contribution
+ * @author Wouter Born - Change to ComponentPropertyType
  */
-public interface ConfigurableService {
+@ComponentPropertyType
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ConfigurableService {
+
+    String PREFIX_ = "service.config.";
 
     /**
      * The config description URI for the configurable service. See also {@link ConfigDescription}.
      */
-    public static final String SERVICE_PROPERTY_DESCRIPTION_URI = "service.config.description.uri";
+    String description_uri();
 
     /**
      * The label of the service to be configured.
      */
-    public static final String SERVICE_PROPERTY_LABEL = "service.config.label";
+    String label() default "";
 
     /**
      * The category of the service to be configured (e.g. binding).
      */
-    public static final String SERVICE_PROPERTY_CATEGORY = "service.config.category";
+    String category() default "";
 
     /**
      * Marker for multiple configurations for this service ("true" = multiple configurations possible)
      */
-    public static final String SERVICE_PROPERTY_FACTORY_SERVICE = "esh.factoryservice";
+    boolean factory() default false;
+
+    /**
+     * The config description URI for the configurable service. See also {@link ConfigDescription}.
+     *
+     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
+     */
+    @Deprecated
+    public static final String SERVICE_PROPERTY_DESCRIPTION_URI = PREFIX_ + "description.uri";
+
+    /**
+     * The label of the service to be configured.
+     *
+     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
+     */
+    @Deprecated
+    public static final String SERVICE_PROPERTY_LABEL = PREFIX_ + "label";
+
+    /**
+     * The category of the service to be configured (e.g. binding).
+     *
+     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
+     */
+    @Deprecated
+    public static final String SERVICE_PROPERTY_CATEGORY = PREFIX_ + "category";
+
+    /**
+     * Marker for multiple configurations for this service ("true" = multiple configurations possible)
+     *
+     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
+     */
+    @Deprecated
+    public static final String SERVICE_PROPERTY_FACTORY_SERVICE = PREFIX_ + "factory";
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -86,16 +86,17 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - added auto-approve functionality
  * @author Henning Sudbrock - added hook for selectively auto-approving inbox entries
  */
-@Component(immediate = true, configurationPid = "org.openhab.inbox", service = EventSubscriber.class, property = {
-        Constants.SERVICE_PID + "=org.openhab.inbox", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Inbox",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=system:inbox" })
+@Component(immediate = true, configurationPid = "org.openhab.inbox", service = EventSubscriber.class, //
+        property = Constants.SERVICE_PID + "=org.openhab.inbox")
+@ConfigurableService(category = "system", label = "Inbox", description_uri = AutomaticInboxProcessor.CONFIG_URI)
 @NonNullByDefault
 public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingStatusInfoChangedEvent>
         implements InboxListener, RegistryChangeListener<Thing> {
 
     public static final String AUTO_IGNORE_CONFIG_PROPERTY = "autoIgnore";
     public static final String ALWAYS_AUTO_APPROVE_CONFIG_PROPERTY = "autoApprove";
+
+    protected static final String CONFIG_URI = "system:inbox";
 
     private final Logger logger = LoggerFactory.getLogger(AutomaticInboxProcessor.class);
 

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -68,10 +68,8 @@ import de.jollyday.util.ResourceUtil;
  *
  * @author Gaël L'hopital - Initial contribution
  */
-@Component(name = "org.openhab.ephemeris", property = { Constants.SERVICE_PID + "=org.openhab.ephemeris",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Ephemeris",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + EphemerisManagerImpl.CONFIG_URI })
+@Component(name = "org.openhab.ephemeris", property = Constants.SERVICE_PID + "=org.openhab.ephemeris")
+@ConfigurableService(category = "system", label = "Ephemeris", description_uri = EphemerisManagerImpl.CONFIG_URI)
 @NonNullByDefault
 public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvider {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -294,8 +294,10 @@ public class ConfigurableServiceResource implements RESTResource {
                     configDescriptionURI = getConfigDescriptionByFactoryPid(factoryPid);
                 }
 
-                boolean multiple = Boolean.parseBoolean(
-                        (String) serviceReference.getProperty(ConfigurableService.SERVICE_PROPERTY_FACTORY_SERVICE));
+                Object factoryProperty = serviceReference
+                        .getProperty(ConfigurableService.SERVICE_PROPERTY_FACTORY_SERVICE);
+                boolean multiple = factoryProperty instanceof Boolean ? (Boolean) factoryProperty
+                        : Boolean.parseBoolean((String) factoryProperty);
 
                 services.add(new ConfigurableServiceDTO(id, label, category, configDescriptionURI, multiple));
             }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstanceMarker.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstanceMarker.java
@@ -23,13 +23,11 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author David Graeff - Initial contribution
  */
-@Component(immediate = true, service = MqttBrokerConnectionServiceInstanceMarker.class, property = {
-        Constants.SERVICE_PID + "=org.openhab.mqttbroker",
-        ConfigurableService.SERVICE_PROPERTY_FACTORY_SERVICE + "=true",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=MQTT system broker connection",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=MQTT",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=mqtt:systemBrokerConnectionInstance" })
+@Component(immediate = true, service = MqttBrokerConnectionServiceInstanceMarker.class, //
+        property = Constants.SERVICE_PID + "=org.openhab.mqttbroker")
+@ConfigurableService(factory = true, category = "MQTT", label = "MQTT system broker connection", description_uri = MqttBrokerConnectionServiceInstanceMarker.CONFIG_URI)
 @NonNullByDefault
 public class MqttBrokerConnectionServiceInstanceMarker {
 
+    protected static final String CONFIG_URI = "mqtt:systemBrokerConnectionInstance";
 }

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -61,11 +61,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(name = "org.openhab.addons", service = { FeatureInstaller.class, ConfigurationListener.class }, property = {
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Add-on Management",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + "system:addons" })
+@Component(name = "org.openhab.addons", service = { FeatureInstaller.class, ConfigurationListener.class })
+@ConfigurableService(category = "system", label = "Add-on Management", description_uri = FeatureInstaller.CONFIG_URI)
 public class FeatureInstaller implements ConfigurationListener {
+
+    protected static final String CONFIG_URI = "system:addons";
 
     public static final String EXTENSION_TYPE_ACTION = "action";
     public static final String EXTENSION_TYPE_BINDING = "binding";

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
@@ -46,14 +46,15 @@ import com.google.inject.Injector;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(immediate = true, service = ModelServer.class, configurationPid = ModelServer.CONFIGURATION_PID, property = {
-        Constants.SERVICE_PID + "=org.openhab.lsp", ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=misc:lsp",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Language Server (LSP)",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=misc" })
+@Component(immediate = true, service = ModelServer.class, configurationPid = ModelServer.CONFIGURATION_PID, //
+        property = Constants.SERVICE_PID + "=org.openhab.lsp")
+@ConfigurableService(category = "misc", label = "Language Server (LSP)", description_uri = ModelServer.CONFIG_URI)
 @NonNullByDefault
 public class ModelServer {
 
     public static final String CONFIGURATION_PID = "org.openhab.lsp";
+    protected static final String CONFIG_URI = "misc:lsp";
+
     private static final String KEY_PORT = "port";
     private static final int DEFAULT_PORT = 5007;
     private final ExecutorService pool = ThreadPoolManager.getPool("lsp");

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
@@ -42,10 +42,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(immediate = true, service = HumanLanguageInterpreter.class, configurationPid = "org.openhab.rulehli", property = {
-        Constants.SERVICE_PID + "=org.openhab.rulehli", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=voice",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Rule Voice Interpreter",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + RuleHumanLanguageInterpreter.CONFIG_URI })
+@Component(immediate = true, service = HumanLanguageInterpreter.class, configurationPid = "org.openhab.rulehli", //
+        property = Constants.SERVICE_PID + "=org.openhab.rulehli")
+@ConfigurableService(category = "voice", label = "Rule Voice Interpreter", description_uri = RuleHumanLanguageInterpreter.CONFIG_URI)
 public class RuleHumanLanguageInterpreter implements HumanLanguageInterpreter {
 
     private final Logger logger = LoggerFactory.getLogger(RuleHumanLanguageInterpreter.class);

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
@@ -41,10 +41,9 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(immediate = true, configurationPid = "org.openhab.persistence", property = {
-        Constants.SERVICE_PID + "=org.openhab.persistence", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Persistence",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + PersistenceServiceRegistryImpl.CONFIG_URI })
+@Component(immediate = true, configurationPid = "org.openhab.persistence", //
+        property = Constants.SERVICE_PID + "=org.openhab.persistence")
+@ConfigurableService(category = "system", label = "Persistence", description_uri = PersistenceServiceRegistryImpl.CONFIG_URI)
 @NonNullByDefault
 public class PersistenceServiceRegistryImpl implements ConfigOptionProvider, PersistenceServiceRegistry {
 

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
@@ -39,10 +39,8 @@ import org.slf4j.LoggerFactory;
  */
 @Component(name = "org.openhab.core.storage.json", configurationPid = "org.openhab.storage.json", property = { //
         Constants.SERVICE_PID + "=org.openhab.storage.json", //
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Json Storage", //
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system", //
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=system:json_storage", //
         "storage.format=json" })
+@ConfigurableService(category = "system", label = "Json Storage", description_uri = JsonStorageService.CONFIG_URI)
 @NonNullByDefault
 public class JsonStorageService implements StorageService {
 
@@ -53,6 +51,7 @@ public class JsonStorageService implements StorageService {
     /** the folder name to store database ({@code jsondb} by default) */
     private String dbFolderName = "jsondb";
 
+    protected static final String CONFIG_URI = "system:json_storage";
     private static final String CFG_MAX_BACKUP_FILES = "backup_files";
     private static final String CFG_WRITE_DELAY = "write_delay";
     private static final String CFG_MAX_DEFER_DELAY = "max_defer_delay";

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
@@ -68,13 +68,14 @@ import org.osgi.service.http.HttpService;
  * @author Chris Jackson - Initial contribution
  * @author Holger Reichert - Support for themes, DPI, legend hiding
  */
-@Component(immediate = true, service = ChartServlet.class, configurationPid = "org.openhab.chart", property = {
-        Constants.SERVICE_PID + "=org.openhab.core.chart", ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Charts",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + "system:chart" })
+@Component(immediate = true, service = ChartServlet.class, configurationPid = "org.openhab.chart", //
+        property = Constants.SERVICE_PID + "=org.openhab.core.chart")
+@ConfigurableService(category = "system", label = "Charts", description_uri = ChartServlet.CONFIG_URI)
 public class ChartServlet extends SmartHomeServlet {
 
     private static final long serialVersionUID = 7700873790924746422L;
+
+    protected static final String CONFIG_URI = "system:chart";
     private static final int CHART_HEIGHT = 240;
     private static final int CHART_WIDTH = 480;
     private static final String DATE_FORMAT = "yyyyMMddHHmm";

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -70,12 +70,9 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Sort TTS options
  */
-@Component(immediate = true, configurationPid = VoiceManagerImpl.CONFIGURATION_PID, property = { //
-        Constants.SERVICE_PID + "=org.openhab.voice", //
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=system", //
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Voice", //
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=" + VoiceManagerImpl.CONFIG_URI //
-})
+@Component(immediate = true, configurationPid = VoiceManagerImpl.CONFIGURATION_PID, //
+        property = Constants.SERVICE_PID + "=org.openhab.voice")
+@ConfigurableService(category = "system", label = "Voice", description_uri = VoiceManagerImpl.CONFIG_URI)
 public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
 
     public static final String CONFIGURATION_PID = "org.openhab.voice";

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.ws.rs.core.Response;
 
@@ -89,11 +90,17 @@ public class ConfigurableServiceResourceOSGiTest extends JavaOSGiTest {
         List<ConfigurableServiceDTO> configurableServices = configurableServiceResource.getAll();
         assertThat(configurableServices.size(), is(num + 1));
 
-        ConfigurableServiceDTO lastService = configurableServices.get(configurableServices.size() - 1);
-        assertThat(lastService.id, is(equalTo("pid")));
-        assertThat(lastService.configDescriptionURI, is(equalTo("someuri")));
-        assertThat(lastService.label, is(equalTo("label")));
-        assertThat(lastService.category, is(equalTo("category")));
+        Optional<ConfigurableServiceDTO> optionalService = configurableServices.stream()
+                .filter(configurableService -> "pid".equals(configurableService.id)).findFirst();
+        assertThat(optionalService.isPresent(), is(true));
+
+        if (optionalService.isPresent()) {
+            ConfigurableServiceDTO service = optionalService.get();
+            assertThat(service.id, is(equalTo("pid")));
+            assertThat(service.configDescriptionURI, is(equalTo("someuri")));
+            assertThat(service.label, is(equalTo("label")));
+            assertThat(service.category, is(equalTo("category")));
+        }
     }
 
     @Test
@@ -109,8 +116,15 @@ public class ConfigurableServiceResourceOSGiTest extends JavaOSGiTest {
         List<ConfigurableServiceDTO> configurableServices = configurableServiceResource.getAll();
         assertThat(configurableServices.size(), is(num + 1));
 
-        ConfigurableServiceDTO lastService = configurableServices.get(configurableServices.size() - 1);
-        assertThat(lastService.id, is(equalTo("component.name")));
+        Optional<ConfigurableServiceDTO> optionalService = configurableServices.stream()
+                .filter(configurableService -> "component.name".equals(configurableService.id)).findFirst();
+        assertThat(optionalService.isPresent(), is(true));
+
+        if (optionalService.isPresent()) {
+            ConfigurableServiceDTO service = optionalService.get();
+            assertThat(service.id, is(equalTo("component.name")));
+            assertThat(service.configDescriptionURI, is(equalTo("someuri")));
+        }
     }
 
     @Test


### PR DESCRIPTION
It is easier to use the `ConfigurableService` properties when it's possible to annotate classes using a `ComponentPropertyType`.

---

I gave it a test and it is backwards compatible with the ported add-ons that still use the properties.