### PR TITLE
Update maven-javadoc-plugin to 3.2.0

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
@@ -63,7 +63,7 @@ public class ASTNode {
     }
 
     /**
-     * @return the value of this node as {link String[]}
+     * @return the value of this node as {@code String[]}
      */
     public String[] getValueAsStringArray() {
         Object[] objs = value instanceof Object[] ? (Object[]) value : new Object[] { value };
@@ -83,10 +83,10 @@ public class ASTNode {
 
     /**
      * Breadth searches this (sub-) tree/node for a node with the given name and returning its value as a
-     * {link String[]}.
+     * {@code String[]}.
      *
      * @param name the name of the named node to be found
-     * @return the value of the resulting node as {link String[]} or null if not found
+     * @return the value of the resulting node as {@code String[]} or null if not found
      */
     public String[] findValueAsStringArray(String name) {
         ASTNode node = findNode(name);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -422,7 +422,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a sequence expression. Matches, if all the given expressions match. They are tested in
-     * the provided order. The resulting nodes's value will be an {link Object[]} that contains all values of the
+     * the provided order. The resulting nodes's value will be an {@code Object[]} that contains all values of the
      * matching expressions.
      *
      * @param expressions the expressions (alternatives) that have to match in sequence
@@ -445,7 +445,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a repeating expression that will match the given expression as often as possible. Always succeeds. The
-     * resulting node's value will be an {link Object[]} that contains all values of the
+     * resulting node's value will be an {@code Object[]} that contains all values of the
      * matches.
      *
      * @param expression the repeating expression
@@ -457,7 +457,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Creates a repeating expression that will match the given expression as often as possible. Only succeeds, if there
-     * is at least one match. The resulting node's value will be an {link Object[]} that contains all values of the
+     * is at least one match. The resulting node's value will be an {@code Object[]} that contains all values of the
      * matches.
      *
      * @param expression the repeating expression

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronScheduler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronScheduler.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * <p>
  * The Unix Cron defines a syntax that is used by the Cron service. A user
  * should register a Cron service with the {@link CronJob#CRON} property. The
- * value is according to the {link http://en.wikipedia.org/wiki/Cron}.
+ * value is according to the <a href="https://en.wikipedia.org/wiki/Cron">Cron</a>.
  * <p>
  *
  * <pre>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -48,6 +48,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@ Import-Package: \\
             <doclint>none</doclint>
             <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
             <additionalJOption>--no-module-directories</additionalJOption>
-            <excludePackageNames>*.internal,*.internal.*,nl.*,org.openhab.core.*.test,org.openhab.core.*.test.*</excludePackageNames>
+            <excludePackageNames>*.internal,*.internal.*</excludePackageNames>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -315,11 +315,20 @@ Import-Package: \\
           <version>3.2.0</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
-            <!-- Turn off doclint -->
             <doclint>none</doclint>
-            <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
-            <additionalJOption>--no-module-directories</additionalJOption>
             <excludePackageNames>*.internal,*.internal.*</excludePackageNames>
+            <!-- The search function is broken without the workaround below -->
+            <!-- See: https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url -->
+            <additionalJOption>--allow-script-in-comments</additionalJOption>
+            <bottom>
+              <![CDATA[
+                <script>
+                if (typeof useModuleDirectories !== 'undefined') {
+                  useModuleDirectories = false;
+                }
+                </script>
+              ]]>
+            </bottom>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -312,13 +312,11 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.2.0</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
             <!-- Turn off doclint -->
-            <additionalparam>-Xdoclint:none</additionalparam>
-            <!-- Frames are deprecated and will disappear at some point -->
-            <additionalparam>--frames</additionalparam>
+            <doclint>none</doclint>
             <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
             <additionalJOption>--no-module-directories</additionalJOption>
             <excludePackageNames>*.internal.*,nl.*</excludePackageNames>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@ Import-Package: \\
             <doclint>none</doclint>
             <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
             <additionalJOption>--no-module-directories</additionalJOption>
-            <excludePackageNames>*.internal,*.internal.*,nl.*</excludePackageNames>
+            <excludePackageNames>*.internal,*.internal.*,nl.*,org.openhab.core.*.test,org.openhab.core.*.test.*</excludePackageNames>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@ Import-Package: \\
             <doclint>none</doclint>
             <!-- Prevents the "undefined" module in path name, which causes a file not found when searching -->
             <additionalJOption>--no-module-directories</additionalJOption>
-            <excludePackageNames>*.internal.*,nl.*</excludePackageNames>
+            <excludePackageNames>*.internal,*.internal.*,nl.*</excludePackageNames>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
See: https://github.com/openhab/openhab-core/pull/1345#issuecomment-632639071

It seems to produce something useful when I run:

`mvn javadoc:javadoc javadoc:aggregate -B -Dfeatures.verify.skip=true -Dspotless.check.skip=true -T 1C`

Can you check the result @mhilbush?