### PR TITLE
Swagger: support injection of ReaderListener, add OAuth2 annotations

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -230,9 +230,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>de.maggu2810.jaxrswb.bundles</groupId>
-      <artifactId>jaxrswb-swagger1-gen</artifactId>
-      <version>0.0.4</version>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <version>1.5.5</version>
+      <scope>compile</scope>
     </dependency>
 
     <!-- XStream -->

--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -226,13 +226,13 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>1.6.1</version>
+      <version>1.5.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
-      <version>1.6.1</version>
+      <version>1.5.5</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -226,13 +226,13 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>1.5.5</version>
+      <version>1.6.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
-      <version>1.5.5</version>
+      <version>1.6.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -986,9 +986,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-models</artifactId>
+      <version>${swagger.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -998,9 +998,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-models</artifactId>
-      <version>${swagger.version}</version>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -986,6 +986,18 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.26.0-GA</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-models</artifactId>
       <version>${swagger.version}</version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -992,20 +992,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- JAX-RS Whiteboard Swagger 1 generator -->
-    <dependency>
-      <groupId>de.maggu2810.jaxrswb.bundles</groupId>
-      <artifactId>jaxrswb-swagger1-gen</artifactId>
-      <version>0.0.4</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.maggu2810.thirdparty.modified.org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.10.v20160429-1435</version>
-      <scope>compile</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -84,6 +84,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 import io.swagger.annotations.ResponseHeader;
 
 /**
@@ -99,7 +101,8 @@ import io.swagger.annotations.ResponseHeader;
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(RuleResource.PATH_RULES)
-@Api(RuleResource.PATH_RULES)
+@Api(value = RuleResource.PATH_RULES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @RolesAllowed({ Role.ADMIN })
 @NonNullByDefault
 public class RuleResource implements RESTResource {

--- a/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
+++ b/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
@@ -34,6 +34,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for accessing the UUID of the instance
@@ -46,7 +48,8 @@ import io.swagger.annotations.ApiResponses;
 @JaxrsName(UUIDResource.PATH_UUID)
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @Path(UUIDResource.PATH_UUID)
-@Api(UUIDResource.PATH_UUID)
+@Api(value = UUIDResource.PATH_UUID, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @RolesAllowed({ Role.ADMIN })
 @NonNullByDefault
 public class UUIDResource implements RESTResource {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -68,6 +68,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for add-ons and provides methods to install and uninstall them.
@@ -83,7 +85,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(AddonResource.PATH_ADDONS)
 @RolesAllowed({ Role.ADMIN })
-@Api(AddonResource.PATH_ADDONS)
+@Api(value = AddonResource.PATH_ADDONS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class AddonResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
@@ -81,7 +81,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(BindingResource.PATH_BINDINGS)
 @RolesAllowed({ Role.ADMIN })
-@Api(BindingResource.PATH_BINDINGS)
+@Api(value = BindingResource.PATH_BINDINGS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class BindingResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
@@ -63,6 +63,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for bindings and is registered with the

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
@@ -67,6 +67,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * Provides access to ChannelType via REST.
@@ -83,7 +85,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ChannelTypeResource.PATH_CHANNEL_TYPES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ChannelTypeResource.PATH_CHANNEL_TYPES)
+@Api(value = ChannelTypeResource.PATH_CHANNEL_TYPES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ChannelTypeResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -54,6 +54,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * {@link ConfigDescriptionResource} provides access to {@link ConfigDescription}s via REST.
@@ -70,7 +72,9 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
 @RolesAllowed({ Role.ADMIN })
-@Api(ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
+@Api(value = ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS, authorizations = {
+        @Authorization(value = "oauth2", scopes = {
+                @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ConfigDescriptionResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
@@ -47,6 +47,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for discovery and is registered with the
@@ -66,7 +68,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(DiscoveryResource.PATH_DISCOVERY)
 @RolesAllowed({ Role.ADMIN })
-@Api(DiscoveryResource.PATH_DISCOVERY)
+@Api(value = DiscoveryResource.PATH_DISCOVERY, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class DiscoveryResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
@@ -57,6 +57,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for the inbox and is registered with the
@@ -76,7 +78,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(InboxResource.PATH_INBOX)
 @RolesAllowed({ Role.ADMIN })
-@Api(InboxResource.PATH_INBOX)
+@Api(value = InboxResource.PATH_INBOX, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class InboxResource implements RESTResource {
     private final Logger logger = LoggerFactory.getLogger(InboxResource.class);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -97,6 +97,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * <p>
@@ -353,7 +355,9 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName: [a-zA-Z_0-9]+}/members/{memberItemName: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Adds a new member to a group item.")
+    @ApiOperation(value = "Adds a new member to a group item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item or member item not found or item is not of type group item."),
             @ApiResponse(code = 405, message = "Member item is not editable.") })
@@ -391,7 +395,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName: [a-zA-Z_0-9]+}/members/{memberItemName: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Removes an existing member from a group item.")
+    @ApiOperation(value = "Removes an existing member from a group item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item or member item not found or item is not of type group item."),
             @ApiResponse(code = 405, message = "Member item is not editable.") })
@@ -429,7 +435,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
-    @ApiOperation(value = "Removes an item from the registry.")
+    @ApiOperation(value = "Removes an item from the registry.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found or item is not editable.") })
     public Response removeItem(@PathParam("itemname") @ApiParam(value = "item name") String itemname) {
@@ -442,7 +450,8 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/tags/{tag}")
-    @ApiOperation(value = "Adds a tag to an item.")
+    @ApiOperation(value = "Adds a tag to an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Item not editable.") })
@@ -467,7 +476,8 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/tags/{tag}")
-    @ApiOperation(value = "Removes a tag from an item.")
+    @ApiOperation(value = "Removes a tag from an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Item not editable.") })
@@ -493,7 +503,8 @@ public class ItemResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/metadata/{namespace}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds metadata to an item.")
+    @ApiOperation(value = "Adds metadata to an item.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { //
             @ApiResponse(code = 200, message = "OK"), //
             @ApiResponse(code = 201, message = "Created"), //
@@ -528,7 +539,9 @@ public class ItemResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/metadata/{namespace}")
-    @ApiOperation(value = "Removes metadata from an item.")
+    @ApiOperation(value = "Removes metadata from an item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found."),
             @ApiResponse(code = 405, message = "Meta data not editable.") })
@@ -563,7 +576,9 @@ public class ItemResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds a new item to the registry or updates the existing item.")
+    @ApiOperation(value = "Adds a new item to the registry or updates the existing item.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 201, message = "Item created."), @ApiResponse(code = 400, message = "Item null."),
             @ApiResponse(code = 404, message = "Item not found."),
@@ -614,7 +629,9 @@ public class ItemResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Adds a list of items to the registry or updates the existing items.")
+    @ApiOperation(value = "Adds a list of items to the registry or updates the existing items.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 400, message = "Item list is null.") })
     public Response createOrUpdateItems(

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -55,6 +55,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for links.
@@ -73,7 +75,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ItemChannelLinkResource.PATH_LINKS)
 @RolesAllowed({ Role.ADMIN })
-@Api(ItemChannelLinkResource.PATH_LINKS)
+@Api(value = ItemChannelLinkResource.PATH_LINKS, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ItemChannelLinkResource implements RESTResource {
 
@@ -129,7 +132,8 @@ public class ItemChannelLinkResource implements RESTResource {
     @PUT
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName}/{channelUID}")
-    @ApiOperation(value = "Links item to a channel.")
+    @ApiOperation(value = "Links item to a channel.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 400, message = "Content does not match the path"),
             @ApiResponse(code = 405, message = "Link is not editable") })
@@ -162,7 +166,8 @@ public class ItemChannelLinkResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{itemName}/{channelUID}")
-    @ApiOperation(value = "Unlinks item from a channel.")
+    @ApiOperation(value = "Unlinks item from a channel.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Link not found."),
             @ApiResponse(code = 405, message = "Link not editable.") })

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -76,6 +76,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for history data and provides different methods to interact with the persistence
@@ -127,7 +129,9 @@ public class PersistenceResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.ADMIN })
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Gets a list of persistence services.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Gets a list of persistence services.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"))
     public Response httpGetPersistenceServices(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = "language") @Nullable String language) {
@@ -141,7 +145,9 @@ public class PersistenceResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/items")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Gets a list of items available via a specific persistence service.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Gets a list of items available via a specific persistence service.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"))
     public Response httpGetPersistenceServiceItems(@Context HttpHeaders headers,
             @ApiParam(value = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId) {
@@ -173,7 +179,9 @@ public class PersistenceResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/items/{itemname: [a-zA-Z_0-9]+}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Delete item data from a specific persistence service.", response = String.class, responseContainer = "List")
+    @ApiOperation(value = "Delete item data from a specific persistence service.", response = String.class, responseContainer = "List", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = String.class, responseContainer = "List"),
             @ApiResponse(code = 400, message = "Invalid filter parameters"),

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -58,6 +58,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * REST resource to obtain profile-types
@@ -72,7 +74,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ProfileTypeResource.PATH_PROFILE_TYPES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ProfileTypeResource.PATH_PROFILE_TYPES)
+@Api(value = ProfileTypeResource.PATH_PROFILE_TYPES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ProfileTypeResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -70,6 +70,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * {@link ConfigurableServiceResource} provides access to configurable services. It lists the available services and
@@ -86,7 +88,8 @@ import io.swagger.annotations.ApiResponses;
 @JSONRequired
 @Path(ConfigurableServiceResource.PATH_SERVICES)
 @RolesAllowed({ Role.ADMIN })
-@Api(ConfigurableServiceResource.PATH_SERVICES)
+@Api(value = ConfigurableServiceResource.PATH_SERVICES, authorizations = { @Authorization(value = "oauth2", scopes = {
+        @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
 @NonNullByDefault
 public class ConfigurableServiceResource implements RESTResource {
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -112,6 +112,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for things and is registered with the
@@ -209,7 +211,9 @@ public class ThingResource implements RESTResource {
     @POST
     @RolesAllowed({ Role.ADMIN })
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Creates a new thing and adds it to the registry.")
+    @ApiOperation(value = "Creates a new thing and adds it to the registry.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 201, message = "Created", response = String.class),
             @ApiResponse(code = 400, message = "A uid must be provided, if no binding can create a thing of this type."),
             @ApiResponse(code = 409, message = "A thing with the same uid already exists.") })
@@ -297,7 +301,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing by UID.")
+    @ApiOperation(value = "Gets thing by UID.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getByUID(
@@ -327,7 +332,9 @@ public class ThingResource implements RESTResource {
     @DELETE
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
-    @ApiOperation(value = "Removes a thing from the registry. Set \'force\' to __true__ if you want the thing te be removed immediately.")
+    @ApiOperation(value = "Removes a thing from the registry. Set \'force\' to __true__ if you want the thing te be removed immediately.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK, was deleted."),
             @ApiResponse(code = 202, message = "ACCEPTED for asynchronous deletion."),
             @ApiResponse(code = 404, message = "Thing not found."),
@@ -385,7 +392,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Updates a thing.")
+    @ApiOperation(value = "Updates a thing.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 404, message = "Thing not found."),
             @ApiResponse(code = 409, message = "Thing could not be updated as it is not editable.") })
@@ -444,7 +452,9 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/config")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Updates thing's configuration.")
+    @ApiOperation(value = "Updates thing's configuration.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 400, message = "Configuration of the thing is not valid."),
             @ApiResponse(code = 404, message = "Thing not found"),
@@ -500,7 +510,8 @@ public class ThingResource implements RESTResource {
     @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{thingUID}/status")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing's status.")
+    @ApiOperation(value = "Gets thing status.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getStatus(
@@ -522,9 +533,11 @@ public class ThingResource implements RESTResource {
     }
 
     @PUT
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/enable")
-    @ApiOperation(value = "Sets the thing enabled status.")
+    @ApiOperation(value = "Sets the thing enabled status.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response setEnabled(
@@ -550,10 +563,11 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/config/status")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets thing's config status.")
+    @ApiOperation(value = "Gets thing config status.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Thing not found.") })
     public Response getConfigStatus(
@@ -577,9 +591,11 @@ public class ThingResource implements RESTResource {
     }
 
     @PUT
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmware/{firmwareVersion}")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Update thing firmware.")
+    @ApiOperation(value = "Update thing firmware.", authorizations = { @Authorization(value = "oauth2", scopes = {
+            @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 400, message = "Firmware update preconditions not satisfied."),
             @ApiResponse(code = 404, message = "Thing not found.") })
@@ -612,8 +628,11 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmware/status")
-    @ApiOperation(value = "Gets thing's firmware status.")
+    @ApiOperation(value = "Gets thing's firmware status.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 204, message = "No firmware status provided by this Thing.") })
     public Response getFirmwareStatus(
@@ -629,9 +648,12 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/firmwares")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get all available firmwares for provided thing UID", response = StrippedThingTypeDTO.class, responseContainer = "Set")
+    @ApiOperation(value = "Get all available firmwares for provided thing UID", response = StrippedThingTypeDTO.class, responseContainer = "Set", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 204, message = "No firmwares found.") })
     public Response getFirmwares(@PathParam("thingUID") @ApiParam(value = "thingUID") String thingUID,

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/AuthSwaggerReaderListener.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/AuthSwaggerReaderListener.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.swagger.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.ReaderListener;
+import io.swagger.models.Swagger;
+import io.swagger.models.auth.OAuth2Definition;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+
+/**
+ * This class adds a security definition to the Swagger object for the OAuth2 flow.
+ *
+ * @author Yannick Schaus - initial contribution
+ */
+@Component
+@NonNullByDefault
+public class AuthSwaggerReaderListener implements ReaderListener {
+    public static final String OAUTH_AUTHORIZE_ENDPOINT = "/auth/authorize";
+    public static final String OAUTH_TOKEN_ENDPOINT = "/rest/auth/token";
+
+    private final Logger logger = LoggerFactory.getLogger(AuthSwaggerReaderListener.class);
+
+    @Override
+    public void beforeScan(@NonNullByDefault({}) Reader reader, @NonNullByDefault({}) Swagger swagger) {
+        logger.debug("Adding securityDefinition to Swagger");
+        SecuritySchemeDefinition oauth2Definition = new OAuth2Definition()
+                .accessCode(OAUTH_AUTHORIZE_ENDPOINT, OAUTH_TOKEN_ENDPOINT).scope("admin", "Administration operations");
+        Map<String, SecuritySchemeDefinition> securityDefinitions = new HashMap<>();
+        securityDefinitions.put("oauth2", oauth2Definition);
+        swagger.setSecurityDefinitions(securityDefinitions);
+    }
+
+    @Override
+    public void afterScan(@NonNullByDefault({}) Reader reader, @NonNullByDefault({}) Swagger swagger) {
+    }
+}

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/InfoSwaggerReaderListener.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/InfoSwaggerReaderListener.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.swagger.impl;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.osgi.service.component.annotations.Component;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.ReaderListener;
+import io.swagger.models.Contact;
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
+
+/**
+ * This class adds information about the REST API to the Swagger object.
+ *
+ * @author Yannick Schaus - initial contribution
+ */
+@Component
+@NonNullByDefault
+public class InfoSwaggerReaderListener implements ReaderListener {
+    public static final String API_TITLE = "openHAB";
+    public static final String API_VERSION = "3";
+    public static final String API_URL = "https://www.openhab.org/docs/";
+
+    @Override
+    public void beforeScan(@NonNullByDefault({}) Reader reader, @NonNullByDefault({}) Swagger swagger) {
+        Info info = new Info();
+        info.setTitle(API_TITLE);
+        info.setVersion(API_VERSION);
+        Contact contact = new Contact();
+        contact.setUrl(API_URL);
+        info.setContact(contact);
+        swagger.setInfo(info);
+    }
+
+    @Override
+    public void afterScan(@NonNullByDefault({}) Reader reader, @NonNullByDefault({}) Swagger swagger) {
+    }
+}

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/InfoSwaggerReaderListener.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/InfoSwaggerReaderListener.java
@@ -13,6 +13,7 @@
 package org.openhab.core.io.rest.swagger.impl;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.io.rest.RESTConstants;
 import org.osgi.service.component.annotations.Component;
 
 import io.swagger.jaxrs.Reader;
@@ -29,17 +30,18 @@ import io.swagger.models.Swagger;
 @Component
 @NonNullByDefault
 public class InfoSwaggerReaderListener implements ReaderListener {
-    public static final String API_TITLE = "openHAB";
-    public static final String API_VERSION = "3";
-    public static final String API_URL = "https://www.openhab.org/docs/";
+    public static final String API_TITLE = "openHAB REST API";
+    public static final String CONTACT_NAME = "openHAB";
+    public static final String CONTACT_URL = "https://www.openhab.org/docs/";
 
     @Override
     public void beforeScan(@NonNullByDefault({}) Reader reader, @NonNullByDefault({}) Swagger swagger) {
         Info info = new Info();
         info.setTitle(API_TITLE);
-        info.setVersion(API_VERSION);
+        info.setVersion(RESTConstants.API_VERSION);
         Contact contact = new Contact();
-        contact.setUrl(API_URL);
+        contact.setName(CONTACT_NAME);
+        contact.setUrl(CONTACT_URL);
         info.setContact(contact);
         swagger.setInfo(info);
     }

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerResource.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/SwaggerResource.java
@@ -13,17 +13,24 @@
 package org.openhab.core.io.rest.swagger.impl;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.io.rest.RESTResource;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,13 +42,20 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.maggu2810.jaxrswb.swagger1.gen.JaxRsWhiteboardSwaggerGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.ReaderListener;
+import io.swagger.models.Swagger;
+import io.swagger.util.Json;
 
 /**
  * An endpoint to generate and provide a Swagger description.
  *
  * @author Markus Rathgeb - Initial contribution
  * @author Kai Kreuzer - made it a RESTResource to register in the root bean
+ * @author Yannick Schaus - add support for ReaderListeners, remove dependency
  */
 @Component(service = SwaggerResource.class)
 @JaxrsResource
@@ -53,33 +67,61 @@ import de.maggu2810.jaxrswb.swagger1.gen.JaxRsWhiteboardSwaggerGenerator;
 public class SwaggerResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(SwaggerResource.class);
-    private final JaxRsWhiteboardSwaggerGenerator generator;
+    private final BundleContext bundleContext;
 
     /**
      * Creates a new instance.
-     *
-     * @param generator the generator
      */
     @Activate
-    public SwaggerResource(final @Reference JaxRsWhiteboardSwaggerGenerator generator) {
-        this.generator = generator;
+    public SwaggerResource(final BundleContext bc, final @Reference Application application) {
+        this.bundleContext = bc;
     }
 
     /**
-     * Gets the current JAX-RS Whiteboard provided endpoint information by Swagger 1.
+     * Gets the current JAX-RS Whiteboard provided endpoint information by Swagger.
      *
-     * @return a Swagger 1 description of the endpoints
+     * @return a Swagger description of the endpoints
      */
     @GET
-    @Produces({ MediaType.APPLICATION_JSON })
+    @Produces(MediaType.APPLICATION_JSON)
     public Object getSwagger() {
-        final Map<String, Object> map;
+        Swagger swagger = new Swagger();
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        Reader swaggerReader = new Reader(swagger);
+
         try {
-            map = generator.generateMap();
-        } catch (final IOException ex) {
-            logger.warn("Error on Swagger DTO generation.", ex);
+            ServiceReference<Application> applicationReference = bundleContext.getServiceReference(Application.class);
+            swagger.setBasePath(
+                    "/" + applicationReference.getProperty(JaxrsWhiteboardConstants.JAX_RS_APPLICATION_BASE));
+
+            Collection<ServiceReference<RESTResource>> resourcesReferences = bundleContext
+                    .getServiceReferences(RESTResource.class, null);
+            resourcesReferences.forEach(sr -> {
+                Object service = bundleContext.getService(sr);
+                classes.add(service.getClass());
+            });
+
+            Collection<ServiceReference<ReaderListener>> readerListenersReferences = bundleContext
+                    .getServiceReferences(ReaderListener.class, null);
+            readerListenersReferences.forEach(sr -> {
+                Object service = bundleContext.getService(sr);
+                classes.add(service.getClass());
+            });
+
+            swaggerReader.read(classes);
+            String json = Json.mapper().writeValueAsString(swagger);
+            return Response.status(Response.Status.OK)
+                    .entity(Json.mapper().readValue(json, new TypeReference<Map<String, Object>>() {
+                    })).build();
+        } catch (JsonProcessingException e) {
+            logger.error("Error while serializing the Swagger object to JSON");
+            return Response.serverError().build();
+        } catch (IOException e) {
+            logger.error("Error while deserializing the Swagger JSON output");
+            return Response.serverError().build();
+        } catch (InvalidSyntaxException e) {
+            logger.error("Error while enumerating services for Swagger generation");
             return Response.serverError().build();
         }
-        return Response.status(Response.Status.OK).entity(map).build();
     }
 }

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
@@ -51,6 +51,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.AuthorizationScope;
 
 /**
  * This class acts as a REST resource for the UI resources and is registered with the
@@ -123,7 +125,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Add an UI component in the specified namespace.")
+    @ApiOperation(value = "Add an UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class) })
     public Response addComponent(@PathParam("namespace") String namespace, RootUIComponent component) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
@@ -136,7 +140,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}/{componentUID}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Update a specific UI component in the specified namespace.")
+    @ApiOperation(value = "Update a specific UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class),
             @ApiResponse(code = 404, message = "Component not found", response = Tile.class) })
     public Response updateComponent(@PathParam("namespace") String namespace,
@@ -159,7 +165,9 @@ public class UIResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/components/{namespace}/{componentUID}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Remove a specific UI component in the specified namespace.")
+    @ApiOperation(value = "Remove a specific UI component in the specified namespace.", authorizations = {
+            @Authorization(value = "oauth2", scopes = {
+                    @AuthorizationScope(scope = "admin", description = "Admin operations") }) })
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Tile.class),
             @ApiResponse(code = 404, message = "Component not found", response = Tile.class) })
     public Response deleteComponent(@PathParam("namespace") String namespace,

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
@@ -23,4 +23,6 @@ public class RESTConstants {
     public static final String REST_URI = "/rest";
 
     public static final String JAX_RS_NAME = "openhab";
+
+    public static final String API_VERSION = "4";
 }

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTResource.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * This is a marker interface for REST resource implementations
  *
  * @author Kai Kreuzer - Initial contribution
- * @author Stefan Triller - Added default implementation for isSatisfied
  */
 @NonNullByDefault
 public interface RESTResource {

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
@@ -15,6 +15,8 @@ package org.openhab.core.io.rest.internal.resources.beans;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.openhab.core.io.rest.RESTConstants;
+
 /**
  * This is a java bean that is used to define the root entry
  * page of the REST interface.
@@ -23,7 +25,7 @@ import java.util.List;
  */
 public class RootBean {
 
-    public final String version = "4";
+    public final String version = RESTConstants.API_VERSION;
 
     public final List<Links> links = new ArrayList<>();
 

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -151,7 +151,9 @@
 		<feature>openhab-core-auth-jaas</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.auth/${project.version}</bundle>
 		<requirement>openhab.tp;filter:="(feature=jose4j)"</requirement>
+		<requirement>openhab.tp;filter:="(feature=swagger-jaxrs)"</requirement>
 		<feature dependency="true">openhab.tp-jose4j</feature>
+		<feature dependency="true">openhab.tp-swagger-jaxrs</feature>
 	</feature>
 
 	<feature name="openhab-core-io-rest-log" version="${project.version}">
@@ -169,8 +171,8 @@
 	<feature name="openhab-core-io-rest-swagger" version="${project.version}">
 		<feature>openhab-core-base</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.swagger/${project.version}</bundle>
-		<requirement>openhab.tp;filter:="(feature=jaxrswb-swagger-gen)"</requirement>
-		<feature dependency="true">openhab.tp-jaxrswb-swagger-gen</feature>
+		<requirement>openhab.tp;filter:="(feature=swagger-jaxrs)"</requirement>
+		<feature dependency="true">openhab.tp-swagger-jaxrs</feature>
 	</feature>
 
 	<feature name="openhab-core-io-rest-audio" version="${project.version}">

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -151,9 +151,7 @@
 		<feature>openhab-core-auth-jaas</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.auth/${project.version}</bundle>
 		<requirement>openhab.tp;filter:="(feature=jose4j)"</requirement>
-		<requirement>openhab.tp;filter:="(feature=swagger-jaxrs)"</requirement>
 		<feature dependency="true">openhab.tp-jose4j</feature>
-		<feature dependency="true">openhab.tp-swagger-jaxrs</feature>
 	</feature>
 
 	<feature name="openhab-core-io-rest-log" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -243,12 +243,8 @@
 		<bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.xbase.ide/2.19.0</bundle>
 	</feature>
 
-	<feature name="openhab.tp-jaxrswb-swagger-gen" description="JAX-RS Whiteboard Swagger 1 generator" version="${project.version}">
-		<details>
-			This feature is currently only for external usage by products and not used by openHAB Core itself.
-		</details>
-		<capability>openhab.tp;feature=jaxrswb-swagger-gen;version=0.0.4</capability>
-		<bundle>mvn:de.maggu2810.jaxrswb.bundles/jaxrswb-swagger1-gen/0.0.4</bundle>
+	<feature name="openhab.tp-swagger-jaxrs" description="JAX-RS Whiteboard Swagger Support" version="${project.version}">
+		<capability>openhab.tp;feature=swagger-jaxrs;version=1.6.1</capability>
 		<feature dependency="true">openhab.tp-jax-rs-whiteboard</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:io.swagger/swagger-jaxrs/1.6.1</bundle>
@@ -260,9 +256,6 @@
 		<bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.2.1</bundle>
 		<bundle dependency="true">mvn:de.maggu2810.thirdparty.modified.org.reflections/reflections/0.9.10.v20160429-1435</bundle>
-		<config name="de.maggu2810.jaxrswb.swagger1.gen">
-			info.title=openHAB REST API
-		</config>
-	</feature>
+</feature>
 
 </features>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -255,7 +255,8 @@
 		<bundle dependency="true">mvn:com.google.guava/failureaccess/1.0.1</bundle>
 		<bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.2.1</bundle>
-		<bundle dependency="true">mvn:de.maggu2810.thirdparty.modified.org.reflections/reflections/0.9.10.v20160429-1435</bundle>
+		<bundle dependency="true">mvn:org.reflections/reflections/0.9.12</bundle>
+		<bundle dependency="true">mvn:org.javassist/javassist/3.26.0-GA</bundle>
 </feature>
 
 </features>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -257,6 +257,6 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.2.1</bundle>
 		<bundle dependency="true">mvn:org.reflections/reflections/0.9.12</bundle>
 		<bundle dependency="true">mvn:org.javassist/javassist/3.26.0-GA</bundle>
-</feature>
+	</feature>
 
 </features>


### PR DESCRIPTION
This is another attempt at #1483 without any blatant (but inadvertent!) third-party code borrowing & relicensing this time.

This introduces the ability to [customize the Swagger Definition](https://github.com/swagger-api/swagger-core/wiki/Annotations-1.5.X#customising-the-swagger-definition) in a way supported directly by swagger-jaxrs by providing `ReaderListener` implementations with DI. Two of them are implemented in this PR: one to add general information and the other to add the OAuth2 security definition (which will only be injected if the auth bundle is installed).

Additionally the enumeration of resources has been simplified for openHAB's purposes as they all implement `RESTResource` and there is only one `Application`, so they can be looked up and fed to the Swagger `Reader` easily.

It seems to work, with no change in functionality, therefore the dependency to  `jaxrswb-swagger1-gen` can be removed, in line with the current push to remove unneeded dependencies, as well as mitigating the risk of relying on third-party libraries when the functionality they offer can be easily replaced with first-party code (nothing personal against @maggu2810! And thanks for the [valuable insight here](https://github.com/maggu2810/jaxrswb/blob/6c57f9a7de310a12213ed3b2fdcab37bebc845a4/bundles/jaxrswb-utils/src/main/java/de/maggu2810/jaxrswb/gen/JaxRsWhiteboardBaseSpecialGenerator.java#L61)).

There was also a problem with a conflict between Guava versions (as discussed [here](https://github.com/openhab/openhab-distro/issues/1045#issuecomment-596255184)), solved by fixing the `org.reflections:reflections` dependency to version 0.9.12 (`swagger-jaxrs` depends on version 0.9.11) because this [recent release](https://github.com/ronmamo/reflections/releases/tag/0.9.12) removes the dependency to an outdated release of Guava. This seems to do the trick without side effects and apparently solves resolutions problems in both the demo app and Karaf. This allows in turn to remove the personal fork of this lib (`de.maggu2810.thirdparty.modified.org.reflections/reflections/0.9.10.v20160429-1435`), in favor of an official version.

The OAuth2 flow in Swagger UI depends on https://github.com/openhab/openhab-webui/pull/257 to work correctly.

![image](https://user-images.githubusercontent.com/2004147/82748812-1e325080-9da5-11ea-9a83-bd2a4fff1671.png)

Signed-off-by: Yannick Schaus <github@schaus.net>
