### PR TITLE
Update nrjavaserial in TP to 5.2.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -486,7 +486,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>5.0.2</version>
+      <version>5.2.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -188,7 +188,7 @@
 
 	<feature name="openhab.tp-serial-rxtx" version="${project.version}">
 		<capability>openhab.tp;feature=serial;impl=rxtx</capability>
-		<bundle>mvn:com.neuronrobotics/nrjavaserial/5.0.2</bundle>
+		<bundle>mvn:com.neuronrobotics/nrjavaserial/5.2.1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">


### PR DESCRIPTION
With this version it will no longer completely exit :exclamation:  the JVM in certain scenarios when ports are closed/reopened.

Related to:

* openhab/org.openhab.binding.zigbee#577
* openhab/org.openhab.binding.zwave#1332