### PR TITLE
Added 'ChannelDescriptionChangedEvent'

### DIFF
--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
@@ -17,12 +17,14 @@ import static org.openhab.core.magic.binding.MagicBindingConstants.*;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.magic.binding.internal.MagicDynamicCommandDescriptionProvider;
 import org.openhab.core.magic.binding.internal.MagicDynamicStateDescriptionProvider;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandOption;
 import org.openhab.core.types.StateOption;
 
 /**
@@ -39,23 +41,26 @@ public class MagicDynamicStateDescriptionThingHandler extends BaseThingHandler {
     private static final String SYSTEM_COMMAND_SUSPEND = "Suspend";
     private static final String SYSTEM_COMMAND_QUIT = "Quit";
 
+    private final MagicDynamicCommandDescriptionProvider commandDescriptionProvider;
     private final MagicDynamicStateDescriptionProvider stateDescriptionProvider;
 
     public MagicDynamicStateDescriptionThingHandler(Thing thing,
+            MagicDynamicCommandDescriptionProvider commandDescriptionProvider,
             MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
         super(thing);
+        this.commandDescriptionProvider = commandDescriptionProvider;
         this.stateDescriptionProvider = stateDescriptionProvider;
     }
 
     @Override
     public void initialize() {
         ChannelUID systemCommandChannelUID = new ChannelUID(getThing().getUID(), CHANNEL_SYSTEM_COMMAND);
-        stateDescriptionProvider.setStateOptions(systemCommandChannelUID,
-                List.of(new StateOption(SYSTEM_COMMAND_HIBERNATE, SYSTEM_COMMAND_HIBERNATE),
-                        new StateOption(SYSTEM_COMMAND_REBOOT, SYSTEM_COMMAND_REBOOT),
-                        new StateOption(SYSTEM_COMMAND_SHUTDOWN, SYSTEM_COMMAND_SHUTDOWN),
-                        new StateOption(SYSTEM_COMMAND_SUSPEND, SYSTEM_COMMAND_SUSPEND),
-                        new StateOption(SYSTEM_COMMAND_QUIT, SYSTEM_COMMAND_QUIT)));
+        commandDescriptionProvider.setCommandOptions(systemCommandChannelUID,
+                List.of(new CommandOption(SYSTEM_COMMAND_HIBERNATE, SYSTEM_COMMAND_HIBERNATE),
+                        new CommandOption(SYSTEM_COMMAND_REBOOT, SYSTEM_COMMAND_REBOOT),
+                        new CommandOption(SYSTEM_COMMAND_SHUTDOWN, SYSTEM_COMMAND_SHUTDOWN),
+                        new CommandOption(SYSTEM_COMMAND_SUSPEND, SYSTEM_COMMAND_SUSPEND),
+                        new CommandOption(SYSTEM_COMMAND_QUIT, SYSTEM_COMMAND_QUIT)));
 
         ChannelUID signalStrengthChannelUID = new ChannelUID(getThing().getUID(), CHANNEL_SIGNAL_STRENGTH);
         stateDescriptionProvider.setStateOptions(signalStrengthChannelUID, List.of(new StateOption("1", "Unusable"),

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicCommandDescriptionProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.magic.binding.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.binding.BaseDynamicCommandDescriptionProvider;
+import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.thing.type.DynamicCommandDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Dynamic provider of command options.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@Component(service = { DynamicCommandDescriptionProvider.class, MagicDynamicCommandDescriptionProvider.class })
+@NonNullByDefault
+public class MagicDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+
+    @Activate
+    public MagicDynamicCommandDescriptionProvider(final @Reference EventPublisher eventPublisher, //
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService, //
+            final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.eventPublisher = eventPublisher;
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+    }
+}

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
@@ -13,9 +13,12 @@
 package org.openhab.core.magic.binding.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.events.EventPublisher;
 import org.openhab.core.thing.binding.BaseDynamicStateDescriptionProvider;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -28,14 +31,12 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class MagicDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
 
-    @Reference
-    protected void setChannelTypeI18nLocalizationService(
-            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+    @Activate
+    public MagicDynamicStateDescriptionProvider(final @Reference EventPublisher eventPublisher, //
+            final @Reference ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService, //
+            final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.eventPublisher = eventPublisher;
         this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
-    }
-
-    protected void unsetChannelTypeI18nLocalizationService(
-            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
-        this.channelTypeI18nLocalizationService = null;
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
     }
 }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
@@ -63,10 +63,13 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
             THING_TYPE_CHATTY_THING, THING_TYPE_ROLLERSHUTTER, THING_TYPE_PLAYER, THING_TYPE_IMAGE,
             THING_TYPE_ACTION_MODULE, THING_TYPE_DYNAMIC_STATE_DESCRIPTION, THING_TYPE_ONLINE_OFFLINE);
 
+    private final MagicDynamicCommandDescriptionProvider commandDescriptionProvider;
     private final MagicDynamicStateDescriptionProvider stateDescriptionProvider;
 
     @Activate
-    public MagicHandlerFactory(final @Reference MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
+    public MagicHandlerFactory(final @Reference MagicDynamicCommandDescriptionProvider commandDescriptionProvider, //
+            final @Reference MagicDynamicStateDescriptionProvider stateDescriptionProvider) {
+        this.commandDescriptionProvider = commandDescriptionProvider;
         this.stateDescriptionProvider = stateDescriptionProvider;
     }
 
@@ -128,7 +131,8 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
             return new MagicActionModuleThingHandler(thing);
         }
         if (THING_TYPE_DYNAMIC_STATE_DESCRIPTION.equals(thingTypeUID)) {
-            return new MagicDynamicStateDescriptionThingHandler(thing, stateDescriptionProvider);
+            return new MagicDynamicStateDescriptionThingHandler(thing, commandDescriptionProvider,
+                    stateDescriptionProvider);
         }
         if (THING_TYPE_ONLINE_OFFLINE.equals(thingTypeUID)) {
             return new MagicOnlineOfflineHandler(thing);

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
@@ -38,7 +38,8 @@ public class MagicHandlerFactoryTest {
 
     @BeforeEach
     public void setup() {
-        factory = new MagicHandlerFactory(mock(MagicDynamicStateDescriptionProvider.class));
+        factory = new MagicHandlerFactory(mock(MagicDynamicCommandDescriptionProvider.class),
+                mock(MagicDynamicStateDescriptionProvider.class));
     }
 
     @Test

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -12,16 +12,11 @@
  */
 package org.openhab.core.thing.binding;
 
-import java.util.Set;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
-import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.events.ChannelDescriptionChangedEvent;
-import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
-import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.osgi.framework.BundleContext;
@@ -52,22 +47,6 @@ public abstract class AbstractDynamicDescriptionProvider {
     protected @Nullable EventPublisher eventPublisher;
     protected @Nullable ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
     protected @Nullable ItemChannelLinkRegistry itemChannelLinkRegistry;
-
-    /**
-     * This method can be used in a subclass in order to create a {@link ChannelDescriptionChangedEvent} and post it
-     * through the openHAB events bus.
-     *
-     * @param field the changed field
-     * @param channelUID the {@link ChannelUID}
-     * @param value the new value
-     * @param oldValue the old value
-     */
-    protected void postChannelDescriptionChangedEvent(CommonChannelDescriptionField field, ChannelUID channelUID,
-            Object value, @Nullable Object oldValue) {
-        postEvent(ThingEventFactory.createChannelDescriptionChangedEvent(field, channelUID,
-                itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
-                value, oldValue));
-    }
 
     /**
      * This method can be used in a subclass in order to post events through the openHAB events bus. A common use case

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -20,6 +20,7 @@ import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.events.ChannelDescriptionChangedEvent;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
 import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.link.ItemChannelLinkRegistry;
@@ -59,9 +60,11 @@ public abstract class AbstractDynamicDescriptionProvider {
      * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      */
-    protected void postChannelDescriptionChangedEvent(String field, ChannelUID channelUID) {
+    protected void postChannelDescriptionChangedEvent(CommonChannelDescriptionField field, ChannelUID channelUID,
+            Object value, @Nullable Object oldValue) {
         postEvent(ThingEventFactory.createChannelDescriptionChangedEvent(field, channelUID,
-                itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of()));
+                itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
+                value, oldValue));
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -48,8 +48,8 @@ public abstract class AbstractDynamicDescriptionProvider {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected @NonNullByDefault({}) BundleContext bundleContext;
-    protected @NonNullByDefault({}) EventPublisher eventPublisher;
-    protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
+    protected @Nullable EventPublisher eventPublisher;
+    protected @Nullable ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
     protected @Nullable ItemChannelLinkRegistry itemChannelLinkRegistry;
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -59,6 +59,8 @@ public abstract class AbstractDynamicDescriptionProvider {
      *
      * @param field the changed field
      * @param channelUID the {@link ChannelUID}
+     * @param value the new value
+     * @param oldValue the old value
      */
     protected void postChannelDescriptionChangedEvent(CommonChannelDescriptionField field, ChannelUID channelUID,
             Object value, @Nullable Object oldValue) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.binding;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent;
+import org.openhab.core.thing.events.ThingEventFactory;
+import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link AbstractDynamicDescriptionProvider} provides a base implementation for dynamic description providers.
+ * <p>
+ * It holds a reference to the {@link ChannelTypeI18nLocalizationService} to provide localized descriptions. Therefore
+ * the inheriting class has to request a reference for the {@link ChannelTypeI18nLocalizationService} on its own.
+ * <p>
+ * It posts {@link ChannelDescriptionChangedEvent}s through the openHAB events bus about a changed dynamic description.
+ * Therefore the subclass has to request references for the {@link EventPublisher} and
+ * {@link ItemChannelLinkRegistry}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AbstractDynamicDescriptionProvider {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected @NonNullByDefault({}) BundleContext bundleContext;
+    protected @NonNullByDefault({}) EventPublisher eventPublisher;
+    protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
+    protected @Nullable ItemChannelLinkRegistry itemChannelLinkRegistry;
+
+    /**
+     * This method can be used in a subclass in order to create a {@link ChannelDescriptionChangedEvent} and post it
+     * through the openHAB events bus.
+     *
+     * @param field the changed field
+     * @param channelUID the {@link ChannelUID}
+     */
+    protected void postChannelDescriptionChangedEvent(String field, ChannelUID channelUID) {
+        postEvent(ThingEventFactory.createChannelDescriptionChangedEvent(field, channelUID,
+                itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of()));
+    }
+
+    /**
+     * This method can be used in a subclass in order to post events through the openHAB events bus. A common use case
+     * is to notify event subscribers about a changed dynamic description.
+     *
+     * @param event the {@link Event}
+     */
+    protected void postEvent(Event event) {
+        if (eventPublisher != null) {
+            try {
+                eventPublisher.post(event);
+            } catch (RuntimeException e) {
+                logger.error("Cannot post '{}' event: {}", event.getType(), e.getMessage(), e);
+            }
+        } else {
+            logger.debug("Cannot post event as EventPublisher is missing");
+        }
+    }
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+        bundleContext = componentContext.getBundleContext();
+    }
+
+    @Deactivate
+    public void deactivate() {
+        bundleContext = null;
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
 import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
@@ -60,8 +59,7 @@ public abstract class BaseDynamicCommandDescriptionProvider extends AbstractDyna
         List<CommandOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postEvent(ThingEventFactory.createChannelDescriptionCommandOptionsChangedEvent(
-                    CommonChannelDescriptionField.COMMAND_OPTIONS, channelUID,
+            postEvent(ThingEventFactory.createChannelDescriptionCommandOptionsChangedEvent(channelUID,
                     itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
                     options, oldOptions));
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -57,7 +58,8 @@ public abstract class BaseDynamicCommandDescriptionProvider extends AbstractDyna
         List<CommandOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postChannelDescriptionChangedEvent("command-options", channelUID);
+            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.COMMAND_OPTIONS, channelUID, options,
+                    oldOptions);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -15,6 +15,7 @@ package org.openhab.core.thing.binding;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,6 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
+import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -58,8 +60,11 @@ public abstract class BaseDynamicCommandDescriptionProvider extends AbstractDyna
         List<CommandOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.COMMAND_OPTIONS, channelUID, options,
-                    oldOptions);
+            postEvent(ThingEventFactory.createChannelDescriptionCommandOptionsChangedEvent(
+                    CommonChannelDescriptionField.COMMAND_OPTIONS, channelUID,
+                    itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
+                    options, oldOptions));
+
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -28,37 +28,37 @@ import org.openhab.core.thing.type.DynamicCommandDescriptionProvider;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandDescriptionBuilder;
 import org.openhab.core.types.CommandOption;
-import org.osgi.framework.BundleContext;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Deactivate;
 
 /**
  * The {@link BaseDynamicCommandDescriptionProvider} provides a base implementation for the
  * {@link DynamicCommandDescriptionProvider}.
  * <p>
- * It provides localized command options. Therefore the inheriting class has to request the reference for the
- * {@link ChannelTypeI18nLocalizationService} on its own.
+ * It provides localized dynamic {@link CommandOption}s. Therefore the inheriting class has to request a reference for
+ * the {@link ChannelTypeI18nLocalizationService} on its own.
  *
  * @author Christoph Weitkamp - Initial contribution
+ * @author Christoph Weitkamp - Added ChannelStateDescriptionChangedEvent
  */
 @NonNullByDefault
-public abstract class BaseDynamicCommandDescriptionProvider implements DynamicCommandDescriptionProvider {
-
-    private @NonNullByDefault({}) BundleContext bundleContext;
-    protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
+public abstract class BaseDynamicCommandDescriptionProvider extends AbstractDynamicDescriptionProvider
+        implements DynamicCommandDescriptionProvider {
 
     protected final Map<ChannelUID, List<CommandOption>> channelOptionsMap = new ConcurrentHashMap<>();
 
     /**
-     * For a given channel UID, set a {@link List} of {@link CommandOption}s that should be used for the channel,
+     * For a given {@link ChannelUID}, set a {@link List} of {@link CommandOption}s that should be used for the channel,
      * instead of the one defined statically in the {@link ChannelType}.
      *
-     * @param channelUID the channel UID of the channel
+     * @param channelUID the {@link ChannelUID} of the channel
      * @param options a {@link List} of {@link CommandOption}s
      */
     public void setCommandOptions(ChannelUID channelUID, List<CommandOption> options) {
-        channelOptionsMap.put(channelUID, options);
+        List<CommandOption> oldOptions = channelOptionsMap.get(channelUID);
+        if (!options.equals(oldOptions)) {
+            channelOptionsMap.put(channelUID, options);
+            postChannelDescriptionChangedEvent("command-options", channelUID);
+        }
     }
 
     @Override
@@ -92,14 +92,10 @@ public abstract class BaseDynamicCommandDescriptionProvider implements DynamicCo
         return options;
     }
 
-    @Activate
-    protected void activate(ComponentContext componentContext) {
-        bundleContext = componentContext.getBundleContext();
-    }
-
+    @Override
     @Deactivate
     public void deactivate() {
         channelOptionsMap.clear();
-        bundleContext = null;
+        super.deactivate();
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -15,6 +15,7 @@ package org.openhab.core.thing.binding;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,6 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
+import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -60,7 +62,10 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         String oldPattern = channelPatternMap.get(channelUID);
         if (!pattern.equals(oldPattern)) {
             channelPatternMap.put(channelUID, pattern);
-            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.PATTERN, channelUID, pattern, oldPattern);
+            postEvent(ThingEventFactory.createChannelDescriptionPatternChangedEvent(
+                    CommonChannelDescriptionField.PATTERN, channelUID,
+                    itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
+                    pattern, oldPattern));
         }
     }
 
@@ -75,8 +80,10 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         List<StateOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.STATE_OPTIONS, channelUID, options,
-                    oldOptions);
+            postEvent(ThingEventFactory.createChannelDescriptionStateOptionsChangedEvent(
+                    CommonChannelDescriptionField.STATE_OPTIONS, channelUID,
+                    itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
+                    options, oldOptions));
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
-import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
 import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
@@ -62,8 +61,7 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         String oldPattern = channelPatternMap.get(channelUID);
         if (!pattern.equals(oldPattern)) {
             channelPatternMap.put(channelUID, pattern);
-            postEvent(ThingEventFactory.createChannelDescriptionPatternChangedEvent(
-                    CommonChannelDescriptionField.PATTERN, channelUID,
+            postEvent(ThingEventFactory.createChannelDescriptionPatternChangedEvent(channelUID,
                     itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
                     pattern, oldPattern));
         }
@@ -80,8 +78,7 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         List<StateOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postEvent(ThingEventFactory.createChannelDescriptionStateOptionsChangedEvent(
-                    CommonChannelDescriptionField.STATE_OPTIONS, channelUID,
+            postEvent(ThingEventFactory.createChannelDescriptionStateOptionsChangedEvent(channelUID,
                     itemChannelLinkRegistry != null ? itemChannelLinkRegistry.getLinkedItemNames(channelUID) : Set.of(),
                     options, oldOptions));
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
@@ -59,7 +60,7 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         String oldPattern = channelPatternMap.get(channelUID);
         if (!pattern.equals(oldPattern)) {
             channelPatternMap.put(channelUID, pattern);
-            postChannelDescriptionChangedEvent("pattern", channelUID);
+            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.PATTERN, channelUID, pattern, oldPattern);
         }
     }
 
@@ -74,7 +75,8 @@ public abstract class BaseDynamicStateDescriptionProvider extends AbstractDynami
         List<StateOption> oldOptions = channelOptionsMap.get(channelUID);
         if (!options.equals(oldOptions)) {
             channelOptionsMap.put(channelUID, options);
-            postChannelDescriptionChangedEvent("state-options", channelUID);
+            postChannelDescriptionChangedEvent(CommonChannelDescriptionField.STATE_OPTIONS, channelUID, options,
+                    oldOptions);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/AbstractThingRegistryEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/AbstractThingRegistryEvent.java
@@ -34,8 +34,8 @@ public abstract class AbstractThingRegistryEvent extends AbstractEvent {
      *
      * @param topic the topic
      * @param payload the payload
-     * @param source the source, can be null
-     * @param thing the thing
+     * @param source the source
+     * @param thing the thing data transfer object
      */
     protected AbstractThingRegistryEvent(String topic, String payload, @Nullable String source, ThingDTO thing) {
         super(topic, payload, source);
@@ -43,9 +43,9 @@ public abstract class AbstractThingRegistryEvent extends AbstractEvent {
     }
 
     /**
-     * Gets the thing.
+     * Gets the thing data transfer object.
      *
-     * @return the thing
+     * @return the thing data transfer object
      */
     public ThingDTO getThing() {
         return thing;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
@@ -77,6 +77,8 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
      * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
+     * @param value the new value
+     * @param oldValue the old value
      */
     protected ChannelDescriptionChangedEvent(String topic, String payload, CommonChannelDescriptionField field,
             ChannelUID channelUID, Set<String> linkedItemNames, Object value, @Nullable Object oldValue) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
@@ -60,14 +60,14 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
     private final Set<String> linkedItemNames;
 
     /**
-     * The new value.
+     * The new value (represented as JSON string).
      */
-    private final Object value;
+    private final String value;
 
     /**
-     * The old value.
+     * The old value (represented as JSON string).
      */
-    private final @Nullable Object oldValue;
+    private final @Nullable String oldValue;
 
     /**
      * Creates a new instance.
@@ -77,11 +77,11 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
      * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
-     * @param value the new value
-     * @param oldValue the old value
+     * @param value the new value (represented as JSON string)
+     * @param oldValue the old value represented as JSON string)
      */
     protected ChannelDescriptionChangedEvent(String topic, String payload, CommonChannelDescriptionField field,
-            ChannelUID channelUID, Set<String> linkedItemNames, Object value, @Nullable Object oldValue) {
+            ChannelUID channelUID, Set<String> linkedItemNames, String value, @Nullable String oldValue) {
         super(topic, payload, null);
         this.field = field;
         this.channelUID = channelUID;
@@ -123,20 +123,20 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
     }
 
     /**
-     * Gets the new value.
+     * Gets the new value (represented as JSON string).
      *
      * @return the new value.
      */
-    public Object getValue() {
+    public String getValue() {
         return value;
     }
 
     /**
-     * Gets the old value.
+     * Gets the old value (represented as JSON string).
      *
      * @return the old value.
      */
-    public @Nullable Object getOldValue() {
+    public @Nullable String getOldValue() {
         return oldValue;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.CommandDescription;
@@ -31,6 +32,13 @@ import org.openhab.core.types.StateDescription;
 @NonNullByDefault
 public class ChannelDescriptionChangedEvent extends AbstractEvent {
 
+    public enum CommonChannelDescriptionField {
+        ALL,
+        COMMAND_OPTIONS,
+        PATTERN,
+        STATE_OPTIONS
+    };
+
     /**
      * The channel description changed event type.
      */
@@ -39,7 +47,7 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
     /**
      * The changed field.
      */
-    private String field;
+    private CommonChannelDescriptionField field;
 
     /**
      * The channel which triggered the event.
@@ -52,6 +60,16 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
     private final Set<String> linkedItemNames;
 
     /**
+     * The new value.
+     */
+    private final Object value;
+
+    /**
+     * The old value.
+     */
+    private final @Nullable Object oldValue;
+
+    /**
      * Creates a new instance.
      *
      * @param topic the topic
@@ -60,12 +78,14 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
      */
-    protected ChannelDescriptionChangedEvent(String topic, String payload, String field, ChannelUID channelUID,
-            Set<String> linkedItemNames) {
+    protected ChannelDescriptionChangedEvent(String topic, String payload, CommonChannelDescriptionField field,
+            ChannelUID channelUID, Set<String> linkedItemNames, Object value, @Nullable Object oldValue) {
         super(topic, payload, null);
         this.field = field;
         this.channelUID = channelUID;
         this.linkedItemNames = linkedItemNames;
+        this.value = value;
+        this.oldValue = oldValue;
     }
 
     @Override
@@ -78,7 +98,7 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
      *
      * @return the changed field
      */
-    public String getField() {
+    public CommonChannelDescriptionField getField() {
         return field;
     }
 
@@ -100,9 +120,28 @@ public class ChannelDescriptionChangedEvent extends AbstractEvent {
         return linkedItemNames;
     }
 
+    /**
+     * Gets the new value.
+     *
+     * @return the new value.
+     */
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * Gets the old value.
+     *
+     * @return the old value.
+     */
+    public @Nullable Object getOldValue() {
+        return oldValue;
+    }
+
     @Override
     public String toString() {
-        return String.format("Description for '%s' of channel '%s' changed for linked items: %s", field, channelUID,
-                linkedItemNames.stream().collect(Collectors.joining(",", "[", "]")));
+        return String.format(
+                "Description for field '%s' of channel '%s' changed from '%s' to '%s' for linked items: %s", field,
+                channelUID, oldValue, value, linkedItemNames.stream().collect(Collectors.joining(",", "[", "]")));
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.events;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.events.AbstractEvent;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.StateDescription;
+
+/**
+ * {@link ChannelDescriptionChangedEvent}s will be delivered through the openHAB event bus if the
+ * {@link CommandDescription} or {@link StateDescription} of a channel has changed. Instances must be created with the
+ * {@link ThingEventFactory}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ChannelDescriptionChangedEvent extends AbstractEvent {
+
+    /**
+     * The channel description changed event type.
+     */
+    public static final String TYPE = ChannelDescriptionChangedEvent.class.getSimpleName();
+
+    /**
+     * The changed field.
+     */
+    private String field;
+
+    /**
+     * The channel which triggered the event.
+     */
+    private final ChannelUID channelUID;
+
+    /**
+     * A {@link Set} of linked item names.
+     */
+    private final Set<String> linkedItemNames;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param field the changed field
+     * @param channelUID the {@link ChannelUID}
+     * @param linkedItemNames a {@link Set} of linked item names
+     */
+    protected ChannelDescriptionChangedEvent(String topic, String payload, String field, ChannelUID channelUID,
+            Set<String> linkedItemNames) {
+        super(topic, payload, null);
+        this.field = field;
+        this.channelUID = channelUID;
+        this.linkedItemNames = linkedItemNames;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Gets the changed field.
+     *
+     * @return the changed field
+     */
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * Gets the {@link ChannelUID}.
+     *
+     * @return the {@link ChannelUID}
+     */
+    public ChannelUID getChannelUID() {
+        return channelUID;
+    }
+
+    /**
+     * Gets the linked item names.
+     *
+     * @return a {@link Set} of linked item names
+     */
+    public Set<String> getLinkedItemNames() {
+        return linkedItemNames;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Description for '%s' of channel '%s' changed for linked items: %s", field, channelUID,
+                linkedItemNames.stream().collect(Collectors.joining(",", "[", "]")));
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelTriggeredEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelTriggeredEvent.java
@@ -58,6 +58,11 @@ public class ChannelTriggeredEvent extends AbstractEvent {
         this.channel = channel;
     }
 
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
     /**
      * Returns the event.
      *
@@ -75,12 +80,7 @@ public class ChannelTriggeredEvent extends AbstractEvent {
     }
 
     @Override
-    public String getType() {
-        return TYPE;
-    }
-
-    @Override
     public String toString() {
-        return channel + " triggered " + event;
+        return String.format("%s triggered %s", channel, event);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
@@ -162,69 +162,64 @@ public class ThingEventFactory extends AbstractEventFactory {
      * Creates a {@link ChannelDescriptionChangedEvent} for a changed pattern. New and optional old value will be
      * serialized to a JSON string from the {@link ChannelDescriptionPatternPayloadBean} object.
      *
-     * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
      * @param pattern the new pattern
      * @param oldPattern the old pattern
      * @return Created {@link ChannelDescriptionChangedEvent}
      */
-    public static ChannelDescriptionChangedEvent createChannelDescriptionPatternChangedEvent(
-            CommonChannelDescriptionField field, ChannelUID channelUID, Set<String> linkedItemNames, String pattern,
-            @Nullable String oldPattern) {
+    public static ChannelDescriptionChangedEvent createChannelDescriptionPatternChangedEvent(ChannelUID channelUID,
+            Set<String> linkedItemNames, String pattern, @Nullable String oldPattern) {
         checkNotNull(linkedItemNames, "linkedItemNames");
         checkNotNull(channelUID, "channelUID");
-        checkNotNull(field, "field");
         checkNotNull(pattern, "pattern");
 
         String patternPayload = serializePayload(new ChannelDescriptionPatternPayloadBean(pattern));
         String oldPatternPayload = oldPattern != null
                 ? serializePayload(new ChannelDescriptionPatternPayloadBean(oldPattern))
                 : null;
-        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(field,
-                channelUID.getAsString(), linkedItemNames, patternPayload, oldPatternPayload);
+        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(
+                CommonChannelDescriptionField.PATTERN, channelUID.getAsString(), linkedItemNames, patternPayload,
+                oldPatternPayload);
         String payload = serializePayload(bean);
         String topic = buildTopic(CHANNEL_DESCRIPTION_CHANGED_TOPIC, channelUID);
-        return new ChannelDescriptionChangedEvent(topic, payload, field, channelUID, linkedItemNames, patternPayload,
-                oldPatternPayload);
+        return new ChannelDescriptionChangedEvent(topic, payload, CommonChannelDescriptionField.PATTERN, channelUID,
+                linkedItemNames, patternPayload, oldPatternPayload);
     }
 
     /**
      * Creates a {@link ChannelDescriptionChangedEvent} for changed {@link StateOption}s. New and optional old value
      * will be serialized to a JSON string from the {@link ChannelDescriptionStateOptionsPayloadBean} object.
      *
-     * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
      * @param options the new {@link StateOption}s
      * @param oldOptions the old {@link StateOption}s
      * @return Created {@link ChannelDescriptionChangedEvent}
      */
-    public static ChannelDescriptionChangedEvent createChannelDescriptionStateOptionsChangedEvent(
-            CommonChannelDescriptionField field, ChannelUID channelUID, Set<String> linkedItemNames,
-            List<StateOption> options, @Nullable List<StateOption> oldOptions) {
+    public static ChannelDescriptionChangedEvent createChannelDescriptionStateOptionsChangedEvent(ChannelUID channelUID,
+            Set<String> linkedItemNames, List<StateOption> options, @Nullable List<StateOption> oldOptions) {
         checkNotNull(linkedItemNames, "linkedItemNames");
         checkNotNull(channelUID, "channelUID");
-        checkNotNull(field, "field");
         checkNotNull(options, "options");
 
         String stateOptionsPayload = serializePayload(new ChannelDescriptionStateOptionsPayloadBean(options));
         String oldStateOptionsPayload = oldOptions != null
                 ? serializePayload(new ChannelDescriptionStateOptionsPayloadBean(oldOptions))
                 : null;
-        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(field,
-                channelUID.getAsString(), linkedItemNames, stateOptionsPayload, oldStateOptionsPayload);
+        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(
+                CommonChannelDescriptionField.STATE_OPTIONS, channelUID.getAsString(), linkedItemNames,
+                stateOptionsPayload, oldStateOptionsPayload);
         String payload = serializePayload(bean);
         String topic = buildTopic(CHANNEL_DESCRIPTION_CHANGED_TOPIC, channelUID);
-        return new ChannelDescriptionChangedEvent(topic, payload, field, channelUID, linkedItemNames,
-                stateOptionsPayload, oldStateOptionsPayload);
+        return new ChannelDescriptionChangedEvent(topic, payload, CommonChannelDescriptionField.STATE_OPTIONS,
+                channelUID, linkedItemNames, stateOptionsPayload, oldStateOptionsPayload);
     }
 
     /**
      * Creates a {@link ChannelDescriptionChangedEvent} for change {@link CommandOption}s. New and optional old value
      * will be serialized to a JSON string from the {@link ChannelDescriptionCommandOptionsPayloadBean} object.
      *
-     * @param field the changed field
      * @param channelUID the {@link ChannelUID}
      * @param linkedItemNames a {@link Set} of linked item names
      * @param options the new {@link CommandOption}s
@@ -232,23 +227,23 @@ public class ThingEventFactory extends AbstractEventFactory {
      * @return Created {@link ChannelDescriptionChangedEvent}
      */
     public static ChannelDescriptionChangedEvent createChannelDescriptionCommandOptionsChangedEvent(
-            CommonChannelDescriptionField field, ChannelUID channelUID, Set<String> linkedItemNames,
-            List<CommandOption> options, @Nullable List<CommandOption> oldOptions) {
+            ChannelUID channelUID, Set<String> linkedItemNames, List<CommandOption> options,
+            @Nullable List<CommandOption> oldOptions) {
         checkNotNull(linkedItemNames, "linkedItemNames");
         checkNotNull(channelUID, "channelUID");
-        checkNotNull(field, "field");
         checkNotNull(options, "options");
 
         String commandOptionsPayload = serializePayload(new ChannelDescriptionCommandOptionsPayloadBean(options));
         String oldCommandOptionsPayload = oldOptions != null
                 ? serializePayload(new ChannelDescriptionCommandOptionsPayloadBean(oldOptions))
                 : null;
-        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(field,
-                channelUID.getAsString(), linkedItemNames, commandOptionsPayload, oldCommandOptionsPayload);
+        ChannelDescriptionChangedEventPayloadBean bean = new ChannelDescriptionChangedEventPayloadBean(
+                CommonChannelDescriptionField.COMMAND_OPTIONS, channelUID.getAsString(), linkedItemNames,
+                commandOptionsPayload, oldCommandOptionsPayload);
         String payload = serializePayload(bean);
         String topic = buildTopic(CHANNEL_DESCRIPTION_CHANGED_TOPIC, channelUID);
-        return new ChannelDescriptionChangedEvent(topic, payload, field, channelUID, linkedItemNames,
-                commandOptionsPayload, oldCommandOptionsPayload);
+        return new ChannelDescriptionChangedEvent(topic, payload, CommonChannelDescriptionField.COMMAND_OPTIONS,
+                channelUID, linkedItemNames, commandOptionsPayload, oldCommandOptionsPayload);
     }
 
     private ChannelDescriptionChangedEvent createChannelDescriptionChangedEvent(String topic, String payload) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProviderTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.binding;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.types.CommandOption;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Tests for {@link BaseDynamicCommandDescriptionProvider}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+class BaseDynamicCommandDescriptionProviderTest {
+
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
+    private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
+
+    @Mock
+    EventPublisher mockEventPublisher;
+
+    @Mock
+    ItemChannelLinkRegistry mockItemChannelLinkRegistry;
+
+    class TestDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+
+        public TestDynamicCommandDescriptionProvider() {
+            this.bundleContext = mock(BundleContext.class);
+            this.eventPublisher = mockEventPublisher;
+            this.itemChannelLinkRegistry = mockItemChannelLinkRegistry;
+        }
+    };
+
+    private TestDynamicCommandDescriptionProvider subject;
+
+    @BeforeEach
+    public void setup() {
+        when(mockItemChannelLinkRegistry.getLinkedItemNames(CHANNEL_UID)).thenReturn(Set.of("item1", "item2"));
+
+        subject = new TestDynamicCommandDescriptionProvider();
+    }
+
+    @Test
+    public void setCommandOptionsPublishesEvent() {
+        subject.setCommandOptions(CHANNEL_UID, List.of(new CommandOption("reboot", "Reboot")));
+
+        ArgumentCaptor<Event> capture = ArgumentCaptor.forClass(Event.class);
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+
+        Event event = capture.getValue();
+        assertTrue(event instanceof ChannelDescriptionChangedEvent);
+        ChannelDescriptionChangedEvent cdce = (ChannelDescriptionChangedEvent) event;
+        assertEquals(CommonChannelDescriptionField.COMMAND_OPTIONS, cdce.getField());
+
+        // check the event is not published again
+        subject.setCommandOptions(CHANNEL_UID, List.of(new CommandOption("reboot", "Reboot")));
+
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+    }
+}

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProviderTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.binding;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent;
+import org.openhab.core.thing.events.ChannelDescriptionChangedEvent.CommonChannelDescriptionField;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.types.StateOption;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Tests for {@link BaseDynamicStateDescriptionProvider}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+class BaseDynamicStateDescriptionProviderTest {
+
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
+    private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
+
+    @Mock
+    EventPublisher mockEventPublisher;
+
+    @Mock
+    ItemChannelLinkRegistry mockItemChannelLinkRegistry;
+
+    class TestBaseDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+
+        public TestBaseDynamicStateDescriptionProvider() {
+            this.bundleContext = mock(BundleContext.class);
+            this.eventPublisher = mockEventPublisher;
+            this.itemChannelLinkRegistry = mockItemChannelLinkRegistry;
+        }
+    };
+
+    private BaseDynamicStateDescriptionProvider subject;
+
+    @BeforeEach
+    public void setup() {
+        when(mockItemChannelLinkRegistry.getLinkedItemNames(CHANNEL_UID)).thenReturn(Set.of("item1", "item2"));
+
+        subject = new TestBaseDynamicStateDescriptionProvider();
+    }
+
+    @Test
+    public void setStatePatternPublishesEvent() {
+        subject.setStatePattern(CHANNEL_UID, "%s");
+
+        ArgumentCaptor<Event> capture = ArgumentCaptor.forClass(Event.class);
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+
+        Event event = capture.getValue();
+        assertTrue(event instanceof ChannelDescriptionChangedEvent);
+        ChannelDescriptionChangedEvent cdce = (ChannelDescriptionChangedEvent) event;
+        assertEquals(CommonChannelDescriptionField.PATTERN, cdce.getField());
+
+        // check the event is not published again
+        subject.setStatePattern(CHANNEL_UID, "%s");
+
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+    }
+
+    @Test
+    public void setStateOptionsPublishesEvent() {
+        subject.setStateOptions(CHANNEL_UID, List.of(new StateOption("offline", "Offline")));
+
+        ArgumentCaptor<Event> capture = ArgumentCaptor.forClass(Event.class);
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+
+        Event event = capture.getValue();
+        assertTrue(event instanceof ChannelDescriptionChangedEvent);
+        ChannelDescriptionChangedEvent cdce = (ChannelDescriptionChangedEvent) event;
+        assertEquals(CommonChannelDescriptionField.STATE_OPTIONS, cdce.getField());
+
+        // check the event is not published again
+        subject.setStateOptions(CHANNEL_UID, List.of(new StateOption("offline", "Offline")));
+
+        verify(mockEventPublisher, times(1)).post(capture.capture());
+    }
+}

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
@@ -165,8 +165,8 @@ public class ThingEventFactoryTest {
 
     @Test
     public void testCreateChannelDescriptionChangedEventOnlyNewValue() {
-        ChannelDescriptionChangedEvent event = ThingEventFactory.createChannelDescriptionPatternChangedEvent(
-                CommonChannelDescriptionField.PATTERN, CHANNEL_UID, Set.of("item1", "item2"), "%s", null);
+        ChannelDescriptionChangedEvent event = ThingEventFactory
+                .createChannelDescriptionPatternChangedEvent(CHANNEL_UID, Set.of("item1", "item2"), "%s", null);
 
         assertEquals(ChannelDescriptionChangedEvent.TYPE, event.getType());
         assertEquals(CHANNEL_DESCRIPTION_CHANGED_EVENT_TOPIC, event.getTopic());
@@ -180,8 +180,8 @@ public class ThingEventFactoryTest {
 
     @Test
     public void testCreateChannelDescriptionChangedEventNewAndOldValue() {
-        ChannelDescriptionChangedEvent event = ThingEventFactory.createChannelDescriptionPatternChangedEvent(
-                CommonChannelDescriptionField.PATTERN, CHANNEL_UID, Set.of("item1", "item2"), "%s", "%unit%");
+        ChannelDescriptionChangedEvent event = ThingEventFactory
+                .createChannelDescriptionPatternChangedEvent(CHANNEL_UID, Set.of("item1", "item2"), "%s", "%unit%");
 
         assertEquals(ChannelDescriptionChangedEvent.TYPE, event.getType());
         assertEquals(CHANNEL_DESCRIPTION_CHANGED_EVENT_TOPIC, event.getTopic());
@@ -227,12 +227,13 @@ public class ThingEventFactoryTest {
         assertEquals(CHANNEL_DESCRIPTION_OLD_PATTERN_PAYLOAD, triggeredEvent.getOldValue());
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testCreateChannelDescriptionChangedEventOnlyNewOptions() {
         Set<String> itemNames = Set.of("item1", "item2");
         List<StateOption> options = List.of(new StateOption("offline", "Offline"));
-        ChannelDescriptionChangedEvent event = ThingEventFactory.createChannelDescriptionStateOptionsChangedEvent(
-                CommonChannelDescriptionField.STATE_OPTIONS, CHANNEL_UID, itemNames, options, null);
+        ChannelDescriptionChangedEvent event = ThingEventFactory
+                .createChannelDescriptionStateOptionsChangedEvent(CHANNEL_UID, itemNames, options, null);
 
         assertEquals(ChannelDescriptionChangedEvent.TYPE, event.getType());
         assertEquals(CHANNEL_DESCRIPTION_CHANGED_EVENT_TOPIC, event.getTopic());
@@ -246,6 +247,7 @@ public class ThingEventFactoryTest {
         assertNull(event.getOldValue());
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testCreateEventChannelDescriptionChangedEventOnlyNewOptions() throws Exception {
         List<StateOption> options = List.of(new StateOption("offline", "Offline"));
@@ -266,13 +268,14 @@ public class ThingEventFactoryTest {
         assertNull(triggeredEvent.getOldValue());
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testCreateChannelDescriptionChangedEventOldAndNewOptions() {
         Set<String> itemNames = Set.of("item1", "item2");
         List<StateOption> options = List.of(new StateOption("offline", "Offline"));
         List<StateOption> oldOptions = List.of(new StateOption("online", "Online"));
-        ChannelDescriptionChangedEvent event = ThingEventFactory.createChannelDescriptionStateOptionsChangedEvent(
-                CommonChannelDescriptionField.STATE_OPTIONS, CHANNEL_UID, itemNames, options, oldOptions);
+        ChannelDescriptionChangedEvent event = ThingEventFactory
+                .createChannelDescriptionStateOptionsChangedEvent(CHANNEL_UID, itemNames, options, oldOptions);
 
         assertEquals(ChannelDescriptionChangedEvent.TYPE, event.getType());
         assertEquals(CHANNEL_DESCRIPTION_CHANGED_EVENT_TOPIC, event.getTopic());
@@ -288,6 +291,7 @@ public class ThingEventFactoryTest {
                 JSONCONVERTER.fromJson(event.getOldValue(), ChannelDescriptionStateOptionsPayloadBean.class).options);
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testCreateEventChannelDescriptionChangedEventOldAndNewOptions() throws Exception {
         List<StateOption> options = List.of(new StateOption("offline", "Offline"));

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.events.Event;
 import org.openhab.core.thing.ChannelUID;
@@ -44,6 +45,7 @@ import com.google.gson.Gson;
  * @author Stefan Bußweiler - Initial contribution
  * @author Christoph Weitkamp - Added ChannelStateDescriptionChangedEvent
  */
+@NonNullByDefault
 public class ThingEventFactoryTest {
     private static final Gson JSONCONVERTER = new Gson();
 

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
@@ -13,8 +13,10 @@
 package org.openhab.core.thing.link.events;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.Test;
 import org.openhab.core.events.Event;
 import org.openhab.core.thing.ChannelUID;
@@ -28,6 +30,7 @@ import com.google.gson.Gson;
  *
  * @author Christoph Weitkamp - Initial contribution
  */
+@NonNullByDefault
 public class LinkEventFactoryTest {
     private static final Gson JSONCONVERTER = new Gson();
 

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.link.events;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.openhab.core.events.Event;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.dto.ItemChannelLinkDTO;
+
+import com.google.gson.Gson;
+
+/**
+ * {@link LinkEventFactoryTests} tests the {@link LinkEventFactory}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class LinkEventFactoryTest {
+    private static final Gson JSONCONVERTER = new Gson();
+
+    private final LinkEventFactory factory = new LinkEventFactory();
+
+    private static final ItemChannelLink LINK = new ItemChannelLink("item", new ChannelUID("a:b:c:d"));
+    private static final ItemChannelLinkDTO LINK_DTO = new ItemChannelLinkDTO(LINK.getItemName(),
+            LINK.getLinkedUID().toString(), LINK.getConfiguration().getProperties());
+
+    private static final String LINK_EVENT_PAYLOAD = JSONCONVERTER.toJson(LINK_DTO);
+    private static final String LINK_ADDED_EVENT_TOPIC = LinkEventFactory.LINK_ADDED_EVENT_TOPIC.replace("{linkID}",
+            LINK.getItemName() + "-" + LINK.getLinkedUID().toString());
+    private static final String LINK_REMOVED_EVENT_TOPIC = LinkEventFactory.LINK_REMOVED_EVENT_TOPIC.replace("{linkID}",
+            LINK.getItemName() + "-" + LINK.getLinkedUID().toString());
+
+    @Test
+    public void testCreateItemChannelLinkAddedEvent() {
+        ItemChannelLinkAddedEvent event = LinkEventFactory.createItemChannelLinkAddedEvent(LINK);
+
+        assertEquals(ItemChannelLinkAddedEvent.TYPE, event.getType());
+        assertEquals(LINK_ADDED_EVENT_TOPIC, event.getTopic());
+        assertEquals(LINK_EVENT_PAYLOAD, event.getPayload());
+    }
+
+    @Test
+    public void testCreateEventItemChannelLinkAddedEvent() throws Exception {
+        Event event = factory.createEvent(ItemChannelLinkAddedEvent.TYPE, LINK_ADDED_EVENT_TOPIC, LINK_EVENT_PAYLOAD,
+                null);
+
+        assertThat(event, is(instanceOf(ItemChannelLinkAddedEvent.class)));
+        ItemChannelLinkAddedEvent triggeredEvent = (ItemChannelLinkAddedEvent) event;
+        assertEquals(ItemChannelLinkAddedEvent.TYPE, triggeredEvent.getType());
+        assertEquals(LINK_ADDED_EVENT_TOPIC, triggeredEvent.getTopic());
+        assertEquals(LINK_EVENT_PAYLOAD, triggeredEvent.getPayload());
+    }
+
+    @Test
+    public void testCreateItemChannelLinkRemovedEvent() {
+        ItemChannelLinkRemovedEvent event = LinkEventFactory.createItemChannelLinkRemovedEvent(LINK);
+
+        assertEquals(ItemChannelLinkRemovedEvent.TYPE, event.getType());
+        assertEquals(LINK_REMOVED_EVENT_TOPIC, event.getTopic());
+        assertEquals(LINK_EVENT_PAYLOAD, event.getPayload());
+    }
+
+    @Test
+    public void testCreateEventItemChannelLinkRemovedEvent() throws Exception {
+        Event event = factory.createEvent(ItemChannelLinkRemovedEvent.TYPE, LINK_REMOVED_EVENT_TOPIC,
+                LINK_EVENT_PAYLOAD, null);
+
+        assertThat(event, is(instanceOf(ItemChannelLinkRemovedEvent.class)));
+        ItemChannelLinkRemovedEvent triggeredEvent = (ItemChannelLinkRemovedEvent) event;
+        assertEquals(ItemChannelLinkRemovedEvent.TYPE, triggeredEvent.getType());
+        assertEquals(LINK_REMOVED_EVENT_TOPIC, triggeredEvent.getTopic());
+        assertEquals(LINK_EVENT_PAYLOAD, triggeredEvent.getPayload());
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
@@ -89,6 +89,6 @@ public class CommandOption {
 
     @Override
     public String toString() {
-        return "CommandOption [command=" + command + ", label=" + label + "]";
+        return String.format("CommandOption [command=%s, label=%s]", command, label);
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
@@ -81,6 +81,6 @@ public final class StateOption {
 
     @Override
     public String toString() {
-        return "StateOption [value=" + value + ", label=" + label + "]";
+        return String.format("StateOption [value=%s, label=%s]", value, label);
     }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.events;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingFactory;
+import org.openhab.core.thing.type.ThingType;
+import org.openhab.core.thing.type.ThingTypeBuilder;
+
+/**
+ * Event Tests for {@link ThingRegistry}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ThingEventOSGiTest extends JavaOSGiTest {
+
+    class ThingEventSubscriber implements EventSubscriber {
+
+        private @Nullable Event lastReceivedEvent;
+
+        @Override
+        public Set<String> getSubscribedEventTypes() {
+            return Set.of(ThingAddedEvent.TYPE, ThingUpdatedEvent.TYPE, ThingRemovedEvent.TYPE);
+        }
+
+        @Override
+        public @Nullable EventFilter getEventFilter() {
+            return null;
+        }
+
+        @Override
+        public void receive(Event event) {
+            lastReceivedEvent = event;
+        }
+
+        public @Nullable Event getLastReceivedEvent() {
+            return lastReceivedEvent;
+        }
+    }
+
+    @BeforeEach
+    public void setup() {
+        registerVolatileStorageService();
+    }
+
+    @Test
+    public void assertThingEventsAreSent() {
+        ThingRegistry thingRegistry = getService(ThingRegistry.class);
+
+        ThingEventSubscriber eventSubscriber = new ThingEventSubscriber();
+        registerService(eventSubscriber);
+
+        ThingType thingType = ThingTypeBuilder.instance("bindingId", "thingTypeId", "label").build();
+        ThingUID thingUID = new ThingUID(thingType.getUID(), "thingId");
+        Configuration configuration = new Configuration();
+        Thing thing = ThingFactory.createThing(thingType, thingUID, configuration);
+
+        thingRegistry.add(thing);
+        waitFor(() -> eventSubscriber.getLastReceivedEvent() != null);
+        waitForAssert(() -> assertThat(eventSubscriber.getLastReceivedEvent().getType(), is(ThingAddedEvent.TYPE)));
+        assertThat(eventSubscriber.getLastReceivedEvent().getTopic(),
+                is(ThingEventFactory.THING_ADDED_EVENT_TOPIC.replace("{thingUID}", thingUID.getAsString())));
+
+        thingRegistry.update(thing);
+        waitForAssert(() -> assertThat(eventSubscriber.getLastReceivedEvent().getType(), is(ThingUpdatedEvent.TYPE)));
+        assertThat(eventSubscriber.getLastReceivedEvent().getTopic(),
+                is(ThingEventFactory.THING_UPDATED_EVENT_TOPIC.replace("{thingUID}", thingUID.getAsString())));
+
+        thingRegistry.forceRemove(thing.getUID());
+        waitForAssert(() -> assertThat(eventSubscriber.getLastReceivedEvent().getType(), is(ThingRemovedEvent.TYPE)));
+        assertThat(eventSubscriber.getLastReceivedEvent().getTopic(),
+                is(ThingEventFactory.THING_REMOVED_EVENT_TOPIC.replace("{thingUID}", thingUID.getAsString())));
+    }
+}


### PR DESCRIPTION
- Added `ChannelDescriptionChangedEvent`

Problem statement: 

OHC framework supports dynamic `StateDescription`s and dynamic `CommandDescription`s which are set by bindings and may change during runtime. When the state options / command options are changed the UI doesn't update automatically. You need to do a page refresh to pick up the changes. This approach introduces a new event (`ChannelDescriptionChangedEvent`) which UIs can subscribe to and reload related widgets. The event payload contains the `ChannelUID`, a field identifier to give a hint which field has changed and a list of linked item names.

See e.g. https://github.com/openhab/openhab-addons/pull/7396#issuecomment-630773749

Closes #1753 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>