### PR TITLE
Added group and system triggers to automation component

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -26,12 +26,15 @@ import org.openhab.core.automation.internal.module.handler.ChannelEventTriggerHa
 import org.openhab.core.automation.internal.module.handler.CompareConditionHandler;
 import org.openhab.core.automation.internal.module.handler.GenericEventConditionHandler;
 import org.openhab.core.automation.internal.module.handler.GenericEventTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.GroupCommandTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.GroupStateTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ItemCommandActionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemCommandTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.RuleEnablementActionHandler;
 import org.openhab.core.automation.internal.module.handler.RunRuleActionHandler;
+import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.ItemRegistry;
@@ -56,12 +59,14 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
     private final Logger logger = LoggerFactory.getLogger(CoreModuleHandlerFactory.class);
 
     private static final Collection<String> TYPES = Arrays.asList(ItemCommandTriggerHandler.MODULE_TYPE_ID,
-            ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID, ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID,
-            ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID, ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID,
-            ItemStateConditionHandler.ITEM_STATE_CONDITION, ItemCommandActionHandler.ITEM_COMMAND_ACTION,
-            GenericEventTriggerHandler.MODULE_TYPE_ID, ChannelEventTriggerHandler.MODULE_TYPE_ID,
-            GenericEventConditionHandler.MODULETYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
-            CompareConditionHandler.MODULE_TYPE, RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
+            GroupCommandTriggerHandler.MODULE_TYPE_ID, ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID,
+            ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID, GroupStateTriggerHandler.UPDATE_MODULE_TYPE_ID,
+            GroupStateTriggerHandler.CHANGE_MODULE_TYPE_ID, ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID,
+            ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID, ItemStateConditionHandler.ITEM_STATE_CONDITION,
+            ItemCommandActionHandler.ITEM_COMMAND_ACTION, GenericEventTriggerHandler.MODULE_TYPE_ID,
+            ChannelEventTriggerHandler.MODULE_TYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
+            GenericEventConditionHandler.MODULETYPE_ID, CompareConditionHandler.MODULE_TYPE,
+            SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID, RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
 
     private ItemRegistry itemRegistry;
     private EventPublisher eventPublisher;
@@ -97,6 +102,10 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
                 ((ItemStateConditionHandler) handler).setItemRegistry(this.itemRegistry);
             } else if (handler instanceof ItemCommandActionHandler) {
                 ((ItemCommandActionHandler) handler).setItemRegistry(this.itemRegistry);
+            } else if (handler instanceof GroupCommandTriggerHandler) {
+                ((GroupCommandTriggerHandler) handler).setItemRegistry(this.itemRegistry);
+            } else if (handler instanceof GroupStateTriggerHandler) {
+                ((GroupStateTriggerHandler) handler).setItemRegistry(this.itemRegistry);
             }
         }
     }
@@ -112,6 +121,10 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
                 ((ItemStateConditionHandler) handler).unsetItemRegistry(this.itemRegistry);
             } else if (handler instanceof ItemCommandActionHandler) {
                 ((ItemCommandActionHandler) handler).unsetItemRegistry(this.itemRegistry);
+            } else if (handler instanceof GroupCommandTriggerHandler) {
+                ((GroupCommandTriggerHandler) handler).unsetItemRegistry(this.itemRegistry);
+            } else if (handler instanceof GroupStateTriggerHandler) {
+                ((GroupStateTriggerHandler) handler).unsetItemRegistry(this.itemRegistry);
             }
         }
         this.itemRegistry = null;
@@ -158,12 +171,24 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
                 return new ChannelEventTriggerHandler((Trigger) module, bundleContext);
             } else if (ItemCommandTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
                 return new ItemCommandTriggerHandler((Trigger) module, bundleContext);
+            } else if (SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID.equals(moduleTypeUID)) {
+                return new SystemTriggerHandler((Trigger) module, bundleContext);
             } else if (ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
                     || ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
                 return new ThingStatusTriggerHandler((Trigger) module, bundleContext);
             } else if (ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
                     || ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
                 return new ItemStateTriggerHandler((Trigger) module, bundleContext);
+            } else if (GroupCommandTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
+                final GroupCommandTriggerHandler handler = new GroupCommandTriggerHandler((Trigger) module,
+                        bundleContext);
+                handler.setItemRegistry(itemRegistry);
+                return handler;
+            } else if (GroupStateTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
+                    || GroupStateTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
+                final GroupStateTriggerHandler handler = new GroupStateTriggerHandler((Trigger) module, bundleContext);
+                handler.setItemRegistry(itemRegistry);
+                return handler;
             }
         } else if (module instanceof Condition) {
             // Handle conditions

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
@@ -72,6 +72,10 @@ public class GenericCronTriggerHandler extends BaseTriggerModuleHandler implemen
 
     @Override
     public void run() {
-        ((TriggerHandlerCallback) callback).triggered(module, null);
+        if (callback != null) {
+            ((TriggerHandlerCallback) callback).triggered(module, null);
+        } else {
+            logger.debug("Tried to trigger, but callback isn't available!");
+        }
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandler.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+
+import org.openhab.core.automation.ModuleHandlerCallback;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.handler.BaseTriggerModuleHandler;
+import org.openhab.core.automation.handler.TriggerHandlerCallback;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.ItemCommandEvent;
+import org.openhab.core.types.Command;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an ModuleHandler implementation for Triggers which trigger the rule
+ * if a member of an item group receives a command.
+ * The group name and command value can be set with the configuration.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class GroupCommandTriggerHandler extends BaseTriggerModuleHandler implements EventSubscriber, EventFilter {
+
+    private final Logger logger = LoggerFactory.getLogger(GroupCommandTriggerHandler.class);
+
+    private final String groupName;
+    private final String command;
+    private final String topic;
+
+    private final Set<String> types;
+    private final BundleContext bundleContext;
+
+    public static final String MODULE_TYPE_ID = "core.GroupCommandTrigger";
+
+    private static final String CFG_GROUPNAME = "groupName";
+    private static final String CFG_COMMAND = "command";
+
+    @SuppressWarnings("rawtypes")
+    private ServiceRegistration eventSubscriberRegistration;
+    private ItemRegistry itemRegistry;
+
+    public GroupCommandTriggerHandler(Trigger module, BundleContext bundleContext) {
+        super(module);
+        this.groupName = (String) module.getConfiguration().get(CFG_GROUPNAME);
+        this.command = (String) module.getConfiguration().get(CFG_COMMAND);
+        this.types = Collections.singleton(ItemCommandEvent.TYPE);
+        this.bundleContext = bundleContext;
+        Dictionary<String, Object> properties = new Hashtable<>();
+        this.topic = "smarthome/items/";
+        properties.put("event.topics", topic);
+        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
+                properties);
+    }
+
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return types;
+    }
+
+    @Override
+    public EventFilter getEventFilter() {
+        return this;
+    }
+
+    @Override
+    public void receive(Event event) {
+        if (callback != null) {
+            ModuleHandlerCallback cb = callback;
+            logger.trace("Received Event: Source: {} Topic: {} Type: {}  Payload: {}", event.getSource(),
+                    event.getTopic(), event.getType(), event.getPayload());
+            Map<String, Object> values = new HashMap<>();
+            if (event instanceof ItemCommandEvent) {
+                String itemName = ((ItemCommandEvent) event).getItemName();
+                Item item = itemRegistry.get(itemName);
+                if (item != null && item.getGroupNames().contains(groupName)) {
+                    Command command = ((ItemCommandEvent) event).getItemCommand();
+                    if (this.command == null || this.command.equals(command.toFullString())) {
+                        values.put("triggeringItem", item);
+                        values.put("command", command);
+                        values.put("event", event);
+                        ((TriggerHandlerCallback) cb).triggered(this.module, values);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * do the cleanup: unregistering eventSubscriber...
+     */
+    @Override
+    public void dispose() {
+        super.dispose();
+        if (eventSubscriberRegistration != null) {
+            eventSubscriberRegistration.unregister();
+            eventSubscriberRegistration = null;
+        }
+    }
+
+    @Override
+    public boolean apply(Event event) {
+        logger.trace("->FILTER: {}", event.getTopic());
+        return event.getTopic().startsWith(topic);
+    }
+
+    public void setItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
+
+    public void unsetItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = null;
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandler.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+
+import org.openhab.core.automation.ModuleHandlerCallback;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.handler.BaseTriggerModuleHandler;
+import org.openhab.core.automation.handler.TriggerHandlerCallback;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.GroupItemStateChangedEvent;
+import org.openhab.core.items.events.ItemStateChangedEvent;
+import org.openhab.core.items.events.ItemStateEvent;
+import org.openhab.core.types.State;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an ModuleHandler implementation for Triggers which trigger the rule
+ * if state event of a member of an item group occurs.
+ * The group name and state value can be set with the configuration.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class GroupStateTriggerHandler extends BaseTriggerModuleHandler implements EventSubscriber, EventFilter {
+    private final Logger logger = LoggerFactory.getLogger(GroupStateTriggerHandler.class);
+
+    private final String groupName;
+    private final String state;
+    private final String previousState;
+    private Set<String> types;
+    private final BundleContext bundleContext;
+    private ItemRegistry itemRegistry;
+
+    public static final String UPDATE_MODULE_TYPE_ID = "core.GroupStateUpdateTrigger";
+    public static final String CHANGE_MODULE_TYPE_ID = "core.GroupStateChangeTrigger";
+
+    private static final String CFG_GROUPNAME = "groupName";
+    private static final String CFG_STATE = "state";
+    private static final String CFG_PREVIOUS_STATE = "previousState";
+
+    @SuppressWarnings("rawtypes")
+    private ServiceRegistration eventSubscriberRegistration;
+
+    public GroupStateTriggerHandler(Trigger module, BundleContext bundleContext) {
+        super(module);
+        this.groupName = (String) module.getConfiguration().get(CFG_GROUPNAME);
+        this.state = (String) module.getConfiguration().get(CFG_STATE);
+        this.previousState = (String) module.getConfiguration().get(CFG_PREVIOUS_STATE);
+        if (UPDATE_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+            this.types = Collections.singleton(ItemStateEvent.TYPE);
+        } else {
+            Set<String> set = new HashSet<>();
+            set.add(ItemStateChangedEvent.TYPE);
+            set.add(GroupItemStateChangedEvent.TYPE);
+            this.types = Collections.unmodifiableSet(set);
+        }
+        this.bundleContext = bundleContext;
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put("event.topics", "smarthome/items/*");
+        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
+                properties);
+    }
+
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return types;
+    }
+
+    @Override
+    public EventFilter getEventFilter() {
+        return this;
+    }
+
+    @Override
+    public void receive(Event event) {
+        if (callback != null) {
+            ModuleHandlerCallback cb = callback;
+            logger.trace("Received Event: Source: {} Topic: {} Type: {}  Payload: {}", event.getSource(),
+                    event.getTopic(), event.getType(), event.getPayload());
+            Map<String, Object> values = new HashMap<>();
+            if (event instanceof ItemStateEvent && UPDATE_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+                String itemName = ((ItemStateEvent) event).getItemName();
+                Item item = itemRegistry.get(itemName);
+                if (item != null && item.getGroupNames().contains(groupName)) {
+                    State state = ((ItemStateEvent) event).getItemState();
+                    if ((this.state == null || this.state.equals(state.toFullString()))) {
+                        values.put("triggeringItem", item);
+                        values.put("state", state);
+                    }
+                }
+            } else if (event instanceof ItemStateChangedEvent && CHANGE_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+                String itemName = ((ItemStateChangedEvent) event).getItemName();
+                Item item = itemRegistry.get(itemName);
+                if (item != null && item.getGroupNames().contains(groupName)) {
+                    State state = ((ItemStateChangedEvent) event).getItemState();
+                    State oldState = ((ItemStateChangedEvent) event).getOldItemState();
+
+                    if (stateMatches(this.state, state) && stateMatches(this.previousState, oldState)) {
+                        values.put("triggeringItem", item);
+                        values.put("oldState", oldState);
+                        values.put("newState", state);
+                    }
+                }
+            }
+            if (!values.isEmpty()) {
+                values.put("event", event);
+                ((TriggerHandlerCallback) cb).triggered(this.module, values);
+            }
+        }
+    }
+
+    private boolean stateMatches(String requiredState, State state) {
+        if (requiredState == null) {
+            return true;
+        }
+
+        String reqState = requiredState.trim();
+        return reqState.isEmpty() || reqState.equals(state.toFullString());
+    }
+
+    /**
+     * do the cleanup: unregistering eventSubscriber...
+     */
+    @Override
+    public void dispose() {
+        super.dispose();
+        if (eventSubscriberRegistration != null) {
+            eventSubscriberRegistration.unregister();
+            eventSubscriberRegistration = null;
+        }
+    }
+
+    @Override
+    public boolean apply(Event event) {
+        logger.trace("->FILTER: {}:{}", event.getTopic(), groupName);
+        return event.getTopic().startsWith("smarthome/items/");
+    }
+
+    public void setItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
+
+    public void unsetItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = null;
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.ModuleHandlerCallback;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.handler.BaseTriggerModuleHandler;
+import org.openhab.core.automation.handler.TriggerHandlerCallback;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.events.system.StartlevelEvent;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a ModuleHandler implementation for Triggers which trigger the rule if a certain system event occurs.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@NonNullByDefault
+public class SystemTriggerHandler extends BaseTriggerModuleHandler implements EventSubscriber, EventFilter {
+
+    private final Logger logger = LoggerFactory.getLogger(SystemTriggerHandler.class);
+
+    public static final String STARTLEVEL_MODULE_TYPE_ID = "core.SystemStartlevelTrigger";
+    private static final String CFG_STARTLEVEL = "startlevel";
+    private static final String OUT_STARTLEVEL = "startlevel";
+
+    private final Integer startlevel;
+    private final Set<String> types;
+    private final BundleContext bundleContext;
+
+    private ServiceRegistration<?> eventSubscriberRegistration;
+
+    public SystemTriggerHandler(Trigger module, BundleContext bundleContext) {
+        super(module);
+        this.startlevel = ((BigDecimal) module.getConfiguration().get(CFG_STARTLEVEL)).intValue();
+        if (STARTLEVEL_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+            this.types = Collections.singleton(StartlevelEvent.TYPE);
+        } else {
+            logger.warn("Module type '{}' is not (yet) handled by this class.", module.getTypeUID());
+            throw new IllegalArgumentException(module.getTypeUID() + " is no valid module type.");
+        }
+        this.bundleContext = bundleContext;
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put("event.topics", "smarthome/system/*");
+        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
+                properties);
+    }
+
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return types;
+    }
+
+    @Override
+    public @Nullable EventFilter getEventFilter() {
+        return this;
+    }
+
+    @Override
+    public void receive(Event event) {
+        final ModuleHandlerCallback callback = this.callback;
+        if (!(callback instanceof TriggerHandlerCallback)) {
+            return;
+        }
+
+        TriggerHandlerCallback thCallback = (TriggerHandlerCallback) callback;
+        logger.trace("Received Event: Source: {} Topic: {} Type: {}  Payload: {}", event.getSource(), event.getTopic(),
+                event.getType(), event.getPayload());
+        Map<String, Object> values = new HashMap<>();
+        if (event instanceof StartlevelEvent && STARTLEVEL_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+            Integer sl = ((StartlevelEvent) event).getStartlevel();
+            if (startlevel.equals(sl)) {
+                values.put(OUT_STARTLEVEL, sl);
+            }
+        }
+        if (!values.isEmpty()) {
+            thCallback.triggered(module, values);
+        }
+    }
+
+    /**
+     * do the cleanup: unregistering eventSubscriber...
+     */
+    @Override
+    public void dispose() {
+        eventSubscriberRegistration.unregister();
+        super.dispose();
+    }
+
+    @Override
+    public boolean apply(Event event) {
+        return true;
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -96,10 +96,8 @@ public class SystemTriggerHandler extends BaseTriggerModuleHandler implements Ev
             Integer sl = ((StartlevelEvent) event).getStartlevel();
             if (startlevel.equals(sl)) {
                 values.put(OUT_STARTLEVEL, sl);
+                thCallback.triggered(module, values);
             }
-        }
-        if (!values.isEmpty()) {
-            thCallback.triggered(module, values);
         }
     }
 

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
@@ -231,6 +231,256 @@
 					"reference": "event"
 				}
 			]
+		},
+		{
+			"uid": "core.GroupCommandTrigger",
+			"label": "a member of an item group receives a command",
+			"description": "This triggers the rule if a member of an item group receives a command.",
+			"configDescriptions": [
+				{
+					"name": "groupName",
+					"type": "TEXT",
+					"context": "item",
+					"label": "Group",
+					"description": "the name of the item group",
+					"required": true
+				},
+				{
+					"name": "command",
+					"type": "TEXT",
+					"label": "Command",
+					"description": "the received command",
+					"required": false,
+					"limitToOptions": false,
+					"options": [
+						{
+							"label": "ON",
+							"value": "ON"
+						},
+						{
+							"label": "OFF",
+							"value": "OFF"
+						},
+						{
+							"label": "OPEN",
+							"value": "OPEN"
+						},
+						{
+							"label": "CLOSED",
+							"value": "CLOSED"
+						},
+						{
+							"label": "UP",
+							"value": "UP"
+						},
+						{
+							"label": "DOWN",
+							"value": "DOWN"
+						}
+					]
+				}
+			],
+			"outputs": [
+				{
+					"name": "triggeringItem",
+					"type": "org.openhab.core.items.Item",
+					"description": "the member of the group that received the command",
+					"label": "Triggering Item"
+				},
+				{
+					"name": "command",
+					"type": "command",
+					"description": "the received command",
+					"label": "Command"
+				},
+				{
+					"name": "event",
+					"type": "org.openhab.core.events.Event",
+					"label": "Event",
+					"description": "The event which was sent.",
+					"reference": "event"
+				}
+			]
+		},
+		{
+			"uid": "core.GroupStateUpdateTrigger",
+			"label": "the state of a member of an item group is updated",
+			"description": "This triggers the rule if the state of a member of an item group is updated (even if it does not change).",
+			"configDescriptions": [
+				{
+					"name": "groupName",
+					"type": "TEXT",
+					"context": "item",
+					"label": "Group",
+					"description": "the name of the item group",
+					"required": true
+				},
+				{
+					"name": "state",
+					"type": "TEXT",
+					"label": "State",
+					"description": "the state of the item",
+					"required": false,
+					"limitToOptions": false,
+					"options": [
+						{
+							"label": "ON",
+							"value": "ON"
+						},
+						{
+							"label": "OFF",
+							"value": "OFF"
+						},
+						{
+							"label": "OPEN",
+							"value": "OPEN"
+						},
+						{
+							"label": "CLOSED",
+							"value": "CLOSED"
+						},
+						{
+							"label": "UP",
+							"value": "UP"
+						},
+						{
+							"label": "DOWN",
+							"value": "DOWN"
+						}
+					]
+				}
+			],
+			"outputs": [
+				{
+					"name": "triggeringItem",
+					"type": "org.openhab.core.items.Item",
+					"description": "the member of the group that updated its state",
+					"label": "Triggering Item"
+				},
+				{
+					"name": "state",
+					"type": "state",
+					"description": "the item state",
+					"label": "State"
+				},
+				{
+					"name": "event",
+					"type": "org.openhab.core.events.Event",
+					"label": "Event",
+					"description": "The event which was sent.",
+					"reference": "event"
+				}
+			]
+		},
+		{
+			"uid": "core.GroupStateChangeTrigger",
+			"label": "the state of a member of an item group changes",
+			"description": "This triggers the rule if the state of a member of an item group has changed.",
+			"configDescriptions": [
+				{
+					"name": "groupName",
+					"type": "TEXT",
+					"context": "item",
+					"label": "Group",
+					"description": "the name of the item group",
+					"required": true
+				},
+				{
+					"name": "previousState",
+					"type": "TEXT",
+					"label": "Previous State",
+					"description": "the required previous state of the item",
+					"required": false,
+					"limitToOptions": false,
+					"options": [
+						{
+							"label": "ON",
+							"value": "ON"
+						},
+						{
+							"label": "OFF",
+							"value": "OFF"
+						},
+						{
+							"label": "OPEN",
+							"value": "OPEN"
+						},
+						{
+							"label": "CLOSED",
+							"value": "CLOSED"
+						},
+						{
+							"label": "UP",
+							"value": "UP"
+						},
+						{
+							"label": "DOWN",
+							"value": "DOWN"
+						}
+					]
+				},
+				{
+					"name": "state",
+					"type": "TEXT",
+					"label": "State",
+					"description": "the state of the item",
+					"required": false,
+					"limitToOptions": false,
+					"options": [
+						{
+							"label": "ON",
+							"value": "ON"
+						},
+						{
+							"label": "OFF",
+							"value": "OFF"
+						},
+						{
+							"label": "OPEN",
+							"value": "OPEN"
+						},
+						{
+							"label": "CLOSED",
+							"value": "CLOSED"
+						},
+						{
+							"label": "UP",
+							"value": "UP"
+						},
+						{
+							"label": "DOWN",
+							"value": "DOWN"
+						}
+					]
+				}
+			],
+			"outputs": [
+				{
+					"name": "triggeringItem",
+					"type": "org.openhab.core.items.Item",
+					"description": "the member of the group that changed its state",
+					"label": "Triggering Item"
+				},
+				{
+					"name": "newState",
+					"type": "state",
+					"description": "the new item state",
+					"label": "New State"
+				},
+				{
+					"name": "oldState",
+					"type": "state",
+					"description": "the old item state",
+					"label": "Old State"
+				},
+				{
+					"name": "event",
+					"type": "org.openhab.core.events.Event",
+					"label": "Event",
+					"description": "The event which was sent.",
+					"reference": "event"
+				}
+			]
 		}
 	]
 }

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/SystemTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/SystemTriggers.json
@@ -1,0 +1,26 @@
+{
+	"triggers": [
+		{
+			"uid": "core.SystemStartlevelTrigger",
+			"label": "A system startlevel is reached",
+			"description": "This triggers the rule if a given startlevel is reached by the system.",
+			"configDescriptions": [
+				{
+					"name": "startlevel",
+					"type": "INTEGER",
+					"label": "Start Level",
+					"description": "The system start level.",
+					"required": true
+				}
+			],
+			"outputs": [
+				{
+					"name": "startlevel",
+					"type": "INTEGER",
+					"label": "Start Level",
+					"description": "The system start level."
+				}
+			]
+		}
+	]
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.events.system;
+
+import org.openhab.core.events.AbstractEvent;
+
+/**
+ * {@link StartlevelEvent}s will be delivered through the openHAB event bus if the start level of the system has
+ * changed.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class StartlevelEvent extends AbstractEvent {
+
+    public static final String TYPE = StartlevelEvent.class.getSimpleName();
+
+    private final Integer startlevel;
+
+    /**
+     * Creates a new system startlevel event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param source the source
+     * @param startlevel the system startlevel
+     */
+    protected StartlevelEvent(String topic, String payload, String source, Integer startlevel) {
+        super(topic, payload, source);
+        this.startlevel = startlevel;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Gets the system startlevel.
+     *
+     * @return the startlevel
+     */
+    public Integer getStartlevel() {
+        return startlevel;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Startlevel '%d' reached.", startlevel);
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.events.system;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.AbstractEvent;
 
 /**
@@ -20,6 +22,7 @@ import org.openhab.core.events.AbstractEvent;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class StartlevelEvent extends AbstractEvent {
 
     public static final String TYPE = StartlevelEvent.class.getSimpleName();
@@ -34,7 +37,7 @@ public class StartlevelEvent extends AbstractEvent {
      * @param source the source
      * @param startlevel the system startlevel
      */
-    protected StartlevelEvent(String topic, String payload, String source, Integer startlevel) {
+    protected StartlevelEvent(String topic, String payload, @Nullable String source, Integer startlevel) {
         super(topic, payload, source);
         this.startlevel = startlevel;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
@@ -15,7 +15,7 @@ package org.openhab.core.events.system;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.AbstractEventFactory;
 import org.openhab.core.events.Event;
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Kai Kreuzer - Initial contribution
  */
 @Component(immediate = true, service = EventFactory.class)
+@NonNullByDefault
 public class SystemEventFactory extends AbstractEventFactory {
 
     static final String SYSTEM_STARTLEVEL_TOPIC = "smarthome/system/startlevel";
@@ -50,8 +51,8 @@ public class SystemEventFactory extends AbstractEventFactory {
     }
 
     @Override
-    protected @NonNull Event createEventByType(@NonNull String eventType, @NonNull String topic,
-            @NonNull String payload, @Nullable String source) throws Exception {
+    protected Event createEventByType(String eventType, String topic, String payload, @Nullable String source)
+            throws Exception {
         return createStartlevelEvent(topic, payload, source);
     }
 
@@ -63,7 +64,7 @@ public class SystemEventFactory extends AbstractEventFactory {
      * @param payload Payload
      * @return created startlevel event
      */
-    public StartlevelEvent createStartlevelEvent(String topic, String payload, String source) {
+    public StartlevelEvent createStartlevelEvent(String topic, String payload, @Nullable String source) {
         SystemEventPayloadBean bean = deserializePayload(payload, SystemEventPayloadBean.class);
         return new StartlevelEvent(topic, payload, source, bean.getStartlevel());
     }
@@ -72,7 +73,7 @@ public class SystemEventFactory extends AbstractEventFactory {
      * This is a java bean that is used to serialize/deserialize system event payload.
      */
     public static class SystemEventPayloadBean {
-        private Integer startlevel;
+        private @NonNullByDefault({}) Integer startlevel;
 
         /**
          * Default constructor for deserialization e.g. by Gson.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.events.system;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.events.AbstractEventFactory;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFactory;
+import org.openhab.core.types.Type;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Factory that creates system events.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@Component(immediate = true, service = EventFactory.class)
+public class SystemEventFactory extends AbstractEventFactory {
+
+    static final String SYSTEM_STARTLEVEL_TOPIC = "smarthome/system/startlevel";
+
+    public SystemEventFactory() {
+        super(Stream.of(StartlevelEvent.TYPE).collect(Collectors.toSet()));
+    }
+
+    /**
+     * Creates a trigger event from a {@link Type}.
+     *
+     * @param startlevel Startlevel of system
+     * @return Created start level event.
+     */
+    public static StartlevelEvent createStartlevelEvent(Integer startlevel) {
+        SystemEventPayloadBean bean = new SystemEventPayloadBean(startlevel);
+        String payload = serializePayload(bean);
+        return new StartlevelEvent(SYSTEM_STARTLEVEL_TOPIC, payload, null, startlevel);
+    }
+
+    @Override
+    protected @NonNull Event createEventByType(@NonNull String eventType, @NonNull String topic,
+            @NonNull String payload, @Nullable String source) throws Exception {
+        return createStartlevelEvent(topic, payload, source);
+    }
+
+    /**
+     * Creates a startlevel event from a payload.
+     *
+     * @param topic Event topic
+     * @param source Event source
+     * @param payload Payload
+     * @return created startlevel event
+     */
+    public StartlevelEvent createStartlevelEvent(String topic, String payload, String source) {
+        SystemEventPayloadBean bean = deserializePayload(payload, SystemEventPayloadBean.class);
+        return new StartlevelEvent(topic, payload, source, bean.getStartlevel());
+    }
+
+    /**
+     * This is a java bean that is used to serialize/deserialize system event payload.
+     */
+    public static class SystemEventPayloadBean {
+        private Integer startlevel;
+
+        /**
+         * Default constructor for deserialization e.g. by Gson.
+         */
+        protected SystemEventPayloadBean() {
+        }
+
+        public SystemEventPayloadBean(Integer startlevel) {
+            this.startlevel = startlevel;
+        }
+
+        public Integer getStartlevel() {
+            return startlevel;
+        }
+    }
+}


### PR DESCRIPTION
This PR completes the automation component to provide the same triggers as the "old" rule engine. It thus specifically adds modules for "member of group" triggers as well as a start level trigger, which can be used to run rules once at system startup (disclaimer: No start level events are defined in this PR yet, so the trigger itself is still rather useless).

This was part of #1451 and has been separated as an independent PR that can already been reviewed and merged independently.

Signed-off-by: Kai Kreuzer <kai@openhab.org>