### PR TITLE
[dsl] Model loading improvements

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -64,8 +64,7 @@ public class FolderObserver extends AbstractWatchService {
     private final ModelRepository modelRepository;
     private static final String READYMARKER_TYPE = "dsl";
 
-    @Reference
-    /* default */ ReadyService readyService;
+    private final ReadyService readyService;
 
     private boolean activated;
 
@@ -80,10 +79,11 @@ public class FolderObserver extends AbstractWatchService {
     private final Map<String, File> nameFileMap = new HashMap<>();
 
     @Activate
-    public FolderObserver(final @Reference ModelRepository modelRepo) {
+    public FolderObserver(final @Reference ModelRepository modelRepo, final @Reference ReadyService readyService) {
         super(ConfigConstants.getConfigFolder());
 
         this.modelRepository = modelRepo;
+        this.readyService = readyService;
     }
 
     @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -127,7 +127,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
      *
      * @param factory The {@link ItemFactory} to add.
      */
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
     public void addItemFactory(ItemFactory factory) {
         itemFactorys.add(factory);
         dispatchBindingsPerItemType(null, factory.getSupportedItemTypes());

--- a/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
+++ b/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
@@ -44,6 +44,7 @@ import org.openhab.core.model.core.ModelParser;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.core.ModelRepositoryChangeListener;
 import org.openhab.core.service.AbstractWatchService;
+import org.openhab.core.service.ReadyService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.osgi.service.component.ComponentContext;
 
@@ -90,6 +91,9 @@ public class FolderObserverTest extends JavaOSGiTest {
     private ModelParser modelParser;
 
     @Mock
+    private ReadyService readyService;
+
+    @Mock
     private ComponentContext context;
     private Dictionary<String, Object> configProps;
 
@@ -126,6 +130,7 @@ public class FolderObserverTest extends JavaOSGiTest {
 
         folderObserver = new FolderObserver(modelRepo);
         folderObserver.addModelParser(modelParser);
+        folderObserver.readyService = readyService;
     }
 
     /**
@@ -350,6 +355,7 @@ public class FolderObserverTest extends JavaOSGiTest {
         };
         FolderObserver localFolderObserver = new FolderObserver(modelRepo);
         localFolderObserver.addModelParser(modelParser);
+        localFolderObserver.readyService = readyService;
 
         String validExtension = "java";
         configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg," + validExtension);

--- a/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
+++ b/itests/org.openhab.core.model.core.tests/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
@@ -128,9 +128,8 @@ public class FolderObserverTest extends JavaOSGiTest {
 
         modelRepo = new ModelRepoDummy();
 
-        folderObserver = new FolderObserver(modelRepo);
+        folderObserver = new FolderObserver(modelRepo, readyService);
         folderObserver.addModelParser(modelParser);
-        folderObserver.readyService = readyService;
     }
 
     /**
@@ -353,9 +352,8 @@ public class FolderObserverTest extends JavaOSGiTest {
                 throw new RuntimeException("intentional failure.");
             }
         };
-        FolderObserver localFolderObserver = new FolderObserver(modelRepo);
+        FolderObserver localFolderObserver = new FolderObserver(modelRepo, readyService);
         localFolderObserver.addModelParser(modelParser);
-        localFolderObserver.readyService = readyService;
 
         String validExtension = "java";
         configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg," + validExtension);


### PR DESCRIPTION
Some further changes extracted from my work in #1451:
- removed superfluous null checks
- improved logging
- fixed bug that cause "_tmp" resources to be loaded (which are only internally temporarily created during model validation)
- added ready marker after finishing loading a model type
- let GenericItemProvider only start once at least one ItemFactory is available (I often had the effect in the IDE that items were not available as the file was loaded before the CoreItemFactory was available).

Signed-off-by: Kai Kreuzer <kai@openhab.org>