### PR TITLE
[dsl] Allow negative numbers in metadata for Items

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
@@ -9,11 +9,11 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 generate items "https://openhab.org/model/Items"
 
-ItemModel :
+ItemModel:
 	{ItemModel} (items+=ModelItem)*
 ;
 
-ModelItem :
+ModelItem:
 	(ModelNormalItem | ModelGroupItem) name=ID
 	(label=STRING)?
 	('<' icon=(ID|STRING) '>')?
@@ -22,28 +22,28 @@ ModelItem :
 	('{' bindings+=ModelBinding (',' bindings+=ModelBinding)* '}')? 
 ;
 
-ModelGroupItem :
+ModelGroupItem:
 	{ModelGroupItem} 'Group' (':' type=ModelItemType ( ':' function=ModelGroupFunction ('(' args+=(ID|STRING) (',' args+=(ID|STRING))* ')')?)?)?
 ;
 
-enum ModelGroupFunction :
+enum ModelGroupFunction:
 	EQUALITY='EQUALITY' | AND='AND' | OR='OR' | NAND='NAND' | NOR='NOR' | AVG='AVG' | SUM='SUM' | MAX='MAX' | MIN='MIN' | COUNT='COUNT' | LATEST='LATEST' | EARLIEST='EARLIEST'
 ;
 
-ModelNormalItem :
+ModelNormalItem:
 	type=ModelItemType
 ;
 
-ModelItemType :
+ModelItemType:
 	BaseModelItemType | ('Number' (':' ID)?)
 ;
-BaseModelItemType :
+BaseModelItemType:
 	'Switch' | 'Rollershutter' | 'String' | 'Dimmer' | 'Contact' | 'DateTime' | 'Color' | 'Player' | 'Location' | 'Call' | 'Image'
 ;
 
 ModelBinding:
-	type=ID '=' configuration=STRING   
-	('['
+    type=ID '=' configuration=STRING
+    ('['
         properties+=ModelProperty? (',' properties+=ModelProperty)*
     ']')?
 ;
@@ -61,18 +61,20 @@ BOOLEAN returns ecore::EBoolean:
 ;
 
 NUMBER returns ecore::EBigDecimal:
-    ID ('.' ID )?
+    ('-')? ID ('.' ID )?
 ;
 
-terminal ID  		: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
+terminal ID: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
 
-terminal STRING	: 
+terminal STRING:
 			'"' ( '\\' ('b'|'t'|'n'|'f'|'r'|'u'|'"'|"'"|'\\') | !('\\'|'"') )* '"' |
 			"'" ( '\\' ('b'|'t'|'n'|'f'|'r'|'u'|'"'|"'"|'\\') | !('\\'|"'") )* "'"
-		; 
-terminal ML_COMMENT	: '/*' -> '*/';
-terminal SL_COMMENT 	: '//' !('\n'|'\r')* ('\r'? '\n')?;
+;
 
-terminal WS			: (' '|'\t'|'\r'|'\n')+;
+terminal ML_COMMENT: '/*' -> '*/';
+
+terminal SL_COMMENT: '//' !('\n'|'\r')* ('\r'? '\n')?;
+
+terminal WS: (' '|'\t'|'\r'|'\n')+;
 
 terminal ANY_OTHER: .;

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/Thing.xtext
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/Thing.xtext
@@ -90,10 +90,10 @@ BOOLEAN returns ecore::EBoolean:
 ;
 
 NUMBER returns ecore::EBigDecimal:
-	ID ('.' ID )?
+	('-')? ID ('.' ID )?
 ;
 
-terminal ID  		: '^'?('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
+terminal ID: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
 
 // INT is disabled due to conflicts with the custom ID rule
 // terminal INT: '0'..'9';

--- a/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
+++ b/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
@@ -570,7 +570,8 @@ public class GenericItemProviderTest extends JavaOSGiTest {
     @Test
     public void testMetadataConfigured() {
         String model = "Switch simple { namespace=\"value\" } " + //
-                "Switch configured { foo=\"bar\" [ answer=42 ] } ";
+                "Switch configured { foo=\"bar\" [ answer=42 ] } " + //
+                "Switch negative { foo=\"bar\" [ property=-42 ] }";
 
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
         Item item = itemRegistry.get("configured");
@@ -580,6 +581,11 @@ public class GenericItemProviderTest extends JavaOSGiTest {
         assertThat(res, is(notNullValue()));
         assertThat(res.getValue(), is("bar"));
         assertThat(res.getConfiguration().get("answer"), is(new BigDecimal(42)));
+
+        res = metadataRegistry.get(new MetadataKey("foo", "negative"));
+        assertThat(res, is(notNullValue()));
+        assertThat(res.getValue(), is("bar"));
+        assertThat(res.getConfiguration().get("property"), is(new BigDecimal(-42)));
 
         Collection<Item> itemsToRemove = itemRegistry.getAll();
         List<AbstractItemRegistryEvent> removedItemEvents = new ArrayList<>();


### PR DESCRIPTION
- Allow negative numbers in metadata for Items

What is the best solution:

> If we compare the grammar to the one for Things there is exactly the "-" sign missing.
> 
> https://github.com/openhab/openhab-core/blob/1f4e374ece9d8d72f5bc77d647152b9430ca7524/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/Thing.xtext#L96
> 
> We have options to solve it.
> 
> 1. Add the "-" sign to the terminal `ID` in the Items grammar. This could lead to an impact on the Item names because the terminal `ID` is used to define allowed characters for it too.
> 2. Add an optional "-" sign for the `NUMBER` definition like this
> 
> ```
> NUMBER returns ecore::EBigDecimal:
>     ('-')? ID ('.' ID )?
> ;
> ```

Closes #1501

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>