### PR TITLE
Use 'ZoneId.systemDefault()' instead of 'TimeZone.getDefault().toZone…

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.core.persistence;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.TimeZone;
 
 import org.openhab.core.types.State;
 
@@ -178,7 +178,7 @@ public class FilterCriteria {
     @Deprecated
     public FilterCriteria setBeginDate(Date beginDate) {
         if (beginDate != null) {
-            this.beginDate = ZonedDateTime.ofInstant(beginDate.toInstant(), TimeZone.getDefault().toZoneId());
+            this.beginDate = ZonedDateTime.ofInstant(beginDate.toInstant(), ZoneId.systemDefault());
         } else {
             this.beginDate = null;
         }
@@ -205,7 +205,7 @@ public class FilterCriteria {
     @Deprecated
     public FilterCriteria setEndDate(Date endDate) {
         if (endDate != null) {
-            this.endDate = ZonedDateTime.ofInstant(endDate.toInstant(), TimeZone.getDefault().toZoneId());
+            this.endDate = ZonedDateTime.ofInstant(endDate.toInstant(), ZoneId.systemDefault());
         } else {
             this.endDate = null;
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -22,7 +22,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
-import java.util.TimeZone;
 
 import javax.measure.Quantity;
 import javax.measure.Unit;
@@ -278,7 +277,7 @@ public class I18nProviderImpl
     public ZoneId getTimeZone() {
         final ZoneId timeZone = this.timeZone;
         if (timeZone == null) {
-            return TimeZone.getDefault().toZoneId();
+            return ZoneId.systemDefault();
         }
         return timeZone;
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nProviderImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nProviderImplTest.java
@@ -23,7 +23,6 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -104,7 +103,7 @@ public class I18nProviderImplTest {
         Locale setLocale = i18nProviderImpl.getLocale();
 
         assertNull(location);
-        assertThat(i18nProviderImpl.getTimeZone(), is(TimeZone.getDefault().toZoneId()));
+        assertThat(i18nProviderImpl.getTimeZone(), is(ZoneId.systemDefault()));
         assertThat(setLocale, is(Locale.getDefault()));
     }
 
@@ -140,7 +139,7 @@ public class I18nProviderImplTest {
         conf.put(TIMEZONE, "invalid");
         i18nProviderImpl.modified(conf);
 
-        assertThat(i18nProviderImpl.getTimeZone(), is(TimeZone.getDefault().toZoneId()));
+        assertThat(i18nProviderImpl.getTimeZone(), is(ZoneId.systemDefault()));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -325,7 +326,7 @@ public class DateTimeTypeTest {
             dt2 = new DateTimeType(zonedDate);
         } else if (inputTimeString != null) {
             dt1 = new DateTimeType(inputTimeString);
-            dt2 = new DateTimeType(dt1.getZonedDateTime().withZoneSameInstant(TimeZone.getDefault().toZoneId()));
+            dt2 = new DateTimeType(dt1.getZonedDateTime().withZoneSameInstant(ZoneId.systemDefault()));
             dt3 = new DateTimeType(dt1.getZonedDateTime());
         } else {
             throw new DateTimeException("Invalid inputs in parameter set");

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -17,10 +17,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +90,7 @@ public class PersistenceResourceTest {
         when(pService.query(any())).thenReturn(items);
 
         when(persistenceServiceRegistry.get(PERSISTENCE_SERVICE_ID)).thenReturn(pService);
-        when(timeZoneProvider.getTimeZone()).thenReturn(TimeZone.getDefault().toZoneId());
+        when(timeZoneProvider.getTimeZone()).thenReturn(ZoneId.systemDefault());
     }
 
     @Test


### PR DESCRIPTION
- Use `ZoneId.systemDefault()` instead of `TimeZone.getDefault().toZoneId()`

Inverted PR of #1358

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>