### PR TITLE
Moved 'parseState()' method into 'GroupFunctionHelper' and apply only if needed

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.internal.items;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.measure.Quantity;
@@ -19,12 +21,16 @@ import javax.measure.Quantity;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GroupFunction;
+import org.openhab.core.items.Item;
 import org.openhab.core.items.dto.GroupFunctionDTO;
+import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.ArithmeticGroupFunction;
 import org.openhab.core.library.types.DateTimeGroupFunction;
 import org.openhab.core.library.types.QuantityTypeArithmeticGroupFunction;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.types.State;
+import org.openhab.core.types.TypeParser;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -36,6 +42,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class GroupFunctionHelper {
 
+    private final Logger logger = LoggerFactory.getLogger(GroupFunctionHelper.class);
+
     /**
      * Creates a {@link GroupFunction} according to the given parameters. In case dimension is given the resulting
      * arithmetic group function will take unit conversion into account.
@@ -45,16 +53,41 @@ public class GroupFunctionHelper {
      * @param dimension an optional interface class from {@link Quantity} defining the dimension for unit conversion.
      * @return a {@link GroupFunction} according to the given parameters.
      */
-    public GroupFunction createGroupFunction(GroupFunctionDTO function, List<State> args,
-            @Nullable Class<? extends Quantity<?>> dimension) {
+    public GroupFunction createGroupFunction(GroupFunctionDTO function, @Nullable Item baseItem) {
+        Class<? extends Quantity<?>> dimension = getDimension(baseItem);
         if (dimension != null) {
-            return createDimensionGroupFunction(function, args, dimension);
+            return createDimensionGroupFunction(function, baseItem, dimension);
         }
-
-        return createDefaultGroupFunction(function, args);
+        return createDefaultGroupFunction(function, baseItem);
     }
 
-    private GroupFunction createDimensionGroupFunction(GroupFunctionDTO function, List<State> args,
+    private List<State> parseStates(@Nullable Item baseItem, String @Nullable [] params) {
+        if (params == null || baseItem == null) {
+            return Collections.emptyList();
+        }
+
+        List<State> states = new ArrayList<>();
+        for (String param : params) {
+            State state = TypeParser.parseState(baseItem.getAcceptedDataTypes(), param);
+            if (state == null) {
+                logger.warn("State '{}' is not valid for a group item with base type '{}'", param, baseItem.getType());
+                states.clear();
+                break;
+            } else {
+                states.add(state);
+            }
+        }
+        return states;
+    }
+
+    private @Nullable Class<? extends Quantity<?>> getDimension(@Nullable Item baseItem) {
+        if (baseItem instanceof NumberItem) {
+            return ((NumberItem) baseItem).getDimension();
+        }
+        return null;
+    }
+
+    private GroupFunction createDimensionGroupFunction(GroupFunctionDTO function, @Nullable Item baseItem,
             Class<? extends Quantity<?>> dimension) {
         String functionName = function.name;
         switch (functionName.toUpperCase()) {
@@ -67,14 +100,16 @@ public class GroupFunctionHelper {
             case "MAX":
                 return new QuantityTypeArithmeticGroupFunction.Max(dimension);
             default:
-                return createDefaultGroupFunction(function, args);
+                return createDefaultGroupFunction(function, baseItem);
         }
     }
 
-    private GroupFunction createDefaultGroupFunction(GroupFunctionDTO function, List<State> args) {
+    private GroupFunction createDefaultGroupFunction(GroupFunctionDTO function, @Nullable Item baseItem) {
         String functionName = function.name;
+        List<State> args;
         switch (functionName.toUpperCase()) {
             case "AND":
+                args = parseStates(baseItem, function.params);
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.And(args.get(0), args.get(1));
                 } else {
@@ -83,6 +118,7 @@ public class GroupFunctionHelper {
                 }
                 break;
             case "OR":
+                args = parseStates(baseItem, function.params);
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.Or(args.get(0), args.get(1));
                 } else {
@@ -91,6 +127,7 @@ public class GroupFunctionHelper {
                 }
                 break;
             case "NAND":
+                args = parseStates(baseItem, function.params);
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.NAnd(args.get(0), args.get(1));
                 } else {
@@ -99,6 +136,7 @@ public class GroupFunctionHelper {
                 }
                 break;
             case "NOR":
+                args = parseStates(baseItem, function.params);
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.NOr(args.get(0), args.get(1));
                 } else {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
@@ -89,7 +89,7 @@ public class GroupFunctionHelper {
 
     private GroupFunction createDimensionGroupFunction(GroupFunctionDTO function, @Nullable Item baseItem,
             Class<? extends Quantity<?>> dimension) {
-        String functionName = function.name;
+        final String functionName = function.name;
         switch (functionName.toUpperCase()) {
             case "AVG":
                 return new QuantityTypeArithmeticGroupFunction.Avg(dimension);
@@ -105,16 +105,15 @@ public class GroupFunctionHelper {
     }
 
     private GroupFunction createDefaultGroupFunction(GroupFunctionDTO function, @Nullable Item baseItem) {
-        String functionName = function.name;
-        List<State> args;
+        final String functionName = function.name;
+        final List<State> args;
         switch (functionName.toUpperCase()) {
             case "AND":
                 args = parseStates(baseItem, function.params);
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.And(args.get(0), args.get(1));
                 } else {
-                    LoggerFactory.getLogger(GroupFunctionHelper.class)
-                            .error("Group function 'AND' requires two arguments. Using Equality instead.");
+                    logger.error("Group function 'AND' requires two arguments. Using Equality instead.");
                 }
                 break;
             case "OR":
@@ -122,8 +121,7 @@ public class GroupFunctionHelper {
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.Or(args.get(0), args.get(1));
                 } else {
-                    LoggerFactory.getLogger(GroupFunctionHelper.class)
-                            .error("Group function 'OR' requires two arguments. Using Equality instead.");
+                    logger.error("Group function 'OR' requires two arguments. Using Equality instead.");
                 }
                 break;
             case "NAND":
@@ -131,8 +129,7 @@ public class GroupFunctionHelper {
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.NAnd(args.get(0), args.get(1));
                 } else {
-                    LoggerFactory.getLogger(GroupFunctionHelper.class)
-                            .error("Group function 'NOT AND' requires two arguments. Using Equality instead.");
+                    logger.error("Group function 'NOT AND' requires two arguments. Using Equality instead.");
                 }
                 break;
             case "NOR":
@@ -140,8 +137,7 @@ public class GroupFunctionHelper {
                 if (args.size() == 2) {
                     return new ArithmeticGroupFunction.NOr(args.get(0), args.get(1));
                 } else {
-                    LoggerFactory.getLogger(GroupFunctionHelper.class)
-                            .error("Group function 'NOT OR' requires two arguments. Using Equality instead.");
+                    logger.error("Group function 'NOT OR' requires two arguments. Using Equality instead.");
                 }
                 break;
             case "COUNT":
@@ -149,8 +145,7 @@ public class GroupFunctionHelper {
                     State countParam = new StringType(function.params[0]);
                     return new ArithmeticGroupFunction.Count(countParam);
                 } else {
-                    LoggerFactory.getLogger(GroupFunctionHelper.class)
-                            .error("Group function 'COUNT' requires one argument. Using Equality instead.");
+                    logger.error("Group function 'COUNT' requires one argument. Using Equality instead.");
                 }
                 break;
             case "AVG":
@@ -168,10 +163,8 @@ public class GroupFunctionHelper {
             case "EQUALITY":
                 return new GroupFunction.Equality();
             default:
-                LoggerFactory.getLogger(GroupFunctionHelper.class)
-                        .error("Unknown group function '{}'. Using Equality instead.", functionName);
+                logger.error("Unknown group function '{}'. Using Equality instead.", functionName);
         }
-
         return new GroupFunction.Equality();
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTOMapper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTOMapper.java
@@ -15,8 +15,6 @@ package org.openhab.core.items.dto;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.measure.Quantity;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.internal.items.GroupFunctionHelper;
@@ -25,10 +23,7 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemBuilder;
 import org.openhab.core.items.ItemBuilderFactory;
-import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.types.State;
-import org.openhab.core.types.TypeParser;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link ItemDTOMapper} is an utility class to map items into item data transfer objects (DTOs).
@@ -89,38 +84,7 @@ public class ItemDTOMapper {
     }
 
     public static GroupFunction mapFunction(@Nullable Item baseItem, GroupFunctionDTO function) {
-        List<State> args = parseStates(baseItem, function.params);
-
-        return GROUP_FUNCTION_HELPER.createGroupFunction(function, args, getDimension(baseItem));
-    }
-
-    private static @Nullable Class<? extends Quantity<?>> getDimension(@Nullable Item baseItem) {
-        if (baseItem instanceof NumberItem) {
-            return ((NumberItem) baseItem).getDimension();
-        }
-
-        return null;
-    }
-
-    private static List<State> parseStates(@Nullable Item baseItem, String @Nullable [] params) {
-        List<State> states = new ArrayList<>();
-
-        if (params == null || baseItem == null) {
-            return states;
-        }
-
-        for (String param : params) {
-            State state = TypeParser.parseState(baseItem.getAcceptedDataTypes(), param);
-            if (state == null) {
-                LoggerFactory.getLogger(ItemDTOMapper.class).warn(
-                        "State '{}' is not valid for a group item with base type '{}'", param, baseItem.getType());
-                states.clear();
-                break;
-            } else {
-                states.add(state);
-            }
-        }
-        return states;
+        return GROUP_FUNCTION_HELPER.createGroupFunction(function, baseItem);
     }
 
     /**
@@ -141,8 +105,9 @@ public class ItemDTOMapper {
         if (item instanceof GroupItem) {
             GroupItem groupItem = (GroupItem) item;
             GroupItemDTO groupItemDTO = (GroupItemDTO) itemDTO;
-            if (groupItem.getBaseItem() != null) {
-                groupItemDTO.groupType = groupItem.getBaseItem().getType();
+            Item baseItem = groupItem.getBaseItem();
+            if (baseItem != null) {
+                groupItemDTO.groupType = baseItem.getType();
                 groupItemDTO.function = mapFunction(groupItem.getFunction());
             }
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
@@ -16,15 +16,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
-
 /**
  * This is a helper class that helps parsing a string into an openHAB type (state or command).
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@NonNullByDefault
 public final class TypeParser {
 
     /**
@@ -42,13 +38,15 @@ public final class TypeParser {
      * @param input input string to parse.
      * @return Parsed type or null, if the type couldn't be parsed.
      */
-    public static @Nullable Type parseType(String typeName, String input) {
+    public static Type parseType(String typeName, String input) {
         try {
             Class<?> stateClass = Class.forName(CORE_LIBRARY_PACKAGE + typeName);
             Method valueOfMethod = stateClass.getMethod("valueOf", String.class);
             return (Type) valueOfMethod.invoke(stateClass, input);
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
-                | InvocationTargetException e) {
+        } catch (ClassNotFoundException e) {
+        } catch (NoSuchMethodException e) {
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
         }
         return null;
     }
@@ -57,7 +55,7 @@ public final class TypeParser {
      * <p>
      * Determines a state from a string. Possible state types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the state.
-     *
+     * 
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -66,7 +64,7 @@ public final class TypeParser {
      * @param s the string to parse
      * @return the corresponding State instance or <code>null</code>
      */
-    public static @Nullable State parseState(List<Class<? extends State>> types, String s) {
+    public static State parseState(List<Class<? extends State>> types, String s) {
         for (Class<? extends Type> type : types) {
             try {
                 Method valueOf = type.getMethod("valueOf", String.class);
@@ -74,8 +72,10 @@ public final class TypeParser {
                 if (state != null) {
                     return state;
                 }
-            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
-                    | InvocationTargetException e) {
+            } catch (NoSuchMethodException e) {
+            } catch (IllegalArgumentException e) {
+            } catch (IllegalAccessException e) {
+            } catch (InvocationTargetException e) {
             }
         }
         return null;
@@ -85,7 +85,7 @@ public final class TypeParser {
      * <p>
      * Determines a command from a string. Possible command types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the command.
-     *
+     * 
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -94,7 +94,7 @@ public final class TypeParser {
      * @param s the string to parse
      * @return the corresponding Command instance or <code>null</code>
      */
-    public static @Nullable Command parseCommand(List<Class<? extends Command>> types, String s) {
+    public static Command parseCommand(List<Class<? extends Command>> types, String s) {
         for (Class<? extends Command> type : types) {
             try {
                 Method valueOf = type.getMethod("valueOf", String.class);
@@ -102,8 +102,10 @@ public final class TypeParser {
                 if (value != null) {
                     return value;
                 }
-            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
-                    | InvocationTargetException e) {
+            } catch (NoSuchMethodException e) {
+            } catch (IllegalArgumentException e) {
+            } catch (IllegalAccessException e) {
+            } catch (InvocationTargetException e) {
             }
         }
         return null;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
@@ -16,11 +16,15 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This is a helper class that helps parsing a string into an openHAB type (state or command).
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public final class TypeParser {
 
     /**
@@ -38,15 +42,13 @@ public final class TypeParser {
      * @param input input string to parse.
      * @return Parsed type or null, if the type couldn't be parsed.
      */
-    public static Type parseType(String typeName, String input) {
+    public static @Nullable Type parseType(String typeName, String input) {
         try {
             Class<?> stateClass = Class.forName(CORE_LIBRARY_PACKAGE + typeName);
             Method valueOfMethod = stateClass.getMethod("valueOf", String.class);
             return (Type) valueOfMethod.invoke(stateClass, input);
-        } catch (ClassNotFoundException e) {
-        } catch (NoSuchMethodException e) {
-        } catch (IllegalAccessException e) {
-        } catch (InvocationTargetException e) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException e) {
         }
         return null;
     }
@@ -55,7 +57,7 @@ public final class TypeParser {
      * <p>
      * Determines a state from a string. Possible state types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the state.
-     * 
+     *
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -64,7 +66,7 @@ public final class TypeParser {
      * @param s the string to parse
      * @return the corresponding State instance or <code>null</code>
      */
-    public static State parseState(List<Class<? extends State>> types, String s) {
+    public static @Nullable State parseState(List<Class<? extends State>> types, String s) {
         for (Class<? extends Type> type : types) {
             try {
                 Method valueOf = type.getMethod("valueOf", String.class);
@@ -72,10 +74,8 @@ public final class TypeParser {
                 if (state != null) {
                     return state;
                 }
-            } catch (NoSuchMethodException e) {
-            } catch (IllegalArgumentException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
+            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
+                    | InvocationTargetException e) {
             }
         }
         return null;
@@ -85,7 +85,7 @@ public final class TypeParser {
      * <p>
      * Determines a command from a string. Possible command types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the command.
-     * 
+     *
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -94,7 +94,7 @@ public final class TypeParser {
      * @param s the string to parse
      * @return the corresponding Command instance or <code>null</code>
      */
-    public static Command parseCommand(List<Class<? extends Command>> types, String s) {
+    public static @Nullable Command parseCommand(List<Class<? extends Command>> types, String s) {
         for (Class<? extends Command> type : types) {
             try {
                 Method valueOf = type.getMethod("valueOf", String.class);
@@ -102,10 +102,8 @@ public final class TypeParser {
                 if (value != null) {
                     return value;
                 }
-            } catch (NoSuchMethodException e) {
-            } catch (IllegalArgumentException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
+            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
+                    | InvocationTargetException e) {
             }
         }
         return null;

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -82,7 +81,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
     @Mock
     private UnitProvider unitProvider;
 
-    private GroupFunctionHelper groupFunctionHelper;
+    private final GroupFunctionHelper groupFunctionHelper = new GroupFunctionHelper();
     private ItemStateConverter itemStateConverter;
 
     @Before
@@ -116,7 +115,6 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
 
         when(unitProvider.getUnit(Temperature.class)).thenReturn(Units.CELSIUS);
 
-        groupFunctionHelper = new GroupFunctionHelper();
         itemStateConverter = new ItemStateConverterImpl(unitProvider);
     }
 
@@ -774,8 +772,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         NumberItem baseItem = createNumberItem("baseItem", Temperature.class, UnDefType.NULL);
         GroupFunctionDTO gfDTO = new GroupFunctionDTO();
         gfDTO.name = "sum";
-        GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, Collections.emptyList(),
-                Temperature.class);
+        GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, baseItem);
         GroupItem groupItem = new GroupItem("number", baseItem, function);
         groupItem.setUnitProvider(unitProvider);
 
@@ -804,8 +801,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         NumberItem baseItem = createNumberItem("baseItem", Temperature.class, UnDefType.NULL);
         GroupFunctionDTO gfDTO = new GroupFunctionDTO();
         gfDTO.name = "sum";
-        GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, Collections.emptyList(),
-                Temperature.class);
+        GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, baseItem);
         GroupItem groupItem = new GroupItem("number", baseItem, function);
         groupItem.setUnitProvider(unitProvider);
         groupItem.setItemStateConverter(itemStateConverter);


### PR DESCRIPTION
- Moved `parseState()` method into `GroupFunctionHelper` and apply only if
needed

Fixes #1531 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>