### PR TITLE
[rest] Suppress ISE in 'SseBroadcaster' if sink already has been closed

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
@@ -93,15 +93,15 @@ public class SseBroadcaster<@NonNull I> implements Closeable {
     public void sendIf(final OutboundSseEvent event, Predicate<I> predicate) {
         logger.trace("broadcast to potential {} sinks", sinks.size());
         sinks.forEach((sink, info) -> {
+            // Check if we should send at all.
+            if (!predicate.test(info)) {
+                return;
+            }
+
             if (sink.isClosed()) {
                 // We are using a concurrent collection, so we are allowed to modify the collection asynchronous (we
                 // don't know if there is currently an iteration in progress or not, but it does not matter).
                 handleRemoval(sink);
-                return;
-            }
-
-            // Check if we should send at all.
-            if (!predicate.test(info)) {
                 return;
             }
 

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
@@ -118,10 +118,11 @@ public class SseBroadcaster<@NonNull I> implements Closeable {
                 if (thClass.equals("class org.eclipse.jetty.io.EofException")) {
                     // The peer terminates the connection.
                 } else if (th instanceof IllegalStateException && message != null
-                        && (message.equals("The sink is already closed, unable to queue SSE event for send")
+                        && (message.equals("The sink is already closed, unable to queue SSE event for send") //
+                                || message.equals("The sink has been already closed") //
                                 || message.equals("AsyncContext completed and/or Request lifecycle recycled"))) {
-                    // java.lang.IllegalStateException: The sink is already closed, unable to queue SSE event for
-                    // send
+                    // java.lang.IllegalStateException: The sink is already closed, unable to queue SSE event for send
+                    // java.lang.IllegalStateException: The sink has been already closed
                     // java.lang.IllegalStateException: AsyncContext completed and/or Request lifecycle recycled
                 } else {
                     logger.warn("failure", th);


### PR DESCRIPTION
- Suppress ISE in `SseBroadcaster` if sink already has been closed

I am having a lot if ISEs in my log when working with new Default UI:
```
07:45:24.448 [WARN ] [g.openhab.core.io.rest.SseBroadcaster] - failure
java.lang.IllegalStateException: The sink has been already closed
	at org.apache.cxf.jaxrs.sse.SseEventSinkImpl.close(SseEventSinkImpl.java:157) [bundleFile:1.0.8]
	at org.openhab.core.io.rest.SseBroadcaster.close(SseBroadcaster.java:148) [bundleFile:?]
	at org.openhab.core.io.rest.SseBroadcaster.lambda$2(SseBroadcaster.java:109) [bundleFile:?]
	at java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:986) [?:?]
	at java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:970) [?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) [?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) [?:?]
	at org.apache.cxf.jaxrs.sse.SseEventSinkImpl.dequeue(SseEventSinkImpl.java:256) [bundleFile:1.0.8]
	at org.eclipse.jetty.server.handler.ContextHandler.handle(ContextHandler.java:1392) [bundleFile:9.4.20.v20190813]
	at org.eclipse.jetty.server.AsyncContextState$1.run(AsyncContextState.java:149) [bundleFile:9.4.20.v20190813]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:782) [bundleFile:9.4.20.v20190813]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:918) [bundleFile:9.4.20.v20190813]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>