### PR TITLE
Remove deprecated method of 'ConfigOptionProvider'

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -287,7 +287,8 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     }
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (CONFIG_URI.equals(uri.toString())) {
             final Locale safeLocale = locale != null ? locale : Locale.getDefault();
             if (CONFIG_DEFAULT_SOURCE.equals(param)) {

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
@@ -222,7 +222,7 @@ public class AudioManagerTest {
         audioManager.addAudioSink(audioSink);
 
         Collection<ParameterOption> parameterOptions = audioManager.getParameterOptions(URI.create("wrong.uri"),
-                AudioManagerImpl.CONFIG_DEFAULT_SINK, Locale.US);
+                AudioManagerImpl.CONFIG_DEFAULT_SINK, null, Locale.US);
         assertThat("The parameter options were not as expected", parameterOptions, is(nullValue()));
     }
 
@@ -294,7 +294,7 @@ public class AudioManagerTest {
         }
 
         Collection<ParameterOption> parameterOptions = audioManager
-                .getParameterOptions(URI.create(AudioManagerImpl.CONFIG_URI), param, locale);
+                .getParameterOptions(URI.create(AudioManagerImpl.CONFIG_URI), param, null, locale);
 
         @SuppressWarnings("null")
         BiFunction<String, String, Boolean> isParameterOptionAdded = (v, l) -> parameterOptions.stream()

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
@@ -29,19 +29,11 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface ConfigOptionProvider {
 
-    /**
-     * Provides a collection of {@link ParameterOptions}s.
-     *
-     * @deprecated Use {@link getParameterOptions} with context instead.
-     *
-     * @param uri the uri of the config description
-     * @param param the parameter name for which the requested options shall be returned
-     * @param locale the locale in which the result is expected
-     * @return the configuration options provided by this provider if any or {@code null} otherwise
-     */
-    @Deprecated
-    @Nullable
-    Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale);
+    // @Deprecated
+    // @Nullable
+    // default Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    // return getParameterOptions(uri, param, null, locale);
+    // }
 
     /**
      * Provides a collection of {@link ParameterOptions}s.
@@ -52,8 +44,7 @@ public interface ConfigOptionProvider {
      * @param locale the locale in which the result is expected
      * @return the configuration options provided by this provider if any or {@code null} otherwise
      */
-    default @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
-            @Nullable Locale locale) {
-        return getParameterOptions(uri, param, locale);
-    }
+    @Nullable
+    Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale);
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
@@ -29,11 +29,10 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface ConfigOptionProvider {
 
-    // @Deprecated
-    // @Nullable
-    // default Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-    // return getParameterOptions(uri, param, null, locale);
-    // }
+    @Deprecated
+    default @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+        return getParameterOptions(uri, param, null, locale);
+    }
 
     /**
      * Provides a collection of {@link ParameterOptions}s.

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -44,7 +44,8 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
     private static final String POSITIVE_OFFSET_FORMAT = "(GMT+%d:%02d) %s";
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if ("system:i18n".equals(uri.toString())) {
             Locale translation = locale != null ? locale : Locale.getDefault();
             return processParamType(param, locale, translation);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
@@ -42,7 +42,8 @@ public class NetworkConfigOptionProvider implements ConfigOptionProvider {
     static final String PARAM_BROADCAST_ADDRESS = "broadcastAddress";
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (!CONFIG_URI.equals(uri)) {
             return null;
         }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
@@ -46,21 +46,21 @@ public class I18nConfigOptionsProviderTest {
 
     @Test
     public void testLanguage() throws Exception {
-        assertThat(provider.getParameterOptions(uriI18N, "language", Locale.US), hasItem(expectedLangEN));
-        assertThat(provider.getParameterOptions(uriI18N, "language", Locale.FRENCH), hasItem(expectedLangFR));
-        assertThat(provider.getParameterOptions(uriI18N, "language", null), not(IsEmptyCollection.empty()));
+        assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.US), hasItem(expectedLangEN));
+        assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.FRENCH), hasItem(expectedLangFR));
+        assertThat(provider.getParameterOptions(uriI18N, "language", null, null), not(IsEmptyCollection.empty()));
     }
 
     @Test
     public void testRegion() throws Exception {
-        assertThat(provider.getParameterOptions(uriI18N, "region", Locale.US), hasItem(expectedCntryEN));
-        assertThat(provider.getParameterOptions(uriI18N, "region", Locale.FRENCH),
+        assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.US), hasItem(expectedCntryEN));
+        assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.FRENCH),
                 anyOf(hasItem(expectedCntryFRJava8), hasItem(expectedCntryFRJava9)));
-        assertThat(provider.getParameterOptions(uriI18N, "region", null), not(IsEmptyCollection.empty()));
+        assertThat(provider.getParameterOptions(uriI18N, "region", null, null), not(IsEmptyCollection.empty()));
     }
 
     @Test
     public void testUnknownParameter() throws Exception {
-        assertThat(provider.getParameterOptions(uriI18N, "unknown", Locale.US), nullValue());
+        assertThat(provider.getParameterOptions(uriI18N, "unknown", null, Locale.US), nullValue());
     }
 }

--- a/bundles/org.openhab.core.config.serial/src/main/java/org/openhab/core/config/serial/internal/SerialConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.serial/src/main/java/org/openhab/core/config/serial/internal/SerialConfigOptionProvider.java
@@ -52,9 +52,4 @@ public class SerialConfigOptionProvider implements ConfigOptionProvider {
         }
         return options;
     }
-
-    @Override
-    public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        return null;
-    }
 }

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -174,7 +174,8 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     }
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (CONFIG_URI.equals(uri.toString())) {
             switch (param) {
                 case CONFIG_COUNTRY:

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
@@ -100,7 +100,8 @@ public class PersistenceServiceRegistryImpl implements ConfigOptionProvider, Per
     }
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (CONFIG_URI.equals(uri.toString()) && CONFIG_DEFAULT.equals(param)) {
             Set<ParameterOption> options = new HashSet<>();
             for (PersistenceService service : getAll()) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -49,7 +49,8 @@ public class MagicServiceImpl implements MagicService {
     static final String PARAMETER_BACKEND_DECIMAL = "select_decimal_limit";
 
     @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (!CONFIG_URI.equals(uri)) {
             return null;
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -667,7 +667,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
     }
 
     @Override
-    public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
+    public Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
         if (CONFIG_URI.equals(uri.toString())) {
             if (CONFIG_DEFAULT_HLI.equals(param)) {
                 return humanLanguageInterpreters.values().stream()

--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -147,7 +147,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     @Test
     public void testConfigOptionProviderDaysetDefault() {
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, "dayset-weekend",
-                null);
+                null, null);
         assertNotNull(options);
         assertEquals(7, options.size());
     }
@@ -155,7 +155,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     @Test
     public void testConfigOptionProviderDaysetUS() {
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, "dayset-weekend",
-                Locale.US);
+                null, Locale.US);
         assertNotNull(options);
         assertEquals(7, options.size());
         assertEquals(Stream.of(new ParameterOption("MONDAY", "Monday"), new ParameterOption("TUESDAY", "Tuesday"),
@@ -167,7 +167,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     @Test
     public void testConfigOptionProviderDaysetGerman() {
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, "dayset-weekend",
-                Locale.GERMAN);
+                null, Locale.GERMAN);
         assertNotNull(options);
         assertEquals(7, options.size());
         assertEquals(Stream.of(new ParameterOption("MONDAY", "Montag"), new ParameterOption("TUESDAY", "Dienstag"),
@@ -179,7 +179,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     @Test
     public void testConfigOptionProviderCountries() {
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_COUNTRY,
-                null);
+                null, null);
         assertNotNull(options);
         assertFalse(options.isEmpty());
         assertEquals(ephemerisManager.countries, options);
@@ -190,7 +190,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
         ephemerisManager.modified(Collections.singletonMap(CONFIG_COUNTRY, COUNTRY_AUSTRALIA_KEY));
 
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_REGION,
-                null);
+                null, null);
         assertNotNull(options);
         assertEquals(8, options.size());
         assertEquals(ephemerisManager.regions.get(COUNTRY_AUSTRALIA_KEY), options);
@@ -199,7 +199,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     @Test
     public void testConfigOptionProviderRegionsGermany() {
         final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_REGION,
-                null);
+                null, null);
         assertNotNull(options);
         assertEquals(16, options.size());
         assertEquals(ephemerisManager.regions.get(Locale.GERMANY.getCountry().toLowerCase()), options);
@@ -212,7 +212,8 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
                         new SimpleEntry<>(CONFIG_REGION, REGION_NORTHRHINEWESTPHALIA_KEY))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
-        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null);
+        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null,
+                null);
         assertNull(options);
     }
 
@@ -223,7 +224,8 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
                         new SimpleEntry<>(CONFIG_REGION, REGION_BAVARIA_KEY))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
-        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null);
+        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null,
+                null);
         assertNotNull(options);
         assertFalse(options.isEmpty());
         assertEquals(ephemerisManager.cities.get(REGION_BAVARIA_KEY), options);
@@ -236,7 +238,8 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
                         new SimpleEntry<>(CONFIG_REGION, REGION_TASMANIA_KEY))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
-        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null);
+        final Collection<ParameterOption> options = ephemerisManager.getParameterOptions(CONFIG_URI, CONFIG_CITY, null,
+                null);
         assertNotNull(options);
         assertFalse(options.isEmpty());
         assertEquals(ephemerisManager.cities.get(REGION_TASMANIA_KEY), options);

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.voice.javavoicemanager;
+package org.openhab.core.voice.internal;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -31,27 +31,18 @@ import org.openhab.core.audio.AudioManager;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.voice.VoiceManager;
-import org.openhab.core.voice.internal.AudioManagerStub;
-import org.openhab.core.voice.internal.AudioSourceStub;
-import org.openhab.core.voice.internal.HumanLanguageInterpreterStub;
-import org.openhab.core.voice.internal.KSServiceStub;
-import org.openhab.core.voice.internal.STTServiceStub;
-import org.openhab.core.voice.internal.SinkStub;
-import org.openhab.core.voice.internal.TTSServiceStub;
-import org.openhab.core.voice.internal.VoiceManagerImpl;
-import org.openhab.core.voice.internal.VoiceStub;
 import org.openhab.core.voice.text.InterpretationException;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
- * Tests for {@link VoiceManagerImpl}
+ * Tests for {@link org.openhab.core.voice.internal.VoiceManagerImpl}
  *
  * @author Mihaela Memova - Initial contribution
  * @author Velin Yordanov - migrated tests from groovy to java
  */
-public class VoiceManagerTest extends JavaOSGiTest {
+public class VoiceManagerImplTest extends JavaOSGiTest {
     private static final String CONFIG_DEFAULT_HLI = "defaultHLI";
     private static final String CONFIG_DEFAULT_KS = "defaultKS";
     private static final String CONFIG_DEFAULT_STT = "defaultSTT";
@@ -265,7 +256,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         boolean isHliStubInTheOptions = false;
 
         Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultHLI",
-                null);
+                null, null);
 
         assertNotNull(options);
 
@@ -290,7 +281,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         boolean isKSStubInTheOptions = false;
 
         Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultKS",
-                null);
+                null, null);
 
         assertNotNull(options);
 
@@ -315,7 +306,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         boolean isSTTStubInTheOptions = false;
 
         Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultSTT",
-                null);
+                null, null);
         assertNotNull(options);
 
         for (ParameterOption option : options) {
@@ -339,7 +330,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         boolean isTTSStubInTheOptions = false;
 
         Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultTTS",
-                null);
+                null, null);
 
         assertNotNull(options);
 
@@ -366,7 +357,7 @@ public class VoiceManagerTest extends JavaOSGiTest {
         boolean isVoiceStubInTheOptions = false;
 
         Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultVoice",
-                null);
+                null, null);
 
         assertNotNull(options);
 


### PR DESCRIPTION
- Remove deprecated method of `ConfigOptionProvider`

Related to #1408

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

---

Depends on https://github.com/openhab/openhab-addons/pull/8093