### PR TITLE
Use the same regex as the install and uninstall method

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/extensions/ExtensionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/extensions/ExtensionResource.java
@@ -138,7 +138,7 @@ public class ExtensionResource implements RESTResource {
     }
 
     @GET
-    @Path("/{extensionId: [a-zA-Z_0-9-]+}")
+    @Path("/{extensionId: [a-zA-Z_0-9-:]+}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get extension with given ID.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),


### PR DESCRIPTION
The getById method is missing the ":". See the install and uninstall method.