### PR TITLE
[rest] introduce nickname attribute in ApiOperation annotation to make operationIds unique

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/binding/BindingResource.java
@@ -109,7 +109,7 @@ public class BindingResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get all bindings.", response = BindingInfoDTO.class, responseContainer = "Set")
+    @ApiOperation(nickname = "getAllBindings", value = "Get all bindings.", response = BindingInfoDTO.class, responseContainer = "Set")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = BindingInfoDTO.class, responseContainer = "Set") })
     public Response getAll(
@@ -123,7 +123,7 @@ public class BindingResource implements RESTResource {
     @GET
     @Path("/{bindingId}/config")
     @Produces({ MediaType.APPLICATION_JSON })
-    @ApiOperation(value = "Get binding configuration for given binding ID.")
+    @ApiOperation(nickname = "getBindingConfiguration", value = "Get binding configuration for given binding ID.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = String.class),
             @ApiResponse(code = 404, message = "Binding does not exist"),
             @ApiResponse(code = 500, message = "Configuration can not be read due to internal error") })


### PR DESCRIPTION
By default the Swagger plugin uses the method name as operationId.
Since the operationId must be unique across all methods and some method names are named the same, we should use the nickname element in the ApiOperation annotation and thus set the operationId manually.

I will create more prs for some other classes that need to be fixed.

Reference:
 * [Nickname attribute](https://docs.swagger.io/swagger-core/v1.5.X/apidocs/io/swagger/annotations/ApiOperation.html#nickname--) in swagger annotations documentation
 * [Operation Object](https://swagger.io/specification/#operation-object) in swagger specification