### PR TITLE
[rest] introduce nickname attribute in ConfigDescriptionResource to make swaggers operationId unique

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -90,7 +90,7 @@ public class ConfigDescriptionResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets all available config descriptions.", response = ConfigDescriptionDTO.class, responseContainer = "List")
+    @ApiOperation(nickname = "getAllConfigDescriptions", value = "Gets all available config descriptions.", response = ConfigDescriptionDTO.class, responseContainer = "List")
     @ApiResponses(value = @ApiResponse(code = 200, message = "OK", response = ConfigDescriptionDTO.class, responseContainer = "List"))
     public Response getAll(@HeaderParam("Accept-Language") @ApiParam(value = "language") @Nullable String language, //
             @QueryParam("scheme") @ApiParam(value = "scheme filter") @Nullable String scheme) {


### PR DESCRIPTION
By default the Swagger plugin uses the method name as operationId.
Since the operationId must be unique across all methods and some method names are named the same, we should use the nickname element in the ApiOperation annotation and thus set the operationId manually.

The `getAll()` method in `ConfigDescriptionResource.java` does not have a nickname set in its `@ApiOperation` annotation.
Swagger uses the method name (getAll) as default operationId which is not unique.

I will create more prs for some other classes that need to be fixed.

Reference:
 * [Nickname attribute](https://docs.swagger.io/swagger-core/v1.5.X/apidocs/io/swagger/annotations/ApiOperation.html#nickname--) in swagger annotations documentation
 * [Operation Object](https://swagger.io/specification/#operation-object) in swagger specification