### PR TITLE
[REST] Change responseContainer from Collection to List in swagger @ApiOperation and @ApiResponse annotations

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -89,9 +89,9 @@ public class ItemChannelLinkResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets all available links.", response = ItemChannelLinkDTO.class, responseContainer = "Collection")
+    @ApiOperation(value = "Gets all available links.", response = ItemChannelLinkDTO.class, responseContainer = "List")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = ItemChannelLinkDTO.class, responseContainer = "Collection") })
+            @ApiResponse(code = 200, message = "OK", response = ItemChannelLinkDTO.class, responseContainer = "List") })
     public Response getAll(
             @QueryParam("channelUID") @ApiParam(value = "filter by channel UID") @Nullable String channelUID,
             @QueryParam("itemName") @ApiParam(value = "filter by item name") @Nullable String itemName) {


### PR DESCRIPTION
This changes the value in the "responseContainer" attribute to one of the three valid values.

The [documentation](https://docs.swagger.io/swagger-core/v1.5.0/apidocs/io/swagger/annotations/ApiResponse.html#responseContainer()) says:
_"Valid values are "List", "Set" or "Map". Any other value will be ignored."_

This fixes #1550 