### PR TITLE
[REST] RuleResource: Change responseContainer from Collection to List in swagger @ApiOperation and @ApiResponse annotations

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -127,9 +127,9 @@ public class RuleResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get available rules, optionally filtered by tags and/or prefix.", response = EnrichedRuleDTO.class, responseContainer = "Collection")
+    @ApiOperation(value = "Get available rules, optionally filtered by tags and/or prefix.", response = EnrichedRuleDTO.class, responseContainer = "List")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = EnrichedRuleDTO.class, responseContainer = "Collection") })
+            @ApiResponse(code = 200, message = "OK", response = EnrichedRuleDTO.class, responseContainer = "List") })
     public Response get(@QueryParam("prefix") final @Nullable String prefix,
             @QueryParam("tags") final @Nullable List<String> tags) {
         // match all


### PR DESCRIPTION
This changes the value in the "responseContainer" attribute to one of the three valid values.

The [documentation](https://docs.swagger.io/swagger-core/v1.5.0/apidocs/io/swagger/annotations/ApiResponse.html#responseContainer()) says:
"Valid values are "List", "Set" or "Map". Any other value will be ignored."

See #1553 