### PR TITLE
[REST] TemplateResource: Change responseContainer from Collection to List in swagger @ApiOperation and @ApiResponse annotations

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
@@ -83,9 +83,9 @@ public class TemplateResource implements RESTResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get all available templates.", response = Template.class, responseContainer = "Collection")
+    @ApiOperation(value = "Get all available templates.", response = Template.class, responseContainer = "List")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "OK", response = Template.class, responseContainer = "Collection") })
+            @ApiResponse(code = 200, message = "OK", response = Template.class, responseContainer = "List") })
     public Response getAll(@HeaderParam("Accept-Language") @ApiParam(value = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
         Collection<RuleTemplateDTO> result = templateRegistry.getAll(locale).stream()


### PR DESCRIPTION
This changes the value in the "responseContainer" attribute to one of the three valid values.

The [documentation](https://docs.swagger.io/swagger-core/v1.5.0/apidocs/io/swagger/annotations/ApiResponse.html#responseContainer()) says:
"Valid values are "List", "Set" or "Map". Any other value will be ignored."

See #1553 and #1554 