### PR TITLE
[Code style] Replace c-style array declaration with java-style array declaration

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronAdjuster.java
@@ -73,7 +73,7 @@ class CronAdjuster implements SchedulerTemporalAdjuster {
      * Constructs the class with a cron specification. containing variables and a cron expression at the last line.
      */
     public CronAdjuster(final String specification) {
-        final String entries[] = specification.split("[\n\r]+");
+        final String[] entries = specification.split("[\n\r]+");
         environmentMap = parseEnvironment(entries);
 
         String cronExpression = entries[entries.length - 1].trim();
@@ -84,7 +84,7 @@ class CronAdjuster implements SchedulerTemporalAdjuster {
             cronExpression = preDeclared(cronExpression);
         }
 
-        final String parts[] = cronExpression.trim().toUpperCase().split("\\s+");
+        final String[] parts = cronExpression.trim().toUpperCase().split("\\s+");
 
         if (parts.length < 6 || parts.length > 7) {
             throw new IllegalArgumentException(
@@ -430,7 +430,7 @@ class CronAdjuster implements SchedulerTemporalAdjuster {
             return r;
         }
 
-        final String parts[] = range.split("-");
+        final String[] parts = range.split("-");
         r[0] = r[1] = parseInt(cronExpression, chronoField, parts[0], min, names);
         if (parts.length == 2) {
             r[1] = parseInt(cronExpression, chronoField, parts[1], min, names);


### PR DESCRIPTION
Replaces the way an array is declared with the way "prefered for java", because the [] is part of the TYPE and not the NAME.

I think this makes it more readable and easier to understand.

See [this stackoverflow post](https://stackoverflow.com/questions/129178/difference-between-int-array-and-int-array) for reference.