### PR TITLE
[Code style] Remove unnecessary conversion to string

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/CidrAddress.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/CidrAddress.java
@@ -46,7 +46,7 @@ public class CidrAddress {
         if (prefix == 0) {
             return address.getHostAddress();
         } else {
-            return address.getHostAddress() + "/" + String.valueOf(prefix);
+            return address.getHostAddress() + "/" + prefix;
         }
     }
 


### PR DESCRIPTION
We can remove the explicit conversion to the string, as this is done implicitly.