### PR TITLE
Use more java 8 features: Replace Collections.sort() with List.sort() (second try)

### DIFF
--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/SmartHomeHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/SmartHomeHttpContext.java
@@ -15,7 +15,6 @@ package org.openhab.core.io.http.internal;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayDeque;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
@@ -82,7 +81,7 @@ public class SmartHomeHttpContext implements WrappingHttpContext {
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     public void addHandler(Handler handler) {
         this.handlers.add(handler);
-        Collections.sort(handlers, Comparator.comparingInt(Handler::getPriority));
+        handlers.sort(Comparator.comparingInt(Handler::getPriority));
     }
 
     public void removeHandler(Handler handler) {

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafExtensionService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafExtensionService.java
@@ -85,12 +85,7 @@ public class KarafExtensionService implements ExtensionService {
         }
 
         // let's sort the result alphabetically
-        Collections.sort(extensions, new Comparator<Extension>() {
-            @Override
-            public int compare(Extension ext1, Extension ext2) {
-                return ext1.getLabel().compareTo(ext2.getLabel());
-            }
-        });
+        extensions.sort(Comparator.comparing(Extension::getLabel));
         return extensions;
     }
 


### PR DESCRIPTION
Uses List.sort() instead of Collections.sort() to sort lists.
This function was introduced with Java 8 and might speed up sorting a bit.

See [javadocs](https://docs.oracle.com/javase/8/docs/api/java/util/List.html#sort-java.util.Comparator-) for reference.

Second try, see #1558 