### PR TITLE
[Code style] Cleanup tests: Simplify assertEquals to assertTrue or assertFalse

### DIFF
--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -126,7 +126,7 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
                 assertEquals(ACTION_INPUT1_DEFAULT_VALUE, in.getDefaultValue());
                 assertEquals(ACTION_INPUT1_DESCRIPTION, in.getDescription());
                 assertEquals(ACTION_INPUT1_REFERENCE, in.getReference());
-                assertEquals(true, in.isRequired());
+                assertTrue(in.isRequired());
                 assertEquals("Item", in.getType());
 
                 Set<String> inputTags = in.getTags();

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -18,7 +18,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -277,9 +276,9 @@ public class MqttBrokerConnectionTests extends JavaTest {
         connection.setLastWill(MqttWillAndTestament.fromString("topic:message:1:true"));
         assertEquals("topic", connection.getLastWill().getTopic());
         assertEquals(1, connection.getLastWill().getQos());
-        assertEquals(true, connection.getLastWill().isRetain());
-        byte b[] = { 'm', 'e', 's', 's', 'a', 'g', 'e' };
-        assertTrue(Arrays.equals(connection.getLastWill().getPayload(), b));
+        assertTrue(connection.getLastWill().isRetain());
+        byte[] b = { 'm', 'e', 's', 's', 'a', 'g', 'e' };
+        assertArrayEquals(connection.getLastWill().getPayload(), b);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -299,7 +298,7 @@ public class MqttBrokerConnectionTests extends JavaTest {
                 "setterGetterTests");
         assertEquals("URL getter", connection.getHost(), "123.123.123.123");
         assertEquals("Name getter", connection.getPort(), 1883); // Check for non-secure port
-        assertEquals("Secure getter", connection.isSecure(), false);
+        assertFalse("Secure getter", connection.isSecure());
         assertEquals("ClientID getter", "setterGetterTests", connection.getClientId());
 
         connection.setCredentials("user@!", "password123@^");

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.thing.internal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -123,7 +123,7 @@ public class ThingManagerImplTest {
 
         ThingManagerImpl thingManager = createThingManager();
 
-        assertEquals(thingManager.isEnabled(unknownUID), true);
+        assertTrue(thingManager.isEnabled(unknownUID));
     }
 
     @Test
@@ -135,11 +135,11 @@ public class ThingManagerImplTest {
 
         ThingManagerImpl thingManager = createThingManager();
 
-        assertEquals(thingManager.isEnabled(unknownUID), true);
+        assertTrue(thingManager.isEnabled(unknownUID));
 
         when(storageMock.containsKey(unknownUID.getAsString())).thenReturn(true);
         when(storageServiceMock.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(storageMock);
 
-        assertEquals(thingManager.isEnabled(unknownUID), false);
+        assertFalse(thingManager.isEnabled(unknownUID));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
@@ -93,7 +93,7 @@ public class QueueingThreadPoolExecutorTest {
         ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
 
         assertEquals(pool.getActiveCount(), 0);
-        assertEquals(pool.allowsCoreThreadTimeOut(), true);
+        assertTrue(pool.allowsCoreThreadTimeOut());
         assertEquals(pool.getCompletedTaskCount(), 0);
         assertEquals(pool.getCorePoolSize(), 1);
         assertEquals(pool.getMaximumPoolSize(), 2);
@@ -148,7 +148,7 @@ public class QueueingThreadPoolExecutorTest {
         assertEquals(pool.getActiveCount(), 1);
         assertTrue(isPoolThreadActive(poolName, 1));
         Thread t1 = getThread(poolName + "-1");
-        assertEquals(t1.isDaemon(), false);
+        assertFalse(t1.isDaemon());
         // thread will be NORM prio or max prio of this thread group, which can
         // < than NORM
         int prio1 = Math.min(t1.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);
@@ -158,7 +158,7 @@ public class QueueingThreadPoolExecutorTest {
         assertEquals(pool.getActiveCount(), 2);
         assertTrue(isPoolThreadActive(poolName, 2));
         Thread t2 = getThread(poolName + "-2");
-        assertEquals(t2.isDaemon(), false);
+        assertFalse(t2.isDaemon());
         // thread will be NORM prio or max prio of this thread group, which can
         // < than NORM
         int prio2 = Math.min(t2.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -109,10 +109,10 @@ public class MetadataCommandDescriptionProviderTest {
         Iterator<CommandOption> it = commandDescription.getCommandOptions().iterator();
         CommandOption commandOption = it.next();
         assertEquals("OPTION1", commandOption.getCommand());
-        assertEquals(null, commandOption.getLabel());
+        assertNull(commandOption.getLabel());
         commandOption = it.next();
         assertEquals("OPTION2", commandOption.getCommand());
-        assertEquals(null, commandOption.getLabel());
+        assertNull(commandOption.getLabel());
         commandOption = it.next();
         assertEquals("3", commandOption.getCommand());
         assertEquals("Option 3", commandOption.getLabel());

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -111,10 +111,10 @@ public class MetadataStateDescriptionFragmentProviderTest {
         Iterator<StateOption> it = stateDescriptionFragment.getOptions().iterator();
         StateOption stateOption = it.next();
         assertEquals("OPTION1", stateOption.getValue());
-        assertEquals(null, stateOption.getLabel());
+        assertNull(stateOption.getLabel());
         stateOption = it.next();
         assertEquals("OPTION2", stateOption.getValue());
-        assertEquals(null, stateOption.getLabel());
+        assertNull(stateOption.getLabel());
         stateOption = it.next();
         assertEquals("3", stateOption.getValue());
         assertEquals("Option 3", stateOption.getLabel());

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
@@ -31,10 +31,11 @@ public class DecimalTypeTest {
         DecimalType dt3 = new DecimalType("99.7");
         PercentType pt = new PercentType("99.7");
 
-        assertEquals(true, dt1.equals(dt2));
-        assertEquals(false, dt1.equals(dt3));
-        assertEquals(true, dt3.equals(pt));
-        assertEquals(false, dt1.equals(pt));
+        // Do not change to assertEquals(), because we want to check if .equals() works as expected!
+        assertTrue(dt1.equals(dt2));
+        assertFalse(dt1.equals(dt3));
+        assertTrue(dt3.equals(pt));
+        assertFalse(dt1.equals(pt));
     }
 
     @Test
@@ -137,6 +138,6 @@ public class DecimalTypeTest {
     @Test
     public void testConversionToPointType() {
         // should not be possible => null
-        assertEquals(null, new DecimalType("0.23").as(PointType.class));
+        assertNull(new DecimalType("0.23").as(PointType.class));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.library.types;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -43,7 +44,7 @@ public class OnOffTypeTest {
     @Test
     public void testConversionToPointType() {
         // should not be possible => null
-        assertEquals(null, OnOffType.ON.as(PointType.class));
-        assertEquals(null, OnOffType.OFF.as(PointType.class));
+        assertNull(OnOffType.ON.as(PointType.class));
+        assertNull(OnOffType.OFF.as(PointType.class));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OpenClosedTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OpenClosedTypeTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.library.types;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ public class OpenClosedTypeTest {
     @Test
     public void testConversionToPointType() {
         // should not be possible => null
-        assertEquals(null, OpenClosedType.CLOSED.as(PointType.class));
-        assertEquals(null, OpenClosedType.OPEN.as(PointType.class));
+        assertNull(OpenClosedType.CLOSED.as(PointType.class));
+        assertNull(OpenClosedType.OPEN.as(PointType.class));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
@@ -51,9 +51,10 @@ public class PercentTypeTest {
         PercentType pt3 = new PercentType(0);
         PercentType pt4 = new PercentType(0);
 
-        assertEquals(true, pt1.equals(pt2));
-        assertEquals(true, pt3.equals(pt4));
-        assertEquals(false, pt3.equals(pt1));
+        // Do not change to assertEquals(), because we want to check if .equals() works as expected!
+        assertTrue(pt1.equals(pt2));
+        assertTrue(pt3.equals(pt4));
+        assertFalse(pt3.equals(pt1));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringTypeTest.java
@@ -35,7 +35,7 @@ public class StringTypeTest {
 
         assertEquals(expected1.hashCode(), new StringType("expected1").hashCode());
         assertEquals(expected2.hashCode(), new StringType("expected2").hashCode());
-        assertFalse(expected1.hashCode() == new StringType("expected2").hashCode());
+        assertNotEquals(expected1.hashCode(), new StringType("expected2").hashCode());
 
         assertEquals(empty, StringType.EMPTY);
         assertEquals(empty, new StringType(""));
@@ -44,16 +44,19 @@ public class StringTypeTest {
 
         assertEquals(expected1, new StringType("expected1"));
         assertEquals(expected2, new StringType("expected2"));
-        assertEquals(false, expected1.equals(new StringType("expected2")));
-        assertEquals(false, expected2.equals(new StringType("expected1")));
-        assertEquals(false, expected1.equals(StringType.EMPTY));
-        assertEquals(false, expected2.equals(StringType.EMPTY));
+        // Do not change to assertEquals(), because we want to check if .equals() works as expected!
+        assertFalse(expected1.equals(new StringType("expected2")));
+        assertFalse(expected2.equals(new StringType("expected1")));
+        assertFalse(expected1.equals(StringType.EMPTY));
+        assertFalse(expected2.equals(StringType.EMPTY));
 
-        assertEquals(true, expected1.equals("expected1"));
-        assertEquals(false, expected1.equals("expected2"));
+        // Do not change to assertEquals(), because we want to check if .equals() works as expected!
+        assertTrue(expected1.equals("expected1"));
+        assertFalse(expected1.equals("expected2"));
 
-        assertEquals(true, new StringType(null).equals(new StringType(null)));
-        assertEquals(true, new StringType("").equals(new StringType(null)));
-        assertEquals(true, new StringType(null).equals(new StringType("")));
+        // Do not change to assertEquals(), because we want to check if .equals() works as expected!
+        assertTrue(new StringType(null).equals(new StringType(null)));
+        assertTrue(new StringType("").equals(new StringType(null)));
+        assertTrue(new StringType(null).equals(new StringType("")));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/UpDownTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/UpDownTypeTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.library.types;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ public class UpDownTypeTest {
     @Test
     public void testConversionToPointType() {
         // should not be possible => null
-        assertEquals(null, UpDownType.UP.as(PointType.class));
-        assertEquals(null, UpDownType.DOWN.as(PointType.class));
+        assertNull(UpDownType.UP.as(PointType.class));
+        assertNull(UpDownType.DOWN.as(PointType.class));
     }
 }

--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -251,10 +251,10 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
         ZonedDateTime sunday = ZonedDateTime.of(2019, 10, 27, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
         ephemerisManager.modified(Collections.singletonMap(CONFIG_DAYSET_PREFIX + INTERNAL_DAYSET,
                 Stream.of("Monday", "Tuesday").collect(Collectors.toList())));
-        assertEquals(true, ephemerisManager.isWeekend(sunday));
-        assertEquals(false, ephemerisManager.isWeekend(monday));
-        assertEquals(true, ephemerisManager.isInDayset(INTERNAL_DAYSET, monday));
-        assertEquals(false, ephemerisManager.isInDayset(INTERNAL_DAYSET, sunday));
+        assertTrue(ephemerisManager.isWeekend(sunday));
+        assertFalse(ephemerisManager.isWeekend(monday));
+        assertTrue(ephemerisManager.isInDayset(INTERNAL_DAYSET, monday));
+        assertFalse(ephemerisManager.isInDayset(INTERNAL_DAYSET, sunday));
     }
 
     @Test
@@ -263,10 +263,10 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
         ZonedDateTime secondday = ZonedDateTime.of(2019, 01, 02, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
 
         boolean vacation = ephemerisManager.isBankHoliday(newyearsday);
-        assertEquals(true, vacation);
+        assertTrue(vacation);
 
         vacation = ephemerisManager.isBankHoliday(secondday);
-        assertEquals(false, vacation);
+        assertFalse(vacation);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
         ZonedDateTime theDay = ZonedDateTime.of(2019, 01, 01, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
 
         boolean vacation = ephemerisManager.isBankHoliday(theDay);
-        assertEquals(true, vacation);
+        assertTrue(vacation);
 
         String code = ephemerisManager.getBankHolidayName(theDay);
         assertEquals("NEW_YEAR", code);
@@ -308,7 +308,7 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
         ZonedDateTime theDay = ZonedDateTime.of(2019, 10, 31, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
 
         boolean vacation = ephemerisManager.isBankHoliday(theDay, url);
-        assertEquals(true, vacation);
+        assertTrue(vacation);
 
         long delay = ephemerisManager.getDaysUntil(today, "Halloween", url);
         assertEquals(3, delay);

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
@@ -342,7 +342,7 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
     public void testNoXbaseConflicts() throws ScriptParsingException, ScriptExecutionException {
         assertEquals(42, (int) runScript("(1..3).forEach[x |println(x)]; return 42;"));
         assertEquals(42, (int) runScript("92 % 50"));
-        assertEquals(true, (boolean) runScript("1 == 1 || 1 != 2"));
+        assertTrue((boolean) runScript("1 == 1 || 1 != 2"));
         assertEquals("\\", runScript("return \"\\\\\""));
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -220,7 +220,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         linkRegistry.add(link);
         //
         final Collection<Item> items = itemRegistry.getItems();
-        assertEquals(false, items.isEmpty());
+        assertFalse(items.isEmpty());
 
         Item item = itemRegistry.getItem("TestItem1");
         assertEquals(CoreItemFactory.NUMBER, item.getType());
@@ -283,7 +283,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         linkRegistry.add(link);
         //
         final Collection<Item> items = itemRegistry.getItems();
-        assertEquals(false, items.isEmpty());
+        assertFalse(items.isEmpty());
 
         Item item = itemRegistry.getItem("TestItem7_2");
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -253,7 +253,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         linkRegistry.add(link);
         //
         final Collection<Item> items = itemRegistry.getItems();
-        assertEquals(false, items.isEmpty());
+        assertFalse(items.isEmpty());
 
         Item item = itemRegistry.getItem("TestItem");
         assertEquals(CoreItemFactory.NUMBER, item.getType());
@@ -265,7 +265,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(BigDecimal.valueOf(100), state.getMaximum());
         assertEquals(BigDecimal.TEN, state.getStep());
         assertEquals("%d Peek", state.getPattern());
-        assertEquals(true, state.isReadOnly());
+        assertTrue(state.isReadOnly());
         List<StateOption> opts = state.getOptions();
         assertEquals(1, opts.size());
         final StateOption opt = opts.get(0);
@@ -282,7 +282,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(BigDecimal.valueOf(256), state.getMaximum());
         assertEquals(BigDecimal.valueOf(8), state.getStep());
         assertEquals("%.0f", state.getPattern());
-        assertEquals(false, state.isReadOnly());
+        assertFalse(state.isReadOnly());
         opts = state.getOptions();
         assertEquals(0, opts.size());
 
@@ -296,7 +296,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertNull(state.getMaximum());
         assertNull(state.getStep());
         assertEquals("%s", state.getPattern());
-        assertEquals(false, state.isReadOnly());
+        assertFalse(state.isReadOnly());
         opts = state.getOptions();
         assertEquals(0, opts.size());
 
@@ -328,7 +328,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(BigDecimal.valueOf(100), state.getMaximum());
         assertEquals(BigDecimal.valueOf(5), state.getStep());
         assertEquals("VALUE %d", state.getPattern());
-        assertEquals(false, state.isReadOnly());
+        assertFalse(state.isReadOnly());
 
         opts = state.getOptions();
         assertNotNull(opts);
@@ -352,7 +352,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(BigDecimal.valueOf(101), state.getMaximum());
         assertEquals(BigDecimal.valueOf(20), state.getStep());
         assertEquals("NEW %d Peek", state.getPattern());
-        assertEquals(false, state.isReadOnly());
+        assertFalse(state.isReadOnly());
 
         opts = state.getOptions();
         assertNotNull(opts);
@@ -381,7 +381,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         linkRegistry.add(link);
         //
         final Collection<Item> items = itemRegistry.getItems();
-        assertEquals(false, items.isEmpty());
+        assertFalse(items.isEmpty());
 
         Item item = itemRegistry.getItem("TestItem7_2");
 
@@ -392,7 +392,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         assertEquals(BigDecimal.valueOf(101), state.getMaximum());
         assertEquals(BigDecimal.valueOf(20), state.getStep());
         assertEquals("NEW %d Peek", state.getPattern());
-        assertEquals(false, state.isReadOnly());
+        assertFalse(state.isReadOnly());
 
         List<StateOption> opts = state.getOptions();
         assertNotNull(opts);


### PR DESCRIPTION
Simplifies JUnit assertions with `assertEquals()` where the expected parameter is `true` or `false`, replacing them with `assertTrue()` or `assertFalse()`.
Also simplifies `assertEquals()` with null parameter (assertions against null) by replacing the function with `assertNull()`.