### PR TITLE
REST: add runtime info to root resource response

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
@@ -82,7 +82,7 @@ public class RootResource {
     }
 
     @GET
-    @ApiOperation(value = "Gets the API version and links to resources.")
+    @ApiOperation(value = "Gets information about the runtime, the API version and links to resources.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Object getRoot(@Context UriInfo uriInfo) {
         // key: path, value: name (this way we could ensure that ever path is added only once).

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.rest.internal.resources.beans;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.openhab.core.OpenHAB;
 import org.openhab.core.io.rest.RESTConstants;
 
 /**
@@ -22,12 +23,22 @@ import org.openhab.core.io.rest.RESTConstants;
  * page of the REST interface.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Yannick Schaus - Add runtime info
  */
 public class RootBean {
 
     public final String version = RESTConstants.API_VERSION;
 
+    public final RuntimeInfo runtimeInfo = new RuntimeInfo();
+
     public final List<Links> links = new ArrayList<>();
+
+    public static class RuntimeInfo {
+        public final String version = OpenHAB.getVersion();
+        public final String buildString = OpenHAB.buildString();
+        public final String configFolder = OpenHAB.getConfigFolder();
+        public final String userdataFolder = OpenHAB.getUserDataFolder();
+    }
 
     public static class Links {
         public Links(String type, String url) {


### PR DESCRIPTION
This adds basic information about the runtime in the response
to the root `/rest` API resource, mostly for display purposes
by UIs: the version, build string and the location of the
configuration and user data folders.

Signed-off-by: Yannick Schaus <github@schaus.net>