### PR TITLE
Added shortcut method 'Channelbuilder.create(ChannelUID)', Enhanced JavaDoc for 'ChannelBuilder'

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
@@ -37,7 +38,7 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 public class ChannelBuilder {
 
     private final ChannelUID channelUID;
-    private @Nullable final String acceptedItemType;
+    private @Nullable String acceptedItemType;
     private ChannelKind kind;
     private @Nullable Configuration configuration;
     private Set<String> defaultTags;
@@ -55,9 +56,19 @@ public class ChannelBuilder {
     }
 
     /**
-     * Creates a channel builder for the given channel UID and item type.
+     * Creates a {@link ChannelBuilder} for the given {@link ChannelUID}.
      *
-     * @param channelUID channel UID
+     * @param channelUID the {@link ChannelUID}
+     * @return channel builder
+     */
+    public static ChannelBuilder create(ChannelUID channelUID) {
+        return new ChannelBuilder(channelUID, null, new HashSet<>());
+    }
+
+    /**
+     * Creates a {@link ChannelBuilder} for the given {@link ChannelUID} and item type.
+     *
+     * @param channelUID the {@link ChannelUID}
      * @param acceptedItemType item type that is accepted by this channel
      * @return channel builder
      */
@@ -66,7 +77,7 @@ public class ChannelBuilder {
     }
 
     /**
-     * Creates a channel builder from the given channel.
+     * Creates a {@link ChannelBuilder} from the given {@link Channel}.
      *
      * @param channel the channel to be changed
      * @return channel builder
@@ -88,9 +99,9 @@ public class ChannelBuilder {
     }
 
     /**
-     * Appends the channel type to the channel to build
+     * Appends the {@link ChannelType} given by its {@link ChannelTypeUID} to the {@link Channel} to be build
      *
-     * @param channelTypeUID channel type UID
+     * @param channelTypeUID the {@link ChannelTypeUID}
      * @return channel builder
      */
     public ChannelBuilder withType(@Nullable ChannelTypeUID channelTypeUID) {
@@ -99,9 +110,9 @@ public class ChannelBuilder {
     }
 
     /**
-     * Appends a configuration to the channel to build.
+     * Appends a {@link Configuration} to the {@link Channel} to be build.
      *
-     * @param configuration configuration
+     * @param configuration the {@link Configuration}
      * @return channel builder
      */
     public ChannelBuilder withConfiguration(Configuration configuration) {
@@ -110,7 +121,7 @@ public class ChannelBuilder {
     }
 
     /**
-     * Adds properties to the channel
+     * Adds properties to the {@link Channel}.
      *
      * @param properties properties to add
      * @return channel builder
@@ -121,7 +132,7 @@ public class ChannelBuilder {
     }
 
     /**
-     * Sets the channel label. This allows overriding of the default label set in the {@link ChannelType}
+     * Sets the channel label. This allows overriding of the default label set in the {@link ChannelType}.
      *
      * @param label the channel label to override the label set in the {@link ChannelType}
      * @return channel builder
@@ -132,9 +143,9 @@ public class ChannelBuilder {
     }
 
     /**
-     * Sets the channel label. This allows overriding of the default label set in the {@link ChannelType}
+     * Sets the channel description. This allows overriding of the default description set in the {@link ChannelType}.
      *
-     * @param label the channel label to override the label set in the {@link ChannelType}
+     * @param label the channel label to override the description set in the {@link ChannelType}
      * @return channel builder
      */
     public ChannelBuilder withDescription(String description) {
@@ -143,7 +154,7 @@ public class ChannelBuilder {
     }
 
     /**
-     * Appends default tags to the channel to build.
+     * Appends default tags to the {@link Channel} to be build.
      *
      * @param defaultTags default tags
      * @return channel builder
@@ -154,24 +165,35 @@ public class ChannelBuilder {
     }
 
     /**
-     * Sets the kind of the channel.
+     * Sets the {@link ChannelKind} of the {@link Channel} to be build.
      *
-     * @param kind kind.
+     * @param kind the {@link ChannelKind}
      * @return channel builder
      */
     public ChannelBuilder withKind(ChannelKind kind) {
         if (kind == null) {
-            throw new IllegalArgumentException("kind must not be null");
+            throw new IllegalArgumentException("'ChannelKind' must not be null");
         }
-
         this.kind = kind;
         return this;
     }
 
     /**
-     * Sets the auto update policy. See {@link AutoUpdatePolicy} for details.
+     * Sets the accepted item type of the {@link Channel} to be build. See
+     * {@link CoreItemFactory#getSupportedItemTypes()} for a list of available item types.
      *
-     * @param policy the auto update policy to use
+     * @param acceptedItemType item type that is accepted by this channel
+     * @return channel builder
+     */
+    public ChannelBuilder withAcceptedItemType(@Nullable String acceptedItemType) {
+        this.acceptedItemType = acceptedItemType;
+        return this;
+    }
+
+    /**
+     * Sets the {@link AutoUpdatePolicy} to the {@link Channel} to be build.
+     *
+     * @param policy the {@link AutoUpdatePolicy} to be used
      * @return channel builder
      */
     public ChannelBuilder withAutoUpdatePolicy(@Nullable AutoUpdatePolicy policy) {
@@ -180,10 +202,11 @@ public class ChannelBuilder {
     }
 
     /**
-     * Builds and returns the channel.
+     * Builds and returns the {@link Channel}.
      *
-     * @return channel
+     * @return the {@link Channel}
      */
+    @SuppressWarnings("deprecation")
     public Channel build() {
         return new Channel(channelUID, channelTypeUID, acceptedItemType, kind, configuration, defaultTags, properties,
                 label, description, autoUpdatePolicy);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
@@ -54,7 +54,7 @@ public class ThingBuilder {
     }
 
     public static ThingBuilder create(ThingTypeUID thingTypeUID, String thingId) {
-        return new ThingBuilder(thingTypeUID, new ThingUID(thingTypeUID.getBindingId(), thingTypeUID.getId(), thingId));
+        return new ThingBuilder(thingTypeUID, new ThingUID(thingTypeUID, thingId));
     }
 
     public static ThingBuilder create(ThingTypeUID thingTypeUID, ThingUID thingUID) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ChannelBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ChannelBuilderTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing.binding.builder;
 
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.SYSTEM_OUTDOOR_TEMPERATURE;
 
@@ -22,6 +23,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ThingTypeUID;
@@ -66,7 +68,7 @@ public class ChannelBuilderTest {
     public void testChannelBuilder() {
         assertThat(channel.getAcceptedItemType(), is(SYSTEM_OUTDOOR_TEMPERATURE.getItemType()));
         assertThat(channel.getChannelTypeUID(), is(SYSTEM_OUTDOOR_TEMPERATURE.getUID()));
-        assertThat(channel.getDefaultTags().size(), is(0));
+        assertThat(channel.getDefaultTags(), hasSize(0));
         assertThat(channel.getDescription(), is("My test channel"));
         assertThat(channel.getKind(), is(ChannelKind.STATE));
         assertThat(channel.getLabel(), is("Test"));
@@ -82,7 +84,7 @@ public class ChannelBuilderTest {
         assertThat(otherChannel.getAcceptedItemType(), is(channel.getAcceptedItemType()));
         assertThat(otherChannel.getChannelTypeUID(), is(channel.getChannelTypeUID()));
         assertThat(otherChannel.getConfiguration(), is(channel.getConfiguration()));
-        assertThat(otherChannel.getDefaultTags().size(), is(channel.getDefaultTags().size()));
+        assertThat(otherChannel.getDefaultTags(), hasSize(channel.getDefaultTags().size()));
         assertThat(otherChannel.getDescription(), is(channel.getDescription()));
         assertThat(otherChannel.getKind(), is(channel.getKind()));
         assertThat(otherChannel.getLabel(), is(channel.getLabel()));
@@ -95,10 +97,11 @@ public class ChannelBuilderTest {
     @Test
     public void subsequentBuildsCreateIndependentChannels() {
         Channel otherChannel = builder.withLabel("Second Test").withDescription("My second test channel")
-                .withProperties(Collections.emptyMap()).build();
+                .withAcceptedItemType(CoreItemFactory.NUMBER).withProperties(Collections.emptyMap()).build();
 
         assertThat(otherChannel.getDescription(), is(not(channel.getDescription())));
         assertThat(otherChannel.getLabel(), is(not(channel.getLabel())));
+        assertThat(otherChannel.getAcceptedItemType(), is(not(channel.getAcceptedItemType())));
         assertThat(otherChannel.getProperties().size(), is(not(channel.getProperties().size())));
     }
 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingBuilderTest.java
@@ -70,29 +70,29 @@ public class ThingBuilderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithChannelDuplicates() {
-        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build());
-        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build());
+        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build());
+        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithChannelsDuplicatesCollections() {
         thingBuilder.withChannels(Arrays.asList( //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(), //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build()));
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build(), //
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build()));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWithChannelsDuplicatesVararg() {
         thingBuilder.withChannels( //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(), //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build());
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build(), //
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build());
     }
 
     @Test
     public void testWithoutChannel() {
         thingBuilder.withChannels( //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(), //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build());
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build(), //
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2")).build());
         thingBuilder.withoutChannel(new ChannelUID(THING_UID, "channel1"));
         Thing thing = thingBuilder.build();
         assertThat(thing.getChannels(), hasSize(1));
@@ -102,8 +102,8 @@ public class ThingBuilderTest {
     @Test
     public void testWithoutChannelMissing() {
         thingBuilder.withChannels( //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(), //
-                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build());
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1")).build(), //
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2")).build());
         thingBuilder.withoutChannel(new ChannelUID(THING_UID, "channel3"));
         assertThat(thingBuilder.build().getChannels(), hasSize(2));
     }
@@ -111,7 +111,7 @@ public class ThingBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void testWithChannelWrongThing() {
         thingBuilder.withChannel(
-                ChannelBuilder.create(new ChannelUID(new ThingUID(THING_TYPE_UID, "wrong"), "channel1"), "").build());
+                ChannelBuilder.create(new ChannelUID(new ThingUID(THING_TYPE_UID, "wrong"), "channel1")).build());
     }
 
     @Test

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -35,6 +35,7 @@ import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.items.events.ItemStateEvent;
 import org.openhab.core.items.events.ItemStatePredictedEvent;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.ChannelUID;
@@ -98,16 +99,16 @@ public class AutoUpdateManagerTest {
         when(onlineThingMock.getHandler()).thenReturn(handlerMock);
         when(onlineThingMock.getStatus()).thenReturn(ThingStatus.ONLINE);
         when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_1.getId())))
-                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_1, "String")
+                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_1, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_ONLINE_1)).build());
         when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_2.getId())))
-                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_2, "String")
+                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_2, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_ONLINE_2)).build());
 
         when(offlineThingMock.getHandler()).thenReturn(handlerMock);
         when(offlineThingMock.getStatus()).thenReturn(ThingStatus.OFFLINE);
         when(offlineThingMock.getChannel(eq(CHANNEL_UID_OFFLINE_1.getId())))
-                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_OFFLINE_1, "String")
+                .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_OFFLINE_1, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_OFFLINE_1)).build());
 
         aum = new AutoUpdateManager(new HashMap<>(), channelTypeRegistryMock, eventPublisherMock, iclRegistryMock,

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -57,6 +57,7 @@ import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventSubscriber;
 import org.openhab.core.i18n.TranslationProvider;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.ChannelUID;
@@ -427,8 +428,8 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         @Override
         public void initialize() {
             ThingBuilder thingBuilder = editThing();
-            thingBuilder
-                    .withChannel(ChannelBuilder.create(new ChannelUID("bindingId:type:thingId:1"), "String").build());
+            thingBuilder.withChannel(
+                    ChannelBuilder.create(new ChannelUID("bindingId:type:thingId:1"), CoreItemFactory.STRING).build());
             updateThing(thingBuilder.build());
             updateStatus(ThingStatus.ONLINE);
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -125,13 +125,13 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     private static final ItemChannelLink LINK_1_T2 = new ItemChannelLink(ITEM_NAME_1, TRIGGER_CHANNEL_UID_2);
     private static final ItemChannelLink LINK_2_T2 = new ItemChannelLink(ITEM_NAME_2, TRIGGER_CHANNEL_UID_2);
     private static final Thing THING = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(
-            ChannelBuilder.create(STATE_CHANNEL_UID_1, "").withKind(ChannelKind.STATE).build(),
-            ChannelBuilder.create(STATE_CHANNEL_UID_2, "").withKind(ChannelKind.STATE).build(),
+            ChannelBuilder.create(STATE_CHANNEL_UID_1).withKind(ChannelKind.STATE).build(),
+            ChannelBuilder.create(STATE_CHANNEL_UID_2).withKind(ChannelKind.STATE).build(),
             ChannelBuilder.create(STATE_CHANNEL_UID_3, "Number:Temperature").withKind(ChannelKind.STATE).build(),
-            ChannelBuilder.create(STATE_CHANNEL_UID_4, "Number").withKind(ChannelKind.STATE)
+            ChannelBuilder.create(STATE_CHANNEL_UID_4, CoreItemFactory.NUMBER).withKind(ChannelKind.STATE)
                     .withType(CHANNEL_TYPE_UID_4).build(),
-            ChannelBuilder.create(TRIGGER_CHANNEL_UID_1, "").withKind(ChannelKind.TRIGGER).build(),
-            ChannelBuilder.create(TRIGGER_CHANNEL_UID_2, "").withKind(ChannelKind.TRIGGER).build()).build();
+            ChannelBuilder.create(TRIGGER_CHANNEL_UID_1).withKind(ChannelKind.TRIGGER).build(),
+            ChannelBuilder.create(TRIGGER_CHANNEL_UID_2).withKind(ChannelKind.TRIGGER).build()).build();
 
     private @Mock @NonNullByDefault({}) AutoUpdateManager autoUpdateManagerMock;
     private @Mock @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistryMock;
@@ -514,8 +514,9 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
     @Test
     public void testItemCommandEventTypeDowncast() {
-        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannels(ChannelBuilder.create(STATE_CHANNEL_UID_2, "Dimmer").withKind(ChannelKind.STATE).build())
+        Thing thing = ThingBuilder
+                .create(THING_TYPE_UID, THING_UID).withChannels(ChannelBuilder
+                        .create(STATE_CHANNEL_UID_2, CoreItemFactory.DIMMER).withKind(ChannelKind.STATE).build())
                 .build();
         thing.setHandler(thingHandlerMock);
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);
@@ -534,8 +535,9 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
     @Test
     public void testItemStateEventTypeDowncast() {
-        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannels(ChannelBuilder.create(STATE_CHANNEL_UID_2, "Dimmer").withKind(ChannelKind.STATE).build())
+        Thing thing = ThingBuilder
+                .create(THING_TYPE_UID, THING_UID).withChannels(ChannelBuilder
+                        .create(STATE_CHANNEL_UID_2, CoreItemFactory.DIMMER).withKind(ChannelKind.STATE).build())
                 .build();
         thing.setHandler(thingHandlerMock);
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -54,6 +54,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.items.events.ItemStateEvent;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.StringType;
@@ -131,8 +132,10 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
     @Before
     @SuppressWarnings("null")
     public void setUp() {
-        thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(ChannelBuilder.create(CHANNEL_UID, "Switch")
-                .withKind(ChannelKind.STATE).withType(CHANNEL_TYPE_UID).build()).build();
+        thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
+                .withChannels(ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.SWITCH).withKind(ChannelKind.STATE)
+                        .withType(CHANNEL_TYPE_UID).build())
+                .build();
 
         registerVolatileStorageService();
 
@@ -309,7 +312,8 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         registerThingTypeProvider();
 
         Thing thing2 = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannels(singletonList(ChannelBuilder.create(CHANNEL_UID, "Switch").build())).build();
+                .withChannels(singletonList(ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.SWITCH).build()))
+                .build();
 
         class ThingHandlerState {
             boolean raceCondition;
@@ -889,7 +893,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         receivedEvents.clear();
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannel(ChannelBuilder.create(CHANNEL_UID, "Switch").build()).build();
+                .withChannel(ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.SWITCH).build()).build();
         managedThingProvider.update(thing);
 
         state.callback.stateUpdated(CHANNEL_UID, new StringType("Value"));

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.ManagedThingProvider;
@@ -54,7 +55,7 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
         registerVolatileStorageService();
         managedThingProvider = getService(ManagedThingProvider.class);
         managedThingProvider.add(ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannel(ChannelBuilder.create(CHANNEL_UID, "Color").build()).build());
+                .withChannel(ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.COLOR).build()).build());
         itemChannelLinkRegistry = getService(ItemChannelLinkRegistry.class);
         managedItemChannelLinkProvider = getService(ManagedItemChannelLinkProvider.class);
         assertNotNull(managedItemChannelLinkProvider);


### PR DESCRIPTION
- Added `Channelbuilder.create(ChannelUID)` method -> as a consequence we additionally need a `withAcceptedItemType(String)` method
- Enhanced JavaDoc for `ChannelBuilder` 

Follow-up of discussion in https://github.com/openhab/openhab-addons/pull/6678#discussion_r457121894 and ff.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>