### PR TITLE
Fix QuantityType.format timezone bug

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -249,7 +249,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             if (millis != null) {
                 try {
                     return String.format(formatPattern,
-                            ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis.longValue()), ZoneId.systemDefault()));
+                            ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis.longValue()), ZoneId.of("UTC")));
                 } catch (IllegalFormatConversionException ifce) {
                     // The conversion is not valid for the type ZonedDateTime. This happens, if the format is like
                     // "%.1f". Fall through to default behavior.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -16,7 +16,7 @@ import static org.eclipse.jdt.annotation.DefaultLocation.*;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.IllegalFormatConversionException;
@@ -249,7 +249,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             if (millis != null) {
                 try {
                     return String.format(formatPattern,
-                            ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis.longValue()), ZoneId.of("UTC")));
+                            ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis.longValue()), ZoneOffset.UTC));
                 } catch (IllegalFormatConversionException ifce) {
                     // The conversion is not valid for the type ZonedDateTime. This happens, if the format is like
                     // "%.1f". Fall through to default behavior.


### PR DESCRIPTION
The following asserts failed for me when building in CEST:


```
        assertThat(seconds.format("%1$tH:%1$tM:%1$tS"), is("00:01:20"));
        assertThat(millis.format("%1$tHh %1$tMm %1$tSs"), is("00h 01m 20s"));
```

In the original code it would convert the quantity to my timezone by adding 1h and thus formatting the 80s quantity as `01:01:20` and `01h 01m 20s` respectively.

Caused by #1470