### PR TITLE
Use version range for Super POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab</groupId>
     <artifactId>openhab-super-pom</artifactId>
-    <version>1.0.2</version>
+    <version>[1.0, 2.0)</version>
   </parent>
 
   <groupId>org.openhab.core</groupId>


### PR DESCRIPTION
I would suggest to use the version range for the Super POM here as well - like we do it in all other repositories (e.g. [here ](https://github.com/openhab/openhab-addons/blob/2.5.x/pom.xml#L7 ) and [here](https://github.com/openhab/openhab-distro/blob/2.5.x/pom.xml#L7)).

Signed-off-by: Patrick Fink <mail@pfink.de>