### PR TITLE
Exclude transitive activation-api dependency from swagger

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -235,6 +235,12 @@
       <artifactId>swagger-jaxrs2</artifactId>
       <version>${swagger.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- XStream -->


### PR DESCRIPTION
This newer version would make bnd resolve the lower bound to 1.2 instead of 1.1 for add-ons.

See: https://github.com/openhab/openhab-core/pull/1576#issuecomment-670972932