### PR TITLE
reduced log levels of ExecUtil

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -85,9 +85,10 @@ public class ExecUtil {
                 logger.debug("exit code '{}', result '{}'", exitCode, result);
                 return result.toString();
             } catch (IOException e) {
-                logger.warn("I/O exception occurred when executing commandLine '{}'", commandLine, e);
+                logger.debug("I/O exception occurred when executing commandLine '{}'", commandLine, e);
             } catch (InterruptedException e) {
-                logger.warn("Timeout occurred when executing commandLine '{}'", commandLine, e);
+                logger.warn("Timeout occurred when executing commandLine '{}'", commandLine);
+                logger.debug("{}", e);
             }
         }
         return null;
@@ -99,13 +100,13 @@ public class ExecUtil {
             if (commandLine.contains(CMD_LINE_DELIMITER)) {
                 final List<String> cmdArray = Arrays.asList(commandLine.split(CMD_LINE_DELIMITER));
                 process = new ProcessBuilder(cmdArray).start();
-                logger.info("executed commandLine '{}'", cmdArray);
+                logger.debug("executed commandLine '{}'", cmdArray);
             } else {
                 process = new ProcessBuilder(commandLine).start();
-                logger.info("executed commandLine '{}'", commandLine);
+                logger.debug("executed commandLine '{}'", commandLine);
             }
         } catch (IOException e) {
-            logger.error("couldn't execute commandLine '{}'", commandLine, e);
+            logger.debug("couldn't execute commandLine '{}'", commandLine, e);
             return null;
         }
         return process;

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -88,7 +88,7 @@ public class ExecUtil {
                 logger.debug("I/O exception occurred when executing commandLine '{}'", commandLine, e);
             } catch (InterruptedException e) {
                 logger.warn("Timeout occurred when executing commandLine '{}'", commandLine);
-                logger.debug("{}", e);
+                logger.debug("{}", e.getMessage(), e);
             }
         }
         return null;


### PR DESCRIPTION
This PR reduces some aggressive log levels that had been introduced with https://github.com/openhab/openhab-core/pull/1359. They cause stack traces to occur when code is testing whether a certain command is available, like the network binding is doing:
```
2020-08-10 22:21:08.205 [ERROR] [rg.openhab.core.io.net.exec.ExecUtil] - couldn't execute commandLine 'arping --help'
java.io.IOException: Cannot run program "arping --help": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1128) ~[?:?]
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1071) ~[?:?]
	at org.openhab.core.io.net.exec.ExecUtil.internalExecute(ExecUtil.java:104) [bundleFile:?]
	at org.openhab.core.io.net.exec.ExecUtil.executeCommandLineAndWaitResponse(ExecUtil.java:72) [bundleFile:?]
	at org.openhab.binding.network.internal.utils.NetworkUtils.determineNativeARPpingMethod(NetworkUtils.java:188) [bundleFile:?]
```

I hence consider this a regression and reducing the log levels should fix this again.

Signed-off-by: Kai Kreuzer <kai@openhab.org>