### PR TITLE
re-added log action to script scope and cleaned up imported extensions

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Log.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Log.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Thomas Eichstaedt-Engelen - Initial contribution
  */
-public class LogAction {
+public class Log {
 
     private static final String LOGGER_NAME_PREFIX = "org.openhab.core.model.script.";
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -28,6 +28,7 @@ import org.openhab.core.library.unit.SmartHomeUnits;
 import org.openhab.core.model.script.actions.BusEvent;
 import org.openhab.core.model.script.actions.Exec;
 import org.openhab.core.model.script.actions.HTTP;
+import org.openhab.core.model.script.actions.Log;
 import org.openhab.core.model.script.actions.Ping;
 import org.openhab.core.model.script.actions.ScriptExecution;
 import org.openhab.core.model.script.engine.IActionServiceProvider;
@@ -69,11 +70,6 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.remove(double.class);
         result.add(NumberExtensions.class);
         result.add(URLEncoder.class);
-        result.add(ScriptExecution.class);
-        result.add(BusEvent.class);
-        result.add(Exec.class);
-        result.add(HTTP.class);
-        result.add(Ping.class);
 
         result.addAll(getActionClasses());
         return result;
@@ -86,6 +82,7 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(BusEvent.class);
         result.add(Exec.class);
         result.add(HTTP.class);
+        result.add(Log.class);
         result.add(Ping.class);
 
         result.add(ImperialUnits.class);

--- a/tools/static-code-analysis/spotbugs/suppressions.xml
+++ b/tools/static-code-analysis/spotbugs/suppressions.xml
@@ -26,7 +26,7 @@
   </Match>
   <!-- The format string is parameter, it can't be constant -->
   <Match>
-    <Class name="org.openhab.core.model.script.actions.LogAction"/>
+    <Class name="org.openhab.core.model.script.actions.Log"/>
     <Bug pattern="SLF4J_FORMAT_SHOULD_BE_CONST"/>
   </Match>
   <Match>


### PR DESCRIPTION
The log feature in scripts got accidentially lost in https://github.com/openhab/openhab-core/pull/1588.

Additionally, I noticed that those classes only need to be added as static imports, but not as extensions. Extensions are merely used for operator overloading and stuff like that.

Signed-off-by: Kai Kreuzer <kai@openhab.org>