### PR TITLE
registered static methods as extensions

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -68,7 +68,14 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.remove(BigInteger.class);
         result.remove(BigDecimal.class);
         result.remove(double.class);
+
         result.add(NumberExtensions.class);
+
+        result.add(BusEvent.class);
+        result.add(HTTP.class);
+        result.add(Log.class);
+        result.add(Ping.class);
+        result.add(ScriptExecution.class);
         result.add(URLEncoder.class);
 
         result.addAll(getActionClasses());
@@ -78,12 +85,13 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
     @Override
     protected List<Class<?>> getStaticImportClasses() {
         List<Class<?>> result = super.getStaticImportClasses();
-        result.add(ScriptExecution.class);
         result.add(BusEvent.class);
         result.add(Exec.class);
         result.add(HTTP.class);
         result.add(Log.class);
         result.add(Ping.class);
+        result.add(ScriptExecution.class);
+        result.add(URLEncoder.class);
 
         result.add(ImperialUnits.class);
         result.add(MetricPrefix.class);


### PR DESCRIPTION
I just learned that [my latest learning](https://github.com/openhab/openhab-core/pull/1590#issue-467620666) was not fully correct. Statically imported methods can/should also be registered as extensions, if it is desired to have them made available as a method on the type of their first parameter. We specifically make use of this feature for sending commands by writing

```
MyItem.sendCommand(ON)
```
instead of
```
sendCommand(MyItem, ON)
```

I accidentially broke that feature with https://github.com/openhab/openhab-core/pull/1590, sorry for that.

It can be neat to have it for some of the other methods as well, so I re-added them again, where it makes sense.

Signed-off-by: Kai Kreuzer <kai@openhab.org>