### PR TITLE
Add dark mode support in authorize page

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/pages/authorize.html
+++ b/bundles/org.openhab.core.io.http.auth/pages/authorize.html
@@ -19,6 +19,19 @@ body {
 		Ubuntu, Cantarell, "Noto Sans", sans-serif, Helvetica, Arial,
 		sans-serif;
 }
+	
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: rgb(18, 18, 18);
+		color: white;
+	}
+	
+	input.field {
+		background-color: rgb(18, 18, 18);
+		color: white;
+		border-bottom: 1px solid #333 !important;
+	}
+}
 
 .logo {
 	margin-top: 3rem;
@@ -49,8 +62,14 @@ input.submit {
 	background-color: rgb(33, 150, 243);
 	color: white;
 	border-radius: 4px;
-	font-size: 11pt;
-	text-transform: uppercase;
+	font-size: 14px;
+	font-weight: 600;
+	padding-left: 1rem;
+	padding-right: 1rem;
+}
+	
+input.submit:hover {
+	background-color:rgb(72, 168, 245);
 }
 </style>
 </head>


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/309.
This only honors the scheme as reported by the `prefers-color-scheme` CSS media feature, i.e. local overrides for the main UI are not taken into account.

Tweak submit button styles to mimc the main UI's desktop theme.

Signed-off-by: Yannick Schaus <github@schaus.net>