### PR TITLE
Use TypeParser in ProfileCallbackImpl#sendUpdate for StringType state

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -137,6 +137,9 @@ public class ProfileCallbackImpl implements ProfileCallback {
         State acceptedState;
         if (state instanceof StringType && !(item instanceof StringItem)) {
             acceptedState = TypeParser.parseState(item.getAcceptedDataTypes(), state.toString());
+            if (acceptedState == null) {
+                acceptedState = state;
+            }
         } else {
             acceptedState = itemStateConverter.convertToAcceptedState(state, item);
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -19,6 +19,8 @@ import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemStateConverter;
 import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandler;
@@ -28,6 +30,7 @@ import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.util.ThingHandlerHelper;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.TypeParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,7 +134,12 @@ public class ProfileCallbackImpl implements ProfileCallback {
     @Override
     public void sendUpdate(State state) {
         Item item = itemProvider.apply(link.getItemName());
-        State acceptedState = itemStateConverter.convertToAcceptedState(state, item);
+        State acceptedState;
+        if (state instanceof StringType && !(item instanceof StringItem)) {
+            acceptedState = TypeParser.parseState(item.getAcceptedDataTypes(), state.toString());
+        } else {
+            acceptedState = itemStateConverter.convertToAcceptedState(state, item);
+        }
         eventPublisher.post(
                 ItemEventFactory.createStateEvent(link.getItemName(), acceptedState, link.getLinkedUID().toString()));
     }


### PR DESCRIPTION
Adding a call to the TypeParser in ProfileCallbackImpl#sendUpdate if the provided state is a StringType (which is what transform profiles return) and the linked item is not a StringItem. This should enable transform profiles to be used with other item types.

Fixes #1565 

Signed-off-by: Anders Alfredsson <andersb86@gmail.com>