### PR TITLE
[audio] fixed m3u and pls audio stream support

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -17,11 +17,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.Socket;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -67,22 +67,32 @@ public class URLAudioStream extends AudioStream {
         try {
             switch (extension) {
                 case M3U_EXTENSION:
-                    for (final String line : Files.readAllLines(Paths.get(URI.create(url)))) {
-                        if (!line.isEmpty() && !line.startsWith("#")) {
-                            url = line;
-                            break;
-                        }
-                    }
-                    break;
-                case PLS_EXTENSION:
-                    for (final String line : Files.readAllLines(Paths.get(URI.create(url)))) {
-                        if (!line.isEmpty() && line.startsWith("File")) {
-                            final Matcher matcher = PLS_STREAM_PATTERN.matcher(line);
-                            if (matcher.find()) {
-                                url = matcher.group(1);
+                    try (Scanner scanner = new Scanner(new URL(url).openStream(), StandardCharsets.UTF_8.name())) {
+                        while (true) {
+                            String line = scanner.nextLine();
+                            if (!line.isEmpty() && !line.startsWith("#")) {
+                                url = line;
                                 break;
                             }
                         }
+                    } catch (NoSuchElementException e) {
+                        // we reached the end of the file, this exception is thus expected
+                    }
+                    break;
+                case PLS_EXTENSION:
+                    try (Scanner scanner = new Scanner(new URL(url).openStream(), StandardCharsets.UTF_8.name())) {
+                        while (true) {
+                            String line = scanner.nextLine();
+                            if (!line.isEmpty() && line.startsWith("File")) {
+                                final Matcher matcher = PLS_STREAM_PATTERN.matcher(line);
+                                if (matcher.find()) {
+                                    url = matcher.group(1);
+                                    break;
+                                }
+                            }
+                        }
+                    } catch (NoSuchElementException e) {
+                        // we reached the end of the file, this exception is thus expected
                     }
                     break;
                 default:


### PR DESCRIPTION
#1441 replaced IOUtils by Java NIO2 Files - unfortunately, Java NIO2 does not support HTTP(S) URIs, see https://stackoverflow.com/questions/48490014/can-i-use-nio2-file-path-for-non-local-file-system-schemas and hence this broke the m3u and pls audio stream support when those are used as an URL (as [our demo files do](https://github.com/openhab/openhab-distro/blob/2.5.x/features/distro-resources/src/main/resources/rules/demo.rules#L159-L160)).

This PR replaces Java NIO2 by a simple `Scanner`, which works quite well.

Signed-off-by: Kai Kreuzer <kai@openhab.org>