### PR TITLE
[audio] fixed reading master volume on macOS

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
@@ -187,7 +187,7 @@ public class JavaSoundAudioSink implements AudioSink {
                         .exec(new String[] { "osascript", "-e", "output volume of (get volume settings)" });
                 String value = null;
                 try (Scanner scanner = new Scanner(p.getInputStream(), StandardCharsets.UTF_8.name())) {
-                    value = scanner.useDelimiter("\\A").next();
+                    value = scanner.useDelimiter("\\A").next().strip();
                 }
                 try {
                     cachedVolume = new PercentType(value);


### PR DESCRIPTION
`value` had a new line at the end, which caused the `PercentType` constructor to fail.

Signed-off-by: Kai Kreuzer <kai@openhab.org>