### PR TITLE
[automation] ensure that DSLScriptContextProvider is injected whenever available

### DIFF
--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngineFactory.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngineFactory.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * An implementation of {@link ScriptEngineFactory} for DSL scripts.
@@ -40,7 +41,7 @@ public class DSLScriptEngineFactory implements ScriptEngineFactory {
 
     private final ScriptEngine scriptEngine;
 
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policyOption = ReferencePolicyOption.GREEDY)
     protected @Nullable DSLScriptContextProvider contextProvider;
 
     @Activate


### PR DESCRIPTION
I've seen especially within the IDE that due to bundle startup order the `DSLScriptContextProvider` didn't get injected. Declaring it as greedy, this fixes the issue and ensures that it is injected whenever a bundle is present that provides an implementation.

Signed-off-by: Kai Kreuzer <kai@openhab.org>