### PR TITLE
Allow property value to be updated to null

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.binding;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -509,7 +510,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @param value the value of the property
      */
     protected void updateProperty(String name, String value) {
-        updateProperties(Map.of(name, value));
+        updateProperties(Collections.singletonMap(name, value));
     }
 
     /**


### PR DESCRIPTION
With the changes in #1598 the BaseThingHandler could no longer update property values to null.

---

In the unchanged Nest tests the following stracktraces were logged:

```
[pool-80-thread-1] WARN  o.o.b.n.i.r.NestStreamingRestClient - An exception occurred while processing the inbound event
java.lang.NullPointerException: null
	at java.base/java.util.Objects.requireNonNull(Objects.java:221)
	at java.base/java.util.ImmutableCollections$Map1.<init>(ImmutableCollections.java:749)
	at java.base/java.util.Map.of(Map.java:1307)
	at org.openhab.core.thing.binding.BaseThingHandler.updateProperty(BaseThingHandler.java:512)
	at org.openhab.binding.nest.internal.handler.NestThermostatHandler.update(NestThermostatHandler.java:211)
	at org.openhab.binding.nest.internal.handler.NestThermostatHandler.update(NestThermostatHandler.java:1)
	at org.openhab.binding.nest.internal.handler.NestBaseHandler.onUpdatedData(NestBaseHandler.java:194)
	at org.openhab.binding.nest.internal.update.NestUpdateHandler.lambda$3(NestUpdateHandler.java:99)
```

See also https://github.com/openhab/openhab-addons/pull/8334#issuecomment-680696040.