### PR TITLE
Removes the incorrect use of the encoding header in each JSON response

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
@@ -94,8 +94,7 @@ public class JSONResponse {
      * @return ResponseBuilder configured for "Content-Type" MediaType.APPLICATION_JSON
      */
     private ResponseBuilder responseBuilder(Response.StatusType status) {
-        return Response.status(status).header("Content-Type", MediaType.APPLICATION_JSON)
-                .encoding(StandardCharsets.UTF_8.name());
+        return Response.status(status).header("Content-Type", MediaType.APPLICATION_JSON);
     }
 
     /**


### PR DESCRIPTION
The ResponseBuilder's `encoding(String encoding)` function sets the http header "Content-Encoding", which is used to compress the media type and not to specify the character encoding.

See [ResponseBuilderImpl](https://github.com/apache/cxf/blob/master/rt/frontend/jaxrs/src/main/java/org/apache/cxf/jaxrs/impl/ResponseBuilderImpl.java#L286):
```java
public ResponseBuilder encoding(String encoding) {
    return this.setHeader("Content-Encoding", encoding);
}
```

The content-encoding header should be used to compress the media type.
See [MDN Web Docs Content-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding).

If you want to specify the charset you should use the content-type header.
See [MDN Web Docs Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type).