### PR TITLE
Remove deprecated methods from Configuration, UID and ThingHelper

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
@@ -91,28 +91,12 @@ public class Configuration {
         return properties.containsKey(key);
     }
 
-    /**
-     * @deprecated Use {@link #get(String)} instead.
-     */
-    @Deprecated
-    public Object get(Object key) {
-        return this.get((String) key);
-    }
-
     public Object get(String key) {
         return properties.get(key);
     }
 
     public Object put(String key, @Nullable Object value) {
         return properties.put(key, ConfigUtil.normalizeType(value, null));
-    }
-
-    /**
-     * @deprecated Use {@link #remove(String)} instead.
-     */
-    @Deprecated
-    public Object remove(Object key) {
-        return remove((String) key);
     }
 
     public Object remove(String key) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
@@ -75,15 +75,6 @@ public abstract class UID extends AbstractUID {
         return getSegment(0);
     }
 
-    /**
-     * @deprecated use {@link #getAllSegments()} instead
-     */
-    @Deprecated
-    protected String[] getSegments() {
-        final List<String> segments = super.getAllSegments();
-        return segments.toArray(new String[segments.size()]);
-    }
-
     @Override
     // Avoid subclasses to require importing the o.e.sh.core.common package
     protected List<String> getAllSegments() {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
@@ -109,19 +109,6 @@ public class ThingHelper {
     }
 
     /**
-     * @deprecated Use {@link ThingHelper#ensureUniqueChannels(Collection)} instead.
-     */
-    @Deprecated
-    public static void ensureUnique(Collection<Channel> channels) {
-        Set<UID> ids = new HashSet<>();
-        for (Channel channel : channels) {
-            if (!ids.add(channel.getUID())) {
-                throw new IllegalArgumentException("Duplicate channels " + channel.getUID().getAsString());
-            }
-        }
-    }
-
-    /**
      * Ensures that there are no duplicate channels in the array (i.e. not using the same ChannelUID)
      *
      * @param channels the channels to check


### PR DESCRIPTION
Removes the following deprecated methods:

* org.openhab.core.config.core.Configuration.get​(Object)
* org.openhab.core.config.core.Configuration.remove​(Object)
* org.openhab.core.thing.UID.getSegments()
* org.openhab.core.thing.util.ThingHelper.ensureUnique​(Collection<Channel>)

---

I could not find any usages of these methods by add-ons/UIs.

Related to #1408