### PR TITLE
Upgrade Travis CI to use Ubuntu 20.04 and fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-sudo: required
-dist: bionic
+os: linux
+dist: focal
 
 language: java
-
 jdk: openjdk11
 
 cache:


### PR DESCRIPTION
Upgrades the Travis CI build environment to Ubuntu 20.04 (Focal Fossa).

Also fixes the following Travis config validation warnings:

* deprecated key sudo (The key `sudo` has no effect anymore.)
* missing os, using the default linux