### PR TITLE
Remove non-existing $HOME/.bnd/cache/ dir from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ jdk: openjdk11
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.bnd/cache/
 
 before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc


### PR DESCRIPTION
There is no `$HOME/.bnd/cache` dir after a Travis build.

There is a `$HOME/.bnd/urlcache` dir, but it contains info about artifacts in `/target` dirs so it's also useless to cache.