### PR TITLE
[automation] Add script extension helpers to track loading/unloading refs

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/Lifecycle.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/Lifecycle.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared.osgi;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows scripts to register for lifecycle events
+ *
+ * @author Jonathan Gilbert
+ */
+public class Lifecycle implements ScriptDisposalAware {
+    private static final Logger logger = LoggerFactory.getLogger(Lifecycle.class);
+    public static final int DEFAULT_PRIORITY = 50;
+    private List<Hook> listeners = new ArrayList<>();
+
+    public void addDisposeHook(Consumer<Object> listener, int priority) {
+        addListener(listener, priority);
+    }
+
+    public void addDisposeHook(Consumer<Object> listener) {
+        addDisposeHook(listener, DEFAULT_PRIORITY);
+    }
+
+    private void addListener(Consumer<Object> listener, int priority) {
+        listeners.add(new Hook(priority, listener));
+    }
+
+    @Override
+    public void unload(String scriptIdentifier) {
+        try {
+            listeners.stream().sorted(Comparator.comparingInt(h -> h.priority))
+                    .forEach(h -> h.fn.accept(scriptIdentifier));
+        } catch (RuntimeException ex) {
+            logger.warn("Script unloading halted due to exception in disposal: {}: {}", ex.getClass(), ex.getMessage());
+        }
+    }
+
+    private static class Hook {
+        public Hook(int priority, Consumer<Object> fn) {
+            this.priority = priority;
+            this.fn = fn;
+        }
+
+        int priority;
+        Consumer<Object> fn;
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/OSGiScriptExtensionProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/OSGiScriptExtensionProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared.osgi;
+
+import org.openhab.core.automation.module.script.ScriptExtensionProvider;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * ScriptExtensionProvider which provides various functions to help scripts to work with OSGi
+ *
+ * @author Jonathan Gilbert - Initial contribution
+ */
+@Component(immediate = true, service = ScriptExtensionProvider.class)
+public class OSGiScriptExtensionProvider extends ScriptDisposalAwareScriptExtensionProvider {
+
+    @Override
+    protected String getPresetName() {
+        return "osgi";
+    }
+
+    @Override
+    protected void initializeTypes(final BundleContext context) {
+
+        addType("bundleContext", k -> context);
+        addType("lifecycle", k -> new Lifecycle());
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/ScriptDisposalAware.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/ScriptDisposalAware.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared.osgi;
+
+/**
+ * Interface denoting an object which is aware of script disposal events.
+ *
+ * @author Jonathan Gilbert
+ */
+public interface ScriptDisposalAware {
+    /**
+     * Script with supplied name has been disposed
+     * 
+     * @param scriptIdentifier the identifier of the script which has been disposed
+     */
+    void unload(String scriptIdentifier);
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/ScriptDisposalAwareScriptExtensionProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/osgi/ScriptDisposalAwareScriptExtensionProvider.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared.osgi;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.openhab.core.automation.module.script.ScriptExtensionProvider;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+
+/**
+ * Base class to offer support for basic script extension providers that provide static objects, which may be interested
+ * in script disposal
+ *
+ * @author Jonathan Gilbert
+ */
+public abstract class ScriptDisposalAwareScriptExtensionProvider
+        implements ScriptExtensionProvider, ScriptDisposalAware {
+    private Map<String, Function<String, Object>> types;
+    private Map<String, Map<String, Object>> idToTypes = new ConcurrentHashMap<>();
+
+    protected abstract String getPresetName();
+
+    protected abstract void initializeTypes(final BundleContext context);
+
+    protected void addType(String name, Function<String, Object> value) {
+        types.put(name, value);
+    }
+
+    @Activate
+    public void activate(final BundleContext context) {
+        types = new HashMap<>();
+        initializeTypes(context);
+    }
+
+    @Override
+    public Collection<String> getDefaultPresets() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<String> getPresets() {
+        return Collections.singleton(getPresetName());
+    }
+
+    @Override
+    public Collection<String> getTypes() {
+        return types.keySet();
+    }
+
+    @Override
+    public Object get(String scriptIdentifier, String type) throws IllegalArgumentException {
+
+        Map<String, Object> forScript = idToTypes.computeIfAbsent(scriptIdentifier, k -> new HashMap<>());
+        return forScript.computeIfAbsent(type, k -> types.get(k).apply(scriptIdentifier));
+    }
+
+    @Override
+    public Map<String, Object> importPreset(String scriptIdentifier, String preset) {
+        if (getPresetName().equals(preset)) {
+            Map<String, Object> results = new HashMap<>(types.size());
+            for (String type : types.keySet()) {
+                results.put(type, get(scriptIdentifier, type));
+            }
+            return results;
+        }
+
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void unload(String scriptIdentifier) {
+        Map<String, Object> forScript = idToTypes.remove(scriptIdentifier);
+
+        if (forScript != null) {
+            for (Object o : forScript.values()) {
+                if (o instanceof ScriptDisposalAware) {
+                    ((ScriptDisposalAware) o).unload(scriptIdentifier);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Script extension module to allow scripts to:
* Register for callbacks when they are unloaded (in case they need to clean up)
* Provide access to the OSGi bundle context to get hold of host services

Example usage: https://github.com/jpg0/ohj/blob/master/osgi.js

Some questions:
* Should this be in 'rulesupport'? I put it here because there is nowhere else obvious, but it's a questionable location. However I also don't want to end up with many tiny bundles.
* Currently script lifecycle and osgi are together. It grew this way because I used it this way, but maybe it shouldn't be together. Again, I'm concerned about fragmentation as splitting would create tiny extension modules.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>