### PR TITLE
[skeleton] Make example logging compliant to Coding Guidelines

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
@@ -63,7 +63,6 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
 
     @Override
     public void initialize() {
-        // logger.debug("Start initializing!");
         config = getConfigAs(${bindingIdCamelCase}Configuration.class);
 
         // TODO: Initialize the handler.
@@ -90,7 +89,10 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
             }
         });
 
-        // logger.debug("Finished initializing!");
+        // These logging types should be primarily used by bindings
+        // logger.trace("Example trace message");
+        // logger.debug("Example debug message");
+        // logger.warn("Example warn message");
 
         // Note: When initialization can NOT be done set the status with more details for further
         // analysis. See also class ThingStatusDetail for all available status details.


### PR DESCRIPTION
See https://www.openhab.org/docs/developer/guidelines.html#f-logging point 4
```
void myFun() {
    logger.trace("Enter myfun"); // DONT, DONT, really DONT do that
    doSomething();
    logger.trace("Leave myfun"); // DONT, DONT, really DONT do that
}
```
Also give an example for the logging severities, as many binding PRs log to info or error.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>