### PR TITLE
Upgrade Aries JAX-RS Whiteboard to 1.0.9

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.apache.aries.jax.rs</groupId>
       <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.aries.jax.rs</groupId>
       <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -92,7 +92,7 @@
 	</feature>
 
 	<feature name="openhab.tp-jax-rs-whiteboard" version="${project.version}">
-		<capability>openhab.tp;feature=jax-rs-whiteboard;version=1.0.8</capability>
+		<capability>openhab.tp;feature=jax-rs-whiteboard;version=1.0.9</capability>
 
 		<!-- BEG: https://issues.apache.org/jira/browse/KARAF-6536 -->
 		<!-- Add it here, so we do not use to rely on a feature that is using version ranges. -->
@@ -104,7 +104,7 @@
 		<bundle dependency="true">mvn:org.osgi/org.osgi.service.jaxrs/1.0.0</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.annotation-api-1.3/1.3_1</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/2.9.0</bundle>
-		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/1.0.8</bundle>
+		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/1.0.9</bundle>
 		<!-- END: https://issues.apache.org/jira/browse/KARAF-6536 -->
 
 		<config name="org.apache.aries.jax.rs.whiteboard.default">

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -38,7 +38,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
 	org.apache.aries.javax.jax.rs-api;version='[1.0.0,1.0.1)',\
-	org.apache.aries.jax.rs.whiteboard;version='[1.0.8,1.0.9)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
@@ -76,4 +75,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)'


### PR DESCRIPTION
This version uses CXF 3.2.13 which has some SSE fixes (see [changelog](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310511&version=12346756)).

---

Since I gave this a test to see if it would f i x https://github.com/openhab/openhab-core/issues/1655, we might as well upgrade to use the newer version. 