### PR TITLE
Remove deprecated BaseThingHandler.initialize()

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -152,15 +152,6 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    @Deprecated
-    public void initialize() {
-        // should be overridden by subclasses!
-        updateStatus(ThingStatus.ONLINE);
-        logger.warn(
-                "BaseThingHandler.initialize() will be removed soon, ThingStatus can be set manually via updateStatus(ThingStatus.ONLINE)");
-    }
-
-    @Override
     public void thingUpdated(Thing thing) {
         dispose();
         this.thing = thing;

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
@@ -91,7 +91,8 @@ public class GenericThingProviderTest4 extends JavaOSGiTest {
                     throw new IllegalStateException("Interrupted while sleeping", e);
                 }
             }
-            super.initialize();
+
+            updateStatus(ThingStatus.ONLINE);
         }
 
         @Override

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -318,6 +318,11 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
             @Override
             public void handleCommand(ChannelUID channelUID, Command command) {
             }
+
+            @Override
+            public void initialize() {
+                updateStatus(ThingStatus.ONLINE);
+            }
         });
 
         ConfigDescriptionProvider mockConfigDescriptionProvider = mock(ConfigDescriptionProvider.class);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
@@ -38,6 +38,7 @@ import org.openhab.core.thing.ManagedThingProvider;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingProvider;
 import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
@@ -145,6 +146,11 @@ public class ThingRegistryOSGiTest extends JavaOSGiTest {
             @Override
             public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
                 changedParameters = configurationParameters;
+            }
+
+            @Override
+            public void initialize() {
+                updateStatus(ThingStatus.ONLINE);
             }
         };
 


### PR DESCRIPTION
Related to #1408, see also https://github.com/openhab/openhab-addons/pull/8553.