### PR TITLE
Fix ConfigurableService deprecations

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.annotations.ComponentPropertyType;
@@ -25,9 +26,8 @@ import org.osgi.service.component.annotations.ComponentPropertyType;
  * <p>
  * {@link ConfigurableService} can be used as a marker interface for configurable services. But the interface itself is
  * not relevant for the runtime. Each service which has the property
- * {@link ConfigurableService#SERVICE_PROPERTY_DESCRIPTION_URI} set will be considered as a configurable service. The
- * properties {@link ConfigurableService#SERVICE_PROPERTY_LABEL} and
- * {@link ConfigurableService#SERVICE_PROPERTY_CATEGORY} are optional.
+ * {@link ConfigurableService#description_uri} set will be considered as a configurable service. The
+ * properties {@link ConfigurableService#label} and {@link ConfigurableService#category} are optional.
  *
  * <p>
  * The services are configured through the OSGi configuration admin. Therefore each service must provide a PID or a
@@ -41,6 +41,7 @@ import org.osgi.service.component.annotations.ComponentPropertyType;
 @ComponentPropertyType
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
+@NonNullByDefault
 public @interface ConfigurableService {
 
     String PREFIX_ = "service.config.";
@@ -64,36 +65,4 @@ public @interface ConfigurableService {
      * Marker for multiple configurations for this service ("true" = multiple configurations possible)
      */
     boolean factory() default false;
-
-    /**
-     * The config description URI for the configurable service. See also {@link ConfigDescription}.
-     *
-     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
-     */
-    @Deprecated
-    public static final String SERVICE_PROPERTY_DESCRIPTION_URI = PREFIX_ + "description.uri";
-
-    /**
-     * The label of the service to be configured.
-     *
-     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
-     */
-    @Deprecated
-    public static final String SERVICE_PROPERTY_LABEL = PREFIX_ + "label";
-
-    /**
-     * The category of the service to be configured (e.g. binding).
-     *
-     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
-     */
-    @Deprecated
-    public static final String SERVICE_PROPERTY_CATEGORY = PREFIX_ + "category";
-
-    /**
-     * Marker for multiple configurations for this service ("true" = multiple configurations possible)
-     *
-     * @deprecated annotate classes with <code>@ConfigurableService</code> instead
-     */
-    @Deprecated
-    public static final String SERVICE_PROPERTY_FACTORY_SERVICE = PREFIX_ + "factory";
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableServiceUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableServiceUtil.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core;
+
+import java.lang.annotation.Annotation;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Provides utility methods for working with {@link ConfigurableService} so the property names can remain hidden.
+ * These methods cannot be part of {@link ConfigurableService} as that introduces an annotation cycle.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigurableServiceUtil {
+
+    /**
+     * The config description URI for the configurable service. See also {@link ConfigDescription}.
+     */
+    static final String SERVICE_PROPERTY_DESCRIPTION_URI = ConfigurableService.PREFIX_ + "description.uri";
+
+    /**
+     * The label of the service to be configured.
+     */
+    static final String SERVICE_PROPERTY_LABEL = ConfigurableService.PREFIX_ + "label";
+
+    /**
+     * The category of the service to be configured (e.g. binding).
+     */
+    static final String SERVICE_PROPERTY_CATEGORY = ConfigurableService.PREFIX_ + "category";
+
+    /**
+     * Marker for multiple configurations for this service ("true" = multiple configurations possible)
+     */
+    static final String SERVICE_PROPERTY_FACTORY_SERVICE = ConfigurableService.PREFIX_ + "factory";
+
+    // all singleton services without multi-config services
+    public static final String CONFIGURABLE_SERVICE_FILTER = "(&(" + SERVICE_PROPERTY_DESCRIPTION_URI + "=*)(!("
+            + SERVICE_PROPERTY_FACTORY_SERVICE + "=*)))";
+
+    // all multi-config services without singleton services
+    public static final String CONFIGURABLE_MULTI_CONFIG_SERVICE_FILTER = "(" + SERVICE_PROPERTY_FACTORY_SERVICE
+            + "=*)";
+
+    public static ConfigurableService asConfigurableService(Function<String, @Nullable Object> propertyResolver) {
+        return new ConfigurableService() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return ConfigurableService.class;
+            }
+
+            @Override
+            public String label() {
+                return resolveString(propertyResolver, SERVICE_PROPERTY_LABEL);
+            }
+
+            @Override
+            public boolean factory() {
+                return resolveBoolean(propertyResolver, SERVICE_PROPERTY_FACTORY_SERVICE);
+            }
+
+            @Override
+            public String description_uri() {
+                return resolveString(propertyResolver, SERVICE_PROPERTY_DESCRIPTION_URI);
+            }
+
+            @Override
+            public String category() {
+                return resolveString(propertyResolver, SERVICE_PROPERTY_CATEGORY);
+            }
+        };
+    }
+
+    private static String resolveString(Function<String, @Nullable Object> propertyResolver, String key) {
+        String value = (String) propertyResolver.apply(key);
+        return value == null ? "" : value;
+    }
+
+    private static boolean resolveBoolean(Function<String, @Nullable Object> propertyResolver, String key) {
+        Boolean value = (Boolean) propertyResolver.apply(key);
+        return value == null ? false : value.booleanValue();
+    }
+}

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+import static org.openhab.core.config.core.ConfigurableServiceUtil.*;
+
+import java.util.Properties;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ConfigurableServiceUtil}.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigurableServiceUtilTest {
+
+    @Test
+    public void asConfigurableServiceDefinedProperties() {
+        String category = "system";
+        String descriptionURI = "system:inbox";
+        boolean factory = true;
+        String label = "Inbox";
+
+        Properties properties = new Properties();
+        properties.put(SERVICE_PROPERTY_CATEGORY, category);
+        properties.put(SERVICE_PROPERTY_DESCRIPTION_URI, descriptionURI);
+        properties.put(SERVICE_PROPERTY_FACTORY_SERVICE, factory);
+        properties.put(SERVICE_PROPERTY_LABEL, label);
+
+        ConfigurableService configurableService = ConfigurableServiceUtil
+                .asConfigurableService((key) -> properties.get(key));
+
+        assertThat(configurableService.annotationType(), is(ConfigurableService.class));
+        assertThat(configurableService.category(), is(category));
+        assertThat(configurableService.description_uri(), is(descriptionURI));
+        assertThat(configurableService.factory(), is(factory));
+        assertThat(configurableService.label(), is(label));
+    }
+
+    @Test
+    public void asConfigurableServiceUndefinedProperties() {
+        Properties properties = new Properties();
+
+        ConfigurableService configurableService = ConfigurableServiceUtil
+                .asConfigurableService((key) -> properties.get(key));
+
+        assertThat(configurableService.annotationType(), is(ConfigurableService.class));
+        assertThat(configurableService.category(), is(emptyString()));
+        assertThat(configurableService.description_uri(), is(emptyString()));
+        assertThat(configurableService.factory(), is(false));
+        assertThat(configurableService.label(), is(emptyString()));
+    }
+}

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -38,11 +38,9 @@ import org.slf4j.LoggerFactory;
  * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
-@Component(configurationPid = "org.openhab.magic", service = ConfigOptionProvider.class, immediate = true, property = {
-        Constants.SERVICE_PID + "=org.openhab.core.magic",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=test:magic",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Magic",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=test" })
+@Component(configurationPid = "org.openhab.magic", service = ConfigOptionProvider.class, immediate = true, //
+        property = Constants.SERVICE_PID + "=org.openhab.core.magic")
+@ConfigurableService(category = "test", label = "Magic", description_uri = "test:magic")
 public class MagicServiceImpl implements MagicService {
     private final Logger logger = LoggerFactory.getLogger(MagicServiceImpl.class);
 

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
@@ -21,12 +21,9 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(immediate = true, service = MagicMultiActionMarker.class, property = {
-        Constants.SERVICE_PID + "=org.openhab.MagicMultiAction",
-        ConfigurableService.SERVICE_PROPERTY_FACTORY_SERVICE + "=true",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=MagicMultiActionsService",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=RuleActions",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=automationAction:magicMultiAction" })
+@Component(immediate = true, service = MagicMultiActionMarker.class, //
+        property = Constants.SERVICE_PID + "=org.openhab.MagicMultiAction")
+@ConfigurableService(category = "RuleActions", label = "MagicMultiActionsService", description_uri = "automationAction:magicMultiAction", factory = true)
 public class MagicMultiActionMarker {
 
 }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
@@ -33,11 +33,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Stefan Triller - Initial contribution
  */
-@Component(configurationPid = "org.openhab.magicsingleaction", property = {
-        Constants.SERVICE_PID + "=org.openhab.automation.action.magicSingleActionService",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=automationAction:magicSingleAction",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=Magic Single Action Service",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=RuleActions" })
+@Component(configurationPid = "org.openhab.magicsingleaction", //
+        property = Constants.SERVICE_PID + "=org.openhab.automation.action.magicSingleActionService")
+@ConfigurableService(category = "RuleActions", label = "Magic Single Action Service", description_uri = "automationAction:magicSingleAction")
 @ActionScope(name = "binding.magicService")
 public class MagicSingleActionService implements AnnotatedActions {
 

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
@@ -21,12 +21,9 @@ import org.osgi.service.component.annotations.Component;
  * @author Stefan Triller - Initial contribution
  */
 
-@Component(immediate = true, service = MagicMultiInstanceServiceMarker.class, property = {
-        Constants.SERVICE_PID + "=org.openhab.magicMultiInstance",
-        ConfigurableService.SERVICE_PROPERTY_FACTORY_SERVICE + "=true",
-        ConfigurableService.SERVICE_PROPERTY_LABEL + "=MagicMultiInstanceService",
-        ConfigurableService.SERVICE_PROPERTY_CATEGORY + "=test",
-        ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI + "=test:multipleMagic" })
+@Component(immediate = true, service = MagicMultiInstanceServiceMarker.class, //
+        property = Constants.SERVICE_PID + "=org.openhab.magicMultiInstance")
+@ConfigurableService(category = "test", label = "MagicMultiInstanceService", description_uri = "test:multipleMagic", factory = true)
 public class MagicMultiInstanceServiceMarker {
     // this is a marker service and represents a service factory so multiple configuration instances of type
     // "org.openhab.core.magicMultiInstance" can be created.


### PR DESCRIPTION
The property keys are now hidden so contributors are now forced to always annotate classes with `@ConfigurableService`.

Related to https://github.com/openhab/openhab-core/issues/1408.