### PR TITLE
Remove deprecate default methods

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
@@ -29,11 +29,6 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface ConfigOptionProvider {
 
-    @Deprecated
-    default @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable Locale locale) {
-        return getParameterOptions(uri, param, null, locale);
-    }
-
     /**
      * Provides a collection of {@link ParameterOptions}s.
      *

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
@@ -68,26 +68,6 @@ public interface DiscoveryListener {
      *            {@code ThingType}s will be removed; if {@code null} then
      *            {@link DiscoveryService#getSupportedThingTypes()} will be used
      *            instead
-     * @return collection of thing UIDs of all removed things
-     * @deprecated use {@link #removeOlderResults(DiscoveryService, long, Collection, ThingUID)} instead
-     */
-    @Deprecated
-    default @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs) {
-        return removeOlderResults(source, timestamp, thingTypeUIDs, null);
-    }
-
-    /**
-     * Removes all results belonging to one of the given types that are older
-     * than the given timestamp.
-     *
-     * @param source the discovery service which is the source of this event (not
-     *            null)
-     * @param timestamp timestamp, all <b>older</b> results will be removed
-     * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
-     *            {@code ThingType}s will be removed; if {@code null} then
-     *            {@link DiscoveryService#getSupportedThingTypes()} will be used
-     *            instead
      * @param bridgeUID if not {@code null} only results of that bridge are being removed
      * @return collection of thing UIDs of all removed things
      */


### PR DESCRIPTION
Removes:

* ConfigOptionProvider.getParameterOptions(URI, String, Locale) (see also #1541)
* DiscoveryListener.removeOlderResults(DiscoveryService, long, Collection<ThingTypeUID>)

Related to #1408