### PR TITLE
Remove deprecated handleUpdate from ThingHandler

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -146,12 +146,6 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    @Deprecated
-    public void handleUpdate(ChannelUID channelUID, State newState) {
-        // can be overridden by subclasses
-    }
-
-    @Override
     public void thingUpdated(Thing thing) {
         dispose();
         this.thing = thing;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandler.java
@@ -25,7 +25,6 @@ import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.types.Command;
-import org.openhab.core.types.State;
 
 /**
  * A {@link ThingHandler} handles the communication between the openHAB framework and an entity from the real
@@ -100,20 +99,6 @@ public interface ThingHandler {
      * @param command the {@link Command}
      */
     void handleCommand(ChannelUID channelUID, Command command);
-
-    /**
-     * Handles a {@link State} update for a given channel.
-     * <p>
-     * This method is only called, if the thing has been initialized (status ONLINE/OFFLINE/UNKNOWN).
-     * <p>
-     *
-     * @param channelUID the {@link ChannelUID} of the channel on which the update was performed
-     * @param newState the new {@link State}
-     * @deprecated in favor of using a "slave" profile. Will be removed before a 1.0 release. Bindings must not
-     *             implement this method!
-     */
-    @Deprecated
-    void handleUpdate(ChannelUID channelUID, State newState);
 
     /**
      * Handles a configuration update.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -97,38 +97,6 @@ public class ProfileCallbackImpl implements ProfileCallback {
     }
 
     @Override
-    public void handleUpdate(State state) {
-        Thing thing = thingProvider.apply(link.getLinkedUID().getThingUID());
-        if (thing != null) {
-            final ThingHandler handler = thing.getHandler();
-            if (handler != null) {
-                if (ThingHandlerHelper.isHandlerInitialized(thing)) {
-                    logger.debug("Delegating update '{}' for item '{}' to handler for channel '{}'", state,
-                            link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler, ThingHandler.class)
-                            .withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT).onTimeout(() -> {
-                                logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
-                                        handler.getThing().getUID(), CommunicationManager.THINGHANDLER_EVENT_TIMEOUT);
-                            }).build().handleUpdate(link.getLinkedUID(), state);
-                } else {
-                    logger.debug("Not delegating update '{}' for item '{}' to handler for channel '{}', "
-                            + "because handler is not initialized (thing must be in status UNKNOWN, ONLINE or OFFLINE but was {}).",
-                            state, link.getItemName(), link.getLinkedUID(), thing.getStatus());
-                }
-            } else {
-                logger.warn("Cannot delegate update '{}' for item '{}' to handler for channel '{}', "
-                        + "because no handler is assigned. Maybe the binding is not installed or not "
-                        + "propertly initialized.", state, link.getItemName(), link.getLinkedUID());
-            }
-        } else {
-            logger.warn(
-                    "Cannot delegate update '{}' for item '{}' to handler for channel '{}', "
-                            + "because no thing with the UID '{}' could be found.",
-                    state, link.getItemName(), link.getLinkedUID(), link.getLinkedUID().getThingUID());
-        }
-    }
-
-    @Override
     public void sendCommand(Command command) {
         eventPublisher
                 .post(ItemEventFactory.createCommandEvent(link.getItemName(), command, link.getLinkedUID().toString()));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfile.java
@@ -60,6 +60,5 @@ public class SystemDefaultProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate(state);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -85,7 +85,6 @@ public class SystemOffsetProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleUpdate((State) applyOffset(state, false));
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
@@ -32,13 +32,6 @@ public interface ProfileCallback {
     void handleCommand(Command command);
 
     /**
-     * Forward the given state update to the respective thing handler.
-     *
-     * @param state
-     */
-    void handleUpdate(State state);
-
-    /**
      * Send a command to the framework.
      *
      * @param command

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
@@ -42,15 +42,6 @@ public class SystemDefaultProfileTest {
     }
 
     @Test
-    public void testOnUpdate() {
-        SystemDefaultProfile profile = new SystemDefaultProfile(mockCallback);
-        profile.onStateUpdateFromItem(OnOffType.ON);
-
-        verify(mockCallback).handleUpdate(eq(OnOffType.ON));
-        verifyNoMoreInteractions(mockCallback);
-    }
-
-    @Test
     public void testStateUpdated() {
         SystemDefaultProfile profile = new SystemDefaultProfile(mockCallback);
         profile.onStateUpdateFromHandler(OnOffType.ON);

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
@@ -65,22 +65,6 @@ public class SystemOffsetProfileTest {
     }
 
     @Test
-    public void testDecimalTypeOnStateUpdateFromItem() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
-
-        State state = new DecimalType(23);
-        offsetProfile.onStateUpdateFromItem(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).handleUpdate(capture.capture());
-
-        State result = capture.getValue();
-        DecimalType decResult = (DecimalType) result;
-        assertEquals(20, decResult.intValue());
-    }
-
-    @Test
     public void testQuantityTypeOnCommandFromItem() {
         ProfileCallback callback = mock(ProfileCallback.class);
         SystemOffsetProfile offsetProfile = createProfile(callback, "3°C");
@@ -92,24 +76,6 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).handleCommand(capture.capture());
 
         Command result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
-        assertEquals(20, decResult.intValue());
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
-    }
-
-    @Test
-    public void testQuantityTypeOnStateUpdateFromItem() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3°C");
-
-        State state = new QuantityType<>("23°C");
-        offsetProfile.onStateUpdateFromItem(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).handleUpdate(capture.capture());
-
-        State result = capture.getValue();
         @SuppressWarnings("unchecked")
         QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
         assertEquals(20, decResult.intValue());


### PR DESCRIPTION
The `handleUpdate` method was deprecated when profiles were introduced (see eclipse-archived/smarthome#4108).
Instead the [follow profile](https://www.openhab.org/docs/developer/transformations/#followprofile) can be used which forwards item updates as commands to handlers.
This profile works with any binding instead of only those that implement the handleUpdate method.

Related to #1408