### PR TITLE
Exclude transitive JAXB 2.3 dependencies

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -232,6 +232,18 @@
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-core</artifactId>
+      <version>${swagger.version}</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2</artifactId>
       <version>${swagger.version}</version>
       <scope>compile</scope>
@@ -239,6 +251,10 @@
         <exclusion>
           <groupId>jakarta.activation</groupId>
           <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -62,6 +62,10 @@
       <version>1.0.9</version>
       <exclusions>
         <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-annotation_1.3_spec</artifactId>
         </exclusion>


### PR DESCRIPTION
The add-ons still depend on JAXB 2.2 so it for instance caused the avmfritz itest to fail.