### PR TITLE
Remove remaining deprecated MQTT transport code

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
@@ -34,8 +34,6 @@ public class MqttBrokerConnectionConfig {
     public @Nullable String clientID;
     // MQTT parameters
     public Integer qos = MqttBrokerConnection.DEFAULT_QOS;
-    @Deprecated
-    public Boolean retainMessages = false;
     /** Keepalive in seconds */
     public @Nullable Integer keepAlive;
     // Last will parameters

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttException.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttException.java
@@ -23,20 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class MqttException extends Exception {
     private static final long serialVersionUID = 301L;
-    private int reasonCode;
     private Throwable cause;
-
-    /**
-     * Constructs a new <code>MqttException</code> with the specified code
-     * as the underlying reason.
-     *
-     * @param reasonCode the reason code for the exception.
-     */
-    @Deprecated
-    public MqttException(int reasonCode) {
-        this.cause = new Exception();
-        this.reasonCode = reasonCode;
-    }
 
     /**
      * Constructs a new <code>MqttException</code> with the specified reason
@@ -45,7 +32,6 @@ public class MqttException extends Exception {
      */
     public MqttException(String reason) {
         this.cause = new Exception("reason");
-        this.reasonCode = Integer.MIN_VALUE;
     }
 
     /**
@@ -55,31 +41,7 @@ public class MqttException extends Exception {
      * @param cause the underlying cause of the exception.
      */
     public MqttException(Throwable cause) {
-        this.reasonCode = Integer.MIN_VALUE;
         this.cause = cause;
-    }
-
-    /**
-     * Constructs a new <code>MqttException</code> with the specified
-     * <code>Throwable</code> as the underlying reason.
-     *
-     * @param reason the reason code for the exception.
-     * @param cause the underlying cause of the exception.
-     */
-    @Deprecated
-    public MqttException(int reason, Throwable cause) {
-        this.reasonCode = reason;
-        this.cause = cause;
-    }
-
-    /**
-     * Returns the reason code for this exception.
-     *
-     * @return the code representing the reason for this exception.
-     */
-    @Deprecated
-    public int getReasonCode() {
-        return reasonCode;
     }
 
     /**

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/MqttServiceImpl.java
@@ -104,7 +104,6 @@ public class MqttServiceImpl implements MqttService {
         }
 
         connection.setQos(config.qos.intValue());
-        connection.setRetain(config.retainMessages);
         if (config.lwtTopic != null) {
             String topic = config.lwtTopic;
             MqttWillAndTestament will = new MqttWillAndTestament(topic,

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -310,10 +310,6 @@ public class MqttBrokerConnectionTests extends JavaTest {
         connection.setKeepAliveInterval(80);
         assertEquals(80, connection.getKeepAliveInterval());
 
-        assertFalse(connection.isRetain());
-        connection.setRetain(true);
-        assertTrue(connection.isRetain());
-
         assertEquals(MqttBrokerConnection.DEFAULT_QOS, connection.getQos());
         connection.setQos(2);
         assertEquals(2, connection.getQos());


### PR DESCRIPTION
This removes the remaining deprecated MQTT transport code which was not part of #1668.

The `retainMessages` configuration parameter in the `MqttBrokerConnectionConfig` is already unused by MQTT Broker Things (see [config description](https://github.com/openhab/openhab-addons/blob/cc042dabff6cb4bc3fabc3f3264d2e520d7cd46b/bundles/org.openhab.binding.mqtt/src/main/resources/OH-INF/thing/thing-types.xml#L11)). So keeping track of it and using it serves no purpose because the value would always be `false`.

Related to #1408