### PR TITLE
Filter empty i18n config parameter options

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -96,7 +96,11 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
 
     private Collection<ParameterOption> getAvailable(@Nullable Locale locale,
             Function<Locale, ParameterOption> mapFunction) {
-        return Arrays.stream(Locale.getAvailableLocales()).map(l -> mapFunction.apply(l)).distinct()
-                .sorted(Comparator.comparing(a -> a.getLabel())).collect(Collectors.toList());
+        return Arrays.stream(Locale.getAvailableLocales()) //
+                .map(l -> mapFunction.apply(l)) //
+                .distinct() //
+                .filter(po -> !po.getValue().isEmpty()) //
+                .sorted(Comparator.comparing(a -> a.getLabel())) //
+                .collect(Collectors.toList());
     }
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -97,7 +97,7 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
     private Collection<ParameterOption> getAvailable(@Nullable Locale locale,
             Function<Locale, ParameterOption> mapFunction) {
         return Arrays.stream(Locale.getAvailableLocales()) //
-                .map(l -> mapFunction.apply(l)) //
+                .map(mapFunction) //
                 .distinct() //
                 .filter(po -> !po.getValue().isEmpty()) //
                 .sorted(Comparator.comparing(a -> a.getLabel())) //

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
@@ -31,6 +31,7 @@ import org.openhab.core.config.core.ParameterOption;
 public class I18nConfigOptionsProviderTest {
 
     private I18nConfigOptionsProvider provider;
+    private final ParameterOption empty = new ParameterOption("", "");
     private final ParameterOption expectedLangEN = new ParameterOption("en", "English");
     private final ParameterOption expectedLangFR = new ParameterOption("en", "anglais");
     private final ParameterOption expectedCntryEN = new ParameterOption("US", "United States");
@@ -47,15 +48,23 @@ public class I18nConfigOptionsProviderTest {
     @Test
     public void testLanguage() throws Exception {
         assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.US), hasItem(expectedLangEN));
+        assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.US), not(hasItem(empty)));
+
         assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.FRENCH), hasItem(expectedLangFR));
+        assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.FRENCH), not(hasItem(empty)));
+
         assertThat(provider.getParameterOptions(uriI18N, "language", null, null), not(IsEmptyCollection.empty()));
     }
 
     @Test
     public void testRegion() throws Exception {
         assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.US), hasItem(expectedCntryEN));
+        assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.US), not(hasItem(empty)));
+
         assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.FRENCH),
                 anyOf(hasItem(expectedCntryFRJava8), hasItem(expectedCntryFRJava9)));
+        assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.FRENCH), not(hasItem(empty)));
+
         assertThat(provider.getParameterOptions(uriI18N, "region", null, null), not(IsEmptyCollection.empty()));
     }
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.util.Locale;
 
 import org.hamcrest.collection.IsEmptyCollection;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.ParameterOption;
 
@@ -30,23 +29,18 @@ import org.openhab.core.config.core.ParameterOption;
  */
 public class I18nConfigOptionsProviderTest {
 
-    private I18nConfigOptionsProvider provider;
+    private final I18nConfigOptionsProvider provider = new I18nConfigOptionsProvider();
+    private final URI uriI18N = URI.create("system:i18n");
+
     private final ParameterOption empty = new ParameterOption("", "");
     private final ParameterOption expectedLangEN = new ParameterOption("en", "English");
     private final ParameterOption expectedLangFR = new ParameterOption("en", "anglais");
     private final ParameterOption expectedCntryEN = new ParameterOption("US", "United States");
     private final ParameterOption expectedCntryFRJava8 = new ParameterOption("US", "Etats-Unis");
     private final ParameterOption expectedCntryFRJava9 = new ParameterOption("US", "États-Unis");
-    private URI uriI18N;
-
-    @BeforeEach
-    public void setup() throws Exception {
-        provider = new I18nConfigOptionsProvider();
-        uriI18N = new URI("system:i18n");
-    }
 
     @Test
-    public void testLanguage() throws Exception {
+    public void testLanguage() {
         assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.US), hasItem(expectedLangEN));
         assertThat(provider.getParameterOptions(uriI18N, "language", null, Locale.US), not(hasItem(empty)));
 
@@ -57,7 +51,7 @@ public class I18nConfigOptionsProviderTest {
     }
 
     @Test
-    public void testRegion() throws Exception {
+    public void testRegion() {
         assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.US), hasItem(expectedCntryEN));
         assertThat(provider.getParameterOptions(uriI18N, "region", null, Locale.US), not(hasItem(empty)));
 
@@ -69,7 +63,7 @@ public class I18nConfigOptionsProviderTest {
     }
 
     @Test
-    public void testUnknownParameter() throws Exception {
+    public void testUnknownParameter() {
         assertThat(provider.getParameterOptions(uriI18N, "unknown", null, Locale.US), nullValue());
     }
 }


### PR DESCRIPTION
There are many locales that do not have a country resulting in these empty parameter options.

Related to #1662