### PR TITLE
Synced guava version with openhab-tp usages

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -420,7 +420,6 @@
 	</feature>
 
 	<feature name="openhab-runtime-base" description="openHAB Runtime Base" version="${project.version}">
-		<bundle>mvn:com.google.guava/guava/18.0</bundle>
 		<requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
 		<feature dependency="true">openhab.tp-commons-net</feature>
 		<feature>openhab-core-base</feature>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -252,8 +252,6 @@
 		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.0</bundle>
 		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.0</bundle>
 		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.0</bundle>
-		<bundle dependency="true">mvn:com.google.guava/guava/27.1-jre</bundle>
-		<bundle dependency="true">mvn:com.google.guava/failureaccess/1.0.1</bundle>
 		<bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.11</bundle>
 		<bundle dependency="true">mvn:org.javassist/javassist/3.26.0-GA</bundle>


### PR DESCRIPTION
I did a fresh install of openHAB 3.0 and ended up 2 activated guava bundles. While 1 is already to much :wink: 
```
 28 │ Active │  80 │ 18.0.0                  │ Guava: Google Core Libraries for Java
 29 │ Active │  80 │ 27.1.0.jre              │ Guava: Google Core Libraries for Java
```
So I tracked down to this dependencies.

My only question. Shouldn't it be removed completely here actually?
