### PR TITLE
Upgrade Maven compiler and fix/upgrade some TP dependencies

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -252,10 +252,6 @@
           <groupId>jakarta.activation</groupId>
           <artifactId>jakarta.activation-api</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 
@@ -279,31 +275,33 @@
 
     <!-- JAXB -->
     <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
-      <version>2.2.11_1</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- JAX-WS -->
     <dependency>
       <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
-      <version>1.3.23_2</version>
+      <artifactId>org.apache.servicemix.specs.saaj-api-1.4</artifactId>
+      <version>1.4_2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jvnet.staxex</groupId>
+          <artifactId>stax-ex</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- jose4j -->

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -137,24 +137,29 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- JAX-B 2.2 API -->
+    <!-- JAX-B 2.3 API -->
     <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-      <version>2.9.0</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>2.3.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
-      <version>2.2.11_1</version>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-osgi</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>osgi-resource-locator</artifactId>
+      <version>1.0.3</version>
     </dependency>
 
-    <!-- Activation 1.1 API -->
+    <!-- Activation 1.2 API -->
     <dependency>
       <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
+      <artifactId>org.apache.servicemix.specs.activation-api-1.2.1</artifactId>
+      <version>1.2.1_2</version>
       <scope>compile</scope>
     </dependency>
 
@@ -173,25 +178,25 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- JAX-WS 2.2 API -->
+    <!-- JAX-WS 2.3 API -->
     <dependency>
       <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.jaxws-api-2.2</artifactId>
-      <version>2.9.0</version>
+      <artifactId>org.apache.servicemix.specs.jaxws-api-2.3</artifactId>
+      <version>2.3_3</version>
       <scope>compile</scope>
     </dependency>
 
-    <!-- SAAJ 1.3 API -->
+    <!-- SAAJ 1.4 API -->
     <dependency>
       <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
-      <version>2.9.0</version>
+      <artifactId>org.apache.servicemix.specs.saaj-api-1.4</artifactId>
+      <version>1.4_2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.saaj-impl</artifactId>
-      <version>1.3.23_2</version>
+      <version>1.4.0_2</version>
     </dependency>
 
     <!-- OSGi Function -->

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -17,6 +17,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-osgi</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.annotation</artifactId>
       <version>2.2.100</version>
@@ -61,10 +66,6 @@
       <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
       <version>1.0.9</version>
       <exclusions>
-        <exclusion>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-annotation_1.3_spec</artifactId>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -103,7 +103,7 @@
 		<bundle dependency="true">mvn:org.osgi/org.osgi.util.promise/1.1.0</bundle>
 		<bundle dependency="true">mvn:org.osgi/org.osgi.service.jaxrs/1.0.0</bundle>
 		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.annotation-api-1.3/1.3_1</bundle>
-		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/2.9.0</bundle>
+		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.3/2.3_3</bundle>
 		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/1.0.9</bundle>
 		<!-- END: https://issues.apache.org/jira/browse/KARAF-6536 -->
 
@@ -132,16 +132,17 @@
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jaxb;version=2.9.0</capability>
-		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
-		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.9.0</bundle>
-		<bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1</bundle>
+		<capability>openhab.tp;feature=jaxb;version=2.3.3</capability>
+		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.2.1/1.2.1_2</bundle>
+		<bundle start-level="10">mvn:jakarta.xml.bind/jakarta.xml.bind-api/2.3.3</bundle>
+		<bundle start-level="20">mvn:com.sun.xml.bind/jaxb-osgi/2.3.3</bundle>
+		<bundle start-level="20">mvn:org.glassfish.hk2/osgi-resource-locator/1.0.3</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxws" description="JAX-WS (SOAP) bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jax-ws;version=2.9.0</capability>
-		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.9.0</bundle>
-		<bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saaj-impl/1.3.23_2</bundle>
+		<capability>openhab.tp;feature=jax-ws;version=1.4.0</capability>
+		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.4/1.4_2</bundle>
+		<bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saaj-impl/1.4.0_2</bundle>
 		<bundle start-level="20">mvn:org.jvnet.staxex/stax-ex/1.7.4</bundle>
 	</feature>
 

--- a/itests/itest-include.bndrun
+++ b/itests/itest-include.bndrun
@@ -25,9 +25,10 @@ Export-Package:
 -exportcontents:
 
 -runrequires.ee: \
-    bnd.identity;id='org.apache.servicemix.specs.activation-api-1.1',\
+    bnd.identity;id='org.apache.servicemix.specs.activation-api-1.2.1',\
     bnd.identity;id='org.apache.servicemix.specs.annotation-api-1.3',\
-    bnd.identity;id='org.apache.servicemix.specs.jaxb-api-2.2'
+    bnd.identity;id='org.glassfish.hk2.osgi-resource-locator',\
+    bnd.identity;id='com.sun.xml.bind.jaxb-osgi'
 
 -runrequires.junit: \
     bnd.identity;id='biz.aQute.tester.junit-platform',\

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -20,10 +20,7 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
@@ -53,4 +50,8 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -14,10 +14,7 @@ Bundle-SymbolicName: ${project.artifactId}
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -46,4 +43,8 @@ Bundle-SymbolicName: ${project.artifactId}
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -15,10 +15,7 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -47,4 +44,8 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -15,10 +15,7 @@ Fragment-Host: org.openhab.core.automation.module.script
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -48,4 +45,8 @@ Fragment-Host: org.openhab.core.automation.module.script
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -17,10 +17,7 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -47,4 +44,8 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -15,10 +15,7 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -47,4 +44,8 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -20,10 +20,7 @@ Fragment-Host: org.openhab.core.binding.xml
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -46,4 +43,8 @@ Fragment-Host: org.openhab.core.binding.xml
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)'
+	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -20,10 +20,7 @@ Fragment-Host: org.openhab.core.config.core
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -46,4 +43,8 @@ Fragment-Host: org.openhab.core.config.core
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -20,10 +20,7 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -48,4 +45,8 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -23,10 +23,7 @@ Fragment-Host: org.openhab.core.config.discovery
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -54,4 +51,8 @@ Fragment-Host: org.openhab.core.config.discovery
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -15,10 +15,7 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
@@ -51,5 +48,9 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
 

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -26,10 +26,7 @@ Provide-Capability: \
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
@@ -60,4 +57,8 @@ Provide-Capability: \
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -18,10 +18,7 @@ Fragment-Host: org.openhab.core.config.dispatch
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -42,4 +39,8 @@ Fragment-Host: org.openhab.core.config.dispatch
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -18,9 +18,6 @@ Fragment-Host: org.openhab.core.config.xml
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -43,4 +40,8 @@ Fragment-Host: org.openhab.core.config.xml
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -29,10 +29,7 @@ feature.openhab-config: \
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.log;version='[1.2.0,1.2.1)',\
@@ -60,4 +57,8 @@ feature.openhab-config: \
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -25,10 +25,7 @@ Fragment-Host: org.openhab.core.io.rest.core
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -63,8 +60,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.test;version='[3.0.0,3.0.1)',\
 	org.openhab.core.thing;version='[3.0.0,3.0.1)',\
 	org.openhab.core.transform;version='[3.0.0,3.0.1)',\
-	javax.xml.soap-api;version='[1.3.5,1.3.6)',\
-	org.apache.servicemix.specs.jaxws-api-2.2;version='[2.9.0,2.9.1)',\
 	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	junit-jupiter-api;version='[5.6.2,5.6.3)',\
 	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
@@ -77,4 +72,9 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
-	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)'
+	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	javax.xml.soap-api;version='[1.4.0,1.4.1)',\
+	org.apache.servicemix.specs.jaxws-api-2.3;version='[2.3.0,2.3.1)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -24,10 +24,7 @@ Fragment-Host: org.openhab.core.model.core
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -102,4 +99,7 @@ Fragment-Host: org.openhab.core.model.core
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)'
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -25,10 +25,7 @@ Fragment-Host: org.openhab.core.model.item
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -101,4 +98,7 @@ Fragment-Host: org.openhab.core.model.item
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)'
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -25,10 +25,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -117,5 +114,8 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)'
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -26,10 +26,7 @@ Fragment-Host: org.openhab.core.model.script
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -100,5 +97,8 @@ Fragment-Host: org.openhab.core.model.script
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)'
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
 	

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -36,9 +36,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava;version='[27.1.0,27.1.1)',\
@@ -113,5 +110,8 @@ Fragment-Host: org.openhab.core.model.thing
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)'
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
 

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -18,10 +18,7 @@ Fragment-Host: org.openhab.core.storage.json
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -42,4 +39,8 @@ Fragment-Host: org.openhab.core.storage.json
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -19,10 +19,7 @@ Fragment-Host: org.openhab.core
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -44,4 +41,8 @@ Fragment-Host: org.openhab.core
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
-	junit-jupiter-engine;version='[5.6.2,5.6.3)'
+	junit-jupiter-engine;version='[5.6.2,5.6.3)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -24,10 +24,7 @@ Fragment-Host: org.openhab.core.thing
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -54,4 +51,8 @@ Fragment-Host: org.openhab.core.thing
 	net.bytebuddy.byte-buddy-agent;version='[1.10.13,1.10.14)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.mockito.mockito-core;version='[3.4.6,3.4.7)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -21,10 +21,7 @@ Fragment-Host: org.openhab.core.thing.xml
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
@@ -49,4 +46,8 @@ Fragment-Host: org.openhab.core.thing.xml
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -21,10 +21,7 @@ Fragment-Host: org.openhab.core.voice
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
-	org.apache.servicemix.specs.activation-api-1.1;version='[2.9.0,2.9.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.specs.jaxb-api-2.2;version='[2.9.0,2.9.1)',\
-	org.apache.servicemix.specs.stax-api-1.2;version='[2.9.0,2.9.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
@@ -59,4 +56,8 @@ Fragment-Host: org.openhab.core.voice
 	junit-platform-engine;version='[1.6.2,1.6.3)',\
 	junit-platform-launcher;version='[1.6.2,1.6.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)'
+	org.opentest4j;version='[1.2.0,1.2.1)',\
+	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
+	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
+	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArgs>
@@ -281,12 +281,12 @@ Import-Package: \\
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-eclipse</artifactId>
-              <version>2.8.5</version>
+              <version>2.8.8</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.16.0</version>
+              <version>3.23.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Upgrades the compiler and its dependencies so the compiler results of Maven builds are more similar to those generated in recent Eclipse versions.

To fix compilation issues in Eclipse for add-ons using classes from javax.xml.stream several dependencies were upgraded/excluded.

---

Upgrading the compiler and its dependencies may also help solving/debugging errors like in this [build](https://ci.openhab.org/job/openHAB-Addons/73/console):

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project org.openhab.binding.alarmdecoder: Compilation failure: Compilation failure:
[ERROR] [ecj] The compiler reported an error but has not written it to its logging
[ERROR] [ecj] The following line(s) might indicate the issue:
[ERROR] at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[ERROR] at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[ERROR] at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[ERROR] at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[ERROR] at java.base/java.lang.Thread.run(Thread.java:834)
[ERROR] -> [Help 1]
````