### PR TITLE
Upgrade to Jollyday 0.5.10

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -267,10 +267,18 @@
     <dependency>
       <groupId>de.jollyday</groupId>
       <artifactId>jollyday</artifactId>
-      <!-- Upgrading to 0.5.9 causes Java 11 builds to fail -->
-      <!-- On Java 11 the bundle requires JAXB 2.3 whereas we depend on JAXB 2.2 for Java 8 compatibility -->
-      <version>0.5.8</version>
+      <version>0.5.10</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- JAXB -->

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -901,10 +901,18 @@
     <dependency>
       <groupId>de.jollyday</groupId>
       <artifactId>jollyday</artifactId>
-      <!-- Upgrading to 0.5.9 and adding compile scope causes Java 11 builds to fail -->
-      <!-- On Java 11 the bundle requires JAXB 2.3 whereas we depend on JAXB 2.2 for Java 8 compatibility -->
-      <version>0.5.8</version>
-      <!-- <scope>compile</scope> -->
+      <version>0.5.10</version>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- jose4j -->

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -147,9 +147,9 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.5.8</capability>
-		<bundle>mvn:org.threeten/threeten-extra/1.4</bundle>
-		<bundle>mvn:de.jollyday/jollyday/0.5.8</bundle>
+		<capability>openhab.tp;feature=jollyday;version=0.5.10</capability>
+		<bundle>mvn:org.threeten/threeten-extra/1.5.0</bundle>
+		<bundle>mvn:de.jollyday/jollyday/0.5.10</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -20,8 +20,6 @@ Bundle-SymbolicName: ${project.artifactId}
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -47,4 +45,6 @@ Bundle-SymbolicName: ${project.artifactId}
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.core.automation
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -48,4 +46,6 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.core.automation
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -48,4 +46,6 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -21,8 +21,6 @@ Fragment-Host: org.openhab.core.automation
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -48,4 +46,6 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -35,8 +35,6 @@ feature.openhab-config: \
 	org.apache.felix.log;version='[1.2.0,1.2.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.security;version='[9.4.20,9.4.21)',\
@@ -61,4 +59,6 @@ feature.openhab-config: \
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -14,7 +14,6 @@ package org.openhab.core.ephemeris.internal;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.openhab.core.ephemeris.internal.EphemerisManagerImpl.*;
 
 import java.net.URI;
@@ -61,9 +60,6 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
 
     @BeforeEach
     public void setUp() {
-        // TODO: Tests currently fail on Java 11 due to Jollyday requiring JAXB 2.3
-        assumeTrue(System.getProperty("java.version").startsWith("1.8"));
-
         ephemerisManager = getService(EphemerisManager.class, EphemerisManagerImpl.class);
         assertNotNull(ephemerisManager);
 

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -42,13 +42,11 @@ Fragment-Host: org.openhab.core.model.core
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.eclipse.xtext.common.types;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	org.eclipse.xtext.xbase;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -102,4 +100,6 @@ Fragment-Host: org.openhab.core.model.core
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -43,13 +43,11 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.xtext.util;version='[2.19.0,2.19.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
 	org.eclipse.xtext.xbase;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -101,4 +99,6 @@ Fragment-Host: org.openhab.core.model.item
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -42,7 +42,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.xtext.util;version='[2.19.0,2.19.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.19.0,2.19.1)',\
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.xbean.bundleutils;version='[4.12.0,4.12.1)',\
 	org.apache.xbean.finder;version='[4.12.0,4.12.1)',\
@@ -65,7 +64,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -117,5 +115,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -48,8 +48,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -100,5 +98,7 @@ Fragment-Host: org.openhab.core.model.script
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'
 	

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -52,8 +52,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.objectweb.asm;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.commons;version='[7.1.0,7.1.1)',\
 	org.objectweb.asm.tree;version='[7.1.0,7.1.1)',\
-	jollyday;version='[0.5.8,0.5.9)',\
-	org.threeten.extra;version='[1.4.0,1.4.1)',\
 	org.eclipse.jetty.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.http;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.io;version='[9.4.20,9.4.21)',\
@@ -113,5 +111,7 @@ Fragment-Host: org.openhab.core.model.thing
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	jollyday;version='[0.5.10,0.5.11)',\
+	org.threeten.extra;version='[1.5.0,1.5.1)'
 


### PR DESCRIPTION
With some excludes and the upgraded JAXB I got the most recent Jollyday version working.
The integration tests also succeed again on Java 11.