### PR TITLE
Upgrade to XStream 1.4.13

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -257,9 +257,9 @@
 
     <!-- XStream -->
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xstream</artifactId>
-      <version>1.4.7_1</version>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.13</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -515,9 +515,9 @@
 
     <!-- XStream -->
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xstream</artifactId>
-      <version>1.4.7_1</version>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.13</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/BindingInfoReader.java
+++ b/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/BindingInfoReader.java
@@ -53,7 +53,7 @@ public class BindingInfoReader extends XmlDocumentReader<BindingInfoXmlResult> {
     }
 
     @Override
-    public void registerConverters(XStream xstream) {
+    protected void registerConverters(XStream xstream) {
         xstream.registerConverter(new NodeAttributesConverter());
         xstream.registerConverter(new NodeValueConverter());
         xstream.registerConverter(new BindingInfoConverter());
@@ -64,7 +64,7 @@ public class BindingInfoReader extends XmlDocumentReader<BindingInfoXmlResult> {
     }
 
     @Override
-    public void registerAliases(XStream xstream) {
+    protected void registerAliases(XStream xstream) {
         xstream.alias("binding", BindingInfoXmlResult.class);
         xstream.alias("name", NodeValue.class);
         xstream.alias("description", NodeValue.class);

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/internal/ConfigDescriptionReader.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/internal/ConfigDescriptionReader.java
@@ -54,7 +54,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
     }
 
     @Override
-    public void registerConverters(XStream xstream) {
+    protected void registerConverters(XStream xstream) {
         xstream.registerConverter(new NodeValueConverter());
         xstream.registerConverter(new NodeListConverter());
         xstream.registerConverter(new NodeAttributesConverter());
@@ -65,7 +65,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
     }
 
     @Override
-    public void registerAliases(XStream xstream) {
+    protected void registerAliases(XStream xstream) {
         xstream.alias("config-descriptions", List.class);
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/util/XmlDocumentReader.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/util/XmlDocumentReader.java
@@ -30,19 +30,28 @@ import com.thoughtworks.xstream.io.xml.StaxDriver;
  * This class uses {@code XStream} and {@code StAX} to parse and convert the XML document.
  *
  * @author Michael Grammling - Initial contribution
+ * @author Wouter Born - Configure XStream security
  *
  * @param <T> the result type of the conversion
  */
 @NonNullByDefault
 public abstract class XmlDocumentReader<@NonNull T> {
 
+    protected static final String[] DEFAULT_ALLOWED_TYPES_WILDCARD = new String[] { "org.openhab.core.**" };
+
     private final XStream xstream = new XStream(new StaxDriver());
 
     /**
-     * The default constructor of this class initializes the {@code XStream} object, and calls
-     * the abstract methods {@link #registerConverters()} and {@link #registerAliases()}.
+     * The default constructor of this class initializes the {@code XStream} object by calling:
+     *
+     * <ol>
+     * <li>{@link #configureSecurity()}</li>
+     * <li>{@link #registerConverters()}</li>
+     * <li>{@link #registerAliases()}</li>
+     * </ol>
      */
     public XmlDocumentReader() {
+        configureSecurity(xstream);
         registerConverters(xstream);
         registerAliases(xstream);
     }
@@ -52,8 +61,20 @@ public abstract class XmlDocumentReader<@NonNull T> {
      *
      * @param classLoader the classloader to set (must not be null)
      */
-    public void setClassLoader(ClassLoader classLoader) {
+    protected void setClassLoader(ClassLoader classLoader) {
         xstream.setClassLoader(classLoader);
+    }
+
+    /**
+     * Configures the security of the {@link XStream} instance to protect against vulnerabilities.
+     *
+     * @param xstream the XStream object to be configured
+     *
+     * @see https://x-stream.github.io/security.html
+     */
+    protected void configureSecurity(XStream xstream) {
+        XStream.setupDefaultSecurity(xstream);
+        xstream.allowTypesByWildcard(DEFAULT_ALLOWED_TYPES_WILDCARD);
     }
 
     /**
@@ -61,14 +82,14 @@ public abstract class XmlDocumentReader<@NonNull T> {
      *
      * @param xstream the XStream object to be configured
      */
-    public abstract void registerConverters(XStream xstream);
+    protected abstract void registerConverters(XStream xstream);
 
     /**
      * Registers any aliases at the {@link XStream} instance.
      *
      * @param xstream the XStream object to be configured
      */
-    public abstract void registerAliases(XStream xstream);
+    protected abstract void registerAliases(XStream xstream);
 
     /**
      * Reads the XML document containing a specific XML tag from the specified {@link URL} and converts it to the

--- a/bundles/org.openhab.core.config.xml/src/test/java/com/acme/Product.java
+++ b/bundles/org.openhab.core.config.xml/src/test/java/com/acme/Product.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package com.acme;
+
+import javax.sql.rowset.spi.XmlReader;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * A class that is in a non-framework package.
+ *
+ * Used to test if the XStream security configuration in the {@link XmlReader} forbids deserialization.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class Product {
+}

--- a/bundles/org.openhab.core.config.xml/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
+++ b/bundles/org.openhab.core.config.xml/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.xml.util;
+
+import static org.eclipse.jdt.annotation.Checks.requireNonNull;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+
+import com.acme.Product;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.ForbiddenClassException;
+
+/**
+ * Tests {@link XmlDocumentReader}.
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@NonNullByDefault
+public class XmlDocumentReaderTest {
+
+    private static final String OHC_PACKAGE_PREFIX = "org.openhab.core.";
+
+    private class ConfigDescriptionReader extends XmlDocumentReader<ConfigDescription> {
+        @Override
+        protected void registerConverters(XStream xstream) {
+        }
+
+        @Override
+        protected void registerAliases(XStream xstream) {
+        }
+    }
+
+    private @Nullable ConfigDescription readXML(String xml) throws IOException {
+        Path tempFile = Files.createTempFile(null, null);
+        tempFile.toFile().deleteOnExit();
+        Files.write(tempFile, xml.getBytes(StandardCharsets.UTF_8));
+        return new ConfigDescriptionReader().readFromXML(tempFile.toUri().toURL());
+    }
+
+    @Test
+    public void defaultSecurityAllowsDeserializingOHCobjects() throws Exception {
+        assertThat(ConfigDescription.class.getPackageName(), startsWith(OHC_PACKAGE_PREFIX));
+
+        URI testURI = URI.create("test:uri");
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(testURI).build();
+
+        String xml = new XStream().toXML(configDescription);
+
+        ConfigDescription readConfigDescription = requireNonNull(readXML(xml));
+
+        assertThat(readConfigDescription.getUID(), is(testURI));
+    }
+
+    @Test
+    public void defaultSecurityDisallowsDeserializingNonOHCobjects() throws Exception {
+        assertThat(Product.class.getPackageName(), not(startsWith(OHC_PACKAGE_PREFIX)));
+
+        String xml = new XStream().toXML(new Product());
+
+        assertThrows(ForbiddenClassException.class, () -> readXML(xml));
+    }
+
+    /**
+     * @see https://x-stream.github.io/CVE-2013-7285.html
+     */
+    @Test
+    public void defaultSecurityProtectsAgainstRemoteCodeExecution() throws Exception {
+        String xml = "<contact class='dynamic-proxy'>\n" //
+                + "  <interface>org.openhab.core.Contact</interface>\n"
+                + "  <handler class='java.beans.EventHandler'>\n" //
+                + "    <target class='java.lang.ProcessBuilder'>\n" //
+                + "      <command>\n" //
+                + "        <string>calc.exe</string>\n" //
+                + "      </command>\n" //
+                + "    </target>\n" //
+                + "    <action>start</action>\n" //
+                + "  </handler>\n" //
+                + "</contact>";
+
+        assertThrows(ForbiddenClassException.class, () -> readXML(xml));
+    }
+
+    /**
+     * @see https://x-stream.github.io/CVE-2017-7957.html
+     */
+    @Test
+    public void defaultSecurityProtectsAgainstDenailOfServiceAttacks() throws Exception {
+        assertThrows(ForbiddenClassException.class, () -> readXML("<void/>"));
+        assertThrows(ForbiddenClassException.class, () -> readXML("<string class='void'>Hello, world!</string>"));
+    }
+}

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -32,7 +32,7 @@
 		<bundle dependency="true">mvn:tec.uom.lib/uom-lib-common/1.0.3</bundle>
 
 		<!-- TODO: Unbundled libraries -->
-		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>
+		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.13</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -47,4 +46,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
@@ -55,4 +54,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core.config.xml
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
@@ -44,4 +43,5 @@ Fragment-Host: org.openhab.core.config.xml
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -30,7 +30,6 @@ feature.openhab-config: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.log;version='[1.2.0,1.2.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
@@ -61,4 +60,5 @@ feature.openhab-config: \
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)'
+	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -99,8 +99,8 @@ Fragment-Host: org.openhab.core.model.core
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	org.openhab.core.model.rule.runtime;version='[3.0.0,3.0.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -98,8 +98,8 @@ Fragment-Host: org.openhab.core.model.item
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	org.openhab.core.model.rule.runtime;version='[3.0.0,3.0.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -103,7 +103,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -97,9 +97,9 @@ Fragment-Host: org.openhab.core.model.script
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	org.openhab.core.model.rule.runtime;version='[3.0.0,3.0.1)'
 	

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -25,7 +25,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
@@ -110,9 +109,10 @@ Fragment-Host: org.openhab.core.model.thing
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.commons;version='[8.0.1,8.0.2)',\
 	org.objectweb.asm.tree;version='[8.0.1,8.0.2)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.0.0,3.0.1)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.2.19,7.2.20)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.2.19,7.2.20)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.2.19,7.2.20)',\
+	org.openhab.core.model.rule.runtime;version='[3.0.0,3.0.1)',\
+	xstream;version='[1.4.13,1.4.14)'
 

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -19,7 +19,6 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.objenesis;version='[2.6.0,2.6.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
@@ -55,4 +54,5 @@ Fragment-Host: org.openhab.core.thing
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	xstream;version='[1.4.13,1.4.14)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
-	org.apache.servicemix.bundles.xstream;version='[1.4.7,1.4.8)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
@@ -50,4 +49,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)'
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
+	xstream;version='[1.4.13,1.4.14)'


### PR DESCRIPTION
* Fixes bugs (vulnerabilities/performance issues)
* Supports OSGi better
* Prevents illegal reflective access warnings on newer Java versions
* Supports java.time converters

For XStream release notes see: https://x-stream.github.io/changes.html

The `XmlDocumentReader` which uses XStream has also been modified to configure XStream security to prevent "Security framework of XStream not initialized, XStream is probably vulnerable" warnings.