### PR TITLE
Remove Jackson 1.x compile dependency

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -105,20 +105,6 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- Jackson -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.2</version>
-      <scope>compile</scope>
-    </dependency>
-
     <!-- Jetty -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
It doesn't seem to be used by anything and it is also not part of the target platform.