### PR TITLE
[REST] Added validation for relation between ThingUID and BridgeUID

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -215,6 +215,7 @@ public class ThingResource implements RESTResource {
     @Operation(summary = "Creates a new thing and adds it to the registry.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = String.class))),
+                    @ApiResponse(responseCode = "400", description = "Thing uid does not match bridge uid."),
                     @ApiResponse(responseCode = "400", description = "A uid must be provided, if no binding can create a thing of this type."),
                     @ApiResponse(responseCode = "409", description = "A thing with the same uid already exists.") })
     public Response create(
@@ -239,6 +240,11 @@ public class ThingResource implements RESTResource {
 
         if (thingBean.bridgeUID != null) {
             bridgeUID = new ThingUID(thingBean.bridgeUID);
+            if (thingUID != null && (!thingUID.getBindingId().equals(bridgeUID.getBindingId())
+                    || !thingUID.getBridgeIds().contains(bridgeUID.getId()))) {
+                return Response.status(Status.BAD_REQUEST)
+                        .entity("Thing UID '" + thingUID + "' does not match bridge UID '" + bridgeUID + "'").build();
+            }
         }
 
         // turn the ThingDTO's configuration into a Configuration

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
@@ -193,10 +193,10 @@ public class ThingRegistryOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatCreateThingDelegatesToRegisteredThingHandlerFactory() {
         ThingTypeUID expectedThingTypeUID = THING_TYPE_UID;
-        ThingUID expectedThingUID = new ThingUID(THING_TYPE_UID, THING1_ID);
-        Configuration expectedConfiguration = new Configuration();
         ThingUID expectedBridgeUID = new ThingUID(THING_TYPE_UID, THING2_ID);
+        ThingUID expectedThingUID = new ThingUID(THING_TYPE_UID, expectedBridgeUID, THING1_ID);
         String expectedLabel = "Test Thing";
+        Configuration expectedConfiguration = new Configuration();
 
         AtomicReference<Thing> thingResultWrapper = new AtomicReference<>();
 


### PR DESCRIPTION
- Check for valid `ThingUID` when creating a `Thing` which is related to a `Bridge`

Similar to https://github.com/openhab/openhab-core/pull/1481

My first idea was to add the check inside [ThingRegistryImpl.createThingOfType(ThingTypeUID, ThingUID, ThingUID, String, Configuration)](https://github.com/openhab/openhab-core/blob/c4b76a0ad11d5098f0f48bb3f86b0f943afc23cf/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java#L245) but I was not sure if it is the best idea to throw an IAE if the given `ThingUID` does not match as it will be API breaking. 

Maybe we should not merge it until we have a valid solution for https://github.com/openhab/openhab-webui/issues/380.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>