### PR TITLE
Simplify core features to prevent unnecessary bundle refreshes

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -74,47 +74,26 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.auth.oauth2client/${project.version}</bundle>
 	</feature>
 
-	<feature name="openhab-core-automation" version="${project.version}">
-		<feature>openhab-core-base</feature>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation/${project.version}</bundle>
-	</feature>
-
 	<feature name="openhab-core-automation-module-script" version="${project.version}">
 		<feature>openhab-core-base</feature>
-		<feature dependency="true">openhab-core-automation</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.module.script/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-core-automation-module-script-rulesupport" version="${project.version}">
 		<feature>openhab-core-base</feature>
-		<feature dependency="true">openhab-core-automation</feature>
 		<feature dependency="true">openhab-core-automation-module-script</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.module.script.rulesupport/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-core-automation-module-media" version="${project.version}">
 		<feature>openhab-core-base</feature>
-		<feature dependency="true">openhab-core-automation</feature>
 		<feature dependency="true">openhab-core-automation-module-script</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.module.media/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-core-automation-rest" version="${project.version}">
 		<feature>openhab-core-base</feature>
-		<feature dependency="true">openhab-core-automation</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.rest/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-core-config-serial" version="${project.version}">
-		<feature>openhab-core-base</feature>
-		<feature>openhab-core-io-transport-serial</feature>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.serial/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-core-config-discovery-usbserial" version="${project.version}">
-		<feature>openhab-core-base</feature>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery.usbserial/${project.version}</bundle>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-core-io-bin2json" description="Binary to JSON converter" version="${project.version}">
@@ -227,15 +206,6 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.mqtt/${project.version}</bundle>
 	</feature>
 
-	<feature name="openhab-core-io-transport-serial" version="${project.version}">
-		<feature>openhab-core-base</feature>
-		<requirement>osgi.service;filter:="(objectClass=org.openhab.core.io.transport.serial.SerialPortManager)"</requirement>
-		<requirement>osgi.service;filter:="(objectClass=org.openhab.core.io.transport.serial.SerialPortProvider)"</requirement>
-		<feature dependency="true">openhab-core-io-transport-serial-rxtx</feature>
-
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial/${project.version}</bundle>
-	</feature>
-
 	<feature name="openhab-core-io-transport-serial-javacomm" version="${project.version}">
 		<feature>openhab-core-base</feature>
 
@@ -244,29 +214,6 @@
 
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial.javacomm/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-core-io-transport-serial-rxtx" version="${project.version}">
-		<feature>openhab-core-base</feature>
-
-		<requirement>openhab.tp;filter:="(&amp;(feature=serial)(impl=rxtx))"</requirement>
-		<feature dependency="true">openhab.tp-serial-rxtx</feature>
-
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial/${project.version}</bundle>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial.rxtx/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-core-io-transport-serial-rfc2217" version="${project.version}">
-		<feature>openhab-core-base</feature>
-
-		<requirement>openhab.tp;filter:="(&amp;(feature=serial)(impl=rxtx))"</requirement>
-		<feature dependency="true">openhab-core-io-transport-serial-rxtx</feature>
-
-		<requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
-		<feature dependency="true">openhab.tp-commons-net</feature>
-
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial/${project.version}</bundle>
-		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-core-io-transport-upnp" version="${project.version}">
@@ -427,7 +374,6 @@
 		<feature>openhab-core-automation-rest</feature>
 		<feature>openhab-core-automation-module-script</feature>
 		<feature>openhab-core-automation-module-media</feature>
-		<feature>openhab-core-automation</feature>
 		<feature>openhab-core-io-console-karaf</feature>
 		<feature>openhab-core-io-http-auth</feature>
 		<feature>openhab-core-io-rest-auth</feature>
@@ -499,9 +445,23 @@
 	</feature>
 
 	<feature name="openhab-transport-serial" description="Serial Transport" version="${project.version}">
-		<feature>openhab-core-io-transport-serial-rfc2217</feature>
-		<feature>openhab-core-config-serial</feature>
-		<feature>openhab-core-config-discovery-usbserial</feature>
+		<feature>openhab-core-base</feature>
+
+		<requirement>osgi.service;filter:="(objectClass=org.openhab.core.io.transport.serial.SerialPortManager)"</requirement>
+		<requirement>osgi.service;filter:="(objectClass=org.openhab.core.io.transport.serial.SerialPortProvider)"</requirement>
+
+		<requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
+		<feature dependency="true">openhab.tp-commons-net</feature>
+
+		<requirement>openhab.tp;filter:="(&amp;(feature=serial)(impl=rxtx))"</requirement>
+		<feature dependency="true">openhab.tp-serial-rxtx</feature>
+
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.serial/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery.usbserial/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial.rxtx/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/${project.version}</bundle>
 	</feature>
 
 	<feature name="openhab-transport-upnp" description="UPnP Transport" version="${project.version}">


### PR DESCRIPTION
It seems that when multiple features install the same bundle it may cause Karaf to refresh bundles when (un)installing features.

I found the bundles which cause these refreshes by (un)installing features with the verbose (-v) option so Karaf shows what happens:

```
openhab> feature:install -v openhab-binding-mail
Adding features: openhab-binding-mail/[3.0.0.SNAPSHOT,3.0.0.SNAPSHOT]
Changes to perform:
  Region: root
    Bundles to install:
      mvn:com.sun.mail/javax.mail/1.6.2
      mvn:org.openhab.addons.bundles/org.openhab.binding.mail/3.0.0-SNAPSHOT
Stopping bundles:
  org.openhab.binding.network/3.0.0.202010080341
  org.openhab.core.automation.rest/3.0.0.202010080309
  org.openhab.core.model.script.runtime/3.0.0.202010080314
  org.openhab.core.model.rule.runtime/3.0.0.202010080314
  org.openhab.core.automation.module.script/3.0.0.202010080308
  org.openhab.core.automation.module.media/3.0.0.202010080308
  org.openhab.core.automation/3.0.0.202010080258
  org.eclipse.jetty.plus/9.4.20.v20190813
  org.eclipse.jetty.jndi/9.4.20.v20190813
Installing bundles:
  mvn:com.sun.mail/javax.mail/1.6.2
  mvn:org.openhab.addons.bundles/org.openhab.binding.mail/3.0.0-SNAPSHOT
Refreshing bundles:
    org.eclipse.jetty.jndi/9.4.20.v20190813 (Should be wired to: com.sun.mail.javax.mail/1.6.2 (through [org.eclipse.jetty.jndi/9.4.20.v20190813] osgi.wiring.package; resolution:=optional; filter:="(&(osgi.wiring.package=javax.mail)(version>=1.4.1)(!(version>=2.0.0)))"))
    org.eclipse.jetty.plus/9.4.20.v20190813 (Wired to org.eclipse.jetty.jndi/9.4.20.v20190813 which is being refreshed)
    org.openhab.binding.network/3.0.0.202010080341 (Wired to org.openhab.core.automation/3.0.0.202010080258 which is being refreshed)
    org.openhab.core.automation/3.0.0.202010080258 (Should be wired to: org.openhab.core.automation/3.0.0.202010080258 (through [org.openhab.core.automation/3.0.0.202010080258] osgi.wiring.package; resolution:=optional; filter:="(osgi.wiring.package=org.openhab.core.automation.annotation)"))
    org.openhab.core.automation.module.media/3.0.0.202010080308 (Wired to org.openhab.core.automation/3.0.0.202010080258 which is being refreshed)
    org.openhab.core.automation.module.script/3.0.0.202010080308 (Wired to org.openhab.core.automation/3.0.0.202010080258 which is being refreshed)
    org.openhab.core.automation.rest/3.0.0.202010080309 (Wired to org.openhab.core.automation/3.0.0.202010080258 which is being refreshed)
    org.openhab.core.model.rule.runtime/3.0.0.202010080314 (Wired to org.openhab.core.automation/3.0.0.202010080258 which is being refreshed)
    org.openhab.core.model.script.runtime/3.0.0.202010080314 (Wired to org.openhab.core.automation.module.script/3.0.0.202010080308 which is being refreshed)
Starting bundles:
  org.openhab.binding.mail/3.0.0.202010080338
  com.sun.mail.javax.mail/1.6.2
Done.
```

In this case it restarted the whole RuleEngine and also the Network Binding because it refreshed the `org.openhab.core.automation` bundle. 

Refreshes of the `org.openhab.core.io.transport.serial` bundle also seems to cause these restarts:

```
openhab> feature:uninstall -v openhab-binding-astro
Removing features: openhab-binding-astro/[3.0.0.SNAPSHOT,3.0.0.SNAPSHOT]
Changes to perform:
  Region: root
    Bundles to uninstall:
      org.openhab.binding.astro/3.0.0.202010092151
Stopping bundles:
  org.openhab.binding.astro/3.0.0.202010092151
  org.openhab.core.config.serial/3.0.0.202010092149
  org.openhab.binding.plugwise/3.0.0.202010092151
  org.openhab.core.io.transport.serial.rxtx.rfc2217/3.0.0.202010092149
  org.openhab.core.io.transport.serial/3.0.0.202010092149
  org.openhab.core.io.transport.serial.rxtx/3.0.0.202010092149
Uninstalling bundles:
  org.openhab.binding.astro/3.0.0.202010092151
Refreshing bundles:
    org.openhab.binding.astro/3.0.0.202010092151 (Bundle will be uninstalled)
    org.openhab.binding.plugwise/3.0.0.202010092151 (Should be wired to: org.openhab.core.io.transport.serial/3.0.0.202010092149 (through [org.openhab.binding.plugwise/3.0.0.202010092151] osgi.wiring.package; filter:="(osgi.wiring.package=org.openhab.core.io.transport.serial)"))
    org.openhab.core.config.serial/3.0.0.202010092149 (Should be wired to: org.openhab.core.io.transport.serial/3.0.0.202010092149 (through [org.openhab.core.config.serial/3.0.0.202010092149] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.openhab.core.io.transport.serial)(version>=3.0.0)(!(version>=4.0.0)))"))
    org.openhab.core.io.transport.serial/3.0.0.202010092149 (Should be wired to: org.openhab.core.io.transport.serial/3.0.0.202010092149 (through [org.openhab.core.io.transport.serial/3.0.0.202010092149] osgi.wiring.package; filter:="(osgi.wiring.package=org.openhab.core.io.transport.serial)"))
    org.openhab.core.io.transport.serial.rxtx/3.0.0.202010092149 (Wired to org.openhab.core.io.transport.serial/3.0.0.202010092149 which is being refreshed)
    org.openhab.core.io.transport.serial.rxtx.rfc2217/3.0.0.202010092149 (Wired to org.openhab.core.io.transport.serial/3.0.0.202010092149 which is being refreshed)
Done.
```

When the (redundant) openhab-core-automation feature is removed and the serial dependencies are merged into the openhab-transport-serial feature these restarts due these bundle refreshes no longer occur.


Fixes #1322
Fixes #1354
