### PR TITLE
Allow basic authentication to authorize API access

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AnonymousUserSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AnonymousUserSecurityContext.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import java.security.Principal;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.Role;
+
+/**
+ * This {@link SecurityContext} can be used to give anonymous users (i.e. unauthenticated requests) the "user" role.
+ *
+ * @author Yannick Schaus - initial contribution
+ */
+@NonNullByDefault
+public class AnonymousUserSecurityContext implements SecurityContext {
+
+    @Override
+    public @Nullable Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserInRole(@Nullable String role) {
+        return role == null || Role.USER.equals(role);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public @Nullable String getAuthenticationScheme() {
+        return null;
+    }
+}

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -67,10 +67,10 @@ public class AuthFilter implements ContainerRequestFilter {
 
     protected static final String CONFIG_URI = "system:restauth";
     private static final String CONFIG_ALLOW_BASIC_AUTH = "allowBasicAuth";
-    private static final String CONFIG_NO_IMPLICIT_USER_ROLE = "noImplicitUserRole";
+    private static final String CONFIG_IMPLICIT_USER_ROLE = "implicitUserRole";
 
     private boolean allowBasicAuth = false;
-    private boolean noUnauthenticatedUserRole = false;
+    private boolean implicitUserRole = true;
 
     @Reference
     private JwtHelper jwtHelper;
@@ -88,8 +88,8 @@ public class AuthFilter implements ContainerRequestFilter {
         if (properties != null) {
             Object value = properties.get(CONFIG_ALLOW_BASIC_AUTH);
             allowBasicAuth = value != null && "true".equals(value.toString());
-            value = properties.get(CONFIG_NO_IMPLICIT_USER_ROLE);
-            noUnauthenticatedUserRole = value != null && "true".equals(value.toString());
+            value = properties.get(CONFIG_IMPLICIT_USER_ROLE);
+            implicitUserRole = value != null && "false".equals(value.toString());
         }
     }
 
@@ -137,7 +137,7 @@ public class AuthFilter implements ContainerRequestFilter {
                 return;
             }
 
-            if (!noUnauthenticatedUserRole) {
+            if (implicitUserRole) {
                 requestContext.setSecurityContext(new AnonymousUserSecurityContext());
             }
 

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -13,6 +13,7 @@
 package org.openhab.core.io.rest.auth.internal;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import javax.annotation.Priority;
 import javax.security.sasl.AuthenticationException;
@@ -26,6 +27,9 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
 
 import org.openhab.core.auth.Authentication;
+import org.openhab.core.auth.User;
+import org.openhab.core.auth.UserRegistry;
+import org.openhab.core.auth.UsernamePasswordCredentials;
 import org.openhab.core.io.rest.JSONResponse;
 import org.openhab.core.io.rest.RESTConstants;
 import org.osgi.service.component.annotations.Component;
@@ -35,10 +39,11 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsExtension;
 
 /**
- * This filter is responsible for parsing a token provided with a request, and hydrating a {@link SecurityContext} from
- * the claims contained in the token.
+ * This filter is responsible for parsing credentials provided with a request, and hydrating a {@link SecurityContext}
+ * from these credentials if they are valid.
  *
  * @author Yannick Schaus - initial contribution
+ * @author Yannick Schaus - Allow basic authentication
  */
 @PreMatching
 @Component
@@ -52,6 +57,9 @@ public class AuthFilter implements ContainerRequestFilter {
     @Reference
     private JwtHelper jwtHelper;
 
+    @Reference
+    private UserRegistry userRegistry;
+
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         try {
@@ -63,6 +71,25 @@ public class AuthFilter implements ContainerRequestFilter {
                         Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(authParts[1]);
                         requestContext.setSecurityContext(new JwtSecurityContext(auth));
                         return;
+                    } else if ("Basic".equals(authParts[0])) {
+                        try {
+                            String[] decodedCredentials = new String(Base64.getDecoder().decode(authParts[1]), "UTF-8")
+                                    .split(":");
+                            if (decodedCredentials.length != 2) {
+                                throw new AuthenticationException("Invalid Basic authentication credential format");
+                            }
+                            UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
+                                    decodedCredentials[0], decodedCredentials[1]);
+                            Authentication auth = userRegistry.authenticate(credentials);
+                            User user = userRegistry.get(auth.getUsername());
+                            if (user == null) {
+                                throw new org.openhab.core.auth.AuthenticationException("User not found in registry");
+                            }
+                            requestContext.setSecurityContext(new UserSecurityContext(user, "Basic"));
+                            return;
+                        } catch (org.openhab.core.auth.AuthenticationException e) {
+                            throw new AuthenticationException("Invalid user name or password");
+                        }
                     }
                 }
             }
@@ -74,7 +101,7 @@ public class AuthFilter implements ContainerRequestFilter {
                 return;
             }
         } catch (AuthenticationException e) {
-            requestContext.abortWith(JSONResponse.createErrorResponse(Status.UNAUTHORIZED, "Invalid token"));
+            requestContext.abortWith(JSONResponse.createErrorResponse(Status.UNAUTHORIZED, "Invalid credentials"));
         }
     }
 }

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -89,7 +89,7 @@ public class AuthFilter implements ContainerRequestFilter {
             Object value = properties.get(CONFIG_ALLOW_BASIC_AUTH);
             allowBasicAuth = value != null && "true".equals(value.toString());
             value = properties.get(CONFIG_IMPLICIT_USER_ROLE);
-            implicitUserRole = value != null && "false".equals(value.toString());
+            implicitUserRole = value == null || !"false".equals(value.toString());
         }
     }
 

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -67,7 +67,7 @@ public class AuthFilter implements ContainerRequestFilter {
 
     protected static final String CONFIG_URI = "system:restauth";
     private static final String CONFIG_ALLOW_BASIC_AUTH = "allowBasicAuth";
-    private static final String CONFIG_NO_UNAUTHENTICATED_USER_ROLE = "noUnauthenticatedUserRole";
+    private static final String CONFIG_NO_IMPLICIT_USER_ROLE = "noImplicitUserRole";
 
     private boolean allowBasicAuth = false;
     private boolean noUnauthenticatedUserRole = false;
@@ -88,7 +88,7 @@ public class AuthFilter implements ContainerRequestFilter {
         if (properties != null) {
             Object value = properties.get(CONFIG_ALLOW_BASIC_AUTH);
             allowBasicAuth = value != null && "true".equals(value.toString());
-            value = properties.get(CONFIG_NO_UNAUTHENTICATED_USER_ROLE);
+            value = properties.get(CONFIG_NO_IMPLICIT_USER_ROLE);
             noUnauthenticatedUserRole = value != null && "true".equals(value.toString());
         }
     }
@@ -100,11 +100,11 @@ public class AuthFilter implements ContainerRequestFilter {
             if (authHeader != null) {
                 String[] authParts = authHeader.split(" ");
                 if (authParts.length == 2) {
-                    if ("Bearer".equals(authParts[0])) {
+                    if ("Bearer".equalsIgnoreCase(authParts[0])) {
                         Authentication auth = jwtHelper.verifyAndParseJwtAccessToken(authParts[1]);
                         requestContext.setSecurityContext(new JwtSecurityContext(auth));
                         return;
-                    } else if ("Basic".equals(authParts[0])) {
+                    } else if ("Basic".equalsIgnoreCase(authParts[0])) {
                         if (!allowBasicAuth) {
                             throw new AuthenticationException("Basic authentication is not allowed");
                         }

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSecurityContext.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import java.security.Principal;
+
+import javax.ws.rs.core.SecurityContext;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.User;
+
+/**
+ * This {@link SecurityContext} contains information about a user, roles and authorizations granted to a client
+ * from a {@link User} instance.
+ *
+ * @author Yannick Schaus - initial contribution
+ */
+@NonNullByDefault
+public class UserSecurityContext implements SecurityContext {
+
+    private User user;
+    private String authenticationScheme;
+
+    /**
+     * Constructs a security context from an instance of {@link User}
+     *
+     * @param user the user
+     * @param authenticationScheme the scheme that was used to authenticate the user, e.g. "Basic"
+     */
+    public UserSecurityContext(User user, String authenticationScheme) {
+        this.user = user;
+        this.authenticationScheme = authenticationScheme;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return user;
+    }
+
+    @Override
+    public boolean isUserInRole(@Nullable String role) {
+        return user.getRoles().contains(role);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return true;
+    }
+
+    @Override
+    public String getAuthenticationScheme() {
+        return authenticationScheme;
+    }
+}

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="system:restauth">
+		<parameter name="allowBasicAuth" type="boolean" required="false">
+			<label>Allow Basic Authentication</label>
+			<description>Allow the use of Basic authentication to access protected API resources.</description>
+		</parameter>
+		<parameter name="noUnauthenticatedUserRole" type="boolean" required="false">
+			<advanced>true</advanced>
+			<label>Deny unauthenticated access to user operations</label>
+			<description>By default, operations requiring the "user" role are available when unauthenticated. Enabling this
+				option will require authentication for these operations. Warning: this will cause clients which don't
+				support
+				authorization to break.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -7,11 +7,14 @@
 	<config-description uri="system:restauth">
 		<parameter name="allowBasicAuth" type="boolean" required="false">
 			<label>Allow Basic Authentication</label>
-			<description>Allow the use of Basic authentication to access protected API resources.</description>
+			<default>false</default>
+			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
+				and API tokens.</description>
 		</parameter>
-		<parameter name="noUnauthenticatedUserRole" type="boolean" required="false">
+		<parameter name="noImplicitUserRole" type="boolean" required="false">
 			<advanced>true</advanced>
-			<label>Deny unauthenticated access to user operations</label>
+			<label>No implicit user role for unauthenticated requests</label>
+			<default>false</default>
 			<description>By default, operations requiring the "user" role are available when unauthenticated. Enabling this
 				option will require authentication for these operations. Warning: this will cause clients which don't
 				support

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -11,13 +11,14 @@
 			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
 				and API tokens.</description>
 		</parameter>
-		<parameter name="noImplicitUserRole" type="boolean" required="false">
+		<parameter name="implicitUserRole" type="boolean" required="false">
 			<advanced>true</advanced>
-			<label>No implicit user role for unauthenticated requests</label>
-			<default>false</default>
-			<description>By default, operations requiring the "user" role are available when unauthenticated. Enabling this
-				option will require authentication for these operations. Warning: This causes clients that do not
-				support authentication to break.</description>
+			<label>Implicit user role for unauthenticated requests</label>
+			<default>true</default>
+			<description>By default, operations requiring the "user" role are available when unauthenticated. Disabling this
+				option will enforce authorization for these operations. Warning: this will cause clients which don't
+				support
+				authorization to break.</description>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -16,9 +16,8 @@
 			<label>Implicit user role for unauthenticated requests</label>
 			<default>true</default>
 			<description>By default, operations requiring the "user" role are available when unauthenticated. Disabling this
-				option will enforce authorization for these operations. Warning: this will cause clients which don't
-				support
-				authorization to break.</description>
+				option will enforce authorization for these operations. Warning: This causes clients that do not
+				support authentication to break.</description>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -16,9 +16,8 @@
 			<label>No implicit user role for unauthenticated requests</label>
 			<default>false</default>
 			<description>By default, operations requiring the "user" role are available when unauthenticated. Enabling this
-				option will require authentication for these operations. Warning: this will cause clients which don't
-				support
-				authorization to break.</description>
+				option will require authentication for these operations. Warning: This causes clients that do not
+				support authentication to break.</description>
 		</parameter>
 	</config-description>
 


### PR DESCRIPTION
Closes #1699.

Note, this opens a minor security issue that allows an attacker
to brute force passwords by making calls to the API - contrary to
the authorization page, the credentials parsing for the REST API
is stateless & doesn't have a lock mechanism to lock user accounts
after too many failed login attempts.

Signed-off-by: Yannick Schaus <github@schaus.net>