### PR TITLE
Fixed name of measurement systems

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -153,10 +153,10 @@ public class I18nProviderImpl
 
         final SystemOfUnits newMeasurementSystem;
         switch (ms) {
-            case "SI":
+            case SIUnits.MEASUREMENT_SYSTEM_NAME:
                 newMeasurementSystem = SIUnits.getInstance();
                 break;
-            case "US":
+            case ImperialUnits.MEASUREMENT_SYSTEM_NAME:
                 newMeasurementSystem = ImperialUnits.getInstance();
                 break;
             default:

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
@@ -39,6 +39,8 @@ import tec.uom.se.unit.Units;
 @NonNullByDefault
 public final class ImperialUnits extends CustomUnits {
 
+    public static final String MEASUREMENT_SYSTEM_NAME = "US";
+
     private static final ImperialUnits INSTANCE = new ImperialUnits();
 
     /** Additionally defined units to be used in openHAB **/
@@ -109,5 +111,10 @@ public final class ImperialUnits extends CustomUnits {
     private static <U extends Unit<?>> U addUnit(U unit) {
         INSTANCE.units.add(unit);
         return unit;
+    }
+
+    @Override
+    public String getName() {
+        return MEASUREMENT_SYSTEM_NAME;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
@@ -82,5 +82,4 @@ public final class SIUnits extends CustomUnits {
     public String getName() {
         return MEASUREMENT_SYSTEM_NAME;
     }
-
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
@@ -36,6 +36,8 @@ import tec.uom.se.unit.Units;
 @NonNullByDefault
 public final class SIUnits extends CustomUnits {
 
+    public static final String MEASUREMENT_SYSTEM_NAME = "SI";
+
     private static final SIUnits INSTANCE = new SIUnits();
 
     public static final Unit<Temperature> CELSIUS = addUnit(Units.CELSIUS);
@@ -75,4 +77,10 @@ public final class SIUnits extends CustomUnits {
         INSTANCE.units.add(unit);
         return unit;
     }
+
+    @Override
+    public String getName() {
+        return MEASUREMENT_SYSTEM_NAME;
+    }
+
 }


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/issues/1678#issuecomment-706775966.

Imho "US" is not really ideal as a name since it is rather "Imperial", but since this is already established and used by the UI (and Alexa), I'd think it is ok to stick to it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>