### PR TITLE
Fixed initialization of group items with aggregation functions

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -74,12 +73,14 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
     private final Logger logger = LoggerFactory.getLogger(ManagedItemProvider.class);
 
-    private final Collection<ItemFactory> itemFactories = new CopyOnWriteArrayList<>();
+    private final ItemBuilderFactory itemBuilderFactory;
     private final Map<String, PersistedItem> failedToCreate = new ConcurrentHashMap<>();
 
     @Activate
-    public ManagedItemProvider(final @Reference StorageService storageService) {
+    public ManagedItemProvider(final @Reference StorageService storageService,
+            final @Reference ItemBuilderFactory itemBuilderFactory) {
         super(storageService);
+        this.itemBuilderFactory = itemBuilderFactory;
     }
 
     /**
@@ -118,16 +119,13 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
     }
 
     private @Nullable Item createItem(String itemType, String itemName) {
-        for (ItemFactory factory : itemFactories) {
-            Item item = factory.createItem(itemType, itemName);
-            if (item != null) {
-                return item;
-            }
+        try {
+            Item item = itemBuilderFactory.newItemBuilder(itemType, itemName).build();
+            return item;
+        } catch (IllegalStateException e) {
+            logger.debug("Couldn't create item '{}' of type '{}'", itemName, itemType);
+            return null;
         }
-
-        logger.debug("Couldn't find ItemFactory for item '{}' of type '{}'", itemName, itemType);
-
-        return null;
     }
 
     /**
@@ -143,8 +141,6 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void addItemFactory(ItemFactory itemFactory) {
-        itemFactories.add(itemFactory);
-
         if (!failedToCreate.isEmpty()) {
             // retry failed creation attempts
             Iterator<Entry<String, PersistedItem>> iterator = failedToCreate.entrySet().iterator();
@@ -153,9 +149,9 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
                 String itemName = entry.getKey();
                 PersistedItem persistedItem = entry.getValue();
                 Item item = itemFactory.createItem(persistedItem.itemType, itemName);
-                if (item != null && item instanceof ActiveItem) {
+                if (item != null && item instanceof GenericItem) {
                     iterator.remove();
-                    configureItem(persistedItem, (ActiveItem) item);
+                    configureItem(persistedItem, (GenericItem) item);
                     notifyListenersAboutAddedElement(item);
                 } else {
                     logger.debug("The added item factory '{}' still could not instantiate item '{}'.", itemFactory,
@@ -169,6 +165,9 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         }
     }
 
+    protected void removeItemFactory(ItemFactory itemFactory) {
+    }
+
     @Override
     protected String getStorageName() {
         return Item.class.getName();
@@ -177,10 +176,6 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
     @Override
     protected String keyToString(String key) {
         return key;
-    }
-
-    protected void removeItemFactory(ItemFactory itemFactory) {
-        itemFactories.remove(itemFactory);
     }
 
     @Override
@@ -204,8 +199,8 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
             item = createItem(persistedItem.itemType, itemName);
         }
 
-        if (item != null && item instanceof ActiveItem) {
-            configureItem(persistedItem, (ActiveItem) item);
+        if (item != null && item instanceof GenericItem) {
+            configureItem(persistedItem, (GenericItem) item);
         }
 
         if (item == null) {
@@ -226,7 +221,7 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         return ItemDTOMapper.mapFunction(baseItem, functionDTO);
     }
 
-    private void configureItem(PersistedItem persistedItem, ActiveItem item) {
+    private void configureItem(PersistedItem persistedItem, GenericItem item) {
         List<String> groupNames = persistedItem.groupNames;
         if (groupNames != null) {
             for (String groupName : groupNames) {

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mock;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.internal.items.ItemBuilderFactoryImpl;
 import org.openhab.core.internal.items.ItemRegistryImpl;
 import org.openhab.core.items.events.ItemAddedEvent;
 import org.openhab.core.items.events.ItemRemovedEvent;
@@ -93,11 +94,8 @@ public class ItemRegistryImplTest extends JavaTest {
         cameraItem4.addTag(CAMERA_TAG_UPPERCASE);
 
         // setup ManageItemProvider with necessary dependencies:
-        itemProvider = new ManagedItemProvider(new VolatileStorageService()) {
-            {
-                addItemFactory(coreItemFactory);
-            }
-        };
+        itemProvider = new ManagedItemProvider(new VolatileStorageService(),
+                new ItemBuilderFactoryImpl(new CoreItemFactory()));
 
         itemProvider.add(new SwitchItem(ITEM_NAME));
         itemProvider.add(cameraItem1);


### PR DESCRIPTION
Fixes #1706

The GroupFunctionHelper still used a lot of deprecated classes and failed creating items if started early, since it still relied on `itemFactories` instead of using the `ItemBuilderFactory`.

Signed-off-by: Kai Kreuzer <kai@openhab.org>