### PR TITLE
Open ProviderTracker asynchronously when activating AbstractRegistry

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -62,6 +62,7 @@ public class MetadataCommandDescriptionProviderTest {
         metadataRegistry = new MetadataRegistryImpl();
         metadataRegistry.setManagedProvider(managedProvider);
         metadataRegistry.activate(bundleContext);
+        metadataRegistry.waitForCompletedAsyncActivationTasks();
 
         ArgumentCaptor<ServiceListener> captor = ArgumentCaptor.forClass(ServiceListener.class);
         verify(bundleContext).addServiceListener(captor.capture(), any());

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
@@ -56,6 +56,7 @@ public class MetadataRegistryImplTest {
         registry = new MetadataRegistryImpl();
         registry.setManagedProvider(managedProvider);
         registry.activate(bundleContext);
+        registry.waitForCompletedAsyncActivationTasks();
 
         ArgumentCaptor<ServiceListener> captor = ArgumentCaptor.forClass(ServiceListener.class);
         verify(bundleContext).addServiceListener(captor.capture(), any());

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -63,6 +63,7 @@ public class MetadataStateDescriptionFragmentProviderTest {
         metadataRegistry = new MetadataRegistryImpl();
         metadataRegistry.setManagedProvider(managedProvider);
         metadataRegistry.activate(bundleContext);
+        metadataRegistry.waitForCompletedAsyncActivationTasks();
 
         ArgumentCaptor<ServiceListener> captor = ArgumentCaptor.forClass(ServiceListener.class);
         verify(bundleContext).addServiceListener(captor.capture(), any());

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.*;
 import java.util.Hashtable;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,7 @@ import org.osgi.service.component.ComponentContext;
  * @author Dennis Nobel - Initial contribution
  * @author Christoph Weitkamp - Migrated tests to pure Java
  */
+@NonNullByDefault
 public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
 
     private static final String ITEM = "item";
@@ -46,9 +48,9 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
     private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
     private static final ItemChannelLink ITEM_CHANNEL_LINK = new ItemChannelLink(ITEM, CHANNEL_UID);
 
-    private ManagedItemChannelLinkProvider managedItemChannelLinkProvider;
-    private ItemChannelLinkRegistry itemChannelLinkRegistry;
-    private ManagedThingProvider managedThingProvider;
+    private @NonNullByDefault({}) ManagedItemChannelLinkProvider managedItemChannelLinkProvider;
+    private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private @NonNullByDefault({}) ManagedThingProvider managedThingProvider;
 
     @BeforeEach
     public void setup() {
@@ -76,7 +78,7 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
 
         managedItemChannelLinkProvider.add(ITEM_CHANNEL_LINK);
 
-        assertEquals(1, itemChannelLinkRegistry.getAll().size());
+        waitForAssert(() -> assertEquals(1, itemChannelLinkRegistry.getAll().size()));
         assertEquals(1, managedItemChannelLinkProvider.getAll().size());
 
         managedItemChannelLinkProvider.remove(ITEM_CHANNEL_LINK.getUID());
@@ -88,7 +90,7 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatIsLinkedReturnsTrue() {
         managedItemChannelLinkProvider.add(ITEM_CHANNEL_LINK);
-        assertTrue(itemChannelLinkRegistry.isLinked(ITEM, CHANNEL_UID));
+        waitForAssert(() -> assertTrue(itemChannelLinkRegistry.isLinked(ITEM, CHANNEL_UID)));
     }
 
     @Test
@@ -99,9 +101,11 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatGetBoundChannelsReturnsChannel() {
         managedItemChannelLinkProvider.add(ITEM_CHANNEL_LINK);
-        Set<ChannelUID> boundChannels = itemChannelLinkRegistry.getBoundChannels(ITEM);
-        assertEquals(1, boundChannels.size());
-        assertTrue(boundChannels.contains(ITEM_CHANNEL_LINK.getLinkedUID()));
+        waitForAssert(() -> {
+            Set<ChannelUID> boundChannels = itemChannelLinkRegistry.getBoundChannels(ITEM);
+            assertEquals(1, boundChannels.size());
+            assertTrue(boundChannels.contains(ITEM_CHANNEL_LINK.getLinkedUID()));
+        });
     }
 
     @Test
@@ -113,9 +117,11 @@ public class ItemChannelLinkOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatGetBoundThingsReturnsThing() {
         managedItemChannelLinkProvider.add(ITEM_CHANNEL_LINK);
-        Set<Thing> boundThings = itemChannelLinkRegistry.getBoundThings(ITEM);
-        assertEquals(1, boundThings.size());
-        assertEquals(CHANNEL_UID.getThingUID(), boundThings.stream().findFirst().get().getUID());
+        waitForAssert(() -> {
+            Set<Thing> boundThings = itemChannelLinkRegistry.getBoundThings(ITEM);
+            assertEquals(1, boundThings.size());
+            assertEquals(CHANNEL_UID.getThingUID(), boundThings.stream().findFirst().get().getUID());
+        });
     }
 
     @Test


### PR DESCRIPTION
Based on the fix in https://github.com/openhab/openhab-core/issues/890#issuecomment-611920483 which seems to work nicely!

This issue seems to have been introduced by the use of constructor injection to prevent null values.

Because of the abstract nature of the `AbstractRegistry`, it cannot inject providers using a `@Reference` MULTIPLE/DYNAMIC annotated method. So instead it has to open a `ServiceTracker` in the activate method to keep track of all available providers. If it were able to use a `@Reference` annotated method the providers would also have been populated asynchronously and there would be no cycle.

Other ways to break the cycle would be to not inject the `ItemRegistry` in the `SemanticsMetadataProvider` constructor but to use a `@Reference` annotated method for this instead. Though that would of course result in less nice code with null checks and a `@Nullable` field.

It highly depends on the order of how components are instantiated if it actually results in a cycle. Most of the time the registry will probably be instantiated before the provider so it will not result in the exception. It will probably be an issue for any provider that depends on a registry that in some way also depends on the same provider.

Start levels may also solve this, but are of course even less preferable.

So I think it is best to apply this generic fix so we can keep writing nice code without this issue ever coming back to haunt us some day.

Fixes #890