### PR TITLE
Fix JSR223 JavaScript files not loading

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -368,6 +368,7 @@
 		<feature>openhab-core-auth-jaas</feature>
 		<feature>openhab-core-automation-rest</feature>
 		<feature>openhab-core-automation-module-script</feature>
+		<feature>openhab-core-automation-module-script-rulesupport</feature>
 		<feature>openhab-core-automation-module-media</feature>
 		<feature>openhab-core-io-console-karaf</feature>
 		<feature>openhab-core-io-http-auth</feature>


### PR DESCRIPTION
This adds a missing feature required for being able to load JSR223 JavaScript rules out of the box.

See also this [community post](https://community.openhab.org/t/oh3-js-rules-gone/106581?u=wborn).