### PR TITLE
Fix issues with configuration PIDs

### DIFF
--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 @Component(configurationPid = "org.openhab.magic", service = ConfigOptionProvider.class, immediate = true, //
-        property = Constants.SERVICE_PID + "=org.openhab.core.magic")
+        property = Constants.SERVICE_PID + "=org.openhab.magic")
 @ConfigurableService(category = "test", label = "Magic", description_uri = "test:magic")
 public class MagicServiceImpl implements MagicService {
     private final Logger logger = LoggerFactory.getLogger(MagicServiceImpl.class);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
@@ -66,7 +66,7 @@ import org.osgi.service.http.HttpService;
  * @author Holger Reichert - Support for themes, DPI, legend hiding
  */
 @Component(immediate = true, service = ChartServlet.class, configurationPid = "org.openhab.chart", //
-        property = Constants.SERVICE_PID + "=org.openhab.core.chart")
+        property = Constants.SERVICE_PID + "=org.openhab.chart")
 @ConfigurableService(category = "system", label = "Charts", description_uri = ChartServlet.CONFIG_URI)
 public class ChartServlet extends SmartHomeServlet {
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Network address change listener
  * @author Tim Roberts - Added primary address change to network address change listener
  */
-@Component(configurationPid = "org.openhab.network", property = { "service.pid=org.openhab.core.network",
+@Component(configurationPid = "org.openhab.network", property = { "service.pid=org.openhab.network",
         "service.config.description.uri=system:network", "service.config.label=Network Settings",
         "service.config.category=system" })
 @NonNullByDefault

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -120,7 +120,7 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.http.auth.basic/${project.version}</bundle>
 
 		<feature>openhab-core-io-http-auth</feature>
-		<config name="org.openhab.core.auth">
+		<config name="org.openhab.auth">
 			enabled = true
 		</config>
 	</feature>
@@ -397,10 +397,10 @@
 		<!-- It is temperarily disabled due to https://github.com/openhab/openhab-core/issues/422 -->
 		<!-- <bundle start-level="30">mvn:org.openhab.core.bundles/org.openhab.ui.start/${project.version}</bundle> -->
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.karaf/${project.version}</bundle>
-		<config name="org.openhab.core.audio">
+		<config name="org.openhab.audio">
 			defaultSink = enhancedjavasound
 		</config>
-		<config name="org.openhab.core.voice">
+		<config name="org.openhab.voice">
 			defaultHLI = rulehli
 		</config>
 	</feature>


### PR DESCRIPTION
* Fixes warnings about "using different service PIDs"
* Fixes missing default values

---

These warnings would show up:

```
[WARN ] [.service.ConfigurableServiceResource] - The component "org.openhab.core.net.NetUtil" is using different service PIDs ([org.openhab.core.network, org.openhab.network]). Different service PIDs are not supported, the first one (org.openhab.core.network) is used.
[WARN ] [.service.ConfigurableServiceResource] - The component "org.openhab.core.ui.internal.chart.ChartServlet" is using different service PIDs ([org.openhab.core.chart, org.openhab.chart]). Different service PIDs are not supported, the first one (org.openhab.core.chart) is used.
```