### PR TITLE
Add missing roles checks

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -99,7 +99,7 @@ public class ProfileTypeResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER })
+    @RolesAllowed({ Role.USER, Role.ADMIN })
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Gets all available profile types.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProfileTypeDTO.class), uniqueItems = true))) })

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -128,7 +128,7 @@ public class ThingTypeResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER })
+    @RolesAllowed({ Role.USER, Role.ADMIN })
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Gets all available thing types without config description, channels and properties.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = StrippedThingTypeDTO.class), uniqueItems = true))) })
@@ -147,7 +147,7 @@ public class ThingTypeResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER })
+    @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{thingTypeUID}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Gets thing type by UID.", responses = {

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
@@ -85,7 +85,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(SseResource.PATH_EVENTS)
-@RolesAllowed({ Role.USER })
+@RolesAllowed({ Role.USER, Role.ADMIN })
 @Tag(name = SseResource.PATH_EVENTS)
 @Singleton
 @NonNullByDefault


### PR DESCRIPTION
(I included these fixes in #1735 but extracted them in a stanalone
PR because it's easier to review and a little more urgent.)

As a result of the refactoring in #1713, the operations annotated with
`@RolesAllowed` containing `Role.USER` are not anymore automatically
considered accessible to all users, regardless of their actual roles.

4 operations are therefore now denied to admins if they only have the
`Role.ADMIN` role, as the first admininistrator is created only with
that role the UI encounters unexpected access denied errors and breaks.
(See https://github.com/openhab/openhab-webui/issues/422).

Closes https://github.com/openhab/openhab-webui/issues/422.

Signed-off-by: Yannick Schaus <github@schaus.net>