### PR TITLE
Improve rule debugging

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -57,7 +57,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     private final String type;
     protected final String script;
 
-    private final String ruleUID;
+    protected final String ruleUID;
 
     public AbstractScriptModuleHandler(T module, String ruleUID, ScriptEngineManager scriptEngineManager) {
         super(module);

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -62,7 +62,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
                 Object result = scriptEngine.eval(script);
                 resultMap.put("result", result);
             } catch (ScriptException e) {
-                logger.error("Script execution failed: {}", e.getMessage());
+                logger.error("Script execution of rule with UID '{}' failed: {}", ruleUID, e.getMessage(),
+                        logger.isDebugEnabled() ? e : null);
             }
         });
 


### PR DESCRIPTION
* Add rule UID to error message
* Add exception with stacktrace when debug level is enabled

Related to #1734

---

Example without debug logging enabled:

```
[ERROR] [.internal.handler.ScriptActionHandler] - Script execution of rule with UID 'demo-10' failed: The name 'Wifi_Levell' cannot be resolved to an item or type; line 128, column 16, length 11 in demo
```

Example with debug logging enabled:

```
[ERROR] [.internal.handler.ScriptActionHandler] - Script execution of rule with UID 'demo-10' failed: The name 'Wifi_Levell' cannot be resolved to an item or type; line 128, column 16, length 11 in demo
javax.script.ScriptException: The name 'Wifi_Levell' cannot be resolved to an item or type; line 128, column 16, length 11 in demo
	at org.openhab.core.model.script.runtime.internal.engine.DSLScriptEngine.eval(DSLScriptEngine.java:120) ~[?:?]
	at org.openhab.core.automation.module.script.internal.handler.ScriptActionHandler.lambda$0(ScriptActionHandler.java:62) [bundleFile:?]
	at java.util.Optional.ifPresent(Optional.java:183) [?:?]
	at org.openhab.core.automation.module.script.internal.handler.ScriptActionHandler.execute(ScriptActionHandler.java:59) [bundleFile:?]
	at org.openhab.core.automation.internal.RuleEngineImpl.executeActions(RuleEngineImpl.java:1179) [bundleFile:?]
	at org.openhab.core.automation.internal.RuleEngineImpl.runRule(RuleEngineImpl.java:987) [bundleFile:?]
	at org.openhab.core.automation.internal.TriggerHandlerCallbackImpl$TriggerData.run(TriggerHandlerCallbackImpl.java:91) [bundleFile:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```