### PR TITLE
[ui] Added unit test for read-only Number- and String-Items to not return a Selection Element

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -242,13 +242,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         } else if (NumberItem.class.isAssignableFrom(itemType) //
                 || StringItem.class.equals(itemType)) {
             boolean isReadOnly = isReadOnly(itemName);
-            if (!isReadOnly && hasStateOptions(itemName)) {
-                return SitemapFactory.eINSTANCE.createSelection();
-            }
             int commandOptionsSize = getCommandOptionsSize(itemName);
             if (!isReadOnly && commandOptionsSize > 0) {
                 return commandOptionsSize <= MAX_BUTTONS ? SitemapFactory.eINSTANCE.createSwitch()
                         : SitemapFactory.eINSTANCE.createSelection();
+            }
+            if (!isReadOnly && hasStateOptions(itemName)) {
+                return SitemapFactory.eINSTANCE.createSelection();
             } else {
                 return SitemapFactory.eINSTANCE.createText();
             }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -1279,7 +1279,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     @Override
     public @Nullable State convertStateToLabelUnit(QuantityType<?> state, String label) {
-        String labelUnit = label.lastIndexOf(" ") > 0 ? label.substring(label.lastIndexOf(" ")) : null;
+        int index = label.lastIndexOf(" ");
+        String labelUnit = index > 0 ? label.substring(index) : null;
         if (labelUnit != null && !state.getUnit().toString().equals(labelUnit)) {
             return state.toUnit(labelUnit);
         }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -23,8 +23,6 @@ import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.junit.jupiter.api.BeforeEach;
@@ -815,11 +813,9 @@ public class ItemUIRegistryImplTest {
         assertThat(defaultWidget, is(instanceOf(Text.class)));
 
         // NumberItem with one to four CommandOptions should return Switch element
-        final CommandDescriptionBuilder builder = CommandDescriptionBuilder.create()
-                .withCommandOptions(Stream
-                        .of(new CommandOption("command1", "label1"), new CommandOption("command2", "label2"),
-                                new CommandOption("command3", "label3"), new CommandOption("command4", "label4"))
-                        .collect(Collectors.toList()));
+        final CommandDescriptionBuilder builder = CommandDescriptionBuilder.create().withCommandOptions(
+                List.of(new CommandOption("command1", "label1"), new CommandOption("command2", "label2"),
+                        new CommandOption("command3", "label3"), new CommandOption("command4", "label4")));
         when(item.getCommandDescription()).thenReturn(builder.build());
         defaultWidget = uiRegistry.getDefaultWidget(NumberItem.class, ITEM_NAME);
         assertThat(defaultWidget, is(instanceOf(Switch.class)));
@@ -832,9 +828,17 @@ public class ItemUIRegistryImplTest {
 
         // NumberItem with one or more StateOptions should return Selection element
         when(item.getStateDescription()).thenReturn(StateDescriptionFragmentBuilder.create()
-                .withOption(new StateOption("value", "label")).build().toStateDescription());
+                .withOptions(List.of(new StateOption("value1", "label1"), new StateOption("value2", "label2"))).build()
+                .toStateDescription());
         defaultWidget = uiRegistry.getDefaultWidget(NumberItem.class, ITEM_NAME);
         assertThat(defaultWidget, is(instanceOf(Selection.class)));
+
+        // Read-only NumberItem with one or more StateOptions should return Text element
+        when(item.getStateDescription()).thenReturn(StateDescriptionFragmentBuilder.create().withReadOnly(Boolean.TRUE)
+                .withOptions(List.of(new StateOption("value1", "label1"), new StateOption("value2", "label2"))).build()
+                .toStateDescription());
+        defaultWidget = uiRegistry.getDefaultWidget(NumberItem.class, ITEM_NAME);
+        assertThat(defaultWidget, is(instanceOf(Text.class)));
     }
 
     @Test
@@ -844,11 +848,9 @@ public class ItemUIRegistryImplTest {
         assertThat(defaultWidget, is(instanceOf(Text.class)));
 
         // StringItem with one to four CommandOptions should return Switch element
-        final CommandDescriptionBuilder builder = CommandDescriptionBuilder.create()
-                .withCommandOptions(Stream
-                        .of(new CommandOption("command1", "label1"), new CommandOption("command2", "label2"),
-                                new CommandOption("command3", "label3"), new CommandOption("command4", "label4"))
-                        .collect(Collectors.toList()));
+        final CommandDescriptionBuilder builder = CommandDescriptionBuilder.create().withCommandOptions(
+                List.of(new CommandOption("command1", "label1"), new CommandOption("command2", "label2"),
+                        new CommandOption("command3", "label3"), new CommandOption("command4", "label4")));
         when(item.getCommandDescription()).thenReturn(builder.build());
         defaultWidget = uiRegistry.getDefaultWidget(StringItem.class, ITEM_NAME);
         assertThat(defaultWidget, is(instanceOf(Switch.class)));
@@ -861,8 +863,16 @@ public class ItemUIRegistryImplTest {
 
         // StringItem with one or more StateOptions should return Selection element
         when(item.getStateDescription()).thenReturn(StateDescriptionFragmentBuilder.create()
-                .withOption(new StateOption("value", "label")).build().toStateDescription());
+                .withOptions(List.of(new StateOption("value1", "label1"), new StateOption("value2", "label2"))).build()
+                .toStateDescription());
         defaultWidget = uiRegistry.getDefaultWidget(StringItem.class, ITEM_NAME);
         assertThat(defaultWidget, is(instanceOf(Selection.class)));
+
+        // Read-only StringItem with one or more StateOptions should return Text element
+        when(item.getStateDescription()).thenReturn(StateDescriptionFragmentBuilder.create().withReadOnly(Boolean.TRUE)
+                .withOptions(List.of(new StateOption("value1", "label1"), new StateOption("value2", "label2"))).build()
+                .toStateDescription());
+        defaultWidget = uiRegistry.getDefaultWidget(StringItem.class, ITEM_NAME);
+        assertThat(defaultWidget, is(instanceOf(Text.class)));
     }
 }


### PR DESCRIPTION
- Added unit test for read-only Number- and String-Items to not return a Selection Element

Related to #1751

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>