### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.java text=auto
+.xml text=auto


### PR DESCRIPTION
Without this configuration there are Spotless issues with line endings on Windows.

See: openhab/openhab-addons#8712