### PR TITLE
[automation] Provide triggering item name in the rule context

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -40,6 +40,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.emf.common.util.EList
+import org.openhab.core.events.Event
 
 /**
  * <p>Infers a JVM model from the source model.</p> 
@@ -132,6 +133,8 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                     if ((containsCommandTrigger(rule)) || (containsStateChangeTrigger(rule)) || (containsStateUpdateTrigger(rule))) {
                         val itemTypeRef = ruleModel.newTypeRef(Item)
                         parameters += rule.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
+                        val itemNameRef = ruleModel.newTypeRef(String)
+                        parameters += rule.toParameter(VAR_TRIGGERING_ITEM_NAME, itemNameRef)
                     }
                     if (containsCommandTrigger(rule)) {
                         val commandTypeRef = ruleModel.newTypeRef(Command)
@@ -142,7 +145,7 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                         parameters += rule.toParameter(VAR_PREVIOUS_STATE, stateTypeRef)
                     }
                     if (containsEventTrigger(rule)) {
-                        val eventTypeRef = ruleModel.newTypeRef(ChannelTriggeredEvent)
+                        val eventTypeRef = ruleModel.newTypeRef(String)
                         parameters += rule.toParameter(VAR_RECEIVED_EVENT, eventTypeRef)
                     }
                     if (containsThingStateChangedEventTrigger(rule) && !containsParam(parameters, VAR_PREVIOUS_STATE)) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory
 import org.openhab.core.items.Item
 import org.openhab.core.types.Command
 import org.openhab.core.types.State
-import org.openhab.core.thing.events.ChannelTriggeredEvent
+import org.openhab.core.events.Event
 
 /**
  * <p>Infers a JVM model from the source model.</p> 
@@ -42,6 +42,9 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
     /** Variable name for the item in a "state triggered" or "command triggered" rule */
     public static final String VAR_TRIGGERING_ITEM = "triggeringItem";
+
+    /** Variable name for the item in a "state triggered" or "command triggered" rule */
+    public static final String VAR_TRIGGERING_ITEM_NAME = "triggeringItemName";
 
     /** Variable name for the previous state of an item in a "changed state triggered" rule */
     public static final String VAR_PREVIOUS_STATE = "previousState";
@@ -108,11 +111,13 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
                 static = true
                 val itemTypeRef = script.newTypeRef(Item)
                 parameters += script.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
+                val itemNameRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_TRIGGERING_ITEM_NAME, itemNameRef)
                 val commandTypeRef = script.newTypeRef(Command)
                 parameters += script.toParameter(VAR_RECEIVED_COMMAND, commandTypeRef)
                 val stateTypeRef = script.newTypeRef(State)
                 parameters += script.toParameter(VAR_PREVIOUS_STATE, stateTypeRef)
-                val eventTypeRef = script.newTypeRef(ChannelTriggeredEvent)
+                val eventTypeRef = script.newTypeRef(String)
                 parameters += script.toParameter(VAR_RECEIVED_EVENT, eventTypeRef)
                 val stateTypeRef2 = script.newTypeRef(State)
                 parameters += script.toParameter(VAR_NEW_STATE, stateTypeRef2)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.items.events;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.types.State;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.types.State;
  *
  * @author Christoph Knauf - Initial contribution
  */
+@NonNullByDefault
 public class GroupItemStateChangedEvent extends ItemStateChangedEvent {
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.core.items.events;
 
-import org.openhab.core.events.AbstractEvent;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.Command;
 
 /**
@@ -21,14 +22,13 @@ import org.openhab.core.types.Command;
  *
  * @author Stefan Bußweiler - Initial contribution
  */
-public class ItemCommandEvent extends AbstractEvent {
+@NonNullByDefault
+public class ItemCommandEvent extends ItemEvent {
 
     /**
      * The item command event type.
      */
     public static final String TYPE = ItemCommandEvent.class.getSimpleName();
-
-    private final String itemName;
 
     private final Command command;
 
@@ -41,9 +41,9 @@ public class ItemCommandEvent extends AbstractEvent {
      * @param command the command
      * @param source the source, can be null
      */
-    protected ItemCommandEvent(String topic, String payload, String itemName, Command command, String source) {
-        super(topic, payload, source);
-        this.itemName = itemName;
+    protected ItemCommandEvent(String topic, String payload, String itemName, Command command,
+            @Nullable String source) {
+        super(topic, payload, itemName, source);
         this.command = command;
     }
 
@@ -57,6 +57,7 @@ public class ItemCommandEvent extends AbstractEvent {
      *
      * @return the item name
      */
+    @Override
     public String getItemName() {
         return itemName;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -53,16 +53,6 @@ public class ItemCommandEvent extends ItemEvent {
     }
 
     /**
-     * Gets the item name.
-     *
-     * @return the item name
-     */
-    @Override
-    public String getItemName() {
-        return itemName;
-    }
-
-    /**
      * Gets the item command.
      *
      * @return the item command

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEvent.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.items.events;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.events.AbstractEvent;
+
+/**
+ * {@link ItemEvent} is an abstract super class for all command and state item events.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@NonNullByDefault
+public abstract class ItemEvent extends AbstractEvent {
+
+    protected final String itemName;
+
+    /**
+     * Constructs a new item state event.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param itemName the item name
+     * @param source the source, can be null
+     */
+    public ItemEvent(String topic, String payload, String itemName, @Nullable String source) {
+        super(topic, payload, source);
+        this.itemName = itemName;
+    }
+
+    /**
+     * Gets the item name.
+     *
+     * @return the item name
+     */
+    public String getItemName() {
+        return itemName;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
@@ -77,7 +77,7 @@ public class ItemEventFactory extends AbstractEventFactory {
         } else if (ItemStateEvent.TYPE.equals(eventType)) {
             return createStateEvent(topic, payload, source);
         } else if (ItemStatePredictedEvent.TYPE.equals(eventType)) {
-            return createStatePredictedEvent(topic, payload, source);
+            return createStatePredictedEvent(topic, payload);
         } else if (ItemStateChangedEvent.TYPE.equals(eventType)) {
             return createStateChangedEvent(topic, payload);
         } else if (ItemAddedEvent.TYPE.equals(eventType)) {
@@ -115,7 +115,7 @@ public class ItemEventFactory extends AbstractEventFactory {
         return new ItemStateEvent(topic, payload, itemName, state, source);
     }
 
-    private Event createStatePredictedEvent(String topic, String payload, String source) {
+    private Event createStatePredictedEvent(String topic, String payload) {
         String itemName = getItemName(topic);
         ItemStatePredictedEventPayloadBean bean = deserializePayload(payload, ItemStatePredictedEventPayloadBean.class);
         State state = getState(bean.getPredictedType(), bean.getPredictedValue());
@@ -262,7 +262,7 @@ public class ItemEventFactory extends AbstractEventFactory {
      * @return the created item state event
      * @throws IllegalArgumentException if itemName or state is null
      */
-    public static ItemStateEvent createStateEvent(String itemName, State state) {
+    public static ItemEvent createStateEvent(String itemName, State state) {
         return createStateEvent(itemName, state, null);
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.items.events;
 
-import org.openhab.core.events.AbstractEvent;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.types.State;
 
 /**
@@ -22,14 +22,13 @@ import org.openhab.core.types.State;
  *
  * @author Dennis Nobel - Initial contribution
  */
-public class ItemStateChangedEvent extends AbstractEvent {
+@NonNullByDefault
+public class ItemStateChangedEvent extends ItemEvent {
 
     /**
      * The item state changed event type.
      */
     public static final String TYPE = ItemStateChangedEvent.class.getSimpleName();
-
-    protected final String itemName;
 
     protected final State itemState;
 
@@ -46,8 +45,7 @@ public class ItemStateChangedEvent extends AbstractEvent {
      */
     protected ItemStateChangedEvent(String topic, String payload, String itemName, State newItemState,
             State oldItemState) {
-        super(topic, payload, null);
-        this.itemName = itemName;
+        super(topic, payload, itemName, null);
         this.itemState = newItemState;
         this.oldItemState = oldItemState;
     }
@@ -62,6 +60,7 @@ public class ItemStateChangedEvent extends AbstractEvent {
      *
      * @return the item name
      */
+    @Override
     public String getItemName() {
         return itemName;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
@@ -56,16 +56,6 @@ public class ItemStateChangedEvent extends ItemEvent {
     }
 
     /**
-     * Gets the item name.
-     *
-     * @return the item name
-     */
-    @Override
-    public String getItemName() {
-        return itemName;
-    }
-
-    /**
      * Gets the item state.
      *
      * @return the item state

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.core.items.events;
 
-import org.openhab.core.events.AbstractEvent;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.State;
 
 /**
@@ -21,14 +22,13 @@ import org.openhab.core.types.State;
  *
  * @author Stefan Bußweiler - Initial contribution
  */
-public class ItemStateEvent extends AbstractEvent {
+@NonNullByDefault
+public class ItemStateEvent extends ItemEvent {
 
     /**
      * The item state event type.
      */
     public static final String TYPE = ItemStateEvent.class.getSimpleName();
-
-    private final String itemName;
 
     private final State itemState;
 
@@ -41,24 +41,14 @@ public class ItemStateEvent extends AbstractEvent {
      * @param itemState the item state
      * @param source the source, can be null
      */
-    protected ItemStateEvent(String topic, String payload, String itemName, State itemState, String source) {
-        super(topic, payload, source);
-        this.itemName = itemName;
+    protected ItemStateEvent(String topic, String payload, String itemName, State itemState, @Nullable String source) {
+        super(topic, payload, itemName, source);
         this.itemState = itemState;
     }
 
     @Override
     public String getType() {
         return TYPE;
-    }
-
-    /**
-     * Gets the item name.
-     *
-     * @return the item name
-     */
-    public String getItemName() {
-        return itemName;
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
@@ -59,16 +59,6 @@ public class ItemStatePredictedEvent extends ItemEvent {
     }
 
     /**
-     * Gets the item name.
-     *
-     * @return the item name
-     */
-    @Override
-    public String getItemName() {
-        return itemName;
-    }
-
-    /**
      * Gets the predicted item state.
      *
      * @return the predicted item state

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.items.events;
 
-import org.openhab.core.events.AbstractEvent;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.types.State;
 
 /**
@@ -26,14 +26,14 @@ import org.openhab.core.types.State;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-public class ItemStatePredictedEvent extends AbstractEvent {
+@NonNullByDefault
+public class ItemStatePredictedEvent extends ItemEvent {
 
     /**
      * The item state predicted event type.
      */
     public static final String TYPE = ItemStatePredictedEvent.class.getSimpleName();
 
-    protected final String itemName;
     protected final State predictedState;
     protected final boolean isConfirmation;
 
@@ -48,8 +48,7 @@ public class ItemStatePredictedEvent extends AbstractEvent {
      */
     public ItemStatePredictedEvent(String topic, String payload, String itemName, State predictedState,
             boolean isConfirmation) {
-        super(topic, payload, null);
-        this.itemName = itemName;
+        super(topic, payload, itemName, null);
         this.predictedState = predictedState;
         this.isConfirmation = isConfirmation;
     }
@@ -64,6 +63,7 @@ public class ItemStatePredictedEvent extends AbstractEvent {
      *
      * @return the item name
      */
+    @Override
     public String getItemName() {
         return itemName;
     }


### PR DESCRIPTION
~~I have created this PR for discussion wrt whether we should merge it or not.~~
It addressed #1768, but as mentioned in that issue, it isn't easily feasible to provide the item itself, but rather only the item name.
My assumption is that this should be ok for most rules as it is really the item name that the user is after, but it nonetheless means a(nother) breaking change.

Fixes #1768

Signed-off-by: Kai Kreuzer <kai@openhab.org>