### PR TITLE
[core] Revert ordering of accepted data types for 'StringItem'

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -36,8 +36,10 @@ import org.openhab.core.types.UnDefType;
 @NonNullByDefault
 public class StringItem extends GenericItem {
 
-    private static final List<Class<? extends State>> ACCEPTED_DATA_TYPES = List.of(StringType.class,
-            DateTimeType.class, UnDefType.class);
+    // UnDefType has to come before StringType, because otherwise every UNDEF state sent as a string would be
+    // interpreted as a StringType
+    private static final List<Class<? extends State>> ACCEPTED_DATA_TYPES = List.of(UnDefType.class, DateTimeType.class,
+            StringType.class);
     private static final List<Class<? extends Command>> ACCEPTED_COMMAND_TYPES = List.of(StringType.class,
             RefreshType.class);
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
@@ -43,10 +43,8 @@ public final class TypeParser {
             Class<?> stateClass = Class.forName(CORE_LIBRARY_PACKAGE + typeName);
             Method valueOfMethod = stateClass.getMethod("valueOf", String.class);
             return (Type) valueOfMethod.invoke(stateClass, input);
-        } catch (ClassNotFoundException e) {
-        } catch (NoSuchMethodException e) {
-        } catch (IllegalAccessException e) {
-        } catch (InvocationTargetException e) {
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException e) {
         }
         return null;
     }
@@ -55,7 +53,7 @@ public final class TypeParser {
      * <p>
      * Determines a state from a string. Possible state types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the state.
-     * 
+     *
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -65,17 +63,15 @@ public final class TypeParser {
      * @return the corresponding State instance or <code>null</code>
      */
     public static State parseState(List<Class<? extends State>> types, String s) {
-        for (Class<? extends Type> type : types) {
+        for (Class<? extends State> type : types) {
             try {
                 Method valueOf = type.getMethod("valueOf", String.class);
                 State state = (State) valueOf.invoke(type, s);
                 if (state != null) {
                     return state;
                 }
-            } catch (NoSuchMethodException e) {
-            } catch (IllegalArgumentException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
+            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
+                    | InvocationTargetException e) {
             }
         }
         return null;
@@ -85,7 +81,7 @@ public final class TypeParser {
      * <p>
      * Determines a command from a string. Possible command types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the command.
-     * 
+     *
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
@@ -102,10 +98,8 @@ public final class TypeParser {
                 if (value != null) {
                     return value;
                 }
-            } catch (NoSuchMethodException e) {
-            } catch (IllegalArgumentException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
+            } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException
+                    | InvocationTargetException e) {
             }
         }
         return null;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TypeParserTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TypeParserTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.types;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.items.GenericItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.StringType;
+
+/**
+ * Test the {@link TypeParser}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+class TypeParserTest {
+
+    private final GenericItem stringItem = new StringItem("Test");
+
+    @Test
+    void testThatUNDEFAsStringIsParsedToUnDefType() {
+        State subject = TypeParser.parseState(stringItem.getAcceptedDataTypes(), "UNDEF");
+        assertThat(subject instanceof UnDefType, is(true));
+    }
+
+    @Test
+    void testThatANumberAsStringIsParsedDateTimeType() {
+        State subject = TypeParser.parseState(stringItem.getAcceptedDataTypes(), "123");
+        assertThat(subject instanceof DateTimeType, is(true));
+    }
+
+    @Test
+    void testThatADateAsStringIsParsedDateTimeType() {
+        State subject = TypeParser.parseState(stringItem.getAcceptedDataTypes(), "2014-03-30T10:58:47.033+0000");
+        assertThat(subject instanceof DateTimeType, is(true));
+    }
+
+    @Test
+    void testThatAStringIsParsedToStringType() {
+        State subject = TypeParser.parseState(stringItem.getAcceptedDataTypes(), "ABC");
+        assertThat(subject instanceof StringType, is(true));
+    }
+}


### PR DESCRIPTION
- Revert ordering of accepted data types for `StringItem`

See https://github.com/openhab/openhab-core/pull/1755 and https://github.com/openhab/openhab-addons/issues/8880#issuecomment-718200422

I tried to move `DateTimeType` too but this probably will result in more conflicts because it now can parse Unix timestamp and every positive integer will be parsed as `DateTimeType`.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>