### PR TITLE
[core] Revert ordering of accepted data types for 'StringItem'

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -38,8 +38,8 @@ public class StringItem extends GenericItem {
 
     // UnDefType has to come before StringType, because otherwise every UNDEF state sent as a string would be
     // interpreted as a StringType
-    private static final List<Class<? extends State>> ACCEPTED_DATA_TYPES = List.of(UnDefType.class, DateTimeType.class,
-            StringType.class);
+    private static final List<Class<? extends State>> ACCEPTED_DATA_TYPES = List.of(UnDefType.class, StringType.class,
+            DateTimeType.class);
     private static final List<Class<? extends Command>> ACCEPTED_COMMAND_TYPES = List.of(StringType.class,
             RefreshType.class);
 


### PR DESCRIPTION
- Revert ordering of accepted data types for `StringItem`

See #1755, https://github.com/openhab/openhab-core/pull/1774 and https://github.com/openhab/openhab-addons/pull/8895#issuecomment-718468959

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>