### PR TITLE
Remove Map null annotation workarounds

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -44,9 +44,9 @@ import org.slf4j.LoggerFactory;
 public class ScriptEngineManagerImpl implements ScriptEngineManager {
 
     private final Logger logger = LoggerFactory.getLogger(ScriptEngineManagerImpl.class);
-    private final Map<String, @Nullable ScriptEngineContainer> loadedScriptEngineInstances = new HashMap<>();
-    private final Map<String, @Nullable ScriptEngineFactory> customSupport = new HashMap<>();
-    private final Map<String, @Nullable ScriptEngineFactory> genericSupport = new HashMap<>();
+    private final Map<String, ScriptEngineContainer> loadedScriptEngineInstances = new HashMap<>();
+    private final Map<String, ScriptEngineFactory> customSupport = new HashMap<>();
+    private final Map<String, ScriptEngineFactory> genericSupport = new HashMap<>();
     private final ScriptExtensionManager scriptExtensionManager;
 
     @Activate

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -124,26 +124,26 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      */
     private final long scheduleReinitializationDelay;
 
-    private final Map<String, @Nullable WrappedRule> managedRules = new ConcurrentHashMap<>();
+    private final Map<String, WrappedRule> managedRules = new ConcurrentHashMap<>();
 
     /**
      * {@link Map} holding all created {@link TriggerHandlerCallback} instances, corresponding to each {@link Rule}.
      * There is only one {@link TriggerHandlerCallback} instance per {@link Rule}. The relation is
      * {@link Rule}'s UID to {@link TriggerHandlerCallback} instance.
      */
-    private final Map<String, @Nullable TriggerHandlerCallbackImpl> thCallbacks = new HashMap<>();
+    private final Map<String, TriggerHandlerCallbackImpl> thCallbacks = new HashMap<>();
 
     /**
      * {@link Map} holding all {@link ModuleType} UIDs that are available in some rule's module definition. The relation
      * is {@link ModuleType}'s UID to {@link Set} of {@link Rule} UIDs.
      */
-    private final Map<String, @Nullable Set<String>> mapModuleTypeToRules = new HashMap<>();
+    private final Map<String, Set<String>> mapModuleTypeToRules = new HashMap<>();
 
     /**
      * {@link Map} holding all available {@link ModuleHandlerFactory}s linked with {@link ModuleType}s that they
      * supporting. The relation is {@link ModuleType}'s UID to {@link ModuleHandlerFactory} instance.
      */
-    private final Map<String, @Nullable ModuleHandlerFactory> moduleHandlerFactories;
+    private final Map<String, ModuleHandlerFactory> moduleHandlerFactories;
 
     /**
      * {@link Set} holding all available {@link ModuleHandlerFactory}s.
@@ -173,7 +173,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * The context map of a {@link Rule} is cleaned when the execution is completed. The relation is
      * {@link Rule}'s UID to Rule context map.
      */
-    private final Map<String, @Nullable Map<String, @Nullable Object>> contextMap;
+    private final Map<String, Map<String, Object>> contextMap;
 
     /**
      * This field holds reference to {@link ModuleTypeRegistry}. The {@link RuleEngineImpl} needs it to auto-map
@@ -191,7 +191,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * UID to
      * re-initialization task as a {@link Future} instance.
      */
-    private final Map<String, @Nullable Future<?>> scheduleTasks = new HashMap<>(31);
+    private final Map<String, Future<?>> scheduleTasks = new HashMap<>(31);
 
     /**
      * Performs the {@link Rule} re-initialization tasks.
@@ -757,9 +757,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         if (r != null) {
             unregister(r);
             synchronized (this) {
-                for (Iterator<Map.Entry<String, @Nullable Set<String>>> it = mapModuleTypeToRules.entrySet()
-                        .iterator(); it.hasNext();) {
-                    Map.Entry<String, @Nullable Set<String>> e = it.next();
+                for (Iterator<Map.Entry<String, Set<String>>> it = mapModuleTypeToRules.entrySet().iterator(); it
+                        .hasNext();) {
+                    Map.Entry<String, Set<String>> e = it.next();
                     Set<String> rules = e.getValue();
                     if (rules != null && rules.contains(rUID)) {
                         rules.remove(rUID);
@@ -911,7 +911,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     private void removeMissingModuleTypes(Collection<String> moduleTypes) {
-        Map<String, @Nullable List<String>> mapMissingHandlers = null;
+        Map<String, List<String>> mapMissingHandlers = null;
         for (String moduleTypeName : moduleTypes) {
             Set<String> rules = null;
             synchronized (this) {
@@ -941,7 +941,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             }
         } // for
         if (mapMissingHandlers != null) {
-            for (Entry<String, @Nullable List<String>> e : mapMissingHandlers.entrySet()) {
+            for (Entry<String, List<String>> e : mapMissingHandlers.entrySet()) {
                 String rUID = e.getKey();
                 List<String> missingTypes = e.getValue();
                 StringBuffer sb = new StringBuffer();
@@ -1053,7 +1053,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param ruleUID the UID of the rule whose context must be cleared.
      */
     protected void clearContext(String ruleUID) {
-        Map<String, @Nullable Object> context = contextMap.get(ruleUID);
+        Map<String, Object> context = contextMap.get(ruleUID);
         if (context != null) {
             context.clear();
         }
@@ -1077,7 +1077,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param outputs new output values.
      */
     private void updateContext(String ruleUID, String moduleUID, @Nullable Map<String, ?> outputs) {
-        Map<String, @Nullable Object> context = getContext(ruleUID, null);
+        Map<String, Object> context = getContext(ruleUID, null);
         if (outputs != null) {
             for (Map.Entry<String, ?> entry : outputs.entrySet()) {
                 String key = moduleUID + OUTPUT_SEPARATOR + entry.getKey();
@@ -1089,8 +1089,8 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     /**
      * @return copy of current context in rule engine
      */
-    private Map<String, @Nullable Object> getContext(String ruleUID, @Nullable Set<Connection> connections) {
-        Map<String, @Nullable Object> context = contextMap.get(ruleUID);
+    private Map<String, Object> getContext(String ruleUID, @Nullable Set<Connection> connections) {
+        Map<String, Object> context = contextMap.get(ruleUID);
         if (context == null) {
             context = new HashMap<>();
             contextMap.put(ruleUID, context);
@@ -1145,7 +1145,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             }
             final Condition condition = wrappedCondition.unwrap();
             ConditionHandler tHandler = wrappedCondition.getModuleHandler();
-            Map<String, @Nullable Object> context = getContext(ruleUID, wrappedCondition.getConnections());
+            Map<String, Object> context = getContext(ruleUID, wrappedCondition.getConnections());
             if (tHandler != null && !tHandler.isSatisfied(Collections.unmodifiableMap(context))) {
                 logger.debug("The condition '{}' of rule '{}' is unsatisfied.", condition.getId(), ruleUID);
                 return false;
@@ -1174,7 +1174,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             final Action action = wrappedAction.unwrap();
             ActionHandler aHandler = wrappedAction.getModuleHandler();
             if (aHandler != null) {
-                Map<String, @Nullable Object> context = getContext(ruleUID, wrappedAction.getConnections());
+                Map<String, Object> context = getContext(ruleUID, wrappedAction.getConnections());
                 try {
                     Map<String, ?> outputs = aHandler.execute(Collections.unmodifiableMap(context));
                     if (outputs != null) {
@@ -1358,7 +1358,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         return result;
     }
 
-    private void initTagsMap(String moduleId, List<Output> outputs, Map<Set<String>, @Nullable OutputRef> tagMap) {
+    private void initTagsMap(String moduleId, List<Output> outputs, Map<Set<String>, OutputRef> tagMap) {
         for (Output output : outputs) {
             Set<String> tags = output.getTags();
             if (!tags.isEmpty()) {

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -62,7 +62,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
     private final MDNSClient mdnsClient;
 
     @Activate
-    public MDNSDiscoveryService(final @Nullable Map<String, @Nullable Object> configProperties,
+    public MDNSDiscoveryService(final @Nullable Map<String, Object> configProperties,
             final @Reference MDNSClient mdnsClient) {
         super(5);
 
@@ -89,7 +89,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
 
     @Modified
     @Override
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
@@ -81,14 +81,14 @@ public class UsbSerialDiscoveryService extends AbstractDiscoveryService implemen
 
     @Override
     @Activate
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         super.activate(configProperties);
         usbSerialDiscovery.registerDiscoveryListener(this);
     }
 
     @Modified
     @Override
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -360,7 +360,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *
      * @param configProperties configuration properties
      */
-    protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void activate(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
             Object property = configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
             if (property != null) {
@@ -383,7 +383,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *
      * @param configProperties configuration properties
      */
-    protected void modified(@Nullable Map<String, @Nullable Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
             Object property = configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
             if (property != null) {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -118,7 +118,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
     }
 
     @Activate
-    protected void activate(@Nullable Map<String, @Nullable Object> properties) {
+    protected void activate(@Nullable Map<String, Object> properties) {
         thingRegistry.addRegistryChangeListener(this);
         inbox.addInboxListener(this);
 
@@ -126,7 +126,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
     }
 
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> properties) {
+    protected void modified(@Nullable Map<String, Object> properties) {
         if (properties != null) {
             Object value = properties.get(AUTO_IGNORE_CONFIG_PROPERTY);
             autoIgnore = value == null || !"false".equals(value.toString());

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -87,7 +87,7 @@ public class AuthFilter implements ContainerRequestFilter {
     }
 
     @Modified
-    protected void modified(@Nullable Map<String, @Nullable Object> properties) {
+    protected void modified(@Nullable Map<String, Object> properties) {
         if (properties != null) {
             Object value = properties.get(CONFIG_ALLOW_BASIC_AUTH);
             allowBasicAuth = value != null && "true".equals(value.toString());

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -284,7 +284,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             SYSTEM_MEDIA_ARTIST, SYSTEM_WIND_DIRECTION, SYSTEM_WIND_SPEED, SYSTEM_OUTDOOR_TEMPERATURE,
             SYSTEM_ATMOSPHERIC_HUMIDITY, SYSTEM_BAROMETRIC_PRESSURE);
 
-    private final Map<LocalizedKey, @Nullable ChannelType> localizedChannelTypeCache = new ConcurrentHashMap<>();
+    private final Map<LocalizedKey, ChannelType> localizedChannelTypeCache = new ConcurrentHashMap<>();
 
     private final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
     private final BundleResolver bundleResolver;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -48,7 +48,7 @@ public abstract class BaseDynamicCommandDescriptionProvider implements DynamicCo
     private @NonNullByDefault({}) BundleContext bundleContext;
     protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
 
-    protected final Map<ChannelUID, @Nullable List<CommandOption>> channelOptionsMap = new ConcurrentHashMap<>();
+    protected final Map<ChannelUID, List<CommandOption>> channelOptionsMap = new ConcurrentHashMap<>();
 
     /**
      * For a given channel UID, set a {@link List} of {@link CommandOption}s that should be used for the channel,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -49,8 +49,8 @@ public abstract class BaseDynamicStateDescriptionProvider implements DynamicStat
     private @NonNullByDefault({}) BundleContext bundleContext;
     protected @NonNullByDefault({}) ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;
 
-    protected final Map<ChannelUID, @Nullable String> channelPatternMap = new ConcurrentHashMap<>();
-    protected final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+    protected final Map<ChannelUID, String> channelPatternMap = new ConcurrentHashMap<>();
+    protected final Map<ChannelUID, List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
 
     /**
      * For a given channel UID, set a pattern that should be used for the channel, instead of the one defined statically

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -60,8 +60,8 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(BaseThingHandlerFactory.class);
 
-    private final Map<String, @Nullable ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
 
     private final Map<ThingUID, Set<ServiceRegistration<?>>> thingHandlerServices = new ConcurrentHashMap<>();
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.Metadata;
@@ -106,7 +105,7 @@ public class AutoUpdateManager {
     }
 
     @Activate
-    public AutoUpdateManager(Map<String, @Nullable Object> configuration,
+    public AutoUpdateManager(Map<String, Object> configuration,
             final @Reference ChannelTypeRegistry channelTypeRegistry, //
             final @Reference EventPublisher eventPublisher,
             final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry,
@@ -122,7 +121,7 @@ public class AutoUpdateManager {
     }
 
     @Modified
-    protected void modified(Map<String, @Nullable Object> configuration) {
+    protected void modified(Map<String, Object> configuration) {
         Object valueEnabled = configuration.get(PROPERTY_ENABLED);
         if (valueEnabled != null) {
             enabled = Boolean.parseBoolean(valueEnabled.toString());

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -137,8 +137,8 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     private final Set<ProfileAdvisor> profileAdvisors = new CopyOnWriteArraySet<>();
 
-    private final Map<String, @Nullable List<Class<? extends Command>>> acceptedCommandTypeMap = new ConcurrentHashMap<>();
-    private final Map<String, @Nullable List<Class<? extends State>>> acceptedStateTypeMap = new ConcurrentHashMap<>();
+    private final Map<String, List<Class<? extends Command>>> acceptedCommandTypeMap = new ConcurrentHashMap<>();
+    private final Map<String, List<Class<? extends State>>> acceptedStateTypeMap = new ConcurrentHashMap<>();
 
     @Override
     public Set<String> getSubscribedEventTypes() {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
@@ -38,9 +38,9 @@ public class SafeCallManagerImpl implements SafeCallManager {
 
     private final Logger logger = LoggerFactory.getLogger(SafeCallManagerImpl.class);
 
-    private final Map<Object, @Nullable Queue<Invocation>> queues = new HashMap<>();
-    private final Map<Object, @Nullable Invocation> activeIdentifiers = new HashMap<>();
-    private final Map<Object, @Nullable Invocation> activeAsyncInvocations = new HashMap<>();
+    private final Map<Object, Queue<Invocation>> queues = new HashMap<>();
+    private final Map<Object, Invocation> activeIdentifiers = new HashMap<>();
+    private final Map<Object, Invocation> activeAsyncInvocations = new HashMap<>();
 
     private final ScheduledExecutorService watcher;
     private final ExecutorService scheduler;


### PR DESCRIPTION
These workarounds to prevent false positives can be removed now the EEAs allow for proper null analysis.

Depends on #1775