### PR TITLE
Fixed provider comparison while unsetting 

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -541,7 +541,7 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
     }
 
     protected void unsetManagedProvider(ManagedProvider<E, K> provider) {
-        if (managedProvider.equals(provider)) {
+        if (managedProvider.isPresent() && managedProvider.get().equals(provider)) {
             managedProvider = Optional.empty();
         }
     }


### PR DESCRIPTION
- Fixed provider comparison as the variable `managedProvider` is of type `Optional<ManagedProvider<E, K>>`

Related to #1506

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>