### PR TITLE
[automation] Added NPE checks for result of 'getSymbolicName()' methods

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -240,7 +240,11 @@ public abstract class AbstractResourceBundleProvider<@NonNull E> {
                     bundle.getBundleId(), e);
             processAutomationProviderUninstalled(bundle);
         }
-        Vendor vendor = new Vendor(bundle.getSymbolicName(), bundle.getVersion().toString());
+        String bsn = bundle.getSymbolicName();
+        if (bsn == null) {
+            bsn = String.format("@bundleId@0x%x", bundle.getBundleId());
+        }
+        Vendor vendor = new Vendor(bsn, bundle.getVersion().toString());
         List<String> previousPortfolio = getPreviousPortfolio(vendor);
         List<String> newPortfolio = new LinkedList<>();
         if (urlEnum != null) {
@@ -326,7 +330,11 @@ public abstract class AbstractResourceBundleProvider<@NonNull E> {
     @SuppressWarnings("unchecked")
     protected void processAutomationProviderUninstalled(Bundle bundle) {
         waitingProviders.remove(bundle);
-        Vendor vendor = new Vendor(bundle.getSymbolicName(), bundle.getVersion().toString());
+        String bsn = bundle.getSymbolicName();
+        if (bsn == null) {
+            bsn = String.format("@bundleId@0x%x", bundle.getBundleId());
+        }
+        Vendor vendor = new Vendor(bsn, bundle.getVersion().toString());
         List<String> portfolio = providerPortfolio.remove(vendor);
         if (portfolio != null && !portfolio.isEmpty()) {
             for (String uid : portfolio) {
@@ -360,7 +368,7 @@ public abstract class AbstractResourceBundleProvider<@NonNull E> {
         if (symbolicName != null) {
             Bundle[] bundles = bundleContext.getBundles();
             for (Bundle bundle : bundles) {
-                if (bundle.getSymbolicName().equals(symbolicName)) {
+                if (symbolicName.equals(bundle.getSymbolicName())) {
                     return bundle;
                 }
             }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
@@ -86,8 +86,12 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
      */
     @Override
     protected void processAutomationProvider(Bundle bundle) {
-        Vendor vendor = new Vendor(bundle.getSymbolicName(), bundle.getVersion().toString());
-        logger.debug("Parse rules from bundle '{}' ", bundle.getSymbolicName());
+        String bsn = bundle.getSymbolicName();
+        if (bsn == null) {
+            bsn = String.format("@bundleId@0x%x", bundle.getBundleId());
+        }
+        Vendor vendor = new Vendor(bsn, bundle.getVersion().toString());
+        logger.debug("Parse rules from bundle '{}' ", bsn);
         Enumeration<URL> urlEnum = null;
         try {
             if (bundle.getState() != Bundle.UNINSTALLED) {
@@ -156,7 +160,11 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
 
     @Override
     protected void processAutomationProviderUninstalled(Bundle bundle) {
-        Vendor vendor = new Vendor(bundle.getSymbolicName(), bundle.getVersion().toString());
+        String bsn = bundle.getSymbolicName();
+        if (bsn == null) {
+            bsn = String.format("@bundleId@0x%x", bundle.getBundleId());
+        }
+        Vendor vendor = new Vendor(bsn, bundle.getVersion().toString());
         waitingProviders.remove(bundle);
         providerPortfolio.remove(vendor);
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/Vendor.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/Vendor.java
@@ -14,6 +14,9 @@ package org.openhab.core.automation.internal.provider;
 
 import java.util.StringTokenizer;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This class is designed to serves as a holder of most significant information for a bundle that provides resources
  * for automation objects - bundle ID and bundle version. These two features of the bundle, define it uniquely and
@@ -21,6 +24,7 @@ import java.util.StringTokenizer;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class Vendor {
 
     private static final String DELIMITER = ";";
@@ -115,7 +119,7 @@ public class Vendor {
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj instanceof Vendor) {
             Vendor other = (Vendor) obj;
             return vendorSymbolicName.equals(other.vendorSymbolicName) && vendorVersion.equals(other.vendorVersion);


### PR DESCRIPTION
-  Added NPE checks for result of `getSymbolicName()` methods

We are using the same fallback in other places:

https://github.com/openhab/openhab-core/blob/61e17ce39e83daa7f1d8c41512dead8d95d6e5d9/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarkerUtils.java#L39

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>