### PR TITLE
[REST Auth] Remove user access to things

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -289,7 +289,7 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Get all available things.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedThingDTO.class), uniqueItems = true))) })
@@ -510,7 +510,7 @@ public class ThingResource implements RESTResource {
     }
 
     @GET
-    @RolesAllowed({ Role.USER, Role.ADMIN })
+    @RolesAllowed({ Role.ADMIN })
     @Path("/{thingUID}/status")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Gets thing status.", security = {


### PR DESCRIPTION
I can't think of a good reason why listing things or querying their status should be allowed for users.
The things layer should only be of concern to admins IMHO.
As noted here: https://community.openhab.org/t/oh3-will-list-all-your-things-even-if-you-are-not-logged-in/108006/3
passwords and other sensible information in configuration could end up being exposed without auth required.

Signed-off-by: Yannick Schaus <github@schaus.net>