### PR TITLE
[automation] Correctly map the state context variable of the ItemStateEvent to the implicit var newState

### DIFF
--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -54,7 +54,8 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
     public static final String MIMETYPE_OPENHAB_DSL_RULE = "application/vnd.openhab.dsl.rule";
 
     private static final Map<String, String> implicitVars = Map.of("command", "receivedCommand", "event",
-            "receivedEvent", "newState", "newState", "oldState", "previousState", "triggeringItem", "triggeringItem");
+            "receivedEvent", "state", "newState", "newState", "newState", "oldState", "previousState", "triggeringItem",
+            "triggeringItem");
 
     private final Logger logger = LoggerFactory.getLogger(DSLScriptEngine.class);
 


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-core/issues/1802

Signed-off-by: Kai Kreuzer <kai@openhab.org>