### PR TITLE
Remove the groupname from the members if the group item is removed

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
@@ -83,6 +83,16 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         this.itemBuilderFactory = itemBuilderFactory;
     }
 
+    @Override
+    public @Nullable Item remove(String key) {
+        Item item = this.get(key);
+        if (item instanceof GroupItem) {
+            this.removeGroupNameFromMembers((GroupItem) item);
+        }
+
+        return super.remove(key);
+    }
+
     /**
      * Removes an item and it´s member if recursive flag is set to true.
      *
@@ -118,6 +128,16 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         return memberNames;
     }
 
+    private Set<Item> getMembers(GroupItem groupItem, Collection<Item> allItems) {
+        Set<Item> members = new HashSet<>();
+        for (Item item : allItems) {
+            if (item.getGroupNames().contains(groupItem.getName())) {
+                members.add(item);
+            }
+        }
+        return members;
+    }
+
     private @Nullable Item createItem(String itemType, String itemName) {
         try {
             Item item = itemBuilderFactory.newItemBuilder(itemType, itemName).build();
@@ -125,6 +145,16 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         } catch (IllegalStateException e) {
             logger.debug("Couldn't create item '{}' of type '{}'", itemName, itemType);
             return null;
+        }
+    }
+
+    private void removeGroupNameFromMembers(GroupItem groupItem) {
+        Set<Item> members = getMembers(groupItem, getAll());
+        for (Item member : members) {
+            if (member instanceof GenericItem) {
+                ((GenericItem) member).removeGroupName(groupItem.getUID());
+                update(member);
+            }
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
@@ -85,9 +85,9 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
     @Override
     public @Nullable Item remove(String key) {
-        Item item = this.get(key);
+        Item item = get(key);
         if (item instanceof GroupItem) {
-            this.removeGroupNameFromMembers((GroupItem) item);
+            removeGroupNameFromMembers((GroupItem) item);
         }
 
         return super.remove(key);

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
@@ -349,4 +349,37 @@ public class ManagedItemProviderOSGiTest extends JavaOSGiTest {
 
         assertThat(itemProvider.getAll().size(), is(0));
     }
+
+    @Test
+    public void assertRemoveGroupnameFromMembersOnGroupitemRemoval() {
+        assertThat(itemProvider.getAll().size(), is(0));
+
+        GroupItem group = new GroupItem("group");
+
+        GenericItem item1 = new SwitchItem("SwitchItem1");
+        item1.addGroupName(group.getName());
+        GenericItem item2 = new SwitchItem("SwitchItem2");
+        item2.addGroupName(group.getName());
+
+        itemProvider.add(group);
+        itemProvider.add(item1);
+        itemProvider.add(item2);
+
+        assertThat(itemProvider.getAll().size(), is(3));
+
+        Item oldItem = itemProvider.remove(group.getName());
+
+        assertThat(oldItem, is(group));
+
+        item1 = (GenericItem) itemProvider.get("SwitchItem1");
+        item2 = (GenericItem) itemProvider.get("SwitchItem2");
+
+        assertNotNull(item1);
+        assertNotNull(item2);
+        if (item1 != null && item2 != null) {
+            assertThat(item1.getGroupNames().size(), is(0));
+            assertThat(item2.getGroupNames().size(), is(0));
+        }
+        assertThat(itemProvider.getAll().size(), is(2));
+    }
 }

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
@@ -367,6 +367,9 @@ public class ManagedItemProviderOSGiTest extends JavaOSGiTest {
 
         assertThat(itemProvider.getAll().size(), is(3));
 
+        assertThat(item1.getGroupNames().size(), is(1));
+        assertThat(item2.getGroupNames().size(), is(1));
+
         Item oldItem = itemProvider.remove(group.getName());
 
         assertThat(oldItem, is(group));


### PR DESCRIPTION
Remove the groupname from the members if the group item is removed. 
This is implemented in the ManagedItemProvider. 

Fixes #1785 
Fixes #1392 