### PR TITLE
[automation] Extracted accessor into interface and added to script engine context …

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -41,6 +41,11 @@ public interface ScriptEngineFactory {
     String CONTEXT_KEY_ENGINE_IDENTIFIER = "oh.engine-identifier";
 
     /**
+     * Key to access Extension Accessor {@link ScriptExtensionAccessor}
+     */
+    String CONTEXT_KEY_EXTENSION_ACCESSOR = "oh.extension-accessor";
+
+    /**
      * This method returns a list of file extensions and MimeTypes that are supported by the ScriptEngine, e.g. py,
      * application/python, js, application/javascript, etc.
      *

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionAccessor.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionAccessor.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Accessor allowing script engines to lookup presets.
+ *
+ * @author Jonathan Gilbert - Initial contribution
+ */
+@NonNullByDefault
+public interface ScriptExtensionAccessor {
+
+    /**
+     * Access the default presets for a script engine
+     *
+     * @param scriptIdentifier the identifier for the script engine
+     * @return map of preset objects
+     */
+    Map<String, Object> findDefaultPresets(String scriptIdentifier);
+
+    /**
+     * Access specific presets for a script engine
+     *
+     * @param preset the name of the preset
+     * @param scriptIdentifier the identifier for the script engine
+     * @return map of preset objects
+     */
+    Map<String, Object> findPreset(String preset, String scriptIdentifier);
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script.internal;
 
 import static org.openhab.core.automation.module.script.ScriptEngineFactory.CONTEXT_KEY_ENGINE_IDENTIFIER;
+import static org.openhab.core.automation.module.script.ScriptEngineFactory.CONTEXT_KEY_EXTENSION_ACCESSOR;
 
 import java.io.InputStreamReader;
 import java.util.HashMap;
@@ -143,6 +144,8 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     }
 
                     scriptContext.setAttribute(CONTEXT_KEY_ENGINE_IDENTIFIER, engineIdentifier,
+                            ScriptContext.ENGINE_SCOPE);
+                    scriptContext.setAttribute(CONTEXT_KEY_EXTENSION_ACCESSOR, scriptExtensionManager,
                             ScriptContext.ENGINE_SCOPE);
                 } else {
                     logger.error("ScriptEngine for language '{}' could not be created for identifier: {}", scriptType,


### PR DESCRIPTION
…to allow access to script extensions from script engine factories

This is to allow script engines the ability to reference extensions (via the script context). Note that I have called the methods `findX` rather than `getX` because `getDefaultPresets` already exists, yet returns the preset names, not the presets themselves.

(I will move out of draft once I've finished testing.)

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>