### PR TITLE
removed deprecated author information from bindings

### DIFF
--- a/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/binding/binding.xml
@@ -6,8 +6,6 @@
 	<name>hue Binding</name>
 	<description>The hue Binding integrates the Philips hue system. It
 		allows to control hue lights.</description>
-	<author>Deutsche Telekom AG</author>
-
 
 	<!-- Dummy config -->
 	<config-description>

--- a/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/binding/binding.xml
@@ -6,6 +6,7 @@
 	<name>hue Binding</name>
 	<description>The hue Binding integrates the Philips hue system. It
 		allows to control hue lights.</description>
+	<author>Deutsche Telekom AG</author>
 
 	<!-- Dummy config -->
 	<config-description>

--- a/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/yahooweather.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.binding.xml.tests/src/main/resources/test-bundle-pool/yahooweather.bundle/OH-INF/binding/binding.xml
@@ -6,6 +6,5 @@
 	<name>YahooWeather Binding</name>
 	<description>The Yahoo Weather Binding requests the Yahoo Weather Service to show the current temperature, humidity and
 		pressure.</description>
-	<author>Kai Kreuzer</author>
 
 </binding:binding>

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannels.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannels.bundle/OH-INF/binding/binding.xml
@@ -6,6 +6,5 @@
 
 	<name>SystemChannels Test Binding</name>
 	<description>Used to test System Wide Channels. Provides definitions of system channels.</description>
-	<author>Deutsche Telekom AG</author>
 
 </binding:binding>

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/OH-INF/binding/binding.xml
@@ -7,6 +7,5 @@
 	<name>SystemChannelsInChannelGroups Test Binding</name>
 	<description>Used to test System Wide Channels which are used within Channel Groups. Provides definitions of system
 		channels.</description>
-	<author>Deutsche Telekom AG</author>
 
 </binding:binding>

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/OH-INF/binding/binding.xml
@@ -7,6 +7,5 @@
 	<name>SystemChannelsNoThingTypes Test Binding</name>
 	<description>Used to test System Wide Channels. Defines system channels
 		without thing types.</description>
-	<author>Deutsche Telekom AG</author>
 
 </binding:binding>

--- a/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsUser.bundle/OH-INF/binding/binding.xml
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/resources/test-bundle-pool/SystemChannelsUser.bundle/OH-INF/binding/binding.xml
@@ -7,6 +7,5 @@
 	<name>SystemChannelsUser Test Binding</name>
 	<description>Used to test System Wide Channels. Consumes System Wide
 		Channels defined by another bundle.</description>
-	<author>Deutsche Telekom AG</author>
 
 </binding:binding>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/binding/binding.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/binding/binding.xml
@@ -5,6 +5,5 @@
 
 	<name>${bindingIdCamelCase} Binding</name>
 	<description>This is the binding for ${bindingIdCamelCase}.</description>
-	<author>${author}</author>
 
 </binding:binding>


### PR DESCRIPTION
This was discussed a long time ago and was planned for the start of openHAB 3 already - it fell of my plate somehow.

In short: Having a single author listed in this file does not make much sense for multiple reasons:
- Bindings in the official repo are considered to be part of the openHAB project and not by an individual.
- Many bindings have different contributors over the course of time, which isn't reflected here either.
- The attribution of contributors is done within the source code.
- We don't have this info for other types of add-on either.
- Naming an author makes sense for marketplace entries, but for those we will anyhow have other metadata files.
- The original purpose of this field was to give companies a possibility to "officially claim" a binding to be implemented and supported by them, but this actually never worked that way.




Signed-off-by: Kai Kreuzer <kai@openhab.org>