### PR TITLE
sync Jetty versions between compile and runtime

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -17,7 +17,7 @@
   <description>The dependencies that are used to compile the core bundles</description>
 
   <properties>
-    <jetty.version>9.3.25.v20180904</jetty.version>
+    <jetty.version>9.4.20.v20190813</jetty.version>
     <swagger.version>2.1.0</swagger.version>
   </properties>
 


### PR DESCRIPTION
There is not really a reason from preventing bindings to use Jetty 9.4 features and I agree with @kgoderis that having them divert can cause confusion and problems.

Fixes https://github.com/openhab/openhab-core/issues/1275

Signed-off-by: Kai Kreuzer <kai@openhab.org>