### PR TITLE
[inbox REST API] Added new optional parameter newThingId to approve

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
@@ -36,6 +36,7 @@ import org.openhab.core.thing.ThingUID;
  * is added, updated or removed.
  *
  * @author Michael Grammling - Initial contribution
+ * @author Laurent Garnier - Added parameter newThingId to method approve
  *
  * @see InboxListener
  */
@@ -127,8 +128,10 @@ public interface Inbox {
      *
      * @param thingUID the UID of the Thing
      * @param label the label of the Thing
+     * @param newThingId the thing ID of the Thing to be created; if not null, it will replace the thing ID from
+     *            parameter thingUID
      * @return the approved Thing
      */
     @Nullable
-    Thing approve(ThingUID thingUID, @Nullable String label);
+    Thing approve(ThingUID thingUID, @Nullable String label, @Nullable String newThingId);
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -166,7 +166,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
             }
         }
         if (alwaysAutoApprove || isToBeAutoApproved(result)) {
-            inbox.approve(result.getThingUID(), result.getLabel());
+            inbox.approve(result.getThingUID(), result.getLabel(), null);
         }
     }
 
@@ -265,7 +265,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         for (DiscoveryResult result : inbox.getAll()) {
             if (DiscoveryResultFlag.NEW.equals(result.getFlag())) {
                 if (alwaysAutoApprove || isToBeAutoApproved(result)) {
-                    inbox.approve(result.getThingUID(), result.getLabel());
+                    inbox.approve(result.getThingUID(), result.getLabel(), null);
                 }
             }
         }
@@ -280,7 +280,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         inboxAutoApprovePredicates.add(inboxAutoApprovePredicate);
         for (DiscoveryResult result : inbox.getAll()) {
             if (DiscoveryResultFlag.NEW.equals(result.getFlag()) && inboxAutoApprovePredicate.test(result)) {
-                inbox.approve(result.getThingUID(), result.getLabel());
+                inbox.approve(result.getThingUID(), result.getLabel(), null);
             }
         }
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -37,6 +37,7 @@ import org.osgi.service.component.annotations.Reference;
  * This class provides console commands around the inbox functionality.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Laurent Garnier - New optional parameter for command approve
  */
 @Component(immediate = true, service = ConsoleCommandExtension.class)
 @NonNullByDefault
@@ -65,6 +66,10 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 case SUBCMD_APPROVE:
                     if (args.length > 2) {
                         String label = args[2];
+                        String newThingId = null;
+                        if (args.length > 3) {
+                            newThingId = args[3];
+                        }
                         try {
                             ThingUID thingUID = new ThingUID(args[1]);
                             List<DiscoveryResult> results = inbox.stream().filter(forThingUID(thingUID))
@@ -73,12 +78,12 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
                                 console.println("No matching inbox entry could be found.");
                                 return;
                             }
-                            inbox.approve(thingUID, label);
+                            inbox.approve(thingUID, label, newThingId);
                         } catch (IllegalArgumentException e) {
                             console.println(e.getMessage());
                         }
                     } else {
-                        console.println("Specify thing id to approve: inbox approve <thingUID> <label>");
+                        console.println("Specify thing id to approve: inbox approve <thingUID> <label> [<newThingID>]");
                     }
                     break;
                 case SUBCMD_IGNORE:
@@ -194,7 +199,8 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
     public List<String> getUsages() {
         return List.of(buildCommandUsage(SUBCMD_LIST, "lists all current inbox entries"),
                 buildCommandUsage(SUBCMD_LIST_IGNORED, "lists all ignored inbox entries"),
-                buildCommandUsage(SUBCMD_APPROVE + " <thingUID> <label>", "creates a thing for an inbox entry"),
+                buildCommandUsage(SUBCMD_APPROVE + " <thingUID> <label> [<newThingID>]",
+                        "creates a thing for an inbox entry"),
                 buildCommandUsage(SUBCMD_CLEAR, "clears all current inbox entries"),
                 buildCommandUsage(SUBCMD_REMOVE + " [<thingUID>|<thingTypeUID>]",
                         "remove the inbox entries of a given thing id or thing type"),

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -60,13 +60,17 @@ import org.openhab.core.thing.type.ThingTypeRegistry;
 
 /**
  * @author Simon Kaufmann - Initial contribution
+ * @author Laurent Garnier - Added tests testApproveWithThingId and testApproveWithInvalidThingId
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.WARN)
 public class PersistentInboxTest {
 
+    private static final String THING_OTHER_ID = "other";
+
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("test", "test");
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "test");
+    private static final ThingUID THING_OTHER_UID = new ThingUID(THING_TYPE_UID, THING_OTHER_ID);
 
     private PersistentInbox inbox;
     private Thing lastAddedThing = null;
@@ -87,6 +91,9 @@ public class PersistentInboxTest {
         when(thingHandlerFactory.supportsThingType(eq(THING_TYPE_UID))).thenReturn(true);
         when(thingHandlerFactory.createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_UID), any()))
                 .then(invocation -> ThingBuilder.create(THING_TYPE_UID, "test")
+                        .withConfiguration((Configuration) invocation.getArguments()[1]).build());
+        when(thingHandlerFactory.createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_OTHER_UID), any()))
+                .then(invocation -> ThingBuilder.create(THING_TYPE_UID, THING_OTHER_ID)
                         .withConfiguration((Configuration) invocation.getArguments()[1]).build());
 
         inbox = new PersistentInbox(storageService, mock(DiscoveryServiceRegistry.class), thingRegistry, thingProvider,
@@ -137,10 +144,35 @@ public class PersistentInboxTest {
         when(storage.getValues()).thenReturn(List.of(result));
 
         inbox.activate();
-        inbox.approve(THING_UID, "Test");
+        inbox.approve(THING_UID, "Test", null);
 
+        assertEquals(THING_UID, lastAddedThing.getUID());
         assertTrue(lastAddedThing.getConfiguration().get("foo") instanceof String);
         assertEquals("3", lastAddedThing.getConfiguration().get("foo"));
+    }
+
+    @Test
+    public void testApproveWithThingId() throws URISyntaxException {
+        DiscoveryResult result = DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build();
+        configureConfigDescriptionRegistryMock("foo", Type.TEXT);
+        when(storage.getValues()).thenReturn(List.of(result));
+
+        inbox.activate();
+        inbox.approve(THING_UID, "Test", THING_OTHER_ID);
+
+        assertEquals(THING_OTHER_UID, lastAddedThing.getUID());
+        assertTrue(lastAddedThing.getConfiguration().get("foo") instanceof String);
+        assertEquals("3", lastAddedThing.getConfiguration().get("foo"));
+    }
+
+    @Test
+    public void testApproveWithInvalidThingId() throws URISyntaxException {
+        DiscoveryResult result = DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build();
+        configureConfigDescriptionRegistryMock("foo", Type.TEXT);
+        when(storage.getValues()).thenReturn(List.of(result));
+
+        inbox.activate();
+        assertNull(inbox.approve(THING_UID, "Test", "invalid:id"));
     }
 
     @Test

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
@@ -71,6 +71,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Franck Dechavanne - Added DTOs to ApiResponses
  * @author Markus Rathgeb - Migrated to JAX-RS Whiteboard Specification
  * @author Wouter Born - Migrated to OpenAPI annotations
+ * @author Laurent Garnier - Added optional parameter newThingId to approve API
  */
 @Component(service = { RESTResource.class, InboxResource.class })
 @JaxrsResource
@@ -105,12 +106,14 @@ public class InboxResource implements RESTResource {
     public Response approve(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
-            @Parameter(description = "thing label") @Nullable String label) {
+            @Parameter(description = "thing label") @Nullable String label,
+            @Parameter(description = "new thing ID") @Nullable String newThingId) {
         ThingUID thingUIDObject = new ThingUID(thingUID);
         String notEmptyLabel = label != null && !label.isEmpty() ? label : null;
+        String notEmptyNewThingId = newThingId != null && !newThingId.isEmpty() ? newThingId : null;
         Thing thing = null;
         try {
-            thing = inbox.approve(thingUIDObject, notEmptyLabel);
+            thing = inbox.approve(thingUIDObject, notEmptyLabel, notEmptyNewThingId);
         } catch (IllegalArgumentException e) {
             logger.error("Thing {} unable to be approved: {}", thingUID, e.getLocalizedMessage());
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Thing unable to be approved.");

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -136,6 +136,8 @@ public class InboxOSGiTest extends JavaOSGiTest {
     private final ThingUID testUID = new ThingUID("binding:type:id");
     private final ThingTypeUID testTypeUID = new ThingTypeUID("binding:type");
     private final Thing testThing = ThingBuilder.create(testTypeUID, testUID).build();
+    private String testId2 = "myId";
+    private final Thing test2Thing = ThingBuilder.create(testTypeUID, testId2).build();
     private final String discoveryResultLabel = "MyLabel";
 
     @SuppressWarnings("serial")
@@ -855,13 +857,13 @@ public class InboxOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertThatApproveThrowsIllegalArgumentExceptionIfNoDiscoveryResultForGivenThingUIDisAvailable() {
-        assertThrows(IllegalArgumentException.class, () -> inbox.approve(new ThingUID("1234"), "label"));
+        assertThrows(IllegalArgumentException.class, () -> inbox.approve(new ThingUID("1234"), "label", null));
     }
 
     @Test
     public void assertThatApproveAddsAllPropertiesOfDiscoveryResultToThingPropertiesIfNoConfigDescriptionParametersForTheThingTypeAreAvailable() {
         inbox.add(testDiscoveryResult);
-        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel);
+        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel, null);
         Thing addedThing = registry.get(testThing.getUID());
 
         assertFalse(addedThing == null);
@@ -880,7 +882,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @SuppressWarnings("null")
     public void assertThatApproveSetsTheExplicitlyGivenLabel() {
         inbox.add(testDiscoveryResult);
-        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel);
+        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel, null);
         Thing addedThing = registry.get(testThing.getUID());
 
         assertThat(approvedThing.getLabel(), is(testThingLabel));
@@ -891,11 +893,23 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @SuppressWarnings("null")
     public void assertThatApproveSetsTheDiscoveredLabelIfNoOtherIsGiven() {
         inbox.add(testDiscoveryResult);
-        Thing approvedThing = inbox.approve(testThing.getUID(), null);
+        Thing approvedThing = inbox.approve(testThing.getUID(), null, null);
         Thing addedThing = registry.get(testThing.getUID());
 
         assertThat(approvedThing.getLabel(), is(discoveryResultLabel));
         assertThat(addedThing.getLabel(), is(discoveryResultLabel));
+    }
+
+    @Test
+    @SuppressWarnings("null")
+    public void assertThatApproveSetsTheExplicitlyGivenThingId() {
+        inbox.add(testDiscoveryResult);
+        Thing approvedThing = inbox.approve(testThing.getUID(), null, testId2);
+        Thing addedThing = registry.get(test2Thing.getUID());
+
+        assertFalse(addedThing == null);
+        assertFalse(approvedThing == null);
+        assertTrue(approvedThing.equals(addedThing));
     }
 
     @Test
@@ -938,7 +952,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
         waitForAssert(
                 () -> assertNotNull(configDescriptionRegistry.getConfigDescription(testConfigDescription.getUID())));
 
-        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel);
+        Thing approvedThing = inbox.approve(testThing.getUID(), testThingLabel, null);
         Thing addedThing = registry.get(testThing.getUID());
         assertTrue(approvedThing.equals(addedThing));
         assertFalse(addedThing == null);

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResourceOSGITest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResourceOSGITest.java
@@ -67,17 +67,17 @@ public class InboxResourceOSGITest extends JavaOSGiTest {
 
     @Test
     public void assertThatApproveApprovesThingsWhichAreInTheInbox() {
-        when(inbox.approve(any(), any())).thenReturn(testThing);
+        when(inbox.approve(any(), any(), any())).thenReturn(testThing);
 
-        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel);
+        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel, null);
         assertTrue(reponse.getStatusInfo().getStatusCode() == Status.OK.getStatusCode());
     }
 
     @Test
     public void assertThatApproveDoesntApproveThingsWhichAreNotInTheInbox() {
-        when(inbox.approve(any(), any())).thenThrow(new IllegalArgumentException());
+        when(inbox.approve(any(), any(), any())).thenThrow(new IllegalArgumentException());
 
-        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel);
+        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel, null);
         assertTrue(reponse.getStatusInfo().getStatusCode() == Status.NOT_FOUND.getStatusCode());
     }
 }


### PR DESCRIPTION
Fix #1783

This change does not break the current API, it just adds an additional parameter that could be used with REST API v4.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>