### PR TITLE
fix null type mismatch in model.thing generic thing provider

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -371,10 +371,11 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                             label = resolvedChannelType.label
                         }
                         autoUpdatePolicy = resolvedChannelType.autoUpdatePolicy
-                        if (resolvedChannelType.configDescriptionURI !== null) {
+                        val cfgDescUriOfresolvedChannelType = resolvedChannelType.configDescriptionURI
+                        if (cfgDescUriOfresolvedChannelType !== null) {
                             ConfigUtil.applyDefaultConfiguration(configuration,
                                 configDescriptionRegistry.getConfigDescription(
-                                resolvedChannelType.configDescriptionURI))
+                                cfgDescUriOfresolvedChannelType))
                         }
                     } else {
                         logger.error("Channel type {} could not be resolved.", channelTypeUID.asString)


### PR DESCRIPTION
This fixes the following problem:

* Description: Null type mismatch (type annotations): required '@NonNull URI' but this expression has type '@Nullable URI'
* Resource: GenericThingProvider.java
* Path: /org.openhab.core.model.thing/xtend-gen/org/openhab/core/model/thing/internal
* Location: line 617
* Type: Java Problem
