### PR TITLE
[automation] Request automation thread pool as a scheduled pool

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -45,7 +45,7 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
     protected TriggerHandlerCallbackImpl(RuleEngineImpl re, String ruleUID) {
         this.re = re;
         this.ruleUID = ruleUID;
-        executor = ThreadPoolManager.getPool(AUTOMATION_THREADPOOL_NAME);
+        executor = ThreadPoolManager.getScheduledPool(AUTOMATION_THREADPOOL_NAME);
     }
 
     @Override


### PR DESCRIPTION
This is necessary since the RulesRefresher uses the same pool and needs to be able to schedule jobs.

Fixes https://github.com/openhab/openhab-core/issues/1867

Signed-off-by: Kai Kreuzer <kai@openhab.org>