### PR TITLE
fix null constraint mismatch in model.thing for generic thing provider

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/AbstractProviderLazyNullness.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/AbstractProviderLazyNullness.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.thing.internal;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.openhab.core.common.registry.AbstractProvider;
+
+/**
+ * This class can be used as workaround if you want to create a sub-class of an abstract provider but you are not able
+ * to annotate the generic type argument with a non-null annotation. This is for example the case if you implement the
+ * class by Xtend.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ *
+ * @param <E> type of the provided elements
+ */
+public abstract class AbstractProviderLazyNullness<E> extends AbstractProvider<@NonNull E> {
+
+}

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory
  * @author Markus Rathgeb - Add locale provider support
  */
 @Component(immediate=true, service=ThingProvider)
-class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvider, ModelRepositoryChangeListener, ReadyService.ReadyTracker {
+class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implements ThingProvider, ModelRepositoryChangeListener, ReadyService.ReadyTracker {
 
     private static final String XML_THING_TYPE = "esh.xmlThingTypes";
 


### PR DESCRIPTION
This fixes the following problem:

* Description: Null constraint mismatch: The type 'Thing' is not a valid substitute for the type parameter '@NonNull E extends Object'
* Resource: GenericThingProvider.java
* Path: /org.openhab.core.model.thing/xtend-gen/org/openhab/core/model/thing/internal
* Location: line 99
* Type: Java Problem