### PR TITLE
Add ability for scripts to create unmanaged rules

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
@@ -106,6 +106,14 @@ public class ScriptedAutomationManager {
     }
 
     public Rule addRule(Rule element) {
+        Rule rule = addUnmanagedRule(element);
+
+        ruleRegistryDelegate.add(rule);
+
+        return rule;
+    }
+
+    public Rule addUnmanagedRule(Rule element) {
         RuleBuilder builder = RuleBuilder.create(element.getUID());
 
         String name = element.getName();
@@ -173,7 +181,6 @@ public class ScriptedAutomationManager {
 
         Rule rule = builder.build();
 
-        ruleRegistryDelegate.add(rule);
         return rule;
     }
 


### PR DESCRIPTION
Allow scripts to register to create rules that are unmanaged: that is will be tied to the lifecycle of the script itself. This typically makes for cleaner script code.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>