### PR TITLE
Remove SmartHome leftovers

### DIFF
--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
@@ -43,8 +43,7 @@ import org.osgi.service.component.annotations.Modified;
 /**
  * Implementation of authentication provider which is backed by JAAS realm.
  *
- * Real authentication logic is embedded in login modules implemented by 3rd party, this code is just for bridging it to
- * smarthome platform.
+ * Real authentication logic is embedded in login modules implemented by 3rd party, this code is just for bridging it.
  *
  * @author Łukasz Dywicki - Initial contribution
  * @author Kai Kreuzer - Removed ManagedService and used DS configuration instead

--- a/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/BindingXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/BindingXmlConfigDescriptionProvider.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "esh.scope=core.xml.binding" })
+@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "openhab.scope=core.xml.binding" })
 @NonNullByDefault
 public class BindingXmlConfigDescriptionProvider extends AbstractXmlConfigDescriptionProvider {
 

--- a/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/XmlBindingInfoProvider.java
+++ b/bundles/org.openhab.core.binding.xml/src/main/java/org/openhab/core/binding/xml/internal/XmlBindingInfoProvider.java
@@ -55,7 +55,7 @@ public class XmlBindingInfoProvider extends AbstractXmlBasedProvider<String, Bin
         implements BindingInfoProvider, XmlDocumentProviderFactory<BindingInfoXmlResult> {
 
     private static final String XML_DIRECTORY = "/OH-INF/binding/";
-    public static final String READY_MARKER = "esh.xmlBindingInfo";
+    public static final String READY_MARKER = "openhab.xmlBindingInfo";
 
     private final BindingI18nLocalizationService bindingI18nService;
     private AbstractXmlConfigDescriptionProvider configDescriptionProvider;
@@ -67,7 +67,7 @@ public class XmlBindingInfoProvider extends AbstractXmlBasedProvider<String, Bin
 
     @Activate
     public XmlBindingInfoProvider(final @Reference BindingI18nLocalizationService bindingI18nService,
-            final @Reference(target = "(esh.scope=core.xml.binding)") ConfigDescriptionProvider configDescriptionProvider,
+            final @Reference(target = "(openhab.scope=core.xml.binding)") ConfigDescriptionProvider configDescriptionProvider,
             final @Reference ReadyService readyService) {
         this.bindingI18nService = bindingI18nService;
         this.configDescriptionProvider = (AbstractXmlConfigDescriptionProvider) configDescriptionProvider;

--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/ConfigXmlConfigDescriptionProvider.java
@@ -41,13 +41,13 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "esh.scope=core.xml.config" })
+@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "openhab.scope=core.xml.config" })
 @NonNullByDefault
 public class ConfigXmlConfigDescriptionProvider extends AbstractXmlConfigDescriptionProvider
         implements XmlDocumentProviderFactory<List<ConfigDescription>> {
 
     private static final String XML_DIRECTORY = "/OH-INF/config/";
-    public static final String READY_MARKER = "esh.xmlConfig";
+    public static final String READY_MARKER = "openhab.xmlConfig";
 
     private final ConfigI18nLocalizationService configI18nService;
     private @Nullable XmlDocumentBundleTracker<List<ConfigDescription>> configDescriptionTracker;

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
@@ -33,7 +33,7 @@ public class ConsoleInterpreter {
         final List<String> usages = ConsoleInterpreter.getUsages(extensions);
         final StringBuffer buffer = new StringBuffer();
 
-        buffer.append("---SmartHome commands---\n\t");
+        buffer.append("---openHAB commands---\n\t");
         for (int i = 0; i < usages.size(); i++) {
             final String usageString = usages.get(i);
             buffer.append(String.format("%s%s%s\n", base, separator, usageString));

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
@@ -53,7 +53,7 @@ public class EventLogger implements EventSubscriber {
     }
 
     private Logger getLogger(String eventType) {
-        String loggerName = "smarthome.event." + eventType;
+        String loggerName = "openhab.event." + eventType;
         Logger logger = eventLoggers.get(loggerName);
         if (logger == null) {
             logger = LoggerFactory.getLogger(loggerName);

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImplTest.java
@@ -77,7 +77,7 @@ public class ExtensibleTrustManagerImplTest {
     @Test
     public void shouldForwardCallsToMockForMatchingCN() throws CertificateException {
         when(topOfChain.getSubjectX500Principal())
-                .thenReturn(new X500Principal("CN=example.org, OU=Smarthome, O=Eclipse, C=DE"));
+                .thenReturn(new X500Principal("CN=example.org, OU=Core, O=openHAB, C=DE"));
 
         subject.checkServerTrusted(chain, "just");
 
@@ -99,7 +99,7 @@ public class ExtensibleTrustManagerImplTest {
     @Test
     public void shouldForwardCallsToMockForMatchingAlternativeNames() throws CertificateException {
         when(topOfChain.getSubjectX500Principal())
-                .thenReturn(new X500Principal("CN=example.com, OU=Smarthome, O=Eclipse, C=DE"));
+                .thenReturn(new X500Principal("CN=example.com, OU=Core, O=openHAB, C=DE"));
         when(topOfChain.getSubjectAlternativeNames())
                 .thenReturn(constructAlternativeNames("example1.com", "example.org"));
 
@@ -115,7 +115,7 @@ public class ExtensibleTrustManagerImplTest {
         writeField(subject, "defaultTrustManager", defaultTrustManager, true);
 
         when(topOfChain.getSubjectX500Principal())
-                .thenReturn(new X500Principal("CN=example.com, OU=Smarthome, O=Eclipse, C=DE"));
+                .thenReturn(new X500Principal("CN=example.com, OU=Core, O=openHAB, C=DE"));
         when(topOfChain.getSubjectAlternativeNames()).thenReturn(null);
 
         subject.checkClientTrusted(chain, "just");
@@ -129,7 +129,7 @@ public class ExtensibleTrustManagerImplTest {
             NoSuchFieldException, SecurityException, IllegalArgumentException {
         writeField(subject, "defaultTrustManager", defaultTrustManager, true);
 
-        when(topOfChain.getSubjectX500Principal()).thenReturn(new X500Principal("OU=Smarthome, O=Eclipse, C=DE"));
+        when(topOfChain.getSubjectX500Principal()).thenReturn(new X500Principal("OU=Core, O=openHAB, C=DE"));
 
         subject.checkClientTrusted(chain, "just");
 
@@ -143,7 +143,7 @@ public class ExtensibleTrustManagerImplTest {
         writeField(subject, "defaultTrustManager", defaultTrustManager, true);
 
         when(topOfChain.getSubjectX500Principal())
-                .thenReturn(new X500Principal("CN=example.com, OU=Smarthome, O=Eclipse, C=DE"));
+                .thenReturn(new X500Principal("CN=example.com, OU=Core, O=openHAB, C=DE"));
         when(topOfChain.getSubjectAlternativeNames())
                 .thenThrow(new CertificateParsingException("Invalid certificate!!!"));
 
@@ -157,9 +157,9 @@ public class ExtensibleTrustManagerImplTest {
     public void shouldNotForwardCallsToMockForDifferentCN() throws CertificateException, IllegalAccessException,
             NoSuchFieldException, SecurityException, IllegalArgumentException {
         writeField(subject, "defaultTrustManager", defaultTrustManager, true);
-        mockSubjectForCertificate(topOfChain, "CN=example.com, OU=Smarthome, O=Eclipse, C=DE");
-        mockIssuerForCertificate(topOfChain, "CN=Eclipse, OU=Smarthome, O=Eclipse, C=DE");
-        mockSubjectForCertificate(bottomOfChain, "CN=Eclipse, OU=Smarthome, O=Eclipse, C=DE");
+        mockSubjectForCertificate(topOfChain, "CN=example.com, OU=Core, O=openHAB, C=DE");
+        mockIssuerForCertificate(topOfChain, "CN=openHAB, OU=Core, O=openHAB, C=DE");
+        mockSubjectForCertificate(bottomOfChain, "CN=openHAB, OU=Core, O=openHAB, C=DE");
         mockIssuerForCertificate(bottomOfChain, "");
         when(topOfChain.getEncoded()).thenReturn(new byte[0]);
 

--- a/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
+++ b/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
@@ -62,7 +62,7 @@ public class MDNSAnnouncer {
             if (mdnsService != null) {
                 mdnsName = bundleContext.getProperty("mdnsName");
                 if (mdnsName == null) {
-                    mdnsName = "smarthome";
+                    mdnsName = "openhab";
                 }
                 try {
                     httpPort = HttpServiceUtil.getHttpServicePort(bundleContext);

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
@@ -44,8 +44,7 @@ public class SseUtil {
     }
 
     /**
-     * Creates a new {@link OutboundSseEvent} object containing an {@link EventDTO} created for the given Eclipse
-     * SmartHome {@link Event}.
+     * Creates a new {@link OutboundSseEvent} object containing an {@link EventDTO} created for the given {@link Event}.
      *
      * @param eventBuilder the builder that should be used
      * @param event the event data transfer object

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/Constants.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/Constants.java
@@ -18,12 +18,5 @@ package org.openhab.core.io.rest.internal;
  * @author Ivan Iliev - Initial contribution
  */
 public class Constants {
-
-    public static final String JAXRS_CONNECTOR_CONFIG = "com.eclipsesource.jaxrs.connector";
-
-    public static final String JAXRS_CONNECTOR_ROOT_PROPERTY = "root";
-
     public static final String CORS_PROPERTY = "enable";
-
-    public static final String JAXRS_CONNECTOR_CORS_PROPERTY_ENABLE_VALUE = "enable";
 }

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
@@ -16,7 +16,7 @@ import java.util.Hashtable;
 
 /**
  * This is a simple data container to keep all details of a service description together.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution
  */
 public class ServiceDescription {
@@ -28,8 +28,8 @@ public class ServiceDescription {
 
     /**
      * Constructor for a {@link ServiceDescription}, which takes all details as parameters
-     * 
-     * @param serviceType String service type, like "_smarthome-server._tcp.local."
+     *
+     * @param serviceType String service type, like "_openhab-server._tcp.local."
      * @param serviceName String service name, like "openHAB"
      * @param servicePort Int service port, like 8080
      * @param serviceProperties Hashtable service props, like url = "/rest"

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -38,7 +38,7 @@ import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver
 
 /**
- * The script interpreter handles ESH specific script components, which are not known
+ * The script interpreter handles specific script components, which are not known
  * to the standard Xbase interpreter.
  * 
  * @author Kai Kreuzer - Initial contribution and API

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
@@ -172,7 +172,7 @@ public class NumberExtensions {
         }
     }
 
-    // Comparison operators between ESH types and numbers
+    // Comparison operators between types and numbers
 
     public static boolean operator_equals(Type type, Number x) {
         if (type instanceof QuantityType && x instanceof QuantityType) {

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -76,7 +76,7 @@ import org.slf4j.LoggerFactory
 @Component(immediate=true, service=ThingProvider)
 class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implements ThingProvider, ModelRepositoryChangeListener, ReadyService.ReadyTracker {
 
-    private static final String XML_THING_TYPE = "esh.xmlThingTypes";
+    private static final String XML_THING_TYPE = "openhab.xmlThingTypes";
 
     private LocaleProvider localeProvider
 

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
@@ -63,9 +63,9 @@ public class SyntheticBundleInstaller {
     private static final int WAIT_TIMOUT = 30; // [seconds]
     private static final String BUNDLE_POOL_PATH = "/test-bundle-pool";
 
-    private static final String XML_THING_TYPE = "esh.xmlThingTypes";
-    private static final String XML_BINDING_INFO = "esh.xmlBindingInfo";
-    private static final String XML_CONFIG = "esh.xmlConfig";
+    private static final String XML_THING_TYPE = "openhab.xmlThingTypes";
+    private static final String XML_BINDING_INFO = "openhab.xmlBindingInfo";
+    private static final String XML_CONFIG = "openhab.xmlConfig";
 
     /**
      * A list of default extensions to be included in the synthetic bundle.

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Simon Kaufmann - Initial contribution
  */
-@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "esh.scope=core.xml.thing" })
+@Component(service = ConfigDescriptionProvider.class, immediate = true, property = { "openhab.scope=core.xml.thing" })
 @NonNullByDefault
 public class ThingXmlConfigDescriptionProvider extends AbstractXmlConfigDescriptionProvider {
 

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Christoph Weitkamp - factored out common aspects into ThingTypeI18nLocalizationService
  */
 @NonNullByDefault
-@Component(property = { "esh.scope=core.xml.channelGroups" })
+@Component(property = { "openhab.scope=core.xml.channelGroups" })
 public class XmlChannelGroupTypeProvider extends AbstractXmlBasedProvider<UID, ChannelGroupType>
         implements ChannelGroupTypeProvider {
 

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Christoph Weitkamp - factored out common aspects into ThingTypeI18nLocalizationService
  */
 @NonNullByDefault
-@Component(property = { "esh.scope=core.xml.channels" })
+@Component(property = { "openhab.scope=core.xml.channels" })
 public class XmlChannelTypeProvider extends AbstractXmlBasedProvider<UID, ChannelType> implements ChannelTypeProvider {
 
     private final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService;

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -56,12 +56,12 @@ import org.osgi.service.component.annotations.Reference;
  * @author Simon Kaufmann - factored out common aspects into {@link AbstractXmlBasedProvider}
  */
 @NonNullByDefault
-@Component(property = { "esh.scope=core.xml.thing" })
+@Component(property = { "openhab.scope=core.xml.thing" })
 public class XmlThingTypeProvider extends AbstractXmlBasedProvider<UID, ThingType>
         implements ThingTypeProvider, XmlDocumentProviderFactory<List<?>> {
 
     private static final String XML_DIRECTORY = "/OH-INF/thing/";
-    public static final String READY_MARKER = "esh.xmlThingTypes";
+    public static final String READY_MARKER = "openhab.xmlThingTypes";
 
     private final ThingTypeI18nLocalizationService thingTypeI18nLocalizationService;
     private final XmlChannelTypeProvider channelTypeProvider;
@@ -75,9 +75,9 @@ public class XmlThingTypeProvider extends AbstractXmlBasedProvider<UID, ThingTyp
 
     @Activate
     public XmlThingTypeProvider(
-            final @Reference(target = "(esh.scope=core.xml.channelGroups)") ChannelGroupTypeProvider channelGroupTypeProvider,
-            final @Reference(target = "(esh.scope=core.xml.channels)") ChannelTypeProvider channelTypeProvider,
-            final @Reference(target = "(esh.scope=core.xml.thing)") ConfigDescriptionProvider configDescriptionProvider,
+            final @Reference(target = "(openhab.scope=core.xml.channelGroups)") ChannelGroupTypeProvider channelGroupTypeProvider,
+            final @Reference(target = "(openhab.scope=core.xml.channels)") ChannelTypeProvider channelTypeProvider,
+            final @Reference(target = "(openhab.scope=core.xml.thing)") ConfigDescriptionProvider configDescriptionProvider,
             final @Reference ReadyService readyService,
             final @Reference ThingTypeI18nLocalizationService thingTypeI18nLocalizationService) {
         this.channelGroupTypeProvider = (XmlChannelGroupTypeProvider) channelGroupTypeProvider;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.AbstractUID;
 
 /**
- * Base class for binding related unique identifiers within the SmartHome framework.
+ * Base class for binding related unique identifiers.
  * <p>
  * A UID must always start with a binding ID.
  *

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -100,13 +100,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link ThingManagerImpl} tracks all things in the {@link ThingRegistry} and
- * mediates the communication between the {@link Thing} and the {@link ThingHandler} from the binding. Therefore it
- * tracks {@link ThingHandlerFactory}s and calls {@link ThingHandlerFactory#registerHandler(Thing)} for each thing, that
- * was added to the {@link ThingRegistry}. In addition the {@link ThingManagerImpl} acts
- * as an {@link EventHandler} and subscribes to smarthome update and command
- * events. Finally the {@link ThingManagerImpl} implement the {@link ThingTypeMigrationService} to offer
- * a way to change the thing type of a {@link Thing}.
+ * {@link ThingManagerImpl} tracks all things in the {@link ThingRegistry} and mediates the communication between the
+ * {@link Thing} and the {@link ThingHandler} from the binding. Therefore it tracks {@link ThingHandlerFactory}s and
+ * calls {@link ThingHandlerFactory#registerHandler(Thing)} for each thing, that was added to the {@link ThingRegistry}.
+ * In addition the {@link ThingManagerImpl} acts as an {@link EventHandler} and subscribes to update and command events.
+ * Finally the {@link ThingManagerImpl} implement the {@link ThingTypeMigrationService} to offer a way to change the
+ * thing type of a {@link Thing}.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Michael Grammling - Added dynamic configuration update

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -125,7 +125,7 @@ import org.slf4j.LoggerFactory;
 public class ThingManagerImpl
         implements ThingManager, ThingTracker, ThingTypeMigrationService, ReadyService.ReadyTracker {
 
-    static final String XML_THING_TYPE = "esh.xmlThingTypes";
+    static final String XML_THING_TYPE = "openhab.xmlThingTypes";
 
     private static final String THING_STATUS_STORAGE_NAME = "thing_status_storage";
     private static final String FORCEREMOVE_THREADPOOL_NAME = "forceRemove";

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
@@ -61,7 +61,7 @@ public class TransformationHelper {
     public static @Nullable TransformationService getTransformationService(@Nullable BundleContext context,
             String transformationType) {
         if (context != null) {
-            String filter = "(smarthome.transform=" + transformationType + ")";
+            String filter = "(openhab.transform=" + transformationType + ")";
             try {
                 Collection<ServiceReference<TransformationService>> refs = context
                         .getServiceReferences(TransformationService.class, filter);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * A non specific base class for unique identifiers within the SmartHome framework.
+ * A non specific base class for unique identifiers.
  *
  * @author Markus Rathgeb - Initial contribution
  */

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFactory.java
@@ -18,10 +18,9 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * An {@link EventFactory} is responsible for creating {@link Event} instances of specific event types. The Eclipse
- * SmartHome framework uses Event Factories in order to create new Events (
- * {@link #createEvent(String, String, String, String)}) based on the event type, the topic, the payload and the source
- * if an event type is supported ( {@link #getSupportedEventTypes()}).
+ * An {@link EventFactory} is responsible for creating {@link Event} instances of specific event types. Event Factories
+ * are used to create new Events ({@link #createEvent(String, String, String, String)}) based on the event type, the
+ * topic, the payload and the source if an event type is supported ({@link #getSupportedEventTypes()}).
  *
  * @author Stefan Bußweiler - Initial contribution
  */

--- a/features/karaf/openhab-tp/.project
+++ b/features/karaf/openhab-tp/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.openhab.core.features.karaf.esh-tp</name>
+	<name>org.openhab.core.features.karaf.openhab-tp</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionI18nTest.java
+++ b/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionI18nTest.java
@@ -47,7 +47,7 @@ public class ConfigDescriptionI18nTest extends JavaOSGiTest {
     @BeforeEach
     public void setUp() {
         configDescriptionProvider = getService(ConfigDescriptionProvider.class,
-                serviceReference -> "core.xml.config".equals(serviceReference.getProperty("esh.scope")));
+                serviceReference -> "core.xml.config".equals(serviceReference.getProperty("openhab.scope")));
         assertThat(configDescriptionProvider, is(notNullValue()));
     }
 

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
@@ -145,7 +145,7 @@ public class GenericThingProviderTest4 extends JavaOSGiTest {
     private void removeReadyMarker() {
         waitForAssert(() -> {
             // wait for the XML processing to be finished, then remove the ready marker again
-            ReadyMarker marker = new ReadyMarker("esh.xmlThingTypes", bundle.getSymbolicName());
+            ReadyMarker marker = new ReadyMarker("openhab.xmlThingTypes", bundle.getSymbolicName());
             assertThat(readyService.isReady(marker), is(true));
             readyService.unmarkReady(marker);
         });
@@ -191,7 +191,7 @@ public class GenericThingProviderTest4 extends JavaOSGiTest {
     private void finishLoading() {
         finished = true;
         assertThat(bridgeInitializeCounter, is(0));
-        readyService.markReady(new ReadyMarker("esh.xmlThingTypes", bundle.getSymbolicName()));
+        readyService.markReady(new ReadyMarker("openhab.xmlThingTypes", bundle.getSymbolicName()));
     }
 
     private void unload() {

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/i18n/TranslationProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/i18n/TranslationProviderOSGiTest.java
@@ -41,16 +41,16 @@ public class TranslationProviderOSGiTest extends JavaOSGiTest {
     private static final String HELLO_WORLD_EN = "Hello World!";
     private static final String HELLO_WORLD_FR = "Bonjour le monde!";
 
-    private static final String[] NAMES = new String[] { "esh", "thing", "rule" };
+    private static final String[] NAMES = new String[] { "openHAB", "thing", "rule" };
     private static final String DEFAULT_SINGLE_NAME_TEXT = "Hi {0}!";
 
-    private static final String HELLO_SINGLE_NAME_DEFAULT = "Hallo esh!";
-    private static final String HELLO_SINGLE_NAME_EN = "Hello esh!";
-    private static final String HELLO_SINGLE_NAME_FR = "Bonjour esh!";
+    private static final String HELLO_SINGLE_NAME_DEFAULT = "Hallo openHAB!";
+    private static final String HELLO_SINGLE_NAME_EN = "Hello openHAB!";
+    private static final String HELLO_SINGLE_NAME_FR = "Bonjour openHAB!";
 
-    private static final String HELLO_MULTIPLE_NAMES_DEFAULT = "Hallo esh, Hallo thing, Hallo rule!";
-    private static final String HELLO_MULTIPLE_NAMES_EN = "Hello esh, Hello thing, Hello rule!";
-    private static final String HELLO_MULTIPLE_NAMES_FR = "Bonjour esh, Bonjour thing, Bonjour rule!";
+    private static final String HELLO_MULTIPLE_NAMES_DEFAULT = "Hallo openHAB, Hallo thing, Hallo rule!";
+    private static final String HELLO_MULTIPLE_NAMES_EN = "Hello openHAB, Hello thing, Hello rule!";
+    private static final String HELLO_MULTIPLE_NAMES_FR = "Bonjour openHAB, Bonjour thing, Bonjour rule!";
 
     private static final String BYE_DEFAULT = "Tschuess!";
 
@@ -169,7 +169,7 @@ public class TranslationProviderOSGiTest extends JavaOSGiTest {
 
         text = translationProvider.getText(bundle, null, DEFAULT_SINGLE_NAME_TEXT, null, (Object[]) NAMES);
         assertThat(text, is(notNullValue()));
-        assertThat(text, is(equalTo("Hi esh!")));
+        assertThat(text, is(equalTo("Hi openHAB!")));
 
         text = translationProvider.getText(bundle, null, DEFAULT_SINGLE_NAME_TEXT, null, (Object[]) null);
         assertThat(text, is(notNullValue()));
@@ -200,12 +200,12 @@ public class TranslationProviderOSGiTest extends JavaOSGiTest {
         assertThat(text, is(equalTo(HELLO_MULTIPLE_NAMES_FR)));
 
         text = translationProvider.getText(bundle, KEY_HELLO_MULTIPLE_NAMES, null, null,
-                (Object[]) new String[] { "esh", "thing", "rule", "config" });
+                (Object[]) new String[] { "openHAB", "thing", "rule", "config" });
         assertThat(text, is(notNullValue()));
         assertThat(text, is(equalTo(HELLO_MULTIPLE_NAMES_DEFAULT)));
 
         text = translationProvider.getText(bundle, null, "Hallo {2}, Hallo {1}, Hallo {0}!", null, (Object[]) NAMES);
         assertThat(text, is(notNullValue()));
-        assertThat(text, is(equalTo("Hallo rule, Hallo thing, Hallo esh!")));
+        assertThat(text, is(equalTo("Hallo rule, Hallo thing, Hallo openHAB!")));
     }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -167,7 +167,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
             try {
                 assertThat(
                         bundleContext.getServiceReferences(ReadyMarker.class,
-                                "(esh.xmlThingTypes=" + bundleContext.getBundle().getSymbolicName() + ")"),
+                                "(openhab.xmlThingTypes=" + bundleContext.getBundle().getSymbolicName() + ")"),
                         is(notNullValue()));
             } catch (InvalidSyntaxException e) {
                 throw new RuntimeException(e);

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
@@ -50,11 +50,11 @@ public class ChannelTypesI18nTest extends JavaOSGiTest {
     public void setUp() {
         // get ONLY the XMLChannelTypeProvider
         channelTypeProvider = getService(ChannelTypeProvider.class,
-                serviceReference -> "core.xml.channels".equals(serviceReference.getProperty("esh.scope")));
+                serviceReference -> "core.xml.channels".equals(serviceReference.getProperty("openhab.scope")));
 
         assertThat(channelTypeProvider, is(notNullValue()));
         channelGroupTypeProvider = getService(ChannelGroupTypeProvider.class,
-                serviceReference -> "core.xml.channelGroups".equals(serviceReference.getProperty("esh.scope")));
+                serviceReference -> "core.xml.channelGroups".equals(serviceReference.getProperty("openhab.scope")));
 
         assertThat(channelGroupTypeProvider, is(notNullValue()));
         thingTypeProvider = getService(ThingTypeProvider.class);

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
@@ -44,10 +44,10 @@ public class ChannelTypesTest extends JavaOSGiTest {
     public void setUp() {
         // get ONLY the XMLChannelTypeProvider
         channelTypeProvider = getService(ChannelTypeProvider.class,
-                serviceReference -> "core.xml.channels".equals(serviceReference.getProperty("esh.scope")));
+                serviceReference -> "core.xml.channels".equals(serviceReference.getProperty("openhab.scope")));
         assertThat(channelTypeProvider, is(notNullValue()));
         channelGroupTypeProvider = getService(ChannelGroupTypeProvider.class,
-                serviceReference -> "core.xml.channelGroups".equals(serviceReference.getProperty("esh.scope")));
+                serviceReference -> "core.xml.channelGroups".equals(serviceReference.getProperty("openhab.scope")));
         assertThat(channelGroupTypeProvider, is(notNullValue()));
     }
 


### PR DESCRIPTION
The only "SmartHome" references that still remain are in:

* [EventLogger](https://github.com/openhab/openhab-core/blob/13c2d7bf2be051fe8c72046d637770a92f517781/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java#L56), could also be changed but it may need some logger configuration updates
* [MDNSAnnouncer](https://github.com/openhab/openhab-core/blob/13c2d7bf2be051fe8c72046d637770a92f517781/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java#L65), changing this would break discoverability with iOS/Android Apps and the Remote openHAB binding.
