### PR TITLE
[icon] Removed references to not existing category "DimmableLight"

### DIFF
--- a/bundles/org.openhab.core.test.magic/src/main/resources/OH-INF/thing/channel-types.xml
+++ b/bundles/org.openhab.core.test.magic/src/main/resources/OH-INF/thing/channel-types.xml
@@ -20,7 +20,7 @@
 		<item-type>Dimmer</item-type>
 		<label>Dimmer</label>
 		<description>The dimmer channel allows to control the brightness.</description>
-		<category>DimmableLight</category>
+		<category>Light</category>
 		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -160,7 +160,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      */
     public static final ChannelType SYSTEM_BRIGHTNESS = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "brightness"), "Brightness", "Dimmer")
-            .withDescription("Controls the brightness and switches the light on and off").withCategory("DimmableLight")
+            .withDescription("Controls the brightness and switches the light on and off").withCategory("Light")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(100)).withPattern("%d %%").build())
             .build();

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
  * resource without a state postfix.
  * If a specific resource for a state is available, it will be used. If not, the default icon without a state postfix is
  * used. If the state is a decimal number between 0 and 100, the implementation will look for a resource with the next
- * smaller state postfix available. Example: For category "DimmableLight" and state 84, it will check for the resources
- * dimmablelight-82.png, dimmablelight-81.png, dimmablelight-80.png and return the first one it can find.
+ * smaller state postfix available. Example: For category "Light" and state 84, it will check for the resources
+ * light-82.png, light-81.png, light-80.png and return the first one it can find.
  *
  * @author Kai Kreuzer - Initial contribution
  */

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -133,8 +133,8 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
                 .state(new ChannelTypeUID("hue:color"), "Color", CoreItemFactory.COLOR).withCategory("ColorLight")
                 .build();
         final ChannelType channelType5 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("hue:brightness"), "Brightness", CoreItemFactory.DIMMER)
-                .withCategory("DimmableLight").build();
+                .state(new ChannelTypeUID("hue:brightness"), "Brightness", CoreItemFactory.DIMMER).withCategory("Light")
+                .build();
         final ChannelType channelType6 = ChannelTypeBuilder
                 .state(new ChannelTypeUID("hue:switch"), "Switch", CoreItemFactory.SWITCH).withCategory("Light")
                 .build();


### PR DESCRIPTION
- Removed references to not existing category "DimmableLight"

Has been removed in https://github.com/eclipse-archived/smarthome/pull/4298

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>