### PR TITLE
Register CommunicationManager to listen on ItemChannelLink changes

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -74,6 +74,7 @@ import org.openhab.core.types.Type;
 import org.openhab.core.types.util.UnitUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
@@ -133,6 +134,13 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
         this.eventPublisher = eventPublisher;
         this.safeCaller = safeCaller;
         this.thingRegistry = thingRegistry;
+
+        itemChannelLinkRegistry.addRegistryChangeListener(this);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        itemChannelLinkRegistry.removeRegistryChangeListener(this);
     }
 
     private final Set<ItemFactory> itemFactories = new CopyOnWriteArraySet<>();
@@ -177,6 +185,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
         synchronized (profiles) {
             Profile profile = profiles.get(link.getUID());
             if (profile != null) {
+                logger.trace("using profile '{}' from cache", profile.getProfileTypeUID());
                 return profile;
             }
             ProfileTypeUID profileTypeUID = determineProfileTypeUID(link, item, thing);
@@ -559,11 +568,12 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     protected void addProfileFactory(ProfileFactory profileFactory) {
-        this.profileFactories.put(profileFactory, ConcurrentHashMap.newKeySet());
+        profileFactories.put(profileFactory, ConcurrentHashMap.newKeySet());
     }
 
+    @SuppressWarnings("null")
     protected void removeProfileFactory(ProfileFactory profileFactory) {
-        Set<String> links = this.profileFactories.remove(profileFactory);
+        Set<String> links = profileFactories.remove(profileFactory);
         synchronized (profiles) {
             links.forEach(link -> {
                 profiles.remove(link);


### PR DESCRIPTION
- Register `CommunicationManager` to listen on `ItemChannelLink` changes

We missed it in #1487.

Fixes #1645

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>