### PR TITLE
Fix remaining deprecations

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
@@ -45,11 +45,9 @@ public class ConfigDescriptionParameterGroup {
      * @param advanced a flag that is set to true if this group contains advanced settings
      * @param label the human readable group label
      * @param description a description that can be provided to the user
-     * @deprecated use {@link ConfigDescriptionParameterGroupBuilder} instead.
      */
-    @Deprecated
-    public ConfigDescriptionParameterGroup(String name, @Nullable String context, Boolean advanced,
-            @Nullable String label, @Nullable String description) {
+    ConfigDescriptionParameterGroup(String name, @Nullable String context, Boolean advanced, @Nullable String label,
+            @Nullable String description) {
         this.name = name;
         this.context = context;
         this.advanced = advanced;

--- a/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/org.openhab.core.thing.xml/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
@@ -31,6 +31,8 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.EventDescription;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateDescriptionFragment;
+import org.openhab.core.types.StateDescriptionFragmentBuilder;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
@@ -173,6 +175,10 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
         Set<String> tags = readTags(nodeIterator);
 
         StateDescription stateDescription = readStateDescription(nodeIterator);
+        StateDescriptionFragment stateDescriptionFragment = stateDescription != null
+                ? StateDescriptionFragmentBuilder.create(stateDescription).build()
+                : null;
+
         CommandDescription commandDescription = readCommandDescription(nodeIterator);
         EventDescription eventDescription = readEventDescription(nodeIterator);
 
@@ -191,7 +197,7 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
         if (cKind == ChannelKind.STATE) {
             builder = ChannelTypeBuilder.state(channelTypeUID, label, itemType).isAdvanced(advanced)
                     .withCategory(category).withConfigDescriptionURI(configDescriptionURI)
-                    .withStateDescription(stateDescription).withAutoUpdatePolicy(autoUpdatePolicy)
+                    .withStateDescriptionFragment(stateDescriptionFragment).withAutoUpdatePolicy(autoUpdatePolicy)
                     .withCommandDescription(commandDescription);
         } else if (cKind == ChannelKind.TRIGGER) {
             builder = ChannelTypeBuilder.trigger(channelTypeUID, label).isAdvanced(advanced).withCategory(category)

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
@@ -26,9 +26,9 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelTypeUID;
 
 /**
- * {@link Channel} is a part of a {@link Thing} that represents a functionality
- * of it. Therefore {@link Item}s can be linked a to a channel. The channel only
- * accepts a specific item type which is specified by {@link Channel#getAcceptedItemType()} methods.
+ * {@link Channel} is a part of a {@link Thing} that represents a functionality of it. Therefore {@link Item}s can be
+ * linked a to a channel. The channel only accepts a specific item type which is specified by
+ * {@link Channel#getAcceptedItemType()} methods. Use the {@link ChannelBuilder} for building channels.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Alex Tugarev - Extended about default tags
@@ -71,10 +71,9 @@ public class Channel {
     }
 
     /**
-     * @deprecated - use {@link ChannelBuilder} instead
+     * Use the {@link ChannelBuilder} for building channels.
      */
-    @Deprecated
-    public Channel(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
+    protected Channel(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
             ChannelKind kind, @Nullable Configuration configuration, Set<String> defaultTags,
             @Nullable Map<String, String> properties, @Nullable String label, @Nullable String description,
             @Nullable AutoUpdatePolicy autoUpdatePolicy) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
@@ -37,6 +37,16 @@ import org.openhab.core.thing.type.ChannelTypeUID;
 @NonNullByDefault
 public class ChannelBuilder {
 
+    private class ChannelImpl extends Channel {
+        ChannelImpl(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
+                ChannelKind kind, @Nullable Configuration configuration, Set<String> defaultTags,
+                @Nullable Map<String, String> properties, @Nullable String label, @Nullable String description,
+                @Nullable AutoUpdatePolicy autoUpdatePolicy) {
+            super(channelUID, channelTypeUID, acceptedItemType, kind, configuration, defaultTags, properties, label,
+                    description, autoUpdatePolicy);
+        }
+    }
+
     private final ChannelUID channelUID;
     private @Nullable String acceptedItemType;
     private ChannelKind kind;
@@ -206,9 +216,8 @@ public class ChannelBuilder {
      *
      * @return the {@link Channel}
      */
-    @SuppressWarnings("deprecation")
     public Channel build() {
-        return new Channel(channelUID, channelTypeUID, acceptedItemType, kind, configuration, defaultTags, properties,
-                label, description, autoUpdatePolicy);
+        return new ChannelImpl(channelUID, channelTypeUID, acceptedItemType, kind, configuration, defaultTags,
+                properties, label, description, autoUpdatePolicy);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -78,20 +78,6 @@ public class ChannelTypeI18nLocalizationService {
         return localizedOptions;
     }
 
-    /**
-     * @deprecated use
-     *             {@link ChannelTypeI18nLocalizationService#createLocalizedStateDescriptionFragment(Bundle, StateDescription, ChannelTypeUID, Locale)}
-     *             instead.
-     */
-    @Deprecated
-    public @Nullable StateDescription createLocalizedStateDescription(final Bundle bundle,
-            final @Nullable StateDescription state, final ChannelTypeUID channelTypeUID,
-            final @Nullable Locale locale) {
-        StateDescriptionFragment stateDescriptionFragment = createLocalizedStateDescriptionFragment(bundle, state,
-                channelTypeUID, locale);
-        return stateDescriptionFragment == null ? null : stateDescriptionFragment.toStateDescription();
-    }
-
     public @Nullable StateDescriptionFragment createLocalizedStateDescriptionFragment(final Bundle bundle,
             final @Nullable StateDescription state, final ChannelTypeUID channelTypeUID,
             final @Nullable Locale locale) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
@@ -12,16 +12,19 @@
  */
 package org.openhab.core.thing.internal.type;
 
+import java.net.URI;
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.type.AutoUpdatePolicy;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.StateChannelTypeBuilder;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.StateDescriptionFragment;
-import org.openhab.core.types.StateDescriptionFragmentBuilder;
 
 /**
  * StateChannelTypeBuilder to create {@link ChannelType}s of kind STATE
@@ -31,6 +34,17 @@ import org.openhab.core.types.StateDescriptionFragmentBuilder;
 @NonNullByDefault
 public class StateChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<StateChannelTypeBuilder>
         implements StateChannelTypeBuilder {
+
+    private class StateChannelTypeImpl extends ChannelType {
+        private StateChannelTypeImpl(ChannelTypeUID uid, boolean advanced, String itemType, String label,
+                @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
+                @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
+                @Nullable URI configDescriptionURI, @Nullable AutoUpdatePolicy autoUpdatePolicy)
+                throws IllegalArgumentException {
+            super(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, state,
+                    commandDescription, null, configDescriptionURI, autoUpdatePolicy);
+        }
+    }
 
     private final String itemType;
     private @Nullable StateDescriptionFragment stateDescriptionFragment;
@@ -45,14 +59,6 @@ public class StateChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<Stat
         }
 
         this.itemType = itemType;
-    }
-
-    @Override
-    public StateChannelTypeBuilder withStateDescription(@Nullable StateDescription stateDescription) {
-        this.stateDescriptionFragment = stateDescription != null
-                ? StateDescriptionFragmentBuilder.create(stateDescription).build()
-                : null;
-        return this;
     }
 
     @Override
@@ -74,10 +80,9 @@ public class StateChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<Stat
         return this;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public ChannelType build() {
-        return new ChannelType(channelTypeUID, advanced, itemType, label, description, category, tags,
+        return new StateChannelTypeImpl(channelTypeUID, advanced, itemType, label, description, category, tags,
                 stateDescriptionFragment != null ? stateDescriptionFragment.toStateDescription() : null,
                 commandDescription, configDescriptionURI, autoUpdatePolicy);
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
@@ -12,8 +12,12 @@
  */
 package org.openhab.core.thing.internal.type;
 
+import java.net.URI;
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.type.TriggerChannelTypeBuilder;
@@ -28,6 +32,15 @@ import org.openhab.core.types.EventDescription;
 public class TriggerChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<TriggerChannelTypeBuilder>
         implements TriggerChannelTypeBuilder {
 
+    private class TriggerChannelTypeImpl extends ChannelType {
+        TriggerChannelTypeImpl(ChannelTypeUID uid, boolean advanced, String label, @Nullable String description,
+                @Nullable String category, @Nullable Set<String> tags, @Nullable EventDescription event,
+                @Nullable URI configDescriptionURI) throws IllegalArgumentException {
+            super(uid, advanced, null, ChannelKind.TRIGGER, label, description, category, tags, null, null, event,
+                    configDescriptionURI, null);
+        }
+    }
+
     private @Nullable EventDescription eventDescription;
 
     public TriggerChannelTypeBuilderImpl(ChannelTypeUID channelTypeUID, String label) {
@@ -40,10 +53,9 @@ public class TriggerChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<Tr
         return this;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public ChannelType build() {
-        return new ChannelType(channelTypeUID, advanced, label, description, category, tags, eventDescription,
-                configDescriptionURI);
+        return new TriggerChannelTypeImpl(channelTypeUID, advanced, label, description, category, tags,
+                eventDescription, configDescriptionURI);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
@@ -27,6 +27,7 @@ import org.openhab.core.types.StateDescription;
  * The {@link ChannelType} describes a concrete type of a {@link Channel}.
  * <p>
  * This description is used as template definition for the creation of the according concrete {@link Channel} object.
+ * Use the {@link ChannelTypeBuilder} for building channel types.
  * <p>
  * <b>Hint:</b> This class is immutable.
  *
@@ -50,34 +51,6 @@ public class ChannelType extends AbstractDescriptionType {
     /**
      * Creates a new instance of this class with the specified parameters.
      *
-     * @deprecated Use the {@link ChannelTypeBuilder#trigger(ChannelTypeUID, String)} instead.
-     */
-    @Deprecated
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String label, @Nullable String description,
-            @Nullable String category, @Nullable Set<String> tags, @Nullable EventDescription event,
-            @Nullable URI configDescriptionURI) throws IllegalArgumentException {
-        this(uid, advanced, null, ChannelKind.TRIGGER, label, description, category, tags, null, null, event,
-                configDescriptionURI, null);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
-     * @deprecated Use the {@link ChannelTypeBuilder#state(ChannelTypeUID, String, String)} instead.
-     */
-    @Deprecated
-    public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, String label,
-            @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
-            @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
-            @Nullable URI configDescriptionURI, @Nullable AutoUpdatePolicy autoUpdatePolicy)
-            throws IllegalArgumentException {
-        this(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, state, commandDescription,
-                null, configDescriptionURI, autoUpdatePolicy);
-    }
-
-    /**
-     * Creates a new instance of this class with the specified parameters.
-     *
      * @param uid the unique identifier which identifies this Channel type within
      *            the overall system (must neither be null, nor empty)
      * @param advanced true if this channel type contains advanced features, otherwise false
@@ -97,8 +70,8 @@ public class ChannelType extends AbstractDescriptionType {
      * @throws IllegalArgumentException if the UID or the item type is null or empty,
      *             or the meta information is null
      */
-    ChannelType(ChannelTypeUID uid, boolean advanced, @Nullable String itemType, ChannelKind kind, String label,
-            @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
+    protected ChannelType(ChannelTypeUID uid, boolean advanced, @Nullable String itemType, ChannelKind kind,
+            String label, @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
             @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
             @Nullable EventDescription event, @Nullable URI configDescriptionURI,
             @Nullable AutoUpdatePolicy autoUpdatePolicy) throws IllegalArgumentException {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/StateChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/StateChannelTypeBuilder.java
@@ -16,7 +16,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandOption;
-import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.StateDescriptionFragment;
 
 /**
@@ -26,17 +25,6 @@ import org.openhab.core.types.StateDescriptionFragment;
  */
 @NonNullByDefault
 public interface StateChannelTypeBuilder extends ChannelTypeBuilder<StateChannelTypeBuilder> {
-
-    /**
-     * Sets the {@link StateDescription} for the {@link ChannelType}
-     *
-     * @param stateDescription StateDescription for the ChannelType
-     * @return this Builder
-     * @deprecated use {@link StateChannelTypeBuilder#withStateDescriptionFragment(StateDescriptionFragment)} instead.
-     */
-    @Deprecated
-    StateChannelTypeBuilder withStateDescription(@Nullable StateDescription stateDescription);
-
     /**
      * Sets the {@link StateDescriptionFragment} for the {@link ChannelType}
      *

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelTypeBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelTypeBuilderTest.java
@@ -139,14 +139,6 @@ public class ChannelTypeBuilderTest {
         assertThat(channelType.getTags(), is(hasSize(2)));
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void withStateDescriptionShouldSetStateDescription() {
-        ChannelType channelType = stateBuilder.withStateDescription(STATE_DESCRIPTION).build();
-
-        assertThat(channelType.getState(), is(STATE_DESCRIPTION));
-    }
-
     @Test
     public void withStateDescriptionFragmentShouldSetStateDescription() {
         ChannelType channelType = stateBuilder.withStateDescriptionFragment(STATE_DESCRIPTION_FRAGMENT).build();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -71,6 +71,7 @@ import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
 import org.openhab.core.thing.type.ThingTypeBuilder;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.StateDescription;
+import org.openhab.core.types.StateDescriptionFragment;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.StateOption;
 import org.openhab.core.util.BundleResolver;
@@ -115,18 +116,19 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         thingHandlerFactory.activate(componentContext);
         registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
 
-        final StateDescription state = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
+        final StateDescriptionFragment state = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                 .withMaximum(BigDecimal.valueOf(100)).withStep(BigDecimal.TEN).withPattern("%d Peek").withReadOnly(true)
-                .withOption(new StateOption("SOUND", "My great sound.")).build().toStateDescription();
+                .withOption(new StateOption("SOUND", "My great sound.")).build();
 
-        final StateDescription state2 = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
-                .withMaximum(BigDecimal.valueOf(256)).withStep(BigDecimal.valueOf(8)).build().toStateDescription();
+        final StateDescriptionFragment state2 = StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
+                .withMaximum(BigDecimal.valueOf(256)).withStep(BigDecimal.valueOf(8)).build();
 
         final ChannelType channelType = ChannelTypeBuilder
-                .state(new ChannelTypeUID("hue:alarm"), " ", CoreItemFactory.NUMBER).withStateDescription(state)
+                .state(new ChannelTypeUID("hue:alarm"), " ", CoreItemFactory.NUMBER).withStateDescriptionFragment(state)
                 .build();
         final ChannelType channelType2 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("hue:num"), " ", CoreItemFactory.NUMBER).withStateDescription(state2).build();
+                .state(new ChannelTypeUID("hue:num"), " ", CoreItemFactory.NUMBER).withStateDescriptionFragment(state2)
+                .build();
         final ChannelType channelType3 = ChannelTypeBuilder
                 .state(new ChannelTypeUID("hue:info"), " ", CoreItemFactory.STRING).isAdvanced(true).build();
         final ChannelType channelType4 = ChannelTypeBuilder
@@ -139,7 +141,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
                 .state(new ChannelTypeUID("hue:switch"), "Switch", CoreItemFactory.SWITCH).withCategory("Light")
                 .build();
         final ChannelType channelType7 = ChannelTypeBuilder.state(CHANNEL_TYPE_7_UID, " ", CoreItemFactory.NUMBER)
-                .withCategory("Light").withStateDescription(state).build();
+                .withCategory("Light").withStateDescriptionFragment(state).build();
 
         List<ChannelType> channelTypes = new ArrayList<>();
         channelTypes.add(channelType);


### PR DESCRIPTION
Fixes #1408

---

Some builders are in different packages as the types they build. So for those I've removed the public constructors by creating some sub-classes that call a protected constructor. That will hopefully make contributors use the builders.  In newer Java versions you can also limit which classes are allowed to subclass a certain type.