### PR TITLE
increase the rule refresher delay

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
 public class RulesRefresher implements ReadyTracker {
 
     // delay in seconds before rule resources are refreshed after items or services have changed
-    private static final long REFRESH_DELAY = 5;
+    private static final long REFRESH_DELAY = 30;
 
     public static final String RULES_REFRESH_MARKER_TYPE = "rules";
     public static final String RULES_REFRESH = "refresh";


### PR DESCRIPTION
Despite the better startup order, the rule refresher still kicks in several times during startup.
This is caused by thing actions being added at a later point (namely after thing handlers are instantiated). Since we do the refresh once all items and things are loaded and thus defined, we can imho easily reduce the frequency of any subsequent refreshes. Allowing 30 seconds should ensure that most thing handlers are instantiated and we thus only have a single further refresh triggered. Note: Once start level 80 is implemented, we should probably use markers to also exactly time this second required refresh.

Signed-off-by: Kai Kreuzer <kai@openhab.org>