### PR TITLE
Translated messages for auth pages

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_de.properties
+++ b/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_de.properties
@@ -1,0 +1,17 @@
+auth.login.prompt = Anmelden, um <b>%s</b> Zugriff auf <b>%s</b> zu gewähren\:
+auth.login.fail = Bitte versuche es erneut.
+auth.createaccount.prompt = Erstelle einen ersten Administrator-Account, um fortzufahren.
+
+auth.changepassword.success = Passwort geändert.
+
+
+
+auth.placeholder.username = Benutzername
+auth.placeholder.password = Passwort
+auth.placeholder.newpassword = Neues Passwort
+auth.placeholder.repeatpassword = Passwort wiederholen
+
+auth.button.signin = Anmelden
+auth.button.createaccount = Konto erstellen
+auth.button.changepassword = Passwort ändern
+auth.button.return = Zur Startseite

--- a/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_it.properties
+++ b/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_it.properties
@@ -1,0 +1,26 @@
+auth.login.prompt = Accedi per concedere l'accesso a <b>%s</b> a <b>%s</b>\:
+auth.login.fail = Per favore riprova.
+auth.createaccount.prompt = Crea un primo account amministratore per continuare.
+
+auth.changepassword.success = Password modificata.
+
+auth.createapitoken.prompt = Crea un nuovo token API per autorizzare servizi esterni.
+auth.createapitoken.name.unique.fail = Esiste già un token con lo stesso nome, per favore riprova.
+auth.createapitoken.name.format.fail = Nome token non valido, si prega di utilizzare solo caratteri alfanumerici.
+auth.createapitoken.success = Nuovo token creato\:
+auth.createapitoken.success.footer = Si prega di copiarlo adesso, non verrà mostrato di nuovo.
+
+auth.password.confirm.fail = La password non corrisponde. Per favore, riprova.
+
+auth.placeholder.username = Nome Utente
+auth.placeholder.password = Password
+auth.placeholder.newpassword = Nuova Password
+auth.placeholder.repeatpassword = Conferma la nuova password
+auth.placeholder.tokenname = Nome Token
+auth.placeholder.tokenscope = Scopo Token (opzionale)
+
+auth.button.signin = Accedi
+auth.button.createaccount = Crea Account
+auth.button.changepassword = Cambia Password
+auth.button.createapitoken = Crea Token API
+auth.button.return = Ritorna Home

--- a/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_nl.properties
+++ b/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_nl.properties
@@ -1,0 +1,26 @@
+auth.login.prompt = Log in om <b>%s</b> toegang te verlenen tot <b>%s</b>\:
+auth.login.fail = Probeer opnieuw aub.
+auth.createaccount.prompt = Maak een eerste administrator-account aan om door te gaan.
+
+auth.changepassword.success = Wachtwoord gewijzigd.
+
+auth.createapitoken.prompt = Maak een nieuwe API-sleutel aan voor het autoriseren van externe diensten.
+auth.createapitoken.name.unique.fail = Er bestaat al een token met dezelfde naam. Probeer het opnieuw.
+auth.createapitoken.name.format.fail = Ongeldige token naam, gebruik alleen alfanumerieke tekens.
+auth.createapitoken.success = Nieuwe token aangemaakt\:
+auth.createapitoken.success.footer = Kopieer het nu, het zal niet meer getoond worden.
+
+auth.password.confirm.fail = Wachtwoorden komen niet overeen. Probeer het opnieuw.
+
+auth.placeholder.username = Gebruikersnaam
+auth.placeholder.password = Wachtwoord
+auth.placeholder.newpassword = Nieuw wachtwoord
+auth.placeholder.repeatpassword = Bevestig Nieuw Wachtwoord
+auth.placeholder.tokenname = Tokennaam
+auth.placeholder.tokenscope = Token Scope (optioneel)
+
+auth.button.signin = Aanmelden
+auth.button.createaccount = Account Aanmaken
+auth.button.changepassword = Wachtwoord Wijzigen
+auth.button.createapitoken = API-token aanmaken
+auth.button.return = Terug naar Startpagina


### PR DESCRIPTION
This is the PR with the messages.properties files in Dutch, German (partial) & Italian extracted from #1929 and converted to the proper ISO-8859 encoding (note the Umlaut below):

![image](https://user-images.githubusercontent.com/2004147/102021867-3094cb80-3d83-11eb-8075-b98fb97b46b1.png)

Signed-off-by: Yannick Schaus <github@schaus.net>