### PR TITLE
[REST] Add firmwareStatus to things in summary mode

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -305,7 +305,7 @@ public class ThingResource implements RESTResource {
                 .distinct();
         if (summary != null && summary == true) {
             thingStream = dtoMapper.limitToFields(thingStream,
-                    "UID,label,bridgeUID,thingTypeUID,statusInfo,location,editable");
+                    "UID,label,bridgeUID,thingTypeUID,statusInfo,firmwareStatus,location,editable");
         }
         return Response.ok(new Stream2JSONInputStream(thingStream)).build();
     }


### PR DESCRIPTION
The "summary" mode for `/rest/things` introduced in https://github.com/openhab/openhab-core/pull/1827
leads to these warnings in the console about `firmwareStatus`:
```
Field 'firmwareStatus' could not be eliminated: Can not set final org.openhab.core.thing.firmware.dto.FirmwareStatusDTO field org.openhab.core.io.rest.core.thing.EnrichedThingDTO.firmwareStatus to null value
```
The easiest solution to remove those warnings is to add it again to the list of fields included in the summaries.

Signed-off-by: Yannick Schaus <github@schaus.net>