### PR TITLE
Add osgi support for ThingHandlerService implementations.

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas Höfer - added config status provider and firmware update handler service registration
  * @author Stefan Bußweiler - API changes due to bridge/thing life cycle refactoring, removed OSGi service registration
  *         for thing handlers
+ * @author Connor Petty - added osgi service registration for thing handler services.
  */
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
@@ -408,6 +409,5 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                 serviceObjs.ungetService(this.serviceInstance);
             }
         }
-
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -15,9 +15,9 @@ package org.openhab.core.thing.binding;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,8 +34,12 @@ import org.openhab.core.thing.binding.firmware.FirmwareUpdateHandler;
 import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.thing.type.ThingTypeRegistry;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +60,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
+    private static final String THING_HANDER_SERVICE_CANONICAL_NAME = ThingHandlerService.class.getCanonicalName();
+
     protected @NonNullByDefault({}) BundleContext bundleContext;
 
     private final Logger logger = LoggerFactory.getLogger(BaseThingHandlerFactory.class);
@@ -63,7 +69,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
     private final Map<String, ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
     private final Map<String, ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
 
-    private final Map<ThingUID, Set<ServiceRegistration<?>>> thingHandlerServices = new ConcurrentHashMap<>();
+    private final Map<ThingUID, Set<RegisteredThingHandlerService<?>>> thingHandlerServices = new ConcurrentHashMap<>();
 
     private @NonNullByDefault({}) ServiceTracker<ThingTypeRegistry, ThingTypeRegistry> thingTypeRegistryServiceTracker;
     private @NonNullByDefault({}) ServiceTracker<ConfigDescriptionRegistry, ConfigDescriptionRegistry> configDescriptionRegistryServiceTracker;
@@ -143,67 +149,73 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private void registerServices(Thing thing, ThingHandler thingHandler) {
         ThingUID thingUID = thing.getUID();
-        for (Class<?> c : thingHandler.getServices()) {
+        for (Class<? extends ThingHandlerService> c : thingHandler.getServices()) {
+            if (!ThingHandlerService.class.isAssignableFrom(c)) {
+                logger.warn(
+                        "Should register service={} for thingUID={}, but it does not implement the interface ThingHandlerService.",
+                        c.getCanonicalName(), thingUID);
+                continue;
+            }
+            registerThingHandlerService(thingUID, thingHandler, c);
+        }
+    }
+
+    private <T extends ThingHandlerService> void registerThingHandlerService(ThingUID thingUID,
+            ThingHandler thingHandler, Class<T> c) {
+
+        RegisteredThingHandlerService<T> registeredService;
+
+        Component component = c.getAnnotation(Component.class);
+        if (component != null && component.enabled()) {
+            if (component.scope() != ServiceScope.PROTOTYPE) {
+                // then we cannot use it.
+                logger.warn("Could not register service for class={}. Service must have a prototype scope",
+                        c.getCanonicalName());
+                return;
+            }
+            if (component.service().length != 1 || component.service()[0] != c) {
+                logger.warn(
+                        "Could not register service for class={}. ThingHandlerService with @Component must only label itself as a service.",
+                        c.getCanonicalName());
+                return;
+            }
+        }
+
+        ServiceReference<T> serviceRef = bundleContext.getServiceReference(c);
+        if (serviceRef != null) {
+            ServiceObjects<T> serviceObjs = bundleContext.getServiceObjects(serviceRef);
+            registeredService = new RegisteredThingHandlerService<>(serviceObjs);
+        } else {
             try {
-                Object serviceInstance = c.getConstructor().newInstance();
-
-                ThingHandlerService ths = null;
-                if (serviceInstance instanceof ThingHandlerService) {
-                    ths = (ThingHandlerService) serviceInstance;
-                    ths.setThingHandler(thingHandler);
-                } else {
-                    logger.warn(
-                            "Should register service={} for thingUID={}, but it does not implement the interface ThingHandlerService.",
-                            c.getCanonicalName(), thingUID);
-                    continue;
-                }
-
-                Set<Class<?>> interfaces = getAllInterfaces(c);
-                List<String> serviceNames = new LinkedList<>();
-                interfaces.forEach(i -> {
-                    String className = i.getCanonicalName();
-                    // we only add specific ThingHandlerServices, i.e. those that derive from the ThingHandlerService
-                    // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
-                    // services later, rather than as a generic ThingHandlerService.
-                    if (className != null && !className.equals(ThingHandlerService.class.getCanonicalName())) {
-                        serviceNames.add(className);
-                    }
-                });
-                if (!serviceNames.isEmpty()) {
-                    String[] serviceNamesArray = serviceNames.toArray(new String[serviceNames.size()]);
-                    ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNamesArray,
-                            serviceInstance, null);
-                    if (serviceReg != null) {
-                        Set<ServiceRegistration<?>> serviceRegs = thingHandlerServices.get(thingUID);
-                        if (serviceRegs == null) {
-                            Set<ServiceRegistration<?>> set = new HashSet<>();
-                            set.add(serviceReg);
-                            thingHandlerServices.put(thingUID, set);
-                        } else {
-                            serviceRegs.add(serviceReg);
-                        }
-                        ths.activate();
-                    }
-                }
+                T serviceInstance = c.getConstructor().newInstance();
+                registeredService = new RegisteredThingHandlerService<>(serviceInstance);
             } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                     | InvocationTargetException e) {
                 logger.warn("Could not register service for class={}", c.getCanonicalName(), e);
+                return;
             }
         }
+
+        String[] serviceNames = getAllInterfaces(c).stream()//
+                .map(clazz -> clazz.getCanonicalName())
+                // we only add specific ThingHandlerServices, i.e. those that derive from the
+                // ThingHandlerService
+                // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
+                // services later, rather than as a generic ThingHandlerService.
+                .filter(className -> className != null && !className.equals(THING_HANDER_SERVICE_CANONICAL_NAME))
+                .toArray(String[]::new);
+
+        registeredService.initializeService(thingHandler, serviceNames);
+
+        Objects.requireNonNull(thingHandlerServices.computeIfAbsent(thingUID, uid -> new HashSet<>()))
+                .add(registeredService);
     }
 
     private void unregisterServices(Thing thing) {
         ThingUID thingUID = thing.getUID();
-        Set<ServiceRegistration<?>> serviceRegs = thingHandlerServices.remove(thingUID);
+        Set<RegisteredThingHandlerService<?>> serviceRegs = thingHandlerServices.remove(thingUID);
         if (serviceRegs != null) {
-            serviceRegs.forEach(serviceReg -> {
-                ThingHandlerService ths = (ThingHandlerService) getBundleContext()
-                        .getService(serviceReg.getReference());
-                serviceReg.unregister();
-                if (ths != null) {
-                    ths.deactivate();
-                }
-            });
+            serviceRegs.forEach(RegisteredThingHandlerService::disposeService);
         }
     }
 
@@ -213,7 +225,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
      * @param clazz The class
      * @return A {@link List} of interfaces
      */
-    private Set<Class<?>> getAllInterfaces(Class<?> clazz) {
+    private static Set<Class<?>> getAllInterfaces(Class<?> clazz) {
         Set<Class<?>> interfaces = new HashSet<>();
         for (Class<?> superclazz = clazz; superclazz != null; superclazz = superclazz.getSuperclass()) {
             interfaces.addAll(Arrays.asList(superclazz.getInterfaces()));
@@ -354,5 +366,48 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                     "Config Description Registry has not been properly initialized. Did you forget to call super.activate()?");
         }
         return configDescriptionRegistryServiceTracker.getService();
+    }
+
+    private class RegisteredThingHandlerService<T extends ThingHandlerService> {
+
+        private T serviceInstance;
+
+        private @Nullable ServiceObjects<T> serviceObjects;
+
+        private @Nullable ServiceRegistration<?> serviceRegistration;
+
+        public RegisteredThingHandlerService(T serviceInstance) {
+            this.serviceInstance = serviceInstance;
+        }
+
+        public RegisteredThingHandlerService(ServiceObjects<T> serviceObjs) {
+            this.serviceInstance = serviceObjs.getService();
+            this.serviceObjects = serviceObjs;
+        }
+
+        public void initializeService(ThingHandler handler, String[] serviceNames) {
+            this.serviceInstance.setThingHandler(handler);
+            if (serviceNames.length > 0) {
+                ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNames, serviceInstance, null);
+                if (serviceReg != null) {
+                    this.serviceRegistration = serviceReg;
+                }
+            }
+            this.serviceInstance.initialize();
+        }
+
+        public void disposeService() {
+            ServiceRegistration<?> serviceReg = this.serviceRegistration;
+            if (serviceReg != null) {
+                serviceReg.unregister();
+            }
+            this.serviceInstance.dispose();
+
+            ServiceObjects<T> serviceObjs = this.serviceObjects;
+            if (serviceObjs != null) {
+                serviceObjs.ungetService(this.serviceInstance);
+            }
+        }
+
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -41,13 +41,35 @@ public interface ThingHandlerService {
 
     /**
      * Method that will be called if this service will be activated
+     *
+     * @deprecated please override initialize instead
      */
+    @Deprecated
     default void activate() {
     }
 
     /**
      * Method that will be called if this service will be deactivated
+     *
+     * @deprecated please override dispose instead
      */
+    @Deprecated
     default void deactivate() {
+
     }
+
+    /**
+     * Method that will be called if this service will be initialized
+     */
+    default void initialize() {
+        activate();
+    }
+
+    /**
+     * Method that will be called if this service will be disposed
+     */
+    default void dispose() {
+        deactivate();
+    }
+
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -55,7 +55,6 @@ public interface ThingHandlerService {
      */
     @Deprecated
     default void deactivate() {
-
     }
 
     /**
@@ -71,5 +70,4 @@ public interface ThingHandlerService {
     default void dispose() {
         deactivate();
     }
-
 }


### PR DESCRIPTION
It was mentioned in https://github.com/openhab/openhab-addons/pull/9044 that this would be a useful feature so I went ahead and added support for it here.

Because osgi doesn't support annotation processing for manually created instances, I came up with a workaround that should be acceptable. To take advantage of the osgi `@Reference` annotations you can make the ThingHandlerService implementation a prototype component and then list the implementation class as the only service.
For example:
```
@Component(scope = ServiceScope.PROTOTYPE, service = FooService.class)
public class FooService implements ThingHandlerService {
...
}
```

There are a couple of things goin on here.
1. By scoping the component as a prototype is will force the bundle to create a new instance of the class every time it is requested for, which in our case is every time a new handler is created. Because the osgi system is still responsible for creating instances of the class, it will also handle all of the component annotations (Reference, Activate, Deactivate, etc..) as well. Because a new instance is retrieved each time we can handle the call to `setThingHandler` after activation. I tried to find a way to be able to call `setThingHandler` before activation but I did not find any way to do so.
2. By listing itself as its only exposed service, it would prevent any outside bundles from gaining access to the instance after osgi activates a new instance of it. This means that we are still free to perform the interface registrations manually, just as we do currently.

There is a small change that I had to make in the ThingHandlerService interface though.
Since this new method of service initialization can only call `ThingHandlerService.setThingHandler` after the component has been activated, it would cause confusion and possibly conflicts for users that expect to implement `ThingHandlerService.activate()` and `ThingHandlerService.deactivate()`. Since `activate` and `deactivate` would happen as part of osgi component creation, users would find that `setThingHandler` would not yet have been called by the framework. They would only have a null thing handler instance during `activate`.
To get around this problem I created two new methods `initialize()` and `dispose()` which would be called after `setThingHandler` is called so that users could do proper initialization of their ThingHandlerService.

I hope that all ThingHandlerService implementations will eventually move over to this new naming convention and we can try removing the `ThingHandlerService.activate` and `ThingHandlerService.deactivate` methods at some point. I've deprecated those methods in the meantime.

Signed-off-by: Connor Petty <mistercpp2000+gitsignoff@gmail.com>