### PR TITLE
Fixed first startup: Let StartLevelService only start once its configuration is available

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
@@ -38,6 +38,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
@@ -68,7 +69,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @NonNullByDefault
-@Component(immediate = true, configurationPid = "org.openhab.startlevel")
+@Component(immediate = true, configurationPid = "org.openhab.startlevel", configurationPolicy = ConfigurationPolicy.REQUIRE)
 public class StartLevelService {
 
     public final static String STARTLEVEL_MARKER_TYPE = "startlevel";


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-core/issues/1937

Signed-off-by: Kai Kreuzer <kai@openhab.org>