### PR TITLE
[automation] Fixed NPE by not calling 'toString()' on parameters passed to a logger

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -55,7 +55,7 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
                 if (returnVal instanceof Boolean) {
                     result = (boolean) returnVal;
                 } else {
-                    logger.error("Script did not return a boolean value, but '{}'", returnVal.toString());
+                    logger.error("Script did not return a boolean value, but '{}'", returnVal);
                 }
             } catch (ScriptException e) {
                 logger.error("Script execution failed: {}", e.getMessage());


### PR DESCRIPTION
- Fixed NPE by not calling `toString()` on parameters passed to a logger

Related to #1946 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>