### PR TITLE
Introduced rule loaded trigger

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class SystemTriggerHandler extends BaseTriggerModuleHandler implements EventSubscriber, EventFilter {
 
     public static final String STARTLEVEL_MODULE_TYPE_ID = "core.SystemStartlevelTrigger";
+    public static final String RULELOADED_MODULE_TYPE_ID = "core.RuleLoadedTrigger";
     public static final String CFG_STARTLEVEL = "startlevel";
     public static final String OUT_STARTLEVEL = "startlevel";
 
@@ -59,14 +60,16 @@ public class SystemTriggerHandler extends BaseTriggerModuleHandler implements Ev
 
     public SystemTriggerHandler(Trigger module, BundleContext bundleContext) {
         super(module);
-        this.startlevel = ((BigDecimal) module.getConfiguration().get(CFG_STARTLEVEL)).intValue();
+        this.bundleContext = bundleContext;
         if (STARTLEVEL_MODULE_TYPE_ID.equals(module.getTypeUID())) {
-            this.types = Set.of(StartlevelEvent.TYPE);
+            this.startlevel = ((BigDecimal) module.getConfiguration().get(CFG_STARTLEVEL)).intValue();
+        } else if (STARTLEVEL_MODULE_TYPE_ID.equals(module.getTypeUID())) {
+            this.startlevel = 50;
         } else {
             logger.warn("Module type '{}' is not (yet) handled by this class.", module.getTypeUID());
             throw new IllegalArgumentException(module.getTypeUID() + " is no valid module type.");
         }
-        this.bundleContext = bundleContext;
+        this.types = Set.of(StartlevelEvent.TYPE);
         Dictionary<String, Object> properties = new Hashtable<>();
         properties.put("event.topics", "openhab/system/*");
         eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/SystemTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/SystemTriggers.json
@@ -43,6 +43,11 @@
 					"description": "The system start level."
 				}
 			]
-		}
+		},
+        {
+            "uid": "core.RuleLoadedTrigger",
+            "label": "the rule has been loaded",
+            "description": "This triggers the rule when it is loaded, e.g. at startup or after modification."
+        }
 	]
 }

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -278,10 +278,8 @@ public class DSLRuleProvider
 
     private @Nullable Trigger mapTrigger(EventTrigger t) {
         if (t instanceof SystemOnStartupTrigger) {
-            Configuration cfg = new Configuration();
-            cfg.put("startlevel", 20);
-            return TriggerBuilder.create().withId(Integer.toString(triggerId++))
-                    .withTypeUID("core.SystemStartlevelTrigger").withConfiguration(cfg).build();
+            return TriggerBuilder.create().withId(Integer.toString(triggerId++)).withTypeUID("core.RuleLoadedTrigger")
+                    .build();
         } else if (t instanceof SystemOnShutdownTrigger) {
             logger.warn("System shutdown rule triggers are no longer supported!");
             return null;


### PR DESCRIPTION
This brings full backward compatibility to DSL system started rules as it re-triggers rules upon modification.
For UI created rules, it adds another choice of trigger besides the start level trigger.

Signed-off-by: Kai Kreuzer <kai@openhab.org>