### PR TITLE
[automation] Correctly trigger rules with start level 50 trigger

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1452,7 +1452,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                 Object slObj = t.getConfiguration().get(SystemTriggerHandler.CFG_STARTLEVEL);
                 try {
                     Integer sl = Integer.valueOf(slObj.toString());
-                    if (sl < StartLevelService.STARTLEVEL_RULEENGINE) {
+                    if (sl <= StartLevelService.STARTLEVEL_RULEENGINE) {
                         return true;
                     }
                 } catch (NumberFormatException e) {


### PR DESCRIPTION
The `SystemTriggerHandler` ignores start level 50 as it assumes that the rule engine itself runs those rules - this fix makes sure that this is really the case.

Signed-off-by: Kai Kreuzer <kai@openhab.org>