### PR TITLE
Fix CORS header to allow preflight requests with authorization payload

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
@@ -59,6 +59,7 @@ public class CorsFilter implements ContainerResponseFilter {
     static final String HTTP_OPTIONS_METHOD = "OPTIONS";
 
     static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE;
+    static final String AUTHORIZATION_HEADER = HttpHeaders.AUTHORIZATION;
 
     static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     static final String ACCESS_CONTROL_ALLOW_METHODS_HEADER = "Access-Control-Allow-Methods";
@@ -132,6 +133,7 @@ public class CorsFilter implements ContainerResponseFilter {
                 responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, origin);
                 responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_METHODS_HEADER, ACCEPTED_HTTP_METHODS);
                 responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_HEADERS, CONTENT_TYPE_HEADER);
+                responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_HEADERS, AUTHORIZATION_HEADER);
 
                 // Add the accepted request headers
                 appendVaryHeader(responseContext);

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/CorsFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/CorsFilterTest.java
@@ -47,6 +47,7 @@ import org.mockito.quality.Strictness;
 public class CorsFilterTest {
 
     private static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE;
+    private static final String AUTHORIZATION_HEADER = HttpHeaders.AUTHORIZATION;
 
     private static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
 
@@ -104,6 +105,7 @@ public class CorsFilterTest {
         assertResponseHasHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, ACCEPTED_HTTP_METHODS);
         assertResponseHasHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, ECLIPSE_ORIGIN);
         assertResponseHasHeader(ACCESS_CONTROL_ALLOW_HEADERS, CONTENT_TYPE_HEADER);
+        assertResponseHasHeader(ACCESS_CONTROL_ALLOW_HEADERS, AUTHORIZATION_HEADER);
         assertResponseHasHeader(VARY_HEADER, VARY_HEADER_VALUE + "," + ORIGIN_HEADER);
     }
 
@@ -157,7 +159,7 @@ public class CorsFilterTest {
 
     private void assertResponseHasHeader(String header, String value) {
         assertTrue(responseHeaders.containsKey(header));
-        assertTrue(responseHeaders.getFirst(header).equals(value));
+        assertTrue(responseHeaders.get(header).contains(value));
     }
 
     private void setupRequestContext(String methodValue, String originValue, final String requestMethodValue,


### PR DESCRIPTION
Due to the introduction of the oAuth authorization layer, the CORS filter for preflight requests needs to be adapted. Currently, pre flight requests with an authorization header are rejected by the API. 
![image](https://user-images.githubusercontent.com/1090452/102678851-55d27100-41ab-11eb-9b30-8cf301a13563.png)
This pull request corrects this behaviour by adding the value "Authorization" to the "Access-Control-Allow-Headers“.

@kaikreuzer: If it's not too late, this fix might be interesting for the stable release.
