### PR TITLE
[auth] Don't allow creating API tokens with no name

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/CreateAPITokenPageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/CreateAPITokenPageServlet.java
@@ -90,7 +90,7 @@ public class CreateAPITokenPageServlet extends AbstractAuthPageServlet {
                 throw new AuthenticationException("no password");
             }
             if (!params.containsKey("token_name")) {
-                throw new AuthenticationException("no new password");
+                throw new AuthenticationException("no token name");
             }
             if (!params.containsKey("csrf_token") || !csrfTokens.containsKey(params.get("csrf_token")[0])) {
                 throw new AuthenticationException("CSRF check failed");
@@ -101,10 +101,7 @@ public class CreateAPITokenPageServlet extends AbstractAuthPageServlet {
             String username = params.get("username")[0];
             String password = params.get("password")[0];
             String tokenName = params.get("token_name")[0];
-            String tokenScope = "";
-            if (params.containsKey("token_name")) {
-                tokenScope = params.get("token_scope")[0];
-            }
+            String tokenScope = params.get("token_scope")[0];
 
             User user = login(username, password);
             String newApiToken;
@@ -119,7 +116,7 @@ public class CreateAPITokenPageServlet extends AbstractAuthPageServlet {
                     return;
                 }
 
-                if (!tokenName.matches("[a-zA-Z0-9]*")) {
+                if (!tokenName.matches("[a-zA-Z0-9]+")) {
                     resp.setContentType("text/html;charset=UTF-8");
                     resp.getWriter().append(
                             getPageBody(params, getLocalizedMessage("auth.createapitoken.name.format.fail"), false));

--- a/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_no.properties
+++ b/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_no.properties
@@ -1,0 +1,26 @@
+auth.login.prompt = Logg inn for å gi <b>%s</b> tilgang til <b>%s</b>\:
+auth.login.fail = Vennligst prøv på nytt.
+auth.createaccount.prompt = Opprett en administratorkonto for å fortsette.
+
+auth.changepassword.success = Passord endret.
+
+auth.createapitoken.prompt = Opprett en ny API-token for å godkjenne eksterne tjenester.
+auth.createapitoken.name.unique.fail = Et token med samme navn eksisterer allerede, prøv igjen.
+auth.createapitoken.name.format.fail = Ugyldig tokennavn, vennligst bruk bare alfanumeriske tegn.
+auth.createapitoken.success = Nytt token opprettet\:
+auth.createapitoken.success.footer = Kopier den nå, den vil ikke bli vist igjen.
+
+auth.password.confirm.fail = Passordene er ikke like, prøv igjen.
+
+auth.placeholder.username = Brukernavn
+auth.placeholder.password = Passord
+auth.placeholder.newpassword = Nytt passord
+auth.placeholder.repeatpassword = Bekreft nytt passord
+auth.placeholder.tokenname = Tokennavn
+auth.placeholder.tokenscope = Token omfang (valgfritt)
+
+auth.button.signin = Logg på
+auth.button.createaccount = Opprett konto
+auth.button.changepassword = Bytt Passord
+auth.button.createapitoken = Opprett API Token
+auth.button.return = Returner hjem


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/674.

Remove unnecessary checks and fix exception message.
Add Norwegian messages for auth pages.

Signed-off-by: Yannick Schaus <github@schaus.net>