### PR TITLE
Fixed NPE in ScriptError if INode is empty

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptError.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptError.java
@@ -62,10 +62,16 @@ public final class ScriptError {
     public ScriptError(final String message, final EObject atEObject) {
         this.message = message;
         INode node = NodeModelUtils.getNode(atEObject);
-        LineAndColumn lac = NodeModelUtils.getLineAndColumn(node, node.getOffset());
-        this.line = lac.getLine();
-        this.column = lac.getColumn();
-        this.length = node.getEndOffset() - node.getOffset();
+        if (node == null) {
+            this.line = 0;
+            this.column = 0;
+            this.length = -1;
+        } else {
+            LineAndColumn lac = NodeModelUtils.getLineAndColumn(node, node.getOffset());
+            this.line = lac.getLine();
+            this.column = lac.getColumn();
+            this.length = node.getEndOffset() - node.getOffset();
+        }
     }
 
     /**


### PR DESCRIPTION
- Fixed NPE in `ScriptError` if `INode` is empty

This will at lest show the message without referencing line and column.

See https://community.openhab.org/t/openhab-3-0-release-discussion/110751/16

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>