### PR TITLE
Updated rule dsl filename to rule uid mapping

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -129,7 +129,7 @@ public class DSLRuleProvider
 
     @Override
     public void modelChanged(String modelFileName, EventType type) {
-        String ruleModelName = modelFileName.substring(0, modelFileName.indexOf("."));
+        String ruleModelName = modelFileName.substring(0, modelFileName.lastIndexOf("."));
         switch (type) {
             case ADDED:
                 EObject model = modelRepository.getModel(modelFileName);


### PR DESCRIPTION
I migrated from openhab 2.x to 3.x and many of my rules managed in `.rules` dsl files where not shown in the UI. I found that the uid of the rules only contained the string before ".".  Examples of my rule filenames: `Bedroom.TV.rules`, `Bedroom.Light.rules`
This resulted in a collision of uids for the rules. With openhab 2.x this was not a problem.

To fix this problem, the full filename without extension should be used in the uid for rules provided by DSL files.
