### PR TITLE
Added unit tests for check if persistence extension returns QuantityType if persistence service returns QuantityType

### DIFF
--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -28,10 +27,13 @@ import java.util.stream.IntStream;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemRegistry;
@@ -50,6 +52,8 @@ import org.openhab.core.persistence.PersistenceServiceRegistry;
  * @author Chris Jackson - Initial contribution
  * @author Jan N. Klug - Fix averageSince calculation
  */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class PersistenceExtensionsTest {
 
     public static final String TEST_NUMBER = "testNumber";
@@ -59,14 +63,10 @@ public class PersistenceExtensionsTest {
     private @Mock UnitProvider unitProvider;
     private @Mock ItemRegistry mockedItemRegistry;
 
-    private AutoCloseable mocksCloseable;
-
     private GenericItem numberItem, quantityItem, switchItem;
 
     @BeforeEach
     public void setUp() {
-        mocksCloseable = openMocks(this);
-
         when(unitProvider.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
 
         CoreItemFactory itemFactory = new CoreItemFactory();
@@ -105,11 +105,6 @@ public class PersistenceExtensionsTest {
                 return TestPersistenceService.ID.equals(serviceId) ? testPersistenceService : null;
             }
         });
-    }
-
-    @AfterEach
-    public void afterEach() throws Exception {
-        mocksCloseable.close();
     }
 
     @Test

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -21,11 +21,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import javax.measure.Unit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
@@ -43,6 +48,12 @@ import org.openhab.core.types.State;
 public class TestPersistenceService implements QueryablePersistenceService {
 
     public static final String ID = "test";
+
+    private final ItemRegistry itemRegistry;
+
+    public TestPersistenceService(ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
 
     @Override
     public String getId() {
@@ -96,9 +107,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 Collections.reverse(results);
             }
             return results;
-        } else
-
-        {
+        } else {
             int startValue = 1950;
             int endValue = 2012;
 
@@ -124,7 +133,9 @@ public class TestPersistenceService implements QueryablePersistenceService {
 
                     @Override
                     public State getState() {
-                        return new DecimalType(year);
+                        Item item = itemRegistry.get(filter.getItemName());
+                        Unit<?> unit = item instanceof NumberItem ? ((NumberItem) item).getUnit() : null;
+                        return unit == null ? new DecimalType(year) : QuantityType.valueOf(year, unit);
                     }
 
                     @Override


### PR DESCRIPTION
- Added unit tests for check if persistence extension returns `QuantityType` if persistence service returns `QuantityType`

This PR adds support for unit tests returning `QuantityType` values and splits test for `historicState()`, `previousState()`, `maximumSince()` and `minimumSince()` to validate to already work like expected.

Related to #1954 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>