### PR TITLE
[Persistence Extensions] Fixed varianceSince and deviationSince

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -397,6 +397,7 @@ public class PersistenceExtensions {
             BigDecimal average = averageSince.toBigDecimal(), sum = BigDecimal.ZERO;
             int count = 0;
 
+            it = result.iterator();
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();
                 DecimalType value = historicItem.getState().as(DecimalType.class);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -236,6 +236,7 @@ public class PersistenceExtensionsTest {
         assertEquals(OnOffType.ON, historicItem.getState());
     }
 
+    @Test
     public void testVarianceSince() {
         numberItem.setState(new DecimalType(3025));
 
@@ -262,6 +263,7 @@ public class PersistenceExtensionsTest {
         assertNull(variance);
     }
 
+    @Test
     public void testDeviationSince() {
         numberItem.setState(new DecimalType(3025));
 


### PR DESCRIPTION
Fixed `varianceSince` and `deviationSince`, which always returned null. Also enabled tests for `varianceSince` and `deviationSince`, which were not being executed (and therefore masking that those functions didn't work).

Signed-off-by: Mark Hilbush <mark@hilbush.com>
