### PR TITLE
Improved error logging when adding rules

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -189,7 +189,7 @@ public class RuleResource implements RESTResource {
 
     private void logException(RuntimeException e, String errMessage) {
         if (logger.isDebugEnabled()) {
-            logger.warn(errMessage, e);
+            logger.warn("{}", errMessage, e);
         } else {
             logger.warn("{}", errMessage);
         }

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -178,12 +178,20 @@ public class RuleResource implements RESTResource {
                     .header("Location", "rules/" + URLEncoder.encode(newRule.getUID(), StandardCharsets.UTF_8)).build();
         } catch (IllegalArgumentException e) {
             String errMessage = "Creation of the rule is refused: " + e.getMessage();
-            logger.warn(errMessage, e);
+            logException(e, errMessage);
             return JSONResponse.createErrorResponse(Status.CONFLICT, errMessage);
         } catch (RuntimeException e) {
             String errMessage = "Creation of the rule is refused: " + e.getMessage();
-            logger.warn(errMessage, e);
+            logException(e, errMessage);
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, errMessage);
+        }
+    }
+
+    private void logException(RuntimeException e, String errMessage) {
+        if (logger.isDebugEnabled()) {
+            logger.warn(errMessage, e);
+        } else {
+            logger.warn("{}", errMessage);
         }
     }
 

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -178,11 +178,11 @@ public class RuleResource implements RESTResource {
                     .header("Location", "rules/" + URLEncoder.encode(newRule.getUID(), StandardCharsets.UTF_8)).build();
         } catch (IllegalArgumentException e) {
             String errMessage = "Creation of the rule is refused: " + e.getMessage();
-            logger.warn("{}", errMessage);
+            logger.warn(errMessage, e);
             return JSONResponse.createErrorResponse(Status.CONFLICT, errMessage);
         } catch (RuntimeException e) {
             String errMessage = "Creation of the rule is refused: " + e.getMessage();
-            logger.warn("{}", errMessage);
+            logger.warn(errMessage, e);
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, errMessage);
         }
     }


### PR DESCRIPTION
I stumbled upon the same issue as described here:

https://community.openhab.org/t/solved-oh3-issue-unable-to-create-rules-scripts-schedules/111325
https://community.openhab.org/t/openhab-3-error-creating-rules-or-scripts-using-blocky/111422

This makes the logging a bit more useful
