### PR TITLE
add getPoolNames method to ThreadPoolManager

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -14,6 +14,7 @@ package org.openhab.core.common;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -166,5 +167,9 @@ public class ThreadPoolManager {
     protected static int getConfig(String poolName) {
         Integer cfg = configs.get(poolName);
         return (cfg != null) ? cfg : DEFAULT_THREAD_POOL_SIZE;
+    }
+
+    public static Set<String> getPoolNames() {
+        return pools.keySet();
     }
 }


### PR DESCRIPTION
This PR adds a new getPoolNames method to ThreadPoolManager in order to iterate over all thread pools. The intention is to extract metrics for a new [Prometheus](https://prometheus.io/) exporter binding I've got in the works. 

Signed-off-by: Robert Bach <openhab@mortalsilence.net> (github: pravussum)