### PR TITLE
Fix parsing integer & booleans parameters in UI component based sitemaps

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.ui.internal.components;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -178,7 +179,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             case "Video":
                 VideoImpl videoWidget = (VideoImpl) SitemapFactory.eINSTANCE.createVideo();
                 widget = videoWidget;
-                setWidgetPropertyFromComponentConfig(widget, component, "url", SitemapPackage.IMAGE__URL);
+                setWidgetPropertyFromComponentConfig(widget, component, "url", SitemapPackage.VIDEO__URL);
                 setWidgetPropertyFromComponentConfig(widget, component, "encoding", SitemapPackage.VIDEO__ENCODING);
                 break;
             case "Chart":
@@ -282,8 +283,21 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
         if (value == null) {
             return;
         }
-        WidgetImpl widgetImpl = (WidgetImpl) widget;
-        widgetImpl.eSet(feature, ConfigUtil.normalizeType(value));
+        try {
+            WidgetImpl widgetImpl = (WidgetImpl) widget;
+            Object normalizedValue = ConfigUtil.normalizeType(value);
+            if (widgetImpl.eGet(feature, false, false) instanceof Integer) {
+                normalizedValue = (normalizedValue instanceof BigDecimal) ? ((BigDecimal) normalizedValue).intValue()
+                        : Integer.valueOf(normalizedValue.toString().split(".")[0]);
+            }
+            if (widgetImpl.eGet(feature, false, false) instanceof Boolean && !(normalizedValue instanceof Boolean)) {
+                normalizedValue = Boolean.valueOf(normalizedValue.toString());
+            }
+            widgetImpl.eSet(feature, normalizedValue);
+        } catch (Exception e) {
+            logger.warn("Cannot set {} parameter for {} widget parameter: {}", configParamName, component.getType(),
+                    e.getMessage());
+        }
     }
 
     private void addWidgetMappings(EList<Mapping> mappings, UIComponent component) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -221,7 +221,6 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 SelectionImpl selectionWidget = (SelectionImpl) SitemapFactory.eINSTANCE.createSelection();
                 addWidgetMappings(selectionWidget.getMappings(), component);
                 widget = selectionWidget;
-                setWidgetPropertyFromComponentConfig(widget, component, "height", SitemapPackage.WEBVIEW__HEIGHT);
                 break;
             case "List":
                 ListImpl listWidget = (ListImpl) SitemapFactory.eINSTANCE.createList();
@@ -288,9 +287,9 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             Object normalizedValue = ConfigUtil.normalizeType(value);
             if (widgetImpl.eGet(feature, false, false) instanceof Integer) {
                 normalizedValue = (normalizedValue instanceof BigDecimal) ? ((BigDecimal) normalizedValue).intValue()
-                        : Integer.valueOf(normalizedValue.toString().split(".")[0]);
-            }
-            if (widgetImpl.eGet(feature, false, false) instanceof Boolean && !(normalizedValue instanceof Boolean)) {
+                        : Integer.valueOf(normalizedValue.toString());
+            } else if (widgetImpl.eGet(feature, false, false) instanceof Boolean
+                    && !(normalizedValue instanceof Boolean)) {
                 normalizedValue = Boolean.valueOf(normalizedValue.toString());
             }
             widgetImpl.eSet(feature, normalizedValue);


### PR DESCRIPTION
Also catch remaining exceptions and log a warning/ignore the parameter
instead of making the whole sitemap building process fail.

Fix wrong feature ID for the video widget URL.

Fixes #2047.
Fixes #2005.
Fixes #1987.
Fixes #1898.
Fixes #1875.
Fixes https://github.com/openhab/openhab-webui/issues/745.

Signed-off-by: Yannick Schaus <github@schaus.net>