### PR TITLE
Add cache for Basic Authentication

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -186,7 +186,7 @@ public class AuthFilter implements ContainerRequestFilter {
 
         String[] decodedCredentials;
         try {
-            decodedCredentials = new String(Base64.getDecoder().decode(credentialString), "UTF-8").split(":");
+            decodedCredentials = new String(Base64.getDecoder().decode(credentialString), StandardCharsets.UTF_8).split(":");
         } catch (UnsupportedEncodingException e) {
             throw new AuthenticationException("Invalid base64 credentials for basic auth");
         }

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthFilter.java
@@ -147,8 +147,7 @@ public class AuthFilter implements ContainerRequestFilter {
         userRegistry.removeRegistryChangeListener(userRegistryListener);
     }
 
-    @Nullable
-    private String getCacheKey(String credentials) {
+    private @Nullable String getCacheKey(String credentials) {
         try {
             final MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(RANDOM_BYTES);

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.auth.internal;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * This class provides a cache for up to 10 UserSecurityContexts.
+ * Entries have a lifetime and are removed from the cache upon the next
+ * get call.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ *
+ */
+public class ExpiringUserSecurityContextCache {
+    final static private int MAX_SIZE = 10;
+    final static private int CLEANUP_FREQUENCY = 10;
+
+    final private long keepPeriod;
+    final private Map<String, Entry> entryMap;
+
+    private int calls = 0;
+
+    ExpiringUserSecurityContextCache(long expirationTime) {
+        this.keepPeriod = expirationTime;
+        entryMap = new LinkedHashMap<>() {
+            private static final long serialVersionUID = -1220310861591070462L;
+
+            protected boolean removeEldestEntry(Map.Entry<String, Entry> eldest) {
+                return size() > MAX_SIZE;
+            }
+        };
+    }
+
+    synchronized UserSecurityContext get(String key) {
+        calls++;
+        if (calls >= CLEANUP_FREQUENCY) {
+            entryMap.keySet().forEach(k -> getEntry(k));
+            calls = 0;
+        }
+        Entry entry = getEntry(key);
+        if (entry != null) {
+            return entry.value;
+        }
+        return null;
+    }
+
+    synchronized void put(String key, UserSecurityContext value) {
+        entryMap.put(key, new Entry(System.currentTimeMillis(), value));
+    }
+
+    synchronized void clear() {
+        entryMap.clear();
+    }
+
+    private Entry getEntry(String key) {
+        Entry entry = entryMap.get(key);
+        if (entry != null) {
+            long entryAge = System.currentTimeMillis() - entry.timestamp;
+            if (entryAge < 0 || entryAge >= keepPeriod) {
+                entryMap.remove(key);
+                entry = null;
+            }
+        }
+        return entry;
+    }
+
+    static class Entry {
+        final public long timestamp;
+        final public UserSecurityContext value;
+
+        Entry(long timestamp, UserSecurityContext value) {
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+    }
+}

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
@@ -71,10 +71,13 @@ public class ExpiringUserSecurityContextCache {
     private @Nullable Entry getEntry(String key) {
         Entry entry = entryMap.get(key);
         if (entry != null) {
-            long entryAge = System.currentTimeMillis() - entry.timestamp;
+            final long curTimeMillis = System.currentTimeMillis();
+            long entryAge = curTimeMillis - entry.timestamp;
             if (entryAge < 0 || entryAge >= keepPeriod) {
                 entryMap.remove(key);
                 entry = null;
+            } else {
+                entry.timestamp = curTimeMillis;
             }
         }
         return entry;

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
@@ -84,7 +84,7 @@ public class ExpiringUserSecurityContextCache {
     }
 
     static class Entry {
-        final public long timestamp;
+        public long timestamp;
         final public UserSecurityContext value;
 
         Entry(long timestamp, UserSecurityContext value) {

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
@@ -15,6 +15,9 @@ package org.openhab.core.io.rest.auth.internal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This class provides a cache for up to 10 UserSecurityContexts.
  * Entries have a lifetime and are removed from the cache upon the next
@@ -23,6 +26,7 @@ import java.util.Map;
  * @author Kai Kreuzer - Initial contribution
  *
  */
+@NonNullByDefault
 public class ExpiringUserSecurityContextCache {
     final static private int MAX_SIZE = 10;
     final static private int CLEANUP_FREQUENCY = 10;
@@ -37,13 +41,13 @@ public class ExpiringUserSecurityContextCache {
         entryMap = new LinkedHashMap<>() {
             private static final long serialVersionUID = -1220310861591070462L;
 
-            protected boolean removeEldestEntry(Map.Entry<String, Entry> eldest) {
+            protected boolean removeEldestEntry(Map.@Nullable Entry<String, Entry> eldest) {
                 return size() > MAX_SIZE;
             }
         };
     }
 
-    synchronized UserSecurityContext get(String key) {
+    synchronized @Nullable UserSecurityContext get(String key) {
         calls++;
         if (calls >= CLEANUP_FREQUENCY) {
             entryMap.keySet().forEach(k -> getEntry(k));
@@ -64,7 +68,7 @@ public class ExpiringUserSecurityContextCache {
         entryMap.clear();
     }
 
-    private Entry getEntry(String key) {
+    private @Nullable Entry getEntry(String key) {
         Entry entry = entryMap.get(key);
         if (entry != null) {
             long entryAge = System.currentTimeMillis() - entry.timestamp;

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -11,6 +11,17 @@
 			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
 				and API tokens.</description>
 		</parameter>
+		<parameter name="cacheExpiration" type="integer">
+			<advanced>true</advanced>
+			<label>Cache Expiration Time</label>
+			<default>6</default>
+			<unitLabel>h</unitLabel>
+			<description>When basic authentication is activated, credentials are put in a cache in order to speed up request
+				authorization.
+				The entries in the cache expire after a while in order to not keep credentials in memory indefinitely.
+				This value defines the expiration time in hours.
+			</description>
+		</parameter>
 		<parameter name="implicitUserRole" type="boolean" required="false">
 			<advanced>true</advanced>
 			<label>Implicit user role for unauthenticated requests</label>

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -11,7 +11,7 @@
 			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
 				and API tokens.</description>
 		</parameter>
-		<parameter name="cacheExpiration" type="integer">
+		<parameter name="cacheExpiration" type="integer" min="1">
 			<advanced>true</advanced>
 			<label>Cache Expiration Time</label>
 			<default>6</default>

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/config.xml
@@ -11,7 +11,7 @@
 			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
 				and API tokens.</description>
 		</parameter>
-		<parameter name="cacheExpiration" type="integer" min="1">
+		<parameter name="cacheExpiration" type="integer" min="0">
 			<advanced>true</advanced>
 			<label>Cache Expiration Time</label>
 			<default>6</default>
@@ -20,6 +20,7 @@
 				authorization.
 				The entries in the cache expire after a while in order to not keep credentials in memory indefinitely.
 				This value defines the expiration time in hours.
+				Set it to 0 for disabling the cache.
 			</description>
 		</parameter>
 		<parameter name="implicitUserRole" type="boolean" required="false">


### PR DESCRIPTION
This PR adds a small cache for calculating the auth hashes which aims to fix the performance issues introduced with OH3.
The cache does **not** store plain text passwords and is limited to a certain size.

Fixes https://github.com/openhab/openhab-core/issues/1899