### PR TITLE
[executeCommandLine] should return STDERR if STDOUT is empty

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -90,12 +90,9 @@ public class ExecUtil {
                 }
             });
 
-            int exitCode;
             if (timeout == null) {
-                exitCode = process.waitFor();
-            } else if (process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
-                exitCode = process.exitValue();
-            } else {
+                process.waitFor();
+            } else if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
                 logger.warn("Timeout occurred when executing commandLine '{}'", Arrays.toString(commandLine));
                 break cleanup;
             }

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -78,9 +78,8 @@ public class ExecUtil {
 
         Process processTemp = null;
         Future<String> outputFuture = null;
-        Future<String> errorFuture = null;
         cleanup: try {
-            Process process = processTemp = new ProcessBuilder(commandLine).start();
+            Process process = processTemp = new ProcessBuilder(commandLine).redirectErrorStream(true).start();
 
             outputFuture = executor.submit(() -> {
                 try (InputStream inputStream = process.getInputStream();
@@ -91,14 +90,6 @@ public class ExecUtil {
                 }
             });
 
-            errorFuture = executor.submit(() -> {
-                try (InputStream inputStream = process.getErrorStream();
-                        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-                    StringWriter output = new StringWriter();
-                    reader.transferTo(output);
-                    return output.toString();
-                }
-            });
             int exitCode;
             if (timeout == null) {
                 exitCode = process.waitFor();
@@ -108,15 +99,7 @@ public class ExecUtil {
                 logger.warn("Timeout occurred when executing commandLine '{}'", Arrays.toString(commandLine));
                 break cleanup;
             }
-            if (exitCode == 0) {
-                return !"".equals(outputFuture.get()) ? outputFuture.get() : errorFuture.get();
-            } else {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("exit code '{}', result '{}', errors '{}'", exitCode, outputFuture.get(),
-                            errorFuture.get());
-                }
-                return errorFuture.get();
-            }
+            return outputFuture.get();
         } catch (ExecutionException e) {
             if (logger.isDebugEnabled()) {
                 logger.warn("Error occurred when executing commandLine '{}'", Arrays.toString(commandLine),
@@ -138,9 +121,6 @@ public class ExecUtil {
         }
         if (outputFuture != null) {
             outputFuture.cancel(true);
-        }
-        if (errorFuture != null) {
-            errorFuture.cancel(true);
         }
         return null;
     }

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -109,7 +109,7 @@ public class ExecUtil {
                 break cleanup;
             }
             if (exitCode == 0) {
-                return outputFuture.get();
+                return !"".equals(outputFuture.get()) ? outputFuture.get() : errorFuture.get();
             } else {
                 if (logger.isDebugEnabled()) {
                     logger.debug("exit code '{}', result '{}', errors '{}'", exitCode, outputFuture.get(),

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
@@ -62,4 +62,17 @@ public class ExecUtilTest {
         String osName = System.getProperty("os.name").toLowerCase();
         return osName.indexOf("windows") >= 0;
     }
+
+    @Test
+    public void testExecuteCommandLineAndWaitStdErrRedirection() {
+        final String result;
+        if (isWindowsSystem()) {
+            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "cmd", "/c", "dir", "xxx.xxx",
+                    "1>", "nul");
+        } else {
+            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "ls", "xxx.xxx");
+        }
+        assertNotNull(result);
+        assertNotEquals("", result);
+    }
 }


### PR DESCRIPTION
NOTE: this relates to Issue https://github.com/openhab/openhab-core/issues/2033#issuecomment-759781893

If ErrorCode == 0 then executeCommandLineAndWaitResponse() would always return the response from STDOUT. 

However on some Unix commands (e.g. wget, curl) if ErrorCode == 0 there is no response on STDOUT, but the commands return valid information on STDERR (even though there was not an error).

In this PR, if ErrorCode == 0, the return value of executeCommandLineAndWaitResponse() is `!"".equals(STDOUT) ? STDOUT : STDERR`

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>