### PR TITLE
Fix BOM dependency issues

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -167,11 +167,6 @@
       <artifactId>jaxb-osgi</artifactId>
       <version>2.3.3</version>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>osgi-resource-locator</artifactId>
-      <version>1.0.3</version>
-    </dependency>
 
     <!-- Activation 1.2 API -->
     <dependency>
@@ -900,7 +895,7 @@
     <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>osgi-resource-locator</artifactId>
-      <version>1.0.1</version>
+      <version>1.0.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bom/test-index/pom.xml
+++ b/bom/test-index/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.tester.junit-platform</artifactId>
-      <version>5.1.2</version>
+      <version>${bnd.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bom</groupId>

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -33,13 +33,11 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.eclipse.jetty.websocket.client;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.auth.oauth2client;version='[3.1.0,3.1.1)',\
 	org.openhab.core.auth.oauth2client.tests;version='[3.1.0,3.1.1)',\
@@ -54,4 +52,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	net.bytebuddy.byte-buddy;version='[1.10.19,1.10.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -48,4 +46,6 @@ Fragment-Host: org.openhab.core.automation
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)'
+	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)'
+	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)'
+	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -28,14 +28,12 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.binding.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.binding.xml.tests;version='[3.1.0,3.1.1)',\
@@ -47,4 +45,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -28,13 +28,11 @@ Fragment-Host: org.openhab.core.config.core
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core.tests;version='[3.1.0,3.1.1)',\
@@ -47,4 +45,6 @@ Fragment-Host: org.openhab.core.config.core
 	net.bytebuddy.byte-buddy;version='[1.10.19,1.10.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -28,13 +28,11 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	javax.jmdns;version='[3.5.6,3.5.7)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
@@ -49,4 +47,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -30,13 +30,11 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.discovery;version='[3.1.0,3.1.1)',\
@@ -56,4 +54,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -28,13 +28,11 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.discovery;version='[3.1.0,3.1.1)',\
@@ -53,5 +51,7 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'
 

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -38,13 +38,11 @@ Provide-Capability: \
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.discovery;version='[3.1.0,3.1.1)',\
@@ -61,4 +59,6 @@ Provide-Capability: \
 	net.bytebuddy.byte-buddy;version='[1.10.19,1.10.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -28,13 +28,11 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.dispatch;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.dispatch.tests;version='[3.1.0,3.1.1)',\
@@ -43,4 +41,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.config.xml
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.xml;version='[3.1.0,3.1.1)',\
@@ -44,4 +42,6 @@ Fragment-Host: org.openhab.core.config.xml
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -41,13 +41,11 @@ feature.openhab-config: \
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
 	org.apache.felix.logback;version='[1.0.2,1.0.3)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
@@ -61,4 +59,6 @@ feature.openhab-config: \
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -39,14 +39,12 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.osgi.util.promise;version='[1.1.0,1.1.1)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.aries.jax.rs.whiteboard;version='[1.0.9,1.0.10)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	javax.xml.soap-api;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.jaxws-api-2.3;version='[2.3.0,2.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -77,4 +75,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -42,13 +42,11 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -104,4 +102,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.1.0,3.1.1)'
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.openhab.core.model.persistence.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -44,13 +44,11 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -102,4 +100,6 @@ Fragment-Host: org.openhab.core.model.item
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.1.0,3.1.1)'
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.openhab.core.model.persistence.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -49,13 +49,11 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -107,5 +105,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.1.0,3.1.1)'
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.openhab.core.model.persistence.runtime;version='[3.1.0,3.1.1)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -44,13 +44,11 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -101,5 +99,7 @@ Fragment-Host: org.openhab.core.model.script
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.1.0,3.1.1)'
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.openhab.core.model.persistence.runtime;version='[3.1.0,3.1.1)'
 	

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -46,13 +46,11 @@ Fragment-Host: org.openhab.core.model.thing
 	org.eclipse.jetty.websocket.common;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
 	org.threeten.extra;version='[1.5.0,1.5.1)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
@@ -115,5 +113,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[3.1.0,3.1.1)'
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
+	org.openhab.core.model.persistence.runtime;version='[3.1.0,3.1.1)'
 

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core.storage.json
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.storage.json;version='[3.1.0,3.1.1)',\
@@ -43,4 +41,6 @@ Fragment-Host: org.openhab.core.storage.json
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -27,13 +27,11 @@ Fragment-Host: org.openhab.core
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.test;version='[3.1.0,3.1.1)',\
 	org.openhab.core.tests;version='[3.1.0,3.1.1)',\
@@ -46,4 +44,6 @@ Fragment-Host: org.openhab.core
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -31,13 +31,11 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.xml;version='[3.1.0,3.1.1)',\
@@ -56,4 +54,6 @@ Fragment-Host: org.openhab.core.thing
 	net.bytebuddy.byte-buddy-agent;version='[1.10.19,1.10.20)',\
 	org.mockito.junit-jupiter;version='[3.7.0,3.7.1)',\
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
-	org.objenesis;version='[3.1.0,3.1.1)'
+	org.objenesis;version='[3.1.0,3.1.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -29,13 +29,11 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.eclipse.jetty.server;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.servlet;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.openhab.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.binding.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
@@ -50,4 +48,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -30,13 +30,11 @@ Fragment-Host: org.openhab.core.voice
 	org.eclipse.jetty.util;version='[9.4.20,9.4.21)',\
 	org.eclipse.jetty.xml;version='[9.4.20,9.4.21)',\
 	org.ops4j.pax.swissbox.optional.jcl;version='[1.8.3,1.8.4)',\
-	biz.aQute.tester.junit-platform;version='[5.1.2,5.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	org.glassfish.hk2.osgi-resource-locator;version='[1.0.1,1.0.2)',\
 	org.apache.xbean.bundleutils;version='[4.17.0,4.17.1)',\
 	org.apache.xbean.finder;version='[4.17.0,4.17.1)',\
 	org.objectweb.asm;version='[8.0.1,8.0.2)',\
@@ -60,4 +58,6 @@ Fragment-Host: org.openhab.core.voice
 	junit-jupiter-params;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
-	junit-platform-launcher;version='[1.7.0,1.7.1)'
+	junit-platform-launcher;version='[1.7.0,1.7.1)',\
+	biz.aQute.tester.junit-platform;version='[5.2.0,5.2.1)',\
+	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)'


### PR DESCRIPTION
* Sync biz.aQute.tester.junit-platform version using bnd.version property
* Remove duplicate osgi-resource-locator dependency, causing warnings/unstability