### PR TITLE
Sort group item by string

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -15,8 +15,10 @@ package org.openhab.core.ui.internal.items;
 import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -733,7 +735,14 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 Item item = getItem(itemName);
                 if (item instanceof GroupItem) {
                     GroupItem groupItem = (GroupItem) item;
-                    for (Item member : groupItem.getMembers()) {
+                    List<Item> members = new ArrayList<>(groupItem.getMembers());
+                    Collections.sort(members, new Comparator<Item>() {
+                        @Override
+                        public int compare(Item u1, Item u2) {
+                            return u1.getName().compareTo(u2.getName());
+                        }
+                    });
+                    for (Item member : members) {
                         Widget widget = getDefaultWidget(member.getClass(), member.getName());
                         if (widget != null) {
                             widget.setItem(member.getName());

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -739,7 +739,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     Collections.sort(members, new Comparator<Item>() {
                         @Override
                         public int compare(Item u1, Item u2) {
-                            return u1.getName().compareTo(u2.getName());
+                            String u1Label = u1.getLabel();
+                            String u2Label = u2.getLabel();
+                            if (u1Label != null && u2Label != null) {
+                                return u1Label.compareTo(u2Label);
+                            } else {
+                                return u1.getName().compareTo(u2.getName());
+                            }
                         }
                     });
                     for (Item member : members) {


### PR DESCRIPTION
When using groups in the sitemap the order is quite randomly.
According [ticket](https://github.com/openhab/openhab-webui/issues/76) was closed in the ui repository as the solution needs to come from the core.

I saw @ghys coming up with some orderid property which I really liked but wasn't sure whether that is a general solution. Would love to implement that if I got some hint.
For now sorting by string (which I implemented with this little PR) is to me much better than a random order.

Signed-off-by: bjoernbrings <bjoernbrings@web.de>