### PR TITLE
[transport.modbus] Remove dependencies on deprecated libraries

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>1.3.1.OH-SNAPSHOT</version>
+      <version>[1.3.0.OH,1.3.1.OH]</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>1.3.0.OH</version>
+      <version>1.3.1.OH-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
@@ -14,8 +14,6 @@ package org.openhab.core.io.transport.modbus;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -33,10 +31,6 @@ import net.wimpi.modbus.Modbus;
  */
 @NonNullByDefault
 public class ModbusReadRequestBlueprint {
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     private final int slaveId;
     private final ModbusReadFunctionCode functionCode;
@@ -110,8 +104,8 @@ public class ModbusReadRequestBlueprint {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("slaveId", slaveId).append("functionCode", functionCode)
-                .append("start", start).append("length", length).append("maxTries", maxTries).toString();
+        return "ModbusReadRequestBlueprint [slaveId=" + slaveId + ", functionCode=" + functionCode + ", start=" + start
+                + ", length=" + length + ", maxTries=" + maxTries + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
@@ -119,7 +119,6 @@ public class ModbusReadRequestBlueprint {
             return false;
         }
         ModbusReadRequestBlueprint rhs = (ModbusReadRequestBlueprint) obj;
-        return functionCode == rhs.functionCode && length == rhs.length && maxTries == rhs.maxTries
-                && slaveId == rhs.slaveId && start == rhs.start;
+        return functionCode == rhs.functionCode && length == rhs.length && slaveId == rhs.slaveId && start == rhs.start;
     }
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.core.io.transport.modbus;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -98,8 +98,7 @@ public class ModbusReadRequestBlueprint {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(81, 3).append(slaveId).append(functionCode).append(start).append(length)
-                .append(maxTries).toHashCode();
+        return Objects.hash(functionCode, length, maxTries, slaveId, start);
     }
 
     @Override
@@ -120,7 +119,7 @@ public class ModbusReadRequestBlueprint {
             return false;
         }
         ModbusReadRequestBlueprint rhs = (ModbusReadRequestBlueprint) obj;
-        return new EqualsBuilder().append(slaveId, rhs.slaveId).append(functionCode, rhs.functionCode)
-                .append(start, rhs.start).append(length, rhs.length).isEquals();
+        return functionCode == rhs.functionCode && length == rhs.length && maxTries == rhs.maxTries
+                && slaveId == rhs.slaveId && start == rhs.start;
     }
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCoilRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCoilRequestBlueprint.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.io.transport.modbus;
 
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -24,12 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class ModbusWriteCoilRequestBlueprint extends ModbusWriteRequestBlueprint {
-
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     private final int slaveId;
     private final int reference;
@@ -110,8 +102,8 @@ public class ModbusWriteCoilRequestBlueprint extends ModbusWriteRequestBlueprint
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("slaveId", slaveId).append("reference", reference)
-                .append("functionCode", getFunctionCode()).append("bits", bits).append("maxTries", maxTries).toString();
+        return "ModbusWriteCoilRequestBlueprint [slaveId=" + slaveId + ", reference=" + reference + ", bits=" + bits
+                + ", maxTries=" + maxTries + ", getFunctionCode()=" + getFunctionCode() + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRegisterRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRegisterRequestBlueprint.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.io.transport.modbus;
 
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -24,12 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public class ModbusWriteRegisterRequestBlueprint extends ModbusWriteRequestBlueprint {
-
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     private final int slaveId;
     private final int reference;
@@ -96,9 +88,8 @@ public class ModbusWriteRegisterRequestBlueprint extends ModbusWriteRequestBluep
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("slaveId", slaveId).append("reference", reference)
-                .append("functionCode", getFunctionCode()).append("registers", registers).append("maxTries", maxTries)
-                .toString();
+        return "ModbusWriteRegisterRequestBlueprint [slaveId=" + slaveId + ", reference=" + reference + ", registers="
+                + registers + ", maxTries=" + maxTries + ", getFunctionCode()=" + getFunctionCode() + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
@@ -130,5 +130,4 @@ public class EndpointPoolConfiguration {
                 && interTransactionDelayMillis == rhs.interTransactionDelayMillis
                 && reconnectAfterMillis == rhs.reconnectAfterMillis;
     }
-
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
@@ -14,8 +14,6 @@ package org.openhab.core.io.transport.modbus.endpoint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -60,12 +58,6 @@ public class EndpointPoolConfiguration {
      * default is respected.
      */
     private int connectTimeoutMillis;
-
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     public long getInterConnectDelayMillis() {
         return interConnectDelayMillis;
@@ -115,11 +107,10 @@ public class EndpointPoolConfiguration {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle)
-                .append("interTransactionDelayMillis", interTransactionDelayMillis)
-                .append("interConnectDelayMillis", interConnectDelayMillis).append("connectMaxTries", connectMaxTries)
-                .append("reconnectAfterMillis", reconnectAfterMillis)
-                .append("connectTimeoutMillis", connectTimeoutMillis).toString();
+        return "EndpointPoolConfiguration [interTransactionDelayMillis=" + interTransactionDelayMillis
+                + ", interConnectDelayMillis=" + interConnectDelayMillis + ", connectMaxTries=" + connectMaxTries
+                + ", reconnectAfterMillis=" + reconnectAfterMillis + ", connectTimeoutMillis=" + connectTimeoutMillis
+                + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.core.io.transport.modbus.endpoint;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -101,8 +101,8 @@ public class EndpointPoolConfiguration {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(2149, 3117).append(interTransactionDelayMillis).append(interConnectDelayMillis)
-                .append(connectMaxTries).append(reconnectAfterMillis).append(connectTimeoutMillis).toHashCode();
+        return Objects.hash(connectMaxTries, connectTimeoutMillis, interConnectDelayMillis, interTransactionDelayMillis,
+                reconnectAfterMillis);
     }
 
     @Override
@@ -125,9 +125,10 @@ public class EndpointPoolConfiguration {
             return false;
         }
         EndpointPoolConfiguration rhs = (EndpointPoolConfiguration) obj;
-        return new EqualsBuilder().append(interTransactionDelayMillis, rhs.interTransactionDelayMillis)
-                .append(interConnectDelayMillis, rhs.interConnectDelayMillis)
-                .append(connectMaxTries, rhs.connectMaxTries).append(reconnectAfterMillis, rhs.reconnectAfterMillis)
-                .append(connectTimeoutMillis, rhs.connectTimeoutMillis).isEquals();
+        return connectMaxTries == rhs.connectMaxTries && connectTimeoutMillis == rhs.connectTimeoutMillis
+                && interConnectDelayMillis == rhs.interConnectDelayMillis
+                && interTransactionDelayMillis == rhs.interTransactionDelayMillis
+                && reconnectAfterMillis == rhs.reconnectAfterMillis;
     }
+
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.core.io.transport.modbus.endpoint;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -45,11 +45,7 @@ public abstract class ModbusIPSlaveEndpoint implements ModbusSlaveEndpoint {
     @Override
     public int hashCode() {
         // differentiate different protocols using the class name, and after that use address and port
-        int protocolHash = this.getClass().getName().hashCode();
-        if (protocolHash % 2 == 0) {
-            protocolHash += 1;
-        }
-        return new HashCodeBuilder(11, protocolHash).append(address).append(port).toHashCode();
+        return Objects.hash(getClass().getName(), address, port);
     }
 
     @Override
@@ -70,6 +66,7 @@ public abstract class ModbusIPSlaveEndpoint implements ModbusSlaveEndpoint {
             return false;
         }
         ModbusIPSlaveEndpoint rhs = (ModbusIPSlaveEndpoint) obj;
-        return new EqualsBuilder().append(address, rhs.address).append(port, rhs.port).isEquals();
+        return Objects.equals(address, rhs.address) && port == rhs.port;
     }
+
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
@@ -14,8 +14,6 @@ package org.openhab.core.io.transport.modbus.endpoint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -30,12 +28,6 @@ public abstract class ModbusIPSlaveEndpoint implements ModbusSlaveEndpoint {
 
     private String address;
     private int port;
-
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     public ModbusIPSlaveEndpoint(String address, int port) {
         this.address = address;
@@ -62,7 +54,7 @@ public abstract class ModbusIPSlaveEndpoint implements ModbusSlaveEndpoint {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("address", address).append("port", port).toString();
+        return "ModbusIPSlaveEndpoint [address=" + address + ", port=" + port + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
@@ -68,5 +68,4 @@ public abstract class ModbusIPSlaveEndpoint implements ModbusSlaveEndpoint {
         ModbusIPSlaveEndpoint rhs = (ModbusIPSlaveEndpoint) obj;
         return Objects.equals(address, rhs.address) && port == rhs.port;
     }
-
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
@@ -13,8 +13,6 @@
 package org.openhab.core.io.transport.modbus.endpoint;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -32,11 +30,6 @@ import net.wimpi.modbus.util.SerialParameters;
 public class ModbusSerialSlaveEndpoint implements ModbusSlaveEndpoint {
 
     private SerialParameters serialParameters;
-    private static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     public ModbusSerialSlaveEndpoint(String portName, int baudRate, int flowControlIn, int flowControlOut, int databits,
             int stopbits, int parity, String encoding, boolean echo, int receiveTimeoutMillis) {
@@ -102,6 +95,6 @@ public class ModbusSerialSlaveEndpoint implements ModbusSlaveEndpoint {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("portName", serialParameters.getPortName()).toString();
+        return "ModbusSerialSlaveEndpoint [getPortName()=" + getPortName() + "]";
     }
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.core.io.transport.modbus.endpoint;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -89,8 +90,7 @@ public class ModbusSerialSlaveEndpoint implements ModbusSlaveEndpoint {
             return false;
         }
         ModbusSerialSlaveEndpoint rhs = (ModbusSerialSlaveEndpoint) obj;
-        return new EqualsBuilder().append(serialParameters.getPortName(), rhs.serialParameters.getPortName())
-                .isEquals();
+        return Objects.equals(getPortName(), rhs.getPortName());
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.core.io.transport.modbus.internal;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.modbus.ModbusFailureCallback;
@@ -71,13 +71,12 @@ public class BasicPollTask implements PollTask {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(69, 5).append(request).append(getEndpoint()).append(getResultCallback())
-                .append(getFailureCallback()).toHashCode();
+        return Objects.hash(request, getEndpoint(), getResultCallback(), getFailureCallback());
     }
 
     @Override
     public String toString() {
-        return "BasicPollTask [endpoint=" + endpoint + ", request=" + request + ", getResultCallback()="
+        return "BasicPollTask [getEndpoint=" + getEndpoint() + ", request=" + request + ", getResultCallback()="
                 + getResultCallback() + ", getFailureCallback()=" + getFailureCallback() + "]";
     }
 
@@ -93,8 +92,8 @@ public class BasicPollTask implements PollTask {
             return false;
         }
         BasicPollTask rhs = (BasicPollTask) obj;
-        return new EqualsBuilder().append(request, rhs.request).append(endpoint, rhs.endpoint)
-                .append(getResultCallback(), rhs.getResultCallback())
-                .append(getFailureCallback(), rhs.getFailureCallback()).isEquals();
+        return Objects.equals(request, rhs.request) && Objects.equals(getEndpoint(), rhs.getEndpoint())
+                && Objects.equals(getResultCallback(), rhs.getResultCallback())
+                && Objects.equals(getFailureCallback(), rhs.getFailureCallback());
     }
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
@@ -14,8 +14,6 @@ package org.openhab.core.io.transport.modbus.internal;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.modbus.ModbusFailureCallback;
@@ -37,11 +35,6 @@ import org.openhab.core.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
  */
 @NonNullByDefault
 public class BasicPollTask implements PollTask {
-
-    static StandardToStringStyle toStringStyle = new StandardToStringStyle();
-    static {
-        toStringStyle.setUseShortClassName(true);
-    }
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusReadRequestBlueprint request;
@@ -84,9 +77,8 @@ public class BasicPollTask implements PollTask {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, toStringStyle).append("request", request).append("endpoint", endpoint)
-                .append("resultCallback", getResultCallback()).append("failureCallback", getFailureCallback())
-                .toString();
+        return "BasicPollTask [endpoint=" + endpoint + ", request=" + request + ", getResultCallback()="
+                + getResultCallback() + ", getFailureCallback()=" + getFailureCallback() + "]";
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicWriteTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicWriteTask.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.io.transport.modbus.internal;
 
-import org.apache.commons.lang.builder.StandardToStringStyle;
-import org.apache.commons.lang.builder.ToStringBuilder;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.transport.modbus.ModbusFailureCallback;
 import org.openhab.core.io.transport.modbus.ModbusWriteCallback;
@@ -29,11 +27,6 @@ import org.openhab.core.io.transport.modbus.endpoint.ModbusSlaveEndpoint;
  */
 @NonNullByDefault
 public class BasicWriteTask implements WriteTask {
-
-    private static final StandardToStringStyle TO_STRING_STYLE = new StandardToStringStyle();
-    static {
-        TO_STRING_STYLE.setUseShortClassName(true);
-    }
 
     private ModbusSlaveEndpoint endpoint;
     private ModbusWriteRequestBlueprint request;
@@ -71,7 +64,7 @@ public class BasicWriteTask implements WriteTask {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this, TO_STRING_STYLE).append("request", request).append("endpoint", endpoint)
-                .append("resultCallback", resultCallback).append("failureCallback", failureCallback).toString();
+        return "BasicWriteTask [endpoint=" + endpoint + ", request=" + request + ", resultCallback=" + resultCallback
+                + ", failureCallback=" + failureCallback + "]";
     }
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -363,7 +363,6 @@ public class ModbusManagerImpl implements ModbusManager {
                         Optional.ofNullable(e).map(ex -> ex.getClass().getSimpleName()).orElse(""),
                         Optional.ofNullable(e).map(ex -> ex.getMessage()).orElse("<null>"), e);
             }
-
         });
         connectionPool = genericKeyedObjectPool;
         this.connectionFactory = connectionFactory;

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -34,7 +34,6 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.io.transport.modbus.AsyncModbusFailure;
 import org.openhab.core.io.transport.modbus.AsyncModbusWriteResult;
@@ -317,7 +316,7 @@ public class ModbusManagerImpl implements ModbusManager {
      */
     private volatile @Nullable ScheduledExecutorService scheduledThreadPoolExecutor;
     private volatile @Nullable ScheduledFuture<?> monitorFuture;
-    private volatile Set<ModbusCommunicationInterfaceImpl> communicationInterfaces = new ConcurrentHashSet<>();
+    private volatile Set<ModbusCommunicationInterfaceImpl> communicationInterfaces = ConcurrentHashMap.newKeySet();
 
     private void constructConnectionPool() {
         ModbusSlaveConnectionFactoryImpl connectionFactory = new ModbusSlaveConnectionFactoryImpl();
@@ -364,6 +363,7 @@ public class ModbusManagerImpl implements ModbusManager {
                         Optional.ofNullable(e).map(ex -> ex.getClass().getSimpleName()).orElse(""),
                         Optional.ofNullable(e).map(ex -> ex.getMessage()).orElse("<null>"), e);
             }
+
         });
         connectionPool = genericKeyedObjectPool;
         this.connectionFactory = connectionFactory;
@@ -725,7 +725,7 @@ public class ModbusManagerImpl implements ModbusManager {
     private class ModbusCommunicationInterfaceImpl implements ModbusCommunicationInterface {
 
         private volatile ModbusSlaveEndpoint endpoint;
-        private volatile Set<PollTask> pollTasksRegisteredByThisCommInterface = new ConcurrentHashSet<>();
+        private volatile Set<PollTask> pollTasksRegisteredByThisCommInterface = ConcurrentHashMap.newKeySet();
         private volatile boolean closed;
         private @Nullable EndpointPoolConfiguration configuration;
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
@@ -17,7 +17,6 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.modbus.BitArray;
@@ -66,7 +65,7 @@ public final class WriteRequestJsonUtilities {
     private static final JsonParser PARSER = new JsonParser();
 
     private WriteRequestJsonUtilities() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/IntegrationTestSupport.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/IntegrationTestSupport.java
@@ -27,7 +27,6 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.function.LongSupplier;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -182,7 +181,7 @@ public class IntegrationTestSupport extends JavaTest {
             } else if (ServerType.SERIAL.equals(serverType)) {
                 // No-op
             } else {
-                throw new NotImplementedException();
+                throw new UnsupportedOperationException();
             }
         }, MAX_WAIT_REQUESTS_MILLIS, 10);
     }
@@ -200,7 +199,7 @@ public class IntegrationTestSupport extends JavaTest {
         } else if (ServerType.SERIAL.equals(serverType)) {
             startSerialServer();
         } else {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -218,7 +217,7 @@ public class IntegrationTestSupport extends JavaTest {
             }
             serialServerThread.interrupt();
         } else {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/SmokeTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +91,8 @@ public class SmokeTest extends IntegrationTestSupport {
      * @return
      */
     private boolean isRunningInCI() {
-        return "true".equals(System.getenv("CI")) || StringUtils.isNotBlank(System.getenv("JENKINS_HOME"));
+        String jenkinsHome = System.getenv("JENKINS_HOME");
+        return "true".equals(System.getenv("CI")) || (jenkinsHome != null && !jenkinsHome.isBlank());
     }
 
     private void generateData() {


### PR DESCRIPTION
Addressing the following Issues..
- https://github.com/openhab/openhab-core/issues/2006 (dependency org.eclipse.jetty.util.ConcurrentHashSet)
- https://github.com/openhab/openhab-core/issues/2115 (dependency org.apache.commons.*)

References..
- https://github.com/openhab/jamod/pull/9

This PR removes a few (but not all) of the deprecated libraries..
- org.eclipse.jetty.util.ConcurrentHashSet
- org.apache.commons.lang.builder.EqualsBuilder
- org.apache.commons.lang.builder.HashCodeBuilder
- org.apache.commons.lang.builder.ToStringBuilder
- org.apache.commons.lang.builder.StandardToStringStyle

**_Note: it does not remove all of the dependencies on 'org.apache.commons.*'_** (but it is a big first step..)

@ssalonen @splatch @cweitkamp 