### PR TITLE
[discovery.upnp] Devices may apply a grace period for removal from the Inbox

### DIFF
--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
@@ -62,4 +62,21 @@ public interface UpnpDiscoveryParticipant {
      */
     @Nullable
     ThingUID getThingUID(RemoteDevice device);
+
+    /**
+     * The JUPnP library strictly follows the UPnP specification insofar as if a device fails to send its next
+     * 'ssdp:alive' notification within its declared 'maxAge' period, it is immediately considered to be gone. But
+     * unfortunately some types of OpenHAB bindings have devices that can sometimes be a bit late in sending their
+     * 'ssdp:alive' notifications even though they have not really gone offline, which means that such devices are
+     * repeatedly removed from, and (re)added to, the InBox.
+     *
+     * To prevent this, a binding that implements a UpnpDiscoveryParticipant may OPTIONALLY implement this method to
+     * specify an additional delay period (grace period) to wait before the device is removed from the Inbox.
+     *
+     * @param device the upnp device on the network
+     * @return the additional grace period delay in seconds before the device will be removed from the Inbox
+     */
+    default int getRemovalGracePeriodSeconds(RemoteDevice device) {
+        return 0;
+    }
 }

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
@@ -66,14 +66,14 @@ public interface UpnpDiscoveryParticipant {
     /**
      * The JUPnP library strictly follows the UPnP specification insofar as if a device fails to send its next
      * 'ssdp:alive' notification within its declared 'maxAge' period, it is immediately considered to be gone. But
-     * unfortunately some types of OpenHAB bindings have devices that can sometimes be a bit late in sending their
-     * 'ssdp:alive' notifications even though they have not really gone offline, which means that such devices are
-     * repeatedly removed from, and (re)added to, the InBox.
+     * unfortunately some openHAB bindings handle devices that can sometimes be a bit late in sending their 'ssdp:alive'
+     * notifications even though they have not really gone offline, which means that such devices are repeatedly removed
+     * from, and (re)added to, the Inbox.
      *
      * To prevent this, a binding that implements a UpnpDiscoveryParticipant may OPTIONALLY implement this method to
      * specify an additional delay period (grace period) to wait before the device is removed from the Inbox.
      *
-     * @param device the upnp device on the network
+     * @param device the UPnP device on the network
      * @return the additional grace period delay in seconds before the device will be removed from the Inbox
      */
     default long getRemovalGracePeriodSeconds(RemoteDevice device) {

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
@@ -76,7 +76,7 @@ public interface UpnpDiscoveryParticipant {
      * @param device the upnp device on the network
      * @return the additional grace period delay in seconds before the device will be removed from the Inbox
      */
-    default int getRemovalGracePeriodSeconds(RemoteDevice device) {
+    default long getRemovalGracePeriodSeconds(RemoteDevice device) {
         return 0;
     }
 }

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -13,11 +13,11 @@
 package org.openhab.core.config.discovery.upnp.internal;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +72,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     /*
      * Map of scheduled tasks to remove devices from the Inbox
      */
-    private Map<UDN, Future<?>> deviceRemovalTasks = new HashMap<>();
+    private Map<UDN, Future<?>> deviceRemovalTasks = new ConcurrentHashMap<>();
 
     @Override
     protected void activate(Map<String, Object> configProperties) {

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -166,8 +166,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
             try {
                 DiscoveryResult result = participant.createResult(device);
                 if (result != null) {
-                    int gracePeriod = participant.getRemovalGracePeriodSeconds(device);
-                    if (gracePeriod > 0) {
+                    if (participant.getRemovalGracePeriodSeconds(device) > 0) {
                         cancelRemovalTask(device.getIdentity().getUdn());
                     }
                     thingDiscovered(result);

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -193,7 +193,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
             try {
                 ThingUID thingUID = participant.getThingUID(device);
                 if (thingUID != null) {
-                    int gracePeriod = participant.getRemovalGracePeriodSeconds(device);
+                    long gracePeriod = participant.getRemovalGracePeriodSeconds(device);
                     if (gracePeriod <= 0) {
                         thingRemoved(thingUID);
                     } else {

--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>1.3.0.OH</version>
+      <version>[1.3.0.OH,1.3.1.OH]</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>[1.3.0.OH,1.3.1.OH]</version>
+      <version>1.3.0.OH</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
**BACKGROUND**

The JUPnP library strictly follows the UPnP specification insofar as if a device fails to send its next 'ssdp:alive' notification within its declared 'maxAge' period, it is immediately considered to be gone. Unfortunately some types of OpenHAB bindings have devices that can sometimes be a bit late in sending their 'ssdp:alive' notifications even though they have not really gone offline (e.g. the Philips Hue bridge), which means that such devices are repeatedly removed from, and (re)added to, the InBox. This leads to confusion in the UI, and repeated logger messages.

**SOLUTION**

To prevent this, when the OH core receives a remoteDeviceRemoved() notification from JUPnP it asks the binding if it should immediately remove the device from the Inbox, or alternatively wait for a further period of time ('grace period') before actually so doing. (And if the device 're-appears' within the grace period, its removal task is cancelled).

**REFERENCES**

Refers to following Issue..
https://github.com/openhab/openhab-addons/issues/9357

**NOTES**

NOTE: this PR extends the UpnpDiscoveryParticipant interface, by declaring a new 'default' method. This 'default' method means that there is no impact on bindings that have been compiled against on prior versions of the interface. Furthermore the return value of the 'default' implementation (0) is such that the behaviour of existing bindings will be unchanged versus prior implementations. Only those bindings that OPTIONALLY choose to override the default method return value will benefit from the enhanced performance of this PR.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>