### PR TITLE
[timer] Add Timer.getExecutionTime()

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
@@ -31,6 +31,13 @@ public interface Timer {
     public boolean cancel();
 
     /**
+     * Gets the scheduled exection time
+     * 
+     * @return the scheduled execution time, or null if the timer was cancelled
+     */
+    public ZonedDateTime getExecutionTime();
+
+    /**
      * Determines whether the scheduled execution is yet to happen.
      *
      * @return true, if the code is still scheduled to execute, false otherwise
@@ -60,5 +67,4 @@ public interface Timer {
      * @return true, if the rescheduling was done successful
      */
     public boolean reschedule(ZonedDateTime newTime);
-
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.script.internal.actions;
 
 import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
 
 import org.openhab.core.model.script.actions.Timer;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
@@ -61,6 +62,11 @@ public class TimerImpl implements Timer {
             logger.warn("Rescheduling failed as execution has already started!");
             return false;
         }
+    }
+
+    @Override
+    public ZonedDateTime getExecutionTime() {
+        return cancelled ? null : ZonedDateTime.now().plusNanos(future.getDelay(TimeUnit.NANOSECONDS));
     }
 
     @Override


### PR DESCRIPTION
This will return a ZonedDateTime of the scheduled execution time. This will allow the timer logic to determine how much extension (via reschedule) a timer would need, based on the current timer schedule.

It will return null if the timer has been cancelled.

It will return a time in the past if the timer has terminated.