### PR TITLE
Stop commons-net proliferation

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -187,12 +187,24 @@
       <artifactId>javaxcomm</artifactId>
       <version>1.0.1</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>3.12.0</version>
+      <version>3.14.0</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Servlet and JAX-RS API -->

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/pom.xml
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/pom.xml
@@ -15,6 +15,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>${commons.net.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.io.transport.serial.rxtx</artifactId>
       <version>${project.version}</version>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -370,8 +370,6 @@
 	</feature>
 
 	<feature name="openhab-runtime-base" description="openHAB Runtime Base" version="${project.version}">
-		<requirement>openhab.tp;filter:="(feature=commons-net)"</requirement>
-		<feature dependency="true">openhab.tp-commons-net</feature>
 		<feature>openhab-core-base</feature>
 		<feature>openhab-core-auth-jaas</feature>
 		<feature>openhab-core-automation-rest</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
     <bnd.version>5.2.0</bnd.version>
+    <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.2.1</eea.version>
     <karaf.compile.version>4.2.1</karaf.compile.version>
     <karaf.tooling.version>4.2.7</karaf.tooling.version>


### PR DESCRIPTION
* Exclude commons-net from core dependencies so it is no longer automatically a transitive compile dependency
* Update nrjavaserial compile dependency to a version that no longer includes commons-net packages
* Define and use commons.net.version property
* Rework features so commons-net is only installed when required

---

This stops commons-net from being automatically available on the compile classpath and in features.
That way we can stop it from being used unintentionally.

Related to:

* https://github.com/openhab/openhab-core/pull/2141
* https://github.com/openhab/openhab-addons/pull/9921
