### PR TITLE
[jsondb] Restore zero byte files from backup

### DIFF
--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
@@ -97,7 +97,7 @@ public class JsonStorage<T> implements Storage<T> {
         commitTimer = new Timer();
 
         Map<String, StorageEntry> inputMap = null;
-        if (file.exists() && file.length() > 0) {
+        if (file.exists()) {
             // Read the file
             inputMap = readDatabase(file);
         }
@@ -216,6 +216,11 @@ public class JsonStorage<T> implements Storage<T> {
 
     @SuppressWarnings("unchecked")
     private @Nullable Map<String, StorageEntry> readDatabase(File inputFile) {
+        if (inputFile.length() == 0) {
+            logger.warn("Json storage file at '{}' is empty - ignoring corrupt file.", inputFile.getAbsolutePath());
+            return null;
+        }
+
         try {
             final Map<String, StorageEntry> inputMap = new ConcurrentHashMap<>();
 

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
@@ -97,7 +97,7 @@ public class JsonStorage<T> implements Storage<T> {
         commitTimer = new Timer();
 
         Map<String, StorageEntry> inputMap = null;
-        if (file.exists()) {
+        if (file.exists() && file.length() > 0) {
             // Read the file
             inputMap = readDatabase(file);
         }


### PR DESCRIPTION
Fixes #2136

A file which has legitimately had all items removed, e.g. deleting all things from the UI, results in a 2 byte file containing just `{}`, so there should be no problem with unintentionally restoring a file from backup.

Here's an example of the output with a zero byte Things DB and a couple of zero byte backups:

```
2021-01-25 17:31:25.590 [WARN ] [re.storage.json.internal.JsonStorage] - Json storage file at '/var/lib/openhab/jsondb/org.openhab.core.thing.Thing.json' is empty - ignoring corrupt file.
2021-01-25 17:31:25.598 [INFO ] [re.storage.json.internal.JsonStorage] - Json storage file at '/var/lib/openhab/jsondb/org.openhab.core.thing.Thing.json' seems to be corrupt - checking for a backup.
2021-01-25 17:31:25.614 [WARN ] [re.storage.json.internal.JsonStorage] - Json storage file at '/var/lib/openhab/jsondb/backup/1611594982095--org.openhab.core.thing.Thing.json' is empty - ignoring corrupt file.
2021-01-25 17:31:25.627 [WARN ] [re.storage.json.internal.JsonStorage] - Json storage file at '/var/lib/openhab/jsondb/backup/1611594528039--org.openhab.core.thing.Thing.json' is empty - ignoring corrupt file.
2021-01-25 17:31:25.721 [INFO ] [re.storage.json.internal.JsonStorage] - Json storage file at '/var/lib/openhab/jsondb/backup/1611594297312--org.openhab.core.thing.Thing.json' is used (backup 3).
```

Signed-off-by: Mike Major <mike_j_major@hotmail.com>