### PR TITLE
Fix changing temperature via BasicUI (#2091)

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -1263,6 +1263,11 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
             // we require the item to define a dimension, otherwise no unit will be reported to the UIs.
             if (item instanceof NumberItem && ((NumberItem) item).getDimension() != null) {
+                if (w.getLabel() == null) {
+                    // if no Label was assigned to the Widget we fallback to the items unit
+                    return ((NumberItem) item).getUnitSymbol();
+                }
+
                 String unit = getUnitFromLabel(w.getLabel());
                 if (!UnitUtils.UNIT_PLACEHOLDER.equals(unit)) {
                     return unit;

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
+import javax.measure.quantity.Temperature;
+
 import org.eclipse.emf.common.util.BasicEList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -874,5 +876,44 @@ public class ItemUIRegistryImplTest {
                 .toStateDescription());
         defaultWidget = uiRegistry.getDefaultWidget(StringItem.class, ITEM_NAME);
         assertThat(defaultWidget, is(instanceOf(Text.class)));
+    }
+
+    @Test
+    public void getUnitForWidgetForNonNumberItem() throws Exception {
+        String unit = uiRegistry.getUnitForWidget(widget);
+
+        assertThat(unit, is(""));
+    }
+
+    @Test
+    public void getUnitForWidgetWithWidgetLabel() throws Exception {
+        // a NumberItem having a Dimension must be returned
+        NumberItem item = mock(NumberItem.class);
+        when(registry.getItem(ITEM_NAME)).thenReturn(item);
+
+        doReturn(Temperature.class).when(item).getDimension();
+
+        // we set the Label on the widget itself
+        when(widget.getLabel()).thenReturn("Label [%.1f °C]");
+
+        String unit = uiRegistry.getUnitForWidget(widget);
+
+        assertThat(unit, is(equalTo("°C")));
+    }
+
+    @Test
+    public void getUnitForWidgetWithItemLabelAndWithoutWidgetLabel() throws Exception {
+        // a NumberItem having a Dimension must be returned
+        NumberItem item = mock(NumberItem.class);
+        when(registry.getItem(ITEM_NAME)).thenReturn(item);
+
+        doReturn(Temperature.class).when(item).getDimension();
+
+        // we set the UnitSymbol on the item, this must be used as a fallback if no Widget label was used
+        when(item.getUnitSymbol()).thenReturn("°C");
+
+        String unit = uiRegistry.getUnitForWidget(widget);
+
+        assertThat(unit, is(equalTo("°C")));
     }
 }


### PR DESCRIPTION
As described in https://github.com/openhab/openhab-webui/issues/765 changing temperature via BasicUI fails as long as the widget in the sitemap doesn't have a label defined.

I debugged the issue on my openHAB instance (v3.0.0) and saw that the unit-symbol of the Item will not be used in case no label was defined and instead of this `null` will be returned.

Therefore I added a small check that will ensure that the unit-symbol of the item will be returned as long as no label is given.

Unfortunately I don't know how to test the changes, I tried replacing the corresponding JAR in the runtime directory, but seems that it doesn't work. If someone could give me some hints how I can check this in my running openHAB instance please let me know.

Anyway I added some unit-tests based on the information I was able to gather during debugging.

Fixes https://github.com/openhab/openhab-webui/issues/765