### PR TITLE
Prevent internal server error on invalid link requests on REST API

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
@@ -23,6 +23,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
 import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Trap exceptions.
@@ -35,10 +37,12 @@ import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsExtension;
 @NonNullByDefault
 public class JSONResponseExceptionMapper implements ExceptionMapper<@NonNull Exception> {
 
+    private final Logger logger = LoggerFactory.getLogger(JSONResponseExceptionMapper.class);
     private final ExceptionMapper<Exception> delegate = new JSONResponse.ExceptionMapper();
 
     @Override
     public Response toResponse(Exception e) {
+        logger.error("Unexpected exception occurred while processing REST request.", e);
         return delegate.toResponse(e);
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -141,9 +141,15 @@ public class ItemChannelLinkResource implements RESTResource {
     public Response link(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
             @PathParam("channelUID") @Parameter(description = "channelUID") String channelUid,
             @Parameter(description = "link data") @Nullable ItemChannelLinkDTO bean) {
+        ChannelUID uid;
+        try {
+            uid = new ChannelUID(channelUid);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Status.BAD_REQUEST).build();
+        }
         ItemChannelLink link;
         if (bean == null) {
-            link = new ItemChannelLink(itemName, new ChannelUID(channelUid), new Configuration());
+            link = new ItemChannelLink(itemName, uid, new Configuration());
         } else {
             if (bean.channelUID != null && !bean.channelUID.equals(channelUid)) {
                 return Response.status(Status.BAD_REQUEST).build();
@@ -151,7 +157,7 @@ public class ItemChannelLinkResource implements RESTResource {
             if (bean.itemName != null && !bean.itemName.equals(itemName)) {
                 return Response.status(Status.BAD_REQUEST).build();
             }
-            link = new ItemChannelLink(itemName, new ChannelUID(channelUid), new Configuration(bean.configuration));
+            link = new ItemChannelLink(itemName, uid, new Configuration(bean.configuration));
         }
         if (itemChannelLinkRegistry.get(link.getUID()) == null) {
             itemChannelLinkRegistry.add(link);
@@ -174,7 +180,13 @@ public class ItemChannelLinkResource implements RESTResource {
                     @ApiResponse(responseCode = "405", description = "Link not editable.") })
     public Response unlink(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
             @PathParam("channelUID") @Parameter(description = "channelUID") String channelUid) {
-        String linkId = AbstractLink.getIDFor(itemName, new ChannelUID(channelUid));
+        ChannelUID uid;
+        try {
+            uid = new ChannelUID(channelUid);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Status.BAD_REQUEST).build();
+        }
+        String linkId = AbstractLink.getIDFor(itemName, uid);
         if (itemChannelLinkRegistry.get(linkId) == null) {
             String message = "Link " + linkId + " does not exist!";
             return JSONResponse.createResponse(Status.NOT_FOUND, null, message);


### PR DESCRIPTION
This fixes the HTTP 500 error that I reported in https://github.com/openhab/openhab-webui/issues/878 and also makes sure that such errors turn up in the log file and are no longer swallowed.

Signed-off-by: Kai Kreuzer <kai@openhab.org>