### PR TITLE
[automation] Make rule engine threading configurable

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -96,7 +96,7 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
             } else {
                 re.logger.debug(
                         "The trigger '{}' of rule '{}' is triggered.  Rule failed to execute due to maximum itterations.",
-                        trigger.getId(), ruleUID, ruleStatus);
+                        trigger.getId(), ruleUID);
                 return;
             }
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -79,7 +79,7 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
             if (executor == null) {
                 return;
             }
-            if ((threadPoolSize == -1) || (RuleStatus.IDLE.equals(ruleStatus))) {
+            if ((threadPoolEnabled == false) || (RuleStatus.IDLE.equals(ruleStatus))) {
                 future = executor.submit(new TriggerData(trigger, outputs));
                 re.logger.debug("The trigger '{}' of rule '{}' is triggered. - Rule Status: '{}' - Rule Executed.",
                         trigger.getId(), ruleUID, ruleStatus);
@@ -136,7 +136,7 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
     }
 
     public void dispose() {
-        if (threadPoolSize == -1) {
+        if (threadPoolEnabled == false) {
             synchronized (this) {
                 AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                     executor.shutdownNow();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -51,12 +51,15 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
     private final RuleEngineImpl re;
 
     private final int threadPoolSize;
+    private final boolean threadPoolEnabled;
 
     protected TriggerHandlerCallbackImpl(RuleEngineImpl re, String ruleUID) {
         this.re = re;
         this.ruleUID = ruleUID;
         this.threadPoolSize = ThreadPoolManager.getConfig(AUTOMATION_THREADPOOL_NAME);
-        if (threadPoolSize == -1) {
+        this.threadPoolEnabled = ThreadPoolManager.getEnabled(AUTOMATION_THREADPOOL_NAME);
+        re.logger.debug("Automation threadpool configured as {} {}", threadPoolSize, threadPoolEnabled);
+        if (threadPoolEnabled == false) {
             re.logger.debug("Firing rule {} using single thread.", ruleUID);
             executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("rule-" + ruleUID));
         } else {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -164,7 +164,7 @@ public class ThreadPoolManager {
         return pool;
     }
 
-    protected static int getConfig(String poolName) {
+    public static int getConfig(String poolName) {
         Integer cfg = configs.get(poolName);
         return (cfg != null) ? cfg : DEFAULT_THREAD_POOL_SIZE;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -85,7 +85,7 @@ public class ThreadPoolManager {
             }
             String poolName = entry.getKey();
             Object config = entry.getValue();
-	    LOGGER.debug("Thread pool config for pool '{}' value '{}'",poolName,config);
+            LOGGER.debug("Thread pool config for pool '{}' value '{}'", poolName, config);
             if (config == null) {
                 configs.remove(poolName);
             }
@@ -104,15 +104,15 @@ public class ThreadPoolManager {
                         LOGGER.debug("Thread pool '{}' configured as {}", poolName, poolSize);
                     }
                     enabled.put(poolName, true);
-		    continue;
+                    continue;
                 } catch (NumberFormatException e) {
                     LOGGER.warn("Ignoring invalid configuration for pool '{}': {}.  Comparing as a boolean next.",
                             poolName, config);
-		}
+                }
                 try {
                     Boolean enable = Boolean.valueOf((String) config);
                     enabled.put(poolName, enable);
-		    LOGGER.debug("Thread pool '{}' configured as {}", poolName, enable);
+                    LOGGER.debug("Thread pool '{}' configured as {}", poolName, enable);
                 } catch (Exception e) {
                     LOGGER.debug(
                             "Configuration of {} for pool {} is not a boolean.  Config must be either an integer or boolean.",

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -104,6 +104,7 @@ public class ThreadPoolManager {
                         LOGGER.debug("Thread pool '{}' configured as {}", poolName, poolSize);
                     }
                     enabled.put(poolName, true);
+		    continue;
                 } catch (NumberFormatException e) {
                     LOGGER.warn("Ignoring invalid configuration for pool '{}': {}.  Comparing as a boolean next.",
                             poolName, config);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -85,6 +85,7 @@ public class ThreadPoolManager {
             }
             String poolName = entry.getKey();
             Object config = entry.getValue();
+	    LOGGER.debug("Thread pool config for pool '{}' value '{}'",poolName,config);
             if (config == null) {
                 configs.remove(poolName);
             }
@@ -103,15 +104,14 @@ public class ThreadPoolManager {
                         LOGGER.debug("Thread pool '{}' configured as {}", poolName, poolSize);
                     }
                     enabled.put(poolName, true);
-                    return;
                 } catch (NumberFormatException e) {
                     LOGGER.warn("Ignoring invalid configuration for pool '{}': {}.  Comparing as a boolean next.",
                             poolName, config);
-                }
+		}
                 try {
                     Boolean enable = Boolean.valueOf((String) config);
                     enabled.put(poolName, enable);
-                    return;
+		    LOGGER.debug("Thread pool '{}' configured as {}", poolName, enable);
                 } catch (Exception e) {
                     LOGGER.debug(
                             "Configuration of {} for pool {} is not a boolean.  Config must be either an integer or boolean.",
@@ -130,7 +130,6 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ScheduledExecutorService getScheduledPool(String poolName) {
-        LOGGER.debug("Attempting to create scheduled thread pool '{}'", poolName);
         ExecutorService pool = pools.get(poolName);
         if (pool == null) {
             synchronized (pools) {
@@ -164,7 +163,6 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ExecutorService getPool(String poolName) {
-        LOGGER.debug("Attempting to create thread pool '{}'", poolName);
         ExecutorService pool = pools.get(poolName);
         if (pool == null) {
             synchronized (pools) {


### PR DESCRIPTION
Originally submited by @kaikreuzer in https://github.com/openhab/openhab-core/pull/1857

Reverted in https://github.com/openhab/openhab-core/pull/1890 because of https://github.com/openhab/openhab-core/issues/1889.  

Users with lower memory available (Pi2/Pi3/etc) seem to be having OutOfMemory issues because of the rules engine.  See: https://community.openhab.org/t/openhab-3-runs-out-of-memory-java-heap-space-errors-cpu-100-after-a-few-hours/110924

Some users had success with the issue because of https://github.com/openhab/openhab-core/issues/2031 but others did not.

To accommodate for all variety of users, this puts the default as a threadpool but allows the user to set the pool size to "-1" to force single threading.  In theory, this should allow the full spectrum of users to have the ability to tune this for their system.

Configuration in services/runtime.cfg would be "org.openhab.threadpool:automation=-1" to disable threadpool to cover the use case of higher end systems.

I would suggest also that this be noted in the release notes as this can cause issues with users who have not been having issues in a single thread per rule environment.  Option 2 would be to set default to -1 and force users to configure a positive value to clamp it down to a threadpool.  I'm not sure where to set that default, I would need someone to either tell me where to make the code change or push a commit to my branch.