### PR TITLE
Make absolute color temperature channel type advanced

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -188,8 +188,8 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelType SYSTEM_COLOR_TEMPERATURE_ABS = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "color-temperature-abs"), "Color Temperature", "Number")
             .withDescription("Controls the color temperature of the light in Kelvin").withCategory("ColorLight")
-            .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(new BigDecimal(1000))
-                    .withMaximum(new BigDecimal(10000)).withPattern("%.0f K").build())
+            .isAdvanced(true).withStateDescriptionFragment(StateDescriptionFragmentBuilder.create()
+                    .withMinimum(new BigDecimal(1000)).withMaximum(new BigDecimal(10000)).withPattern("%.0f K").build())
             .build();
 
     // media channels


### PR DESCRIPTION
Currently, Things that support this channel type always show two color temperature channels, which looks weird and distracting to the user:

<img width="733" alt="Screenshot 2021-02-07 at 21 35 51" src="https://user-images.githubusercontent.com/3244965/107158741-7ab5ba00-698c-11eb-8c76-a7c9520d7d81.png">

As the absolute channel is an optional feature for advanced users and use cases, it should imho also only appear as an advanced channel.

Signed-off-by: Kai Kreuzer <kai@openhab.org>