### PR TITLE
Add profile to generate semantics classes with groovy-maven-plugin

### DIFF
--- a/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
+++ b/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
@@ -12,6 +12,9 @@
  */
 @Grab('com.xlson.groovycsv:groovycsv:1.1')
 import static com.xlson.groovycsv.CsvParser.parseCsv
+import java.nio.file.Paths
+
+baseDir = Paths.get(getClass().protectionDomain.codeSource.location.toURI()).getParent().getParent().toAbsolutePath()
 
 def tagSets = new TreeMap<String, String>()
 def locations = new TreeSet<String>()
@@ -19,10 +22,10 @@ def equipments = new TreeSet<String>()
 def points = new TreeSet<String>()
 def properties = new TreeSet<String>()
 
-def labelsFile = new FileWriter('../src/main/resources/tags.properties')
+def labelsFile = new FileWriter("${baseDir}/src/main/resources/tags.properties")
 labelsFile.write("# Generated content - do not edit!\n")
 
-for(line in parseCsv(new FileReader('SemanticTags.csv'), separator: ',')) {
+for(line in parseCsv(new FileReader("${baseDir}/model/SemanticTags.csv"), separator: ',')) {
     println "Processing Tag $line.Tag"
 
     def tagSet = (line.Parent ? tagSets.get(line.Parent) : line.Type) + "_" + line.Tag
@@ -61,7 +64,7 @@ def createTagSetClass(def line, String tagSet) {
     def parent = line.Parent
     def parentClass = parent ? parent : type
     def pkg = type.toLowerCase()
-    def file = new FileWriter("../src/main/java/org/openhab/core/semantics/model/" + pkg + "/" + tag + ".java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/" + pkg + "/" + tag + ".java")
     file.write(header())
     file.write("package org.openhab.core.semantics.model." + pkg + ";\n\n")
     file.write("import org.eclipse.jdt.annotation.NonNullByDefault;\n")
@@ -92,12 +95,12 @@ def appendLabelsFile(FileWriter file, def line, String tagSet) {
 }
 
 def createLocationsFile(Set<String> locations) {
-    def file = new FileWriter("../src/main/java/org/openhab/core/semantics/model/location/Locations.java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/location/Locations.java")
     file.write(header())
     file.write("""package org.openhab.core.semantics.model.location;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -132,12 +135,12 @@ public class Locations {
 }
 
 def createEquipmentsFile(Set<String> equipments) {
-    def file = new FileWriter("../src/main/java/org/openhab/core/semantics/model/equipment/Equipments.java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/equipment/Equipments.java")
     file.write(header())
     file.write("""package org.openhab.core.semantics.model.equipment;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -172,12 +175,12 @@ public class Equipments {
 }
 
 def createPointsFile(Set<String> points) {
-    def file = new FileWriter("../src/main/java/org/openhab/core/semantics/model/point/Points.java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/point/Points.java")
     file.write(header())
     file.write("""package org.openhab.core.semantics.model.point;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -212,12 +215,12 @@ public class Points {
 }
 
 def createPropertiesFile(Set<String> properties) {
-    def file = new FileWriter("../src/main/java/org/openhab/core/semantics/model/property/Properties.java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/property/Properties.java")
     file.write(header())
     file.write("""package org.openhab.core.semantics.model.property;
 
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
+++ b/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
@@ -25,7 +25,7 @@ def properties = new TreeSet<String>()
 def labelsFile = new FileWriter("${baseDir}/src/main/resources/tags.properties")
 labelsFile.write("# Generated content - do not edit!\n")
 
-for(line in parseCsv(new FileReader("${baseDir}/model/SemanticTags.csv"), separator: ',')) {
+for (line in parseCsv(new FileReader("${baseDir}/model/SemanticTags.csv"), separator: ',')) {
     println "Processing Tag $line.Tag"
 
     def tagSet = (line.Parent ? tagSets.get(line.Parent) : line.Type) + "_" + line.Tag
@@ -40,7 +40,7 @@ for(line in parseCsv(new FileReader("${baseDir}/model/SemanticTags.csv"), separa
         case "Point"               : points.add(line.Tag); break;
         case "Property"            : properties.add(line.Tag); break;
         default : println "Unrecognized type " + line.Type
-    }    
+    }
 }
 
 labelsFile.close()
@@ -51,8 +51,8 @@ createPointsFile(points)
 createPropertiesFile(properties)
 
 println "\n\nTagSets:"
-for(String tagSet : tagSets) {
-    println tagSet    
+for (String tagSet : tagSets) {
+    println tagSet
 }
 
 def createTagSetClass(def line, String tagSet) {
@@ -64,11 +64,11 @@ def createTagSetClass(def line, String tagSet) {
     def parent = line.Parent
     def parentClass = parent ? parent : type
     def pkg = type.toLowerCase()
-    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/" + pkg + "/" + tag + ".java")
+    def file = new FileWriter("${baseDir}/src/main/java/org/openhab/core/semantics/model/${pkg}/${tag}.java")
     file.write(header())
     file.write("package org.openhab.core.semantics.model." + pkg + ";\n\n")
     file.write("import org.eclipse.jdt.annotation.NonNullByDefault;\n")
-    if(!parent) {
+    if (!parent) {
             file.write("import org.openhab.core.semantics.model." + type + ";\n")
     }
     file.write("""import org.openhab.core.semantics.model.TagInfo;
@@ -88,7 +88,7 @@ public interface ${tag} extends ${parentClass} {
 
 def appendLabelsFile(FileWriter file, def line, String tagSet) {
     file.write(tagSet + "=" + line.Label)
-    if(line.Synonyms) {
+    if (line.Synonyms) {
         file.write("," + line.Synonyms.replaceAll(", ", ","))
     }
     file.write("\n")
@@ -119,10 +119,8 @@ public class Locations {
     static {
         LOCATIONS.add(Location.class);
 """)    
-    Iterator it = locations.iterator();
-    while(it.hasNext() ) {
-        String location = it.next();
-        file.write("        LOCATIONS.add(" + location + ".class);\n")
+    for (String location : locations) {
+        file.write("        LOCATIONS.add(${location}.class);\n")
     }
     file.write("""    }
 
@@ -159,10 +157,8 @@ public class Equipments {
     static {
         EQUIPMENTS.add(Equipment.class);
 """)    
-    Iterator it = equipments.iterator();
-    while(it.hasNext() ) {
-        String equipment = it.next();
-        file.write("        EQUIPMENTS.add(" + equipment + ".class);\n")
+    for (String equipment : equipments) {
+        file.write("        EQUIPMENTS.add(${equipment}.class);\n")
     }
     file.write("""    }
 
@@ -199,10 +195,8 @@ public class Points {
     static {
         POINTS.add(Point.class);
 """)    
-    Iterator it = points.iterator();
-    while(it.hasNext() ) {
-        String point = it.next();
-        file.write("        POINTS.add(" + point + ".class);\n")
+    for (String point : points) {
+        file.write("        POINTS.add(${point}.class);\n")
     }
     file.write("""    }
 
@@ -239,10 +233,8 @@ public class Properties {
     static {
         PROPERTIES.add(Property.class);
 """)    
-    Iterator it = properties.iterator();
-    while(it.hasNext() ) {
-        String property = it.next();
-        file.write("        PROPERTIES.add(" + property + ".class);\n")
+    for (String property : properties) {
+        file.write("        PROPERTIES.add(${property}.class);\n")
     }
     file.write("""    }
 

--- a/bundles/org.openhab.core.semantics/pom.xml
+++ b/bundles/org.openhab.core.semantics/pom.xml
@@ -22,4 +22,42 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>generate-tag-classes</id>
+      <activation>
+        <property>
+          <name>generateTagClasses</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmaven</groupId>
+            <artifactId>groovy-maven-plugin</artifactId>
+            <version>2.1.1</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.ivy</groupId>
+                <artifactId>ivy</artifactId>
+                <version>2.5.0</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <source>${project.basedir}/model/generateTagClasses.groovy</source>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
This way you can generate the classes with Maven when adding `-DgenerateTagClasses` to your build command.
I.e. you no longer need to have Groovy locally installed for this.
Also properly sorts the generated imports so they match the Spotless configuration.