### PR TITLE
[modbus] Modbus poolconfig handling

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
@@ -29,7 +29,7 @@ public interface ModbusManager {
      * Open communication interface to endpoint
      *
      * @param endpoint endpoint pointing to modbus slave
-     * @param configuration configuration for the endpoint
+     * @param configuration configuration for the endpoint. Use null to use default pool configuration
      * @return Communication interface for interacting with the slave
      * @throws IllegalArgumentException if there is already open communication interface with same endpoint but
      *             differing configuration
@@ -45,5 +45,5 @@ public interface ModbusManager {
      * @param endpoint endpoint to query
      * @return general connection settings of the given endpoint
      */
-    public @Nullable EndpointPoolConfiguration getEndpointPoolConfiguration(ModbusSlaveEndpoint endpoint);
+    public EndpointPoolConfiguration getEndpointPoolConfiguration(ModbusSlaveEndpoint endpoint);
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -878,7 +878,10 @@ public class ModbusManagerImpl implements ModbusManager {
             @Nullable EndpointPoolConfiguration configuration) throws IllegalArgumentException {
         boolean openCommFoundWithSameEndpointDifferentConfig = communicationInterfaces.stream()
                 .filter(comm -> comm.endpoint.equals(endpoint))
-                .anyMatch(comm -> comm.configuration != null && !comm.configuration.equals(configuration));
+                .anyMatch(comm -> !Optional.ofNullable(comm.configuration)
+                        .orElseGet(() -> DEFAULT_POOL_CONFIGURATION.apply(endpoint))
+                        .equals(Optional.ofNullable(configuration)
+                                .orElseGet(() -> DEFAULT_POOL_CONFIGURATION.apply(endpoint))));
         if (openCommFoundWithSameEndpointDifferentConfig) {
             throw new IllegalArgumentException(
                     "Communication interface is already open with different configuration to this same endpoint");

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -728,7 +728,7 @@ public class ModbusManagerImpl implements ModbusManager {
         private @Nullable EndpointPoolConfiguration configuration;
 
         @SuppressWarnings("null")
-        public ModbusCommunicationInterfaceImpl(ModbusSlaveEndpoint endpoint,
+        private ModbusCommunicationInterfaceImpl(ModbusSlaveEndpoint endpoint,
                 @Nullable EndpointPoolConfiguration configuration) {
             this.endpoint = endpoint;
             this.configuration = configuration;

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -541,9 +541,7 @@ public class ModbusManagerImpl implements ModbusManager {
         F failureCallback = task.getFailureCallback();
         int maxTries = task.getMaxTries();
         AtomicReference<@Nullable Exception> lastError = new AtomicReference<>();
-        @SuppressWarnings("null") // since cfg in lambda cannot be really null
-        long retryDelay = Optional.ofNullable(connectionFactory.getEndpointPoolConfiguration(endpoint))
-                .map(cfg -> cfg.getInterTransactionDelayMillis()).orElse(0L);
+        long retryDelay = getEndpointPoolConfiguration(endpoint).getInterTransactionDelayMillis();
 
         if (maxTries <= 0) {
             throw new IllegalArgumentException("maxTries should be positive");

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -275,6 +275,11 @@ public class ModbusManagerImpl implements ModbusManager {
     public static final long DEFAULT_SERIAL_INTER_TRANSACTION_DELAY_MILLIS = 35;
 
     /**
+     * Default connection timeout
+     */
+    public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 10_000;
+
+    /**
      * Thread naming for modbus read & write requests. Also used by the monitor thread
      */
     private static final String MODBUS_POLLER_THREAD_POOL_NAME = "modbusManagerPollerThreadPool";
@@ -301,6 +306,7 @@ public class ModbusManagerImpl implements ModbusManager {
                 EndpointPoolConfiguration endpointPoolConfig = new EndpointPoolConfiguration();
                 endpointPoolConfig.setInterTransactionDelayMillis(DEFAULT_TCP_INTER_TRANSACTION_DELAY_MILLIS);
                 endpointPoolConfig.setConnectMaxTries(Modbus.DEFAULT_RETRIES);
+                endpointPoolConfig.setConnectTimeoutMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS);
                 return endpointPoolConfig;
             }
 
@@ -311,6 +317,7 @@ public class ModbusManagerImpl implements ModbusManager {
                 endpointPoolConfig.setReconnectAfterMillis(-1);
                 endpointPoolConfig.setInterTransactionDelayMillis(DEFAULT_SERIAL_INTER_TRANSACTION_DELAY_MILLIS);
                 endpointPoolConfig.setConnectMaxTries(Modbus.DEFAULT_RETRIES);
+                endpointPoolConfig.setConnectTimeoutMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS);
                 return endpointPoolConfig;
             }
 
@@ -319,6 +326,7 @@ public class ModbusManagerImpl implements ModbusManager {
                 EndpointPoolConfiguration endpointPoolConfig = new EndpointPoolConfiguration();
                 endpointPoolConfig.setInterTransactionDelayMillis(DEFAULT_TCP_INTER_TRANSACTION_DELAY_MILLIS);
                 endpointPoolConfig.setConnectMaxTries(Modbus.DEFAULT_RETRIES);
+                endpointPoolConfig.setConnectTimeoutMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS);
                 return endpointPoolConfig;
             }
         });


### PR DESCRIPTION
Small fixes and consistency improvements when utilizing default `EndpointPoolConfiguration`, i.e. creating `newModbusCommunicationInterface` with `null` configuration.

Note: this code path is never executed with real openHAB bindings as they always construct `EndpointPoolConfiguration` explicitly. https://github.com/openhab/openhab-addons/pull/10147 ensures that all  `EndpointPoolConfiguration` parameters have the correct defaults