### PR TITLE
Fix sitemap proxy URL provided by Rest API

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -618,7 +618,7 @@ public class SitemapResource
         if (uri.getPort() >= 0) {
             sb.append(":").append(uri.getPort());
         }
-        sb.append("/proxy?sitemap=").append(sitemapName).append(".sitemap&widgetId=").append(wId);
+        sb.append("/proxy?sitemap=").append(sitemapName).append("&widgetId=").append(wId);
         return sb.toString();
     }
 


### PR DESCRIPTION
Resolves issue with interfaces that use the API to generate content.   

https://github.com/openhab/openhab-core/pull/2178#issuecomment-779386044

The problem is the rest api adds a .sitemap extension to sitemaps, so this will now fail with the new proxy that does it's lookups based on name, not relying on the .sitemap extension to know it was file generated.   

This brings the API in line with everything else.   