### PR TITLE
Fix MQTT QoS levels setting

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
@@ -88,9 +88,9 @@ public abstract class MqttAsyncClientWrapper {
     protected MqttQos getMqttQosFromInt(int qos) {
         switch (qos) {
             case 0:
-                return MqttQos.AT_LEAST_ONCE;
-            case 1:
                 return MqttQos.AT_MOST_ONCE;
+            case 1:
+                return MqttQos.AT_LEAST_ONCE;
             case 2:
                 return MqttQos.EXACTLY_ONCE;
             default:


### PR DESCRIPTION
Solves issue #2145 "io transport mqtt sets wrong QoS levels to hiveMQ" 
https://github.com/openhab/openhab-core/issues/2145

Fix is simply exchanging the enum values returned for the case 0 and case 1 branches, as they have been mixed up as compared to the mqtt specification:

> According to https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/, the QoS levels are:
> 
> - At most once (0)
> - At least once (1)
> - Exactly once (2)
