### PR TITLE
[automation] Added automation script StartLevels

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.jetbrains.annotations.NotNull;
+import org.openhab.core.service.StartLevelService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Script File wrapper offering various methods to inspect the script
+ *
+ * @author Jonathan Gilbert - initial contribution
+ */
+@NonNullByDefault
+public class ScriptFileReference implements Comparable<ScriptFileReference> {
+
+    private static final Set<String> EXCLUDED_FILE_EXTENSIONS = new HashSet<>(
+            Arrays.asList("txt", "old", "example", "backup", "md", "swp", "tmp", "bak"));
+
+    private static final Pattern[] startLevelPatterns = new Pattern[] { Pattern.compile(".*/sl(\\d{2})/[^/]+"), // script
+                                                                                                                // in
+                                                                                                                // immediate
+                                                                                                                // slXX
+                                                                                                                // directory
+            Pattern.compile(".*/[^/]+\\.sl(\\d{2})\\.[^/.]+") // script named <name>.slXX.<ext>
+    };
+
+    private static final Logger logger = LoggerFactory.getLogger(ScriptFileReference.class);
+
+    private final URL scriptFileURL;
+
+    public ScriptFileReference(URL scriptFileURL) {
+        this.scriptFileURL = scriptFileURL;
+    }
+
+    public URL getScriptFileURL() {
+        return scriptFileURL;
+    }
+
+    public int getStartLevel() {
+        for (Pattern p : startLevelPatterns) {
+            Matcher m = p.matcher(scriptFileURL.getPath());
+            if (m.find() && m.groupCount() > 0) {
+                try {
+                    return Integer.parseInt(m.group(1));
+                } catch (NumberFormatException nfe) {
+                    logger.warn("Extracted start level {} from {}, but it's not an integer. Ignoring.", m.group(1),
+                            scriptFileURL.getPath());
+                }
+            }
+        }
+
+        return StartLevelService.STARTLEVEL_RULEENGINE;
+    }
+
+    public Optional<String> getScriptType() {
+        String fileName = scriptFileURL.getPath();
+        int index = fileName.lastIndexOf(".");
+        if (index == -1) {
+            return Optional.empty();
+        }
+        String fileExtension = fileName.substring(index + 1);
+
+        // ignore known file extensions for "temp" files
+        if (EXCLUDED_FILE_EXTENSIONS.contains(fileExtension) || fileExtension.endsWith("~")) {
+            return Optional.empty();
+        }
+        return Optional.of(fileExtension);
+    }
+
+    public String getScriptIdentifier() {
+        return scriptFileURL.toString();
+    }
+
+    @Override
+    public int compareTo(@NotNull ScriptFileReference other) {
+        try {
+            Path path1 = Paths.get(scriptFileURL.toURI());
+            String name1 = path1.getFileName().toString();
+            logger.trace("o1 [{}], path1 [{}], name1 [{}]", scriptFileURL, path1, name1);
+
+            Path path2 = Paths.get(other.scriptFileURL.toURI());
+            String name2 = path2.getFileName().toString();
+            logger.trace("o2 [{}], path2 [{}], name2 [{}]", other.scriptFileURL, path2, name2);
+
+            int nameCompare = name1.compareToIgnoreCase(name2);
+            if (nameCompare != 0) {
+                return nameCompare;
+            } else {
+                return path1.getParent().toString().compareToIgnoreCase(path2.getParent().toString());
+            }
+        } catch (URISyntaxException e) {
+            logger.error("URI syntax exception", e);
+            return 0;
+        }
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implementation of {@link ScheduledExecutorService} which simply delegates to the instance supplied.
+ *
+ * @author Jonathan Gilbert - initial contribution
+ */
+public class DelegatingScheduledExecutorService implements ScheduledExecutorService {
+    private ScheduledExecutorService delegate;
+
+    public DelegatingScheduledExecutorService(ScheduledExecutorService delegate) {
+        this.delegate = delegate;
+    }
+
+    @NotNull
+    @Override
+    public ScheduledFuture<?> schedule(@NotNull Runnable command, long delay, @NotNull TimeUnit unit) {
+        return delegate.schedule(command, delay, unit);
+    }
+
+    @NotNull
+    @Override
+    public <V> ScheduledFuture<V> schedule(@NotNull Callable<V> callable, long delay, @NotNull TimeUnit unit) {
+        return delegate.schedule(callable, delay, unit);
+    }
+
+    @NotNull
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(@NotNull Runnable command, long initialDelay, long period,
+            @NotNull TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @NotNull
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(@NotNull Runnable command, long initialDelay, long delay,
+            @NotNull TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @NotNull
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, @NotNull TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @NotNull
+    @Override
+    public <T> Future<T> submit(@NotNull Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @NotNull
+    @Override
+    public <T> Future<T> submit(@NotNull Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @NotNull
+    @Override
+    public Future<?> submit(@NotNull Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @NotNull
+    @Override
+    public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @NotNull
+    @Override
+    public <T> List<Future<T>> invokeAll(@NotNull Collection<? extends Callable<T>> tasks, long timeout,
+            @NotNull TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @NotNull
+    @Override
+    public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(@NotNull Collection<? extends Callable<T>> tasks, long timeout, @NotNull TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(@NotNull Runnable command) {
+        delegate.execute(command);
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileWatcherTest.java
@@ -1,0 +1,325 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.script.ScriptEngine;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.openhab.core.automation.module.script.ScriptDependencyListener;
+import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.ReadyService;
+import org.openhab.core.service.StartLevelService;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Test for Script File Watcher, covering differing start levels and dependency tracking
+ *
+ * @author Jonathan Gilbert - initial contribution
+ */
+class ScriptFileWatcherTest {
+
+    private ScriptFileWatcher scriptFileWatcher;
+    private ScriptEngineManager scriptEngineManager;
+    private DependencyTracker dependencyTracker;
+    private ReadyService readyService;
+
+    @TempDir
+    Path tempScriptDir;
+
+    @BeforeEach
+    public void setUp() {
+        scriptEngineManager = mock(ScriptEngineManager.class);
+        dependencyTracker = mock(DependencyTracker.class);
+        readyService = mock(ReadyService.class);
+        scriptFileWatcher = new ScriptFileWatcher(scriptEngineManager, dependencyTracker, readyService);
+        scriptFileWatcher.activate();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        scriptFileWatcher.deactivate();
+    }
+
+    protected Path getFile(String name) {
+        Path tempFile = tempScriptDir.resolve(name);
+        try {
+            File parent = tempFile.getParent().toFile();
+
+            if (!parent.exists() && !parent.mkdirs()) {
+                fail("Failed to create parent directories");
+            }
+
+            if (!tempFile.toFile().createNewFile()) {
+                fail("Failed to create temp script file");
+            }
+        } catch (IOException e) {
+            throw new AssertionFailedError("Failed to create temp script file: " + e.getMessage());
+        }
+        return Path.of(tempFile.toUri());
+    }
+
+    void updateStartLevel(int level) {
+        scriptFileWatcher
+                .onReadyMarkerAdded(new ReadyMarker(StartLevelService.STARTLEVEL_MARKER_TYPE, Integer.toString(level)));
+    }
+
+    @Test
+    public void testLoadOneDefaultFileAlreadyStarted() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        updateStartLevel(100);
+
+        Path p = getFile("script.js");
+
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        verify(scriptEngineManager).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testLoadOneDefaultFileWaitUntilStarted() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p = getFile("script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        // verify is called when the start level increases
+        updateStartLevel(100);
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testLoadOneCustomFileWaitUntilStarted() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        updateStartLevel(50);
+
+        Path p = getFile("script.sl60.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        // verify is called when the start level increases
+        updateStartLevel(100);
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testLoadTwoCustomFilesDifferentStartLevels() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p1 = getFile("script.sl70.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p1);
+        Path p2 = getFile("script.sl50.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p2);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        updateStartLevel(40);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        updateStartLevel(60);
+
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), eq(p1.toFile().toURI().toString()));
+
+        updateStartLevel(80);
+
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testLoadTwoCustomFilesAlternativePatternDifferentStartLevels() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p1 = getFile("sl70/script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p1);
+        Path p2 = getFile("sl50/script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p2);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        updateStartLevel(40);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        updateStartLevel(60);
+
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), eq(p1.toFile().toURI().toString()));
+
+        updateStartLevel(80);
+
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testLoadOneDefaultFileDelayedSupport() {
+
+        // set an executor which captures the scheduled task
+        ScheduledExecutorService scheduledExecutorService = spy(
+                new DelegatingScheduledExecutorService(Executors.newSingleThreadScheduledExecutor()));
+        ArgumentCaptor<Runnable> scheduledTask = ArgumentCaptor.forClass(Runnable.class);
+        scriptFileWatcher.setExecuterFactory(() -> scheduledExecutorService);
+
+        when(scriptEngineManager.isSupported("js")).thenReturn(false);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+        updateStartLevel(100);
+
+        verify(scheduledExecutorService).scheduleWithFixedDelay(scheduledTask.capture(), anyLong(), anyLong(), any());
+
+        Path p = getFile("script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        // verify not yet called
+        verify(scriptEngineManager, never()).createScriptEngine(anyString(), anyString());
+
+        // add support is added for .js files
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        // update (in current thread)
+        scheduledTask.getValue().run();
+
+        // verify script has now been processed
+        verify(scriptEngineManager, times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testOrderingWithinSingleStartLevel() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p64 = getFile("script.sl64.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p64);
+        Path p66 = getFile("script.sl66.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p66);
+        Path p65 = getFile("script.sl65.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p65);
+
+        updateStartLevel(70);
+
+        InOrder inOrder = inOrder(scriptEngineManager);
+
+        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+                p64.toFile().toURI().toString());
+        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+                p65.toFile().toURI().toString());
+        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+                p66.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testReloadActiveWhenDependencyChanged() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        updateStartLevel(100);
+
+        Path p = getFile("script.js");
+
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        scriptFileWatcher.onDependencyChange(p.toFile().toURI().toString());
+
+        verify(scriptEngineManager, times(2)).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testNotReloadInactiveWhenDependencyChanged() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p = getFile("script.js");
+
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        scriptFileWatcher.onDependencyChange(p.toFile().toURI().toString());
+
+        verify(scriptEngineManager, never()).createScriptEngine("js", p.toFile().toURI().toString());
+    }
+
+    @Test
+    public void testRegisterDependency() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        updateStartLevel(100);
+
+        Path p = getFile("script.js");
+
+        when(scriptEngineContainer.getIdentifier()).thenReturn(p.toFile().toURI().toString());
+
+        // capture and run the listener
+        ArgumentCaptor<ScriptDependencyListener> listener = ArgumentCaptor.forClass(ScriptDependencyListener.class);
+
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
+
+        verify(scriptEngineManager).loadScript(eq(p.toFile().toURI().toString()), any(), listener.capture());
+
+        listener.getValue().accept("test");
+
+        // verify the dependency was tracked
+        verify(dependencyTracker).addLibForScript(p.toFile().toURI().toString(), "test");
+    }
+}


### PR DESCRIPTION
Allows scripts to specify per-script start levels (which differ from the start level for the `ScriptFileWatcher` itself). Also extracted various functionality from ScriptFileWatcher into distinct components & added unit tests to cover all script loading functionality.

This fixes #2002 and possibly #1983 too. The vast majority of the new LOC are unit tests.

Signed-off-by: jpg0 <jpg@trillica.com>
