### PR TITLE
[automation] Sink might be null

### DIFF
--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
@@ -44,7 +44,7 @@ public class PlayActionHandler extends BaseActionModuleHandler {
     private final AudioManager audioManager;
 
     private final String sound;
-    private final String sink;
+    private final @Nullable String sink;
     private final @Nullable PercentType volume;
 
     public PlayActionHandler(Action module, AudioManager audioManager) {
@@ -52,7 +52,9 @@ public class PlayActionHandler extends BaseActionModuleHandler {
         this.audioManager = audioManager;
 
         this.sound = module.getConfiguration().get(PARAM_SOUND).toString();
-        this.sink = module.getConfiguration().get(PARAM_SINK).toString();
+
+        Object sinkParam = module.getConfiguration().get(PARAM_SINK);
+        this.sink = sinkParam != null ? sinkParam.toString() : null;
 
         Object volumeParam = module.getConfiguration().get(PARAM_VOLUME);
         this.volume = volumeParam instanceof BigDecimal ? new PercentType((BigDecimal) volumeParam) : null;

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
@@ -39,15 +39,17 @@ public class SayActionHandler extends BaseActionModuleHandler {
     private final VoiceManager voiceManager;
 
     private final String text;
-    private final String sink;
+    private final @Nullable String sink;
     private final @Nullable PercentType volume;
 
     public SayActionHandler(Action module, VoiceManager voiceManager) {
         super(module);
         this.voiceManager = voiceManager;
 
-        text = module.getConfiguration().get(PARAM_TEXT).toString();
-        sink = module.getConfiguration().get(PARAM_SINK).toString();
+        this.text = module.getConfiguration().get(PARAM_TEXT).toString();
+
+        Object sinkParam = module.getConfiguration().get(PARAM_SINK);
+        this.sink = sinkParam != null ? sinkParam.toString() : null;
 
         Object volumeParam = module.getConfiguration().get(PARAM_VOLUME);
         this.volume = volumeParam instanceof BigDecimal ? new PercentType((BigDecimal) volumeParam) : null;


### PR DESCRIPTION
- sink might be null

Otherwise you cannot use the action without specifying a sink:

![grafik](https://user-images.githubusercontent.com/5131747/109957632-84111880-7ce5-11eb-8e51-e838a58b0d7f.png)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>