### PR TITLE
Upgrade Jackson to 2.12.2

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -16,7 +16,7 @@
   <name>openHAB Core :: BOM :: Runtime</name>
 
   <properties>
-    <jackson.version>2.10.3</jackson.version>
+    <jackson.version>2.12.2</jackson.version>
     <jetty.version>9.4.20.v20190813</jetty.version>
     <pax.web.version>7.2.19</pax.web.version>
     <swagger.version>2.1.0</swagger.version>
@@ -947,6 +947,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-cbor</artifactId>
       <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -78,17 +78,18 @@
 	</feature>
 
 	<feature name="openhab.tp-jackson" description="FasterXML Jackson bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jackson;version=2.10.3</capability>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.10.3</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.10.3</bundle>
-		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.26</bundle>
+		<capability>openhab.tp;feature=jackson;version=2.12.2</capability>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.12.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.12.2</bundle>
+		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.27</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jax-rs-whiteboard" version="${project.version}">


### PR DESCRIPTION
Upgrades Jackson from 2.10.3 to 2.12.2.

For release notes see:

* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.10
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.11
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12

Also adds jackson-dataformat-cbor to the feature and runtime BOM so it can be more easily managed as it is a small bundle that is used by a few add-ons.