### PR TITLE
Upgrade Swagger to 2.1.7

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <jetty.version>9.4.20.v20190813</jetty.version>
-    <swagger.version>2.1.0</swagger.version>
+    <swagger.version>2.1.7</swagger.version>
   </properties>
 
   <dependencies>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -19,7 +19,7 @@
     <jackson.version>2.12.2</jackson.version>
     <jetty.version>9.4.20.v20190813</jetty.version>
     <pax.web.version>7.2.19</pax.web.version>
-    <swagger.version>2.1.0</swagger.version>
+    <swagger.version>2.1.7</swagger.version>
   </properties>
 
   <dependencyManagement>
@@ -1021,13 +1021,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.26.0-GA</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.12</version>
+      <version>3.27.0-GA</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -240,18 +240,17 @@
 	</feature>
 
 	<feature name="openhab.tp-swagger-jaxrs" description="JAX-RS Whiteboard Swagger Support" version="${project.version}">
-		<capability>openhab.tp;feature=swagger-jaxrs;version=2.1.0</capability>
+		<capability>openhab.tp;feature=swagger-jaxrs;version=2.1.7</capability>
 		<feature dependency="true">openhab.tp-jax-rs-whiteboard</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.1.0</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.1.0</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.0</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.0</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.0</bundle>
-		<bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
-		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.11</bundle>
-		<bundle dependency="true">mvn:org.javassist/javassist/3.26.0-GA</bundle>
-		<bundle dependency="true">mvn:org.reflections/reflections/0.9.12</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.1.7</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.1.7</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.7</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.7</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.7</bundle>
+		<bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/2.0.2</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.12.0</bundle>
+		<bundle dependency="true">mvn:org.javassist/javassist/3.27.0-GA</bundle>
 	</feature>
 
 </features>


### PR DESCRIPTION
Upgrades Swagger from 2.1.0 to 2.1.7 .

See the tags on GitHub for release notes, e.g.:

https://github.com/swagger-api/swagger-core/releases/tag/v2.1.7