### PR TITLE
Fix createChannelBuilders not using overriden label/description

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
@@ -134,32 +134,11 @@ public class ThingFactoryHelper {
 
     private static Channel createChannel(ChannelDefinition channelDefinition, ThingUID thingUID, String groupId,
             ConfigDescriptionRegistry configDescriptionRegistry) {
-        ChannelType type = withChannelTypeRegistry(channelTypeRegistry -> {
-            return (channelTypeRegistry != null)
-                    ? channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID())
-                    : null;
-        });
-        if (type == null) {
-            logger.warn(
-                    "Could not create channel '{}' for thing type '{}', because channel type '{}' could not be found.",
-                    channelDefinition.getId(), thingUID, channelDefinition.getChannelTypeUID());
-            return null;
-        }
-
         final ChannelUID channelUID = new ChannelUID(thingUID, groupId, channelDefinition.getId());
-        final ChannelBuilder channelBuilder = createChannelBuilder(channelUID, type, configDescriptionRegistry);
-
-        // If we want to override the label, add it...
-        final String label = channelDefinition.getLabel();
-        if (label != null) {
-            channelBuilder.withLabel(label);
-        }
-
-        // If we want to override the description, add it...
-        final String description = channelDefinition.getDescription();
-        if (description != null) {
-            channelBuilder.withDescription(description);
-        }
+        final ChannelBuilder channelBuilder = createChannelBuilder(channelUID, channelDefinition,
+                configDescriptionRegistry);
+        if (channelBuilder == null)
+            return null;
 
         return channelBuilder.withProperties(channelDefinition.getProperties()).build();
     }
@@ -188,9 +167,20 @@ public class ThingFactoryHelper {
         return channelBuilder;
     }
 
-    static ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelType channelType,
-            ChannelDefinition channelDefinition, ConfigDescriptionRegistry configDescriptionRegistry,
-            ChannelTypeRegistry channelTypeRegistry) {
+    static ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelDefinition channelDefinition,
+            ConfigDescriptionRegistry configDescriptionRegistry) {
+
+        ChannelType channelType = withChannelTypeRegistry(channelTypeRegistry -> {
+            return (channelTypeRegistry != null)
+                    ? channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID())
+                    : null;
+        });
+        if (channelType == null) {
+            logger.warn("Could not create channel '{}', because channel type '{}' could not be found.",
+                    channelDefinition.getId(), channelDefinition.getChannelTypeUID());
+            return null;
+        }
+
         String label = channelDefinition.getLabel();
         if (label == null)
             label = channelType.getLabel();

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
@@ -188,6 +188,38 @@ public class ThingFactoryHelper {
         return channelBuilder;
     }
 
+    static ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelType channelType,
+            ChannelDefinition channelDefinition, ConfigDescriptionRegistry configDescriptionRegistry,
+            ChannelTypeRegistry channelTypeRegistry) {
+        String label = channelDefinition.getLabel();
+        if (label == null)
+            label = channelType.getLabel();
+
+        final ChannelBuilder channelBuilder = ChannelBuilder.create(channelUID, channelType.getItemType()) //
+                .withType(channelType.getUID()) //
+                .withDefaultTags(channelType.getTags()) //
+                .withKind(channelType.getKind()) //
+                .withLabel(label) //
+                .withAutoUpdatePolicy(channelType.getAutoUpdatePolicy());
+
+        String description = channelDefinition.getDescription();
+        if (description == null) {
+            description = channelType.getDescription();
+        }
+        if (description != null) {
+            channelBuilder.withDescription(description);
+        }
+
+        // Initialize channel configuration with default-values
+        if (channelType.getConfigDescriptionURI() != null) {
+            final Configuration configuration = new Configuration();
+            applyDefaultConfiguration(configuration, channelType, configDescriptionRegistry);
+            channelBuilder.withConfiguration(configuration);
+        }
+
+        return channelBuilder;
+    }
+
     /**
      * Apply the {@link ThingType}'s default values to the given {@link Configuration}.
      *

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -336,8 +336,10 @@ public class ThingManagerImpl
                 ChannelType channelType = channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID());
                 if (channelType != null) {
                     ChannelUID channelUID = new ChannelUID(channelGroupUID, channelDefinition.getId());
-                    channelBuilders.add(ThingFactoryHelper.createChannelBuilder(channelUID, channelType,
-                            channelDefinition, configDescriptionRegistry, channelTypeRegistry));
+                    ChannelBuilder channelBuilder = ThingFactoryHelper.createChannelBuilder(channelUID,
+                            channelDefinition, configDescriptionRegistry);
+                    if (channelBuilder != null)
+                        channelBuilders.add(channelBuilder);
                 }
             }
             return channelBuilders;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -337,7 +337,7 @@ public class ThingManagerImpl
                 if (channelType != null) {
                     ChannelUID channelUID = new ChannelUID(channelGroupUID, channelDefinition.getId());
                     channelBuilders.add(ThingFactoryHelper.createChannelBuilder(channelUID, channelType,
-                            configDescriptionRegistry));
+                            channelDefinition, configDescriptionRegistry, channelTypeRegistry));
                 }
             }
             return channelBuilders;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -102,6 +102,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
 
     private static final String BINDING_ID = "binding";
     private static final String CHANNEL_ID = "channel";
+    private static final String CHANNEL2_ID = "channel2";
 
     private static final ChannelTypeUID CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, CHANNEL_ID);
 
@@ -116,6 +117,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private static final ThingUID BRIDGE_UID = new ThingUID(BRIDGE_TYPE_UID, "bridge");
 
     private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, CHANNEL_ID);
+    private static final ChannelUID CHANNEL2_UID = new ChannelUID(THING_UID, CHANNEL2_ID);
 
     private static final ChannelGroupUID CHANNEL_GROUP_UID = new ChannelGroupUID(THING_UID, CHANNEL_GROUP_ID);
 
@@ -291,18 +293,29 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         List<ChannelBuilder> channelBuilders = thc.get().createChannelBuilders(CHANNEL_GROUP_UID,
                 CHANNEL_GROUP_TYPE_UID);
         assertNotNull(channelBuilders);
-        assertEquals(1, channelBuilders.size());
+        assertEquals(2, channelBuilders.size());
 
-        for (ChannelBuilder channelBuilder : channelBuilders) {
-            assertNotNull(channelBuilder);
-            validateChannel(channelBuilder.build());
-        }
+        assertNotNull(channelBuilders.get(0));
+        validateChannel(channelBuilders.get(0).build());
+        assertNotNull(channelBuilders.get(1));
+        validateChannelOverridden(channelBuilders.get(1).build());
     }
 
     private void validateChannel(Channel channel) {
         assertNotNull(channel);
         assertEquals("Test Label", channel.getLabel());
         assertEquals("Test Description", channel.getDescription());
+        assertEquals("Switch", channel.getAcceptedItemType());
+        assertEquals(CHANNEL_TYPE_UID, channel.getChannelTypeUID());
+        assertNotNull(channel.getDefaultTags());
+        assertEquals(1, channel.getDefaultTags().size());
+        assertEquals("Test Tag", channel.getDefaultTags().iterator().next());
+    }
+
+    private void validateChannelOverridden(Channel channel) {
+        assertNotNull(channel);
+        assertEquals("Test Label Overridden", channel.getLabel());
+        assertEquals("Test Description Overridden", channel.getDescription());
         assertEquals("Switch", channel.getAcceptedItemType());
         assertEquals(CHANNEL_TYPE_UID, channel.getChannelTypeUID());
         assertNotNull(channel.getDefaultTags());
@@ -1035,7 +1048,9 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private void registerChannelGroupTypeProvider() throws Exception {
         ChannelGroupType channelGroupType = ChannelGroupTypeBuilder.instance(CHANNEL_GROUP_TYPE_UID, "Test Group Label")
                 .withDescription("Test Group Description").withCategory("Test Group Category")
-                .withChannelDefinitions(List.of(new ChannelDefinitionBuilder(CHANNEL_ID, CHANNEL_TYPE_UID).build()))
+                .withChannelDefinitions(List.of(new ChannelDefinitionBuilder(CHANNEL_ID, CHANNEL_TYPE_UID).build(),
+                        new ChannelDefinitionBuilder(CHANNEL2_ID, CHANNEL_TYPE_UID).withLabel("Test Label Overridden")
+                                .withDescription("Test Description Overridden").build()))
                 .build();
 
         ChannelGroupTypeProvider mockChannelGroupTypeProvider = mock(ChannelGroupTypeProvider.class);


### PR DESCRIPTION
Fixes createChannelBuilders not using the overridden label/description (#2225)

Below example would lead to a channel with label "Original Label", with the new code it will lead to "Label Overridden" as expected.

thing-types.xml
```
	<channel-group-type id="channel_group_type_example">
		<label>Channel Group Type Example</label>
		<channels>
			<channel id="channel_example" typeId="channel_type_example">
				<label>Label Overridden</label>
			</channel>
                </channels>
        </channel-group-type>

        <channel-type id="channel_type_example">
		<item-type>String</item-type>
		<label>Original Label</label>
	</channel-type>
```

In the ThingHandler:
```
    void updateChannels() {
        List<Channel> toBeAddedChannels = new ArrayList<>();
        toBeAddedChannels.addAll(createChannelsForGroup(groupID, CHANNEL_GROUP_TYPE_EXTRUDER));
    }

    private List<Channel> createChannelsForGroup(String channelGroupId, ChannelGroupTypeUID channelGroupTypeUID) {
        List<Channel> channels = new ArrayList<>();
        ThingHandlerCallback callback = getCallback();
        if (callback != null) {
            for (ChannelBuilder channelBuilder : callback.createChannelBuilders(
                    new ChannelGroupUID(getThing().getUID(), channelGroupId), channelGroupTypeUID)) {
                channels.add(channelBuilder.build());
            }
        }
        return channels;
    }
```
