### PR TITLE
Added nullness annotations to fix NPE in HttpServiceUtil

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/HttpServiceUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/HttpServiceUtil.java
@@ -13,7 +13,6 @@
 package org.openhab.core.net;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
@@ -38,77 +37,74 @@ public class HttpServiceUtil {
      * @param bc the bundle context used for lookup
      * @return the port if used, -1 if no port could be found
      */
-    public static int getHttpServicePort(final @Nullable BundleContext bc) {
+    public static int getHttpServicePort(final BundleContext bc) {
         return getHttpServicePortProperty(bc, "org.osgi.service.http.port");
     }
 
-    public static int getHttpServicePortSecure(final @Nullable BundleContext bc) {
+    public static int getHttpServicePortSecure(final BundleContext bc) {
         return getHttpServicePortProperty(bc, "org.osgi.service.http.port.secure");
     }
 
     // Utility method that could be used for non-secure and secure port.
-    private static int getHttpServicePortProperty(final @Nullable BundleContext bc, final String propertyName) {
-        if (bc != null) {
-            // Try to find the port by using the service property (respect service ranking).
-            final ServiceReference<?>[] refs;
-            try {
-                refs = bc.getAllServiceReferences("org.osgi.service.http.HttpService", null);
-            } catch (final InvalidSyntaxException ex) {
-                // This point of code should never be reached.
-                final Logger logger = LoggerFactory.getLogger(HttpServiceUtil.class);
-                logger.warn(
-                        "This error should only be thrown if a filter could not be parsed. We don't use a filter...");
-                return -1;
-            }
-
-            Object value;
-            int port = -1;
-
-            if (refs != null) {
-                int candidate = Integer.MIN_VALUE;
-                for (final ServiceReference<?> ref : refs) {
-                    value = ref.getProperty(propertyName);
-                    if (value == null) {
-                        continue;
-                    }
-                    final int servicePort;
-                    try {
-                        servicePort = Integer.parseInt(value.toString());
-                    } catch (final NumberFormatException ex) {
-                        continue;
-                    }
-                    value = ref.getProperty(Constants.SERVICE_RANKING);
-                    final int serviceRanking;
-                    if (value == null || !(value instanceof Integer)) {
-                        serviceRanking = 0;
-                    } else {
-                        serviceRanking = (Integer) value;
-                    }
-                    if (serviceRanking >= candidate) {
-                        candidate = serviceRanking;
-                        port = servicePort;
-                    }
-                }
-            }
-            if (port > 0) {
-                return port;
-            }
-
-            // If the service does not provide the port, try to use the system property.
-            value = bc.getProperty(propertyName);
-            if (value != null) {
-                if (value instanceof String) {
-                    try {
-                        return Integer.parseInt(value.toString());
-                    } catch (final NumberFormatException ex) {
-                        // If the property could not be parsed, the HTTP servlet itself has to care and warn about.
-                    }
-                } else if (value instanceof Integer) {
-                    return (Integer) value;
-                }
-            }
-
+    private static int getHttpServicePortProperty(final BundleContext bc, final String propertyName) {
+        // Try to find the port by using the service property (respect service ranking).
+        final ServiceReference<?>[] refs;
+        try {
+            refs = bc.getAllServiceReferences("org.osgi.service.http.HttpService", null);
+        } catch (final InvalidSyntaxException ex) {
+            // This point of code should never be reached.
+            final Logger logger = LoggerFactory.getLogger(HttpServiceUtil.class);
+            logger.warn("This error should only be thrown if a filter could not be parsed. We don't use a filter...");
+            return -1;
         }
+
+        Object value;
+        int port = -1;
+
+        if (refs != null) {
+            int candidate = Integer.MIN_VALUE;
+            for (final ServiceReference<?> ref : refs) {
+                value = ref.getProperty(propertyName);
+                if (value == null) {
+                    continue;
+                }
+                final int servicePort;
+                try {
+                    servicePort = Integer.parseInt(value.toString());
+                } catch (final NumberFormatException ex) {
+                    continue;
+                }
+                value = ref.getProperty(Constants.SERVICE_RANKING);
+                final int serviceRanking;
+                if (value == null || !(value instanceof Integer)) {
+                    serviceRanking = 0;
+                } else {
+                    serviceRanking = (Integer) value;
+                }
+                if (serviceRanking >= candidate) {
+                    candidate = serviceRanking;
+                    port = servicePort;
+                }
+            }
+        }
+        if (port > 0) {
+            return port;
+        }
+
+        // If the service does not provide the port, try to use the system property.
+        value = bc.getProperty(propertyName);
+        if (value != null) {
+            if (value instanceof String) {
+                try {
+                    return Integer.parseInt(value.toString());
+                } catch (final NumberFormatException ex) {
+                    // If the property could not be parsed, the HTTP servlet itself has to care and warn about.
+                }
+            } else if (value instanceof Integer) {
+                return (Integer) value;
+            }
+        }
+
         return -1;
     }
 }


### PR DESCRIPTION
- Added nullness annotations to fix NPE in `HttpServiceUtil`

```
2021-03-12 12:28:48.124 [ERROR] [core.thing.internal.ThingManagerImpl] - Exception occurred while calling thing handler factory 'org.openhab.binding.chromecast.internal.factory.ChromecastHandlerFactory@6a197e': null
java.lang.NullPointerException: null
	at org.openhab.core.net.HttpServiceUtil.getHttpServicePortProperty(HttpServiceUtil.java:54) ~[?:?]
	at org.openhab.core.net.HttpServiceUtil.getHttpServicePort(HttpServiceUtil.java:39) ~[?:?]
	at org.openhab.binding.chromecast.internal.factory.ChromecastHandlerFactory.createCallbackUrl(ChromecastHandlerFactory.java:101) ~[?:?]
	at org.openhab.binding.chromecast.internal.factory.ChromecastHandlerFactory.createHandler(ChromecastHandlerFactory.java:80) ~[?:?]
	at org.openhab.core.thing.binding.BaseThingHandlerFactory.registerHandler(BaseThingHandlerFactory.java:129) ~[bundleFile:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.doRegisterHandler(ThingManagerImpl.java:664) [bundleFile:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.registerHandler(ThingManagerImpl.java:641) [bundleFile:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.registerAndInitializeHandler(ThingManagerImpl.java:1110) [bundleFile:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.lambda$10(ThingManagerImpl.java:1092) [bundleFile:?]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(Unknown Source) [?:?]
	at java.util.concurrent.CopyOnWriteArraySet.forEach(Unknown Source) [?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.lambda$9(ThingManagerImpl.java:1089) [bundleFile:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source) [?:?]
	at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source) [?:?]
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(Unknown Source) [?:?]
	at java.util.stream.ReferencePipeline.forEach(Unknown Source) [?:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.handleThingHandlerFactoryAddition(ThingManagerImpl.java:1088) [bundleFile:?]
	at org.openhab.core.thing.internal.ThingManagerImpl.onReadyMarkerAdded(ThingManagerImpl.java:1076) [bundleFile:?]
	at org.openhab.core.internal.service.ReadyServiceImpl.lambda$0(ReadyServiceImpl.java:52) [bundleFile:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source) [?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(Unknown Source) [?:?]
	at java.util.stream.ReferencePipeline$2$1.accept(Unknown Source) [?:?]
	at java.util.HashMap$EntrySpliterator.forEachRemaining(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.copyInto(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) [?:?]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) [?:?]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) [?:?]
	at java.util.stream.AbstractPipeline.evaluate(Unknown Source) [?:?]
	at java.util.stream.ReferencePipeline.forEach(Unknown Source) [?:?]
	at org.openhab.core.internal.service.ReadyServiceImpl.notifyTrackers(ReadyServiceImpl.java:79) [bundleFile:?]
	at org.openhab.core.internal.service.ReadyServiceImpl.markReady(ReadyServiceImpl.java:52) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.registerReadyMarker(XmlDocumentBundleTracker.java:419) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.finishBundle(XmlDocumentBundleTracker.java:362) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker.processBundle(XmlDocumentBundleTracker.java:385) [bundleFile:?]
	at org.openhab.core.config.xml.osgi.XmlDocumentBundleTracker$2.run(XmlDocumentBundleTracker.java:347) [bundleFile:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:?]
	at java.util.concurrent.FutureTask.run(Unknown Source) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:?]
	at java.lang.Thread.run(Unknown Source) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>