### PR TITLE
Remove commons-lang dependency

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -66,9 +66,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -405,9 +405,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -24,7 +24,7 @@
 		<!-- Apache Commons -->
 		<bundle dependency="true">mvn:commons-codec/commons-codec/1.6</bundle>
 		<bundle dependency="true">mvn:commons-io/commons-io/2.2</bundle>
-		<bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.12.0</bundle>
 
 		<!-- Measurement -->
 		<bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>
@@ -249,7 +249,6 @@
 		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.7</bundle>
 		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.7</bundle>
 		<bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/2.0.2</bundle>
-		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.12.0</bundle>
 		<bundle dependency="true">mvn:org.javassist/javassist/3.27.0-GA</bundle>
 	</feature>
 


### PR DESCRIPTION
There was already a transitive commons-lang3:3.9 compile dependency used by several add-ons.
This is a transitive dependency of pax-web-jetty and swagger-core.

---

Depends on:
* https://github.com/openhab/openhab-addons/pull/10314
* https://github.com/openhab/openhab-webui/pull/955