### PR TITLE
Exclude jetbrains annotations

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -179,6 +179,12 @@
       <artifactId>hivemq-mqtt-client</artifactId>
       <version>1.1.2</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Serial Communication -->


### PR DESCRIPTION
This helps with preventing contributors from annotating classes with wrong annotations.

Related to:
* https://github.com/openhab/openhab-core/pull/2241
* https://github.com/openhab/openhab-addons/pull/10334
* https://github.com/openhab/org.openhab.binding.zwave/pull/1558