### PR TITLE
Upgrade Gson to 2.8.6

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -91,9 +91,9 @@
 
     <!-- Gson -->
     <dependency>
-      <groupId>org.eclipse.orbit.bundles</groupId>
-      <artifactId>com.google.gson</artifactId>
-      <version>2.8.2.v20180104-1110</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -436,9 +436,9 @@
 
     <!-- Gson -->
     <dependency>
-      <groupId>org.eclipse.orbit.bundles</groupId>
-      <artifactId>com.google.gson</artifactId>
-      <version>2.8.2.v20180104-1110</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
@@ -62,8 +62,6 @@ public final class WriteRequestJsonUtilities {
      */
     public static final int DEFAULT_MAX_TRIES = 3;
 
-    private static final JsonParser PARSER = new JsonParser();
-
     private WriteRequestJsonUtilities() {
         throw new UnsupportedOperationException();
     }
@@ -93,7 +91,7 @@ public final class WriteRequestJsonUtilities {
      * @see WriteRequestJsonUtilities.JSON_MAX_TRIES
      */
     public static Collection<ModbusWriteRequestBlueprint> fromJson(int unitId, String jsonString) {
-        JsonArray jsonArray = PARSER.parse(jsonString).getAsJsonArray();
+        JsonArray jsonArray = JsonParser.parseString(jsonString).getAsJsonArray();
         if (jsonArray.size() == 0) {
             return new LinkedList<>();
         }

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -49,8 +49,8 @@
 	</feature>
 
 	<feature name="openhab.tp-gson" description="Gson" version="${project.version}">
-		<capability>openhab.tp;feature=gson;version=2.8.2.v20180104-1110</capability>
-		<bundle>mvn:org.eclipse.orbit.bundles/com.google.gson/2.8.2.v20180104-1110</bundle>
+		<capability>openhab.tp;feature=gson;version=2.8.6</capability>
+		<bundle>mvn:com.google.code.gson/gson/2.8.6</bundle>
 	</feature>
 
 	<feature name="openhab.tp-hivemqclient" description="MQTT Client" version="${project.version}">

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -54,4 +53,5 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
@@ -48,4 +47,5 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
@@ -49,4 +48,5 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
@@ -49,4 +48,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -16,7 +16,6 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
@@ -49,4 +48,5 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
@@ -49,4 +48,5 @@ Fragment-Host: org.openhab.core.automation
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -47,4 +46,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.config.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -47,4 +46,5 @@ Fragment-Host: org.openhab.core.config.core
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -49,4 +48,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -20,7 +20,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -56,4 +55,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.scr;version='[2.1.10,2.1.11)',\
@@ -53,5 +52,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'
 

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -21,7 +21,6 @@ Provide-Capability: \
 -runbundles: \
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -61,4 +60,5 @@ Provide-Capability: \
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
@@ -43,4 +42,5 @@ Fragment-Host: org.openhab.core.config.dispatch
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -16,7 +16,6 @@ Fragment-Host: org.openhab.core.config.xml
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -44,4 +43,5 @@ Fragment-Host: org.openhab.core.config.xml
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -28,7 +28,6 @@ feature.openhab-config: \
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
 	org.apache.felix.log;version='[1.2.0,1.2.1)',\
@@ -61,4 +60,5 @@ feature.openhab-config: \
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -22,7 +22,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
@@ -77,4 +76,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -20,7 +20,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -105,4 +104,5 @@ Fragment-Host: org.openhab.core.model.core
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
-	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'
+	com.google.gson;version='[2.8.6,2.8.7)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -21,7 +21,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -103,4 +102,5 @@ Fragment-Host: org.openhab.core.model.item
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
-	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'
+	com.google.gson;version='[2.8.6,2.8.7)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -21,7 +21,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -107,5 +106,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -22,7 +22,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	org.apache.felix.configadmin;version='[1.9.8,1.9.9)',\
@@ -102,4 +101,5 @@ Fragment-Host: org.openhab.core.model.script
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
-	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'
+	com.google.gson;version='[2.8.6,2.8.7)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -27,7 +27,6 @@ Fragment-Host: org.openhab.core.model.thing
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -116,4 +115,4 @@ Fragment-Host: org.openhab.core.model.thing
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
-	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core.storage.json
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -43,4 +42,5 @@ Fragment-Host: org.openhab.core.storage.json
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -46,4 +45,5 @@ Fragment-Host: org.openhab.core
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -21,7 +21,6 @@ Fragment-Host: org.openhab.core.thing
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -56,4 +55,5 @@ Fragment-Host: org.openhab.core.thing
 	org.mockito.mockito-core;version='[3.7.0,3.7.1)',\
 	org.objenesis;version='[3.1.0,3.1.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -19,7 +19,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -50,4 +49,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.voice
 	ch.qos.logback.core;version='[1.2.3,1.2.4)',\
 	slf4j.api;version='[1.7.25,1.7.26)',\
 	ch.qos.logback.classic;version='[1.2.3,1.2.4)',\
-	com.google.gson;version='[2.8.2,2.8.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
 	tec.uom.se;version='[1.0.10,1.0.11)',\
@@ -60,4 +59,5 @@ Fragment-Host: org.openhab.core.voice
 	junit-platform-engine;version='[1.7.0,1.7.1)',\
 	junit-platform-launcher;version='[1.7.0,1.7.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
-	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)'
+	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
+	com.google.gson;version='[2.8.6,2.8.7)'


### PR DESCRIPTION
Upgrades Gson from 2.8.2 to 2.8.6.

See change log: https://github.com/google/gson/blob/master/CHANGELOG.md