### PR TITLE
Correctly unload script before reload. Fixes #2246

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
@@ -16,12 +16,14 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.service.StartLevelService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,5 +115,22 @@ public class ScriptFileReference implements Comparable<ScriptFileReference> {
             LOGGER.error("URI syntax exception", e);
             return 0;
         }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScriptFileReference that = (ScriptFileReference) o;
+        return scriptFileURL.equals(that.scriptFileURL);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scriptFileURL);
     }
 }


### PR DESCRIPTION
#2222 accidentally prevented unload of scripts before reload upon modification, due to omission of equality implementation for script file references.

This PR fixes the bug by implementing equality, plus adds a unit test to verify the corrected behaviour.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>