### PR TITLE
Add missing netty-codec-http2 to openhab.tp-netty

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -124,6 +124,7 @@
 		<bundle dependency="true">mvn:io.netty/netty-common/4.1.42.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.42.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.42.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.42.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.42.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.42.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.42.Final</bundle>


### PR DESCRIPTION
This bundle is required when using Netty with DynamoDB.