### PR TITLE
Upgrade lastnpe EEA to 2.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <bnd.version>5.3.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
-    <eea.version>2.2.1</eea.version>
+    <eea.version>2.3.0</eea.version>
     <karaf.compile.version>4.2.1</karaf.compile.version>
     <karaf.tooling.version>4.2.7</karaf.tooling.version>
     <sat.version>0.10.0</sat.version>


### PR DESCRIPTION
For release notes, see:

https://github.com/lastnpe/eclipse-null-eea-augments/releases/tag/v2.3.0