### PR TITLE
[skeleton] Use real world examples; fix imports

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
@@ -23,7 +23,9 @@ package ${package}.internal;
 public class ${bindingIdCamelCase}Configuration {
 
     /**
-     * Sample configuration parameter. Replace with your own.
+     * Sample configuration parameters. Replace with your own.
      */
-    public String config1;
+    public String hostname;
+    public String password;
+    public int refreshInterval;
 }

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -17,7 +17,6 @@ package ${package}.internal;
 
 import static ${package}.internal.${bindingIdCamelCase}BindingConstants.*;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/i18n/__bindingId___xx.properties
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/i18n/__bindingId___xx.properties
@@ -9,8 +9,12 @@ thing-type.${bindingId}.sample.label = <Your localized Thing label>
 thing-type.${bindingId}.sample.description = <Your localized Thing description>
 
 # thing type config description
-thing-type.config.${bindingId}.sample.config1.label = <Your localized config parameter label>
-thing-type.config.${bindingId}.sample.config1.description = <Your localized config parameter description>
+thing-type.config.${bindingId}.sample.hostname.label = <Your localized config parameter label>
+thing-type.config.${bindingId}.sample.hostname.description = <Your localized config parameter description>
+thing-type.config.${bindingId}.sample.password.label = <Your localized config parameter label>
+thing-type.config.${bindingId}.sample.password.description = <Your localized config parameter description>
+thing-type.config.${bindingId}.sample.refreshInterval.label = <Your localized config parameter label>
+thing-type.config.${bindingId}.sample.refreshInterval.description = <Your localized config parameter description>
 
 # channel types
 channel-type.${bindingId}.sample-channel.label = <Your localized Channel label>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/thing/thing-types.xml
@@ -6,6 +6,12 @@
 
 	<!-- Sample Thing Type -->
 	<thing-type id="sample">
+		<!-- Comment this in for Things which need a Bridge to function.
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="${bindingIdCamelCase}Bridge" />
+		</supported-bridge-type-refs>
+		-->
+
 		<label>${bindingIdCamelCase} Binding Thing</label>
 		<description>Sample thing for ${bindingIdCamelCase} Binding</description>
 
@@ -14,19 +20,23 @@
 		</channels>
 
 		<config-description>
-			<parameter name="config1" type="text" required="true">
-				<label>Sample Parameter</label>
-				<description>This is a sample text configuration parameter</description>
+			<parameter name="hostname" type="text" required="true">
+				<context>network-address</context>
+				<label>Hostname</label>
+				<description>Hostname or IP address of the device</description>
+			</parameter>
+			<parameter name="password" type="text" required="true">
+				<context>password</context>
+				<label>Password</label>
+				<description>Passwort to access the device</description>
 			</parameter>
 		</config-description>
-
 	</thing-type>
 
 	<!-- Sample Channel Type -->
 	<channel-type id="sample-channel">
-		<item-type>${bindingId}Item</item-type>
-		<label>${bindingIdCamelCase} Binding Channel</label>
+		<item-type>Number:Temperature</item-type>
+		<label>Example Temperature</label> <!-- Use uppercase words for labels, except prepositions and so on -->
 		<description>Sample channel for ${bindingIdCamelCase} Binding</description>
 	</channel-type>
-
 </thing:thing-descriptions>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/resources/OH-INF/thing/thing-types.xml
@@ -7,9 +7,9 @@
 	<!-- Sample Thing Type -->
 	<thing-type id="sample">
 		<!-- Comment this in for Things which need a Bridge to function.
-		<supported-bridge-type-refs>
+			<supported-bridge-type-refs>
 			<bridge-type-ref id="${bindingIdCamelCase}Bridge" />
-		</supported-bridge-type-refs>
+			</supported-bridge-type-refs>
 		-->
 
 		<label>${bindingIdCamelCase} Binding Thing</label>
@@ -30,13 +30,17 @@
 				<label>Password</label>
 				<description>Passwort to access the device</description>
 			</parameter>
+			<parameter name="refreshInterval" type="integer" unit="s" min="1">
+				<label>Refresh Interval</label>
+				<description>Interval the device is polled in sec.</description>
+			</parameter>
 		</config-description>
 	</thing-type>
 
 	<!-- Sample Channel Type -->
 	<channel-type id="sample-channel">
 		<item-type>Number:Temperature</item-type>
-		<label>Example Temperature</label> <!-- Use uppercase words for labels, except prepositions and so on -->
+		<label>Example Temperature</label><!-- Use uppercase words, except prepositions. 2-3 words, max 25 chars -->
 		<description>Sample channel for ${bindingIdCamelCase} Binding</description>
 	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
Added some examples as many new bindings don't make use of context tags or supported bridges.

Also add a refresh parameter to show the `unit` and `min` attributes.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>