### PR TITLE
[modbus] Workaround for nrjavaserial issues: do not disconnect serial

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -627,9 +627,15 @@ public class ModbusManagerImpl implements ModbusManager {
                                 "Last try {} failed when executing request ({}). Aborting. Error was I/O error, so reseting the connection. Error details: {} {} [operation ID {}]",
                                 tryIndex, request, e.getClass().getName(), e.getMessage(), operationId);
                     }
-                    // Invalidate connection, and empty (so that new connection is acquired before new retry)
-                    timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
-                    connection = Optional.empty();
+                    if (endpoint instanceof ModbusSerialSlaveEndpoint) {
+                        // Workaround for https://github.com/openhab/openhab-core/issues/1842
+                        // Avoid disconnect/re-connect serial interfaces
+                        logger.debug("Skipping invalidation of serial connection to workaround openhab-core#1842.");
+                    } else {
+                        // Invalidate connection, and empty (so that new connection is acquired before new retry)
+                        timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
+                        connection = Optional.empty();
+                    }
                     continue;
                 } catch (ModbusIOException e) {
                     lastError.set(new ModbusSlaveIOExceptionImpl(e));
@@ -644,9 +650,15 @@ public class ModbusManagerImpl implements ModbusManager {
                                 "Last try {} failed when executing request ({}). Aborting. Error was I/O error, so reseting the connection. Error details: {} {} [operation ID {}]",
                                 tryIndex, request, e.getClass().getName(), e.getMessage(), operationId);
                     }
-                    // Invalidate connection, and empty (so that new connection is acquired before new retry)
-                    timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
-                    connection = Optional.empty();
+                    if (endpoint instanceof ModbusSerialSlaveEndpoint) {
+                        // Workaround for https://github.com/openhab/openhab-core/issues/1842
+                        // Avoid disconnect/re-connect serial interfaces
+                        logger.debug("Skipping invalidation of serial connection to workaround openhab-core#1842.");
+                    } else {
+                        // Invalidate connection, and empty (so that new connection is acquired before new retry)
+                        timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
+                        connection = Optional.empty();
+                    }
                     continue;
                 } catch (ModbusSlaveException e) {
                     lastError.set(new ModbusSlaveErrorResponseExceptionImpl(e));
@@ -674,9 +686,15 @@ public class ModbusManagerImpl implements ModbusManager {
                                 "Last try {} failed when executing request ({}). Aborting. The response did not match the request. Reseting the connection. Error details: {} {} [operation ID {}]",
                                 tryIndex, request, e.getClass().getName(), e.getMessage(), operationId);
                     }
-                    // Invalidate connection, and empty (so that new connection is acquired before new retry)
-                    timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
-                    connection = Optional.empty();
+                    if (endpoint instanceof ModbusSerialSlaveEndpoint) {
+                        // Workaround for https://github.com/openhab/openhab-core/issues/1842
+                        // Avoid disconnect/re-connect serial interfaces
+                        logger.debug("Skipping invalidation of serial connection to workaround openhab-core#1842.");
+                    } else {
+                        // Invalidate connection, and empty (so that new connection is acquired before new retry)
+                        timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
+                        connection = Optional.empty();
+                    }
                     continue;
                 } catch (ModbusException e) {
                     lastError.set(e);
@@ -717,9 +735,15 @@ public class ModbusManagerImpl implements ModbusManager {
         } catch (InterruptedException e) {
             logger.warn("Poll task was canceled -- not executing/proceeding with the poll: {} [operation ID {}]",
                     e.getMessage(), operationId);
-            // Invalidate connection, and empty (so that new connection is acquired before new retry)
-            timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
-            connection = Optional.empty();
+            if (endpoint instanceof ModbusSerialSlaveEndpoint) {
+                // Workaround for https://github.com/openhab/openhab-core/issues/1842
+                // Avoid disconnect/re-connect serial interfaces
+                logger.debug("Skipping invalidation of serial connection to workaround openhab-core#1842.");
+            } else {
+                // Invalidate connection, and empty (so that new connection is acquired before new retry)
+                timer.connection.timeConsumer(c -> invalidate(endpoint, c), connection);
+                connection = Optional.empty();
+            }
         } finally {
             timer.connection.timeConsumer(c -> returnConnection(endpoint, c), connection);
             logger.trace("Connection was returned to the pool, ending operation [operation ID {}]", operationId);


### PR DESCRIPTION
Workaround for https://github.com/openhab/openhab-core/issues/1842.
Typically serial connections are disconnected and reconnected on IO
errors. This has turned out to be problematic with the recent
nrjavaserial updates brought by OH3 (locking behaviour of nrjavaserial
seems to be prone to deadlocks).

We workaround the issues by trying to keep the serial connection open
as long as possible.

This might not a foolproof fix as commented by @fwolter https://github.com/openhab/openhab-core/issues/1842#issuecomment-792978074 :
> [...] I often observed the error right after the start of the JVM.
> I agree that this problem is very annoying. A "quick" solution would be to disable the locks in general.

But on the other hand the community reports seem to be very often related to "I/O" errors and the disconnect/re-connect logic in modbus transport.

Pre-compiled jar in zip: 
[org.openhab.core.io.transport.modbus-3.1.0-SNAPSHOT.zip](https://github.com/openhab/openhab-core/files/6259049/org.openhab.core.io.transport.modbus-3.1.0-SNAPSHOT.zip)
(corresponding to commit https://github.com/openhab/openhab-core/pull/2272/commits/1dc4094b770242c626d784c3482552cad729b592) 



Signed-off-by: Sami Salonen <ssalonen@gmail.com>