### PR TITLE
Align Jetty/JNA version properties with Karaf 4.3.1

### DIFF
--- a/features/karaf/openhab-core/pom.xml
+++ b/features/karaf/openhab-core/pom.xml
@@ -16,8 +16,8 @@
   <description>openHAB Core Features</description>
 
   <properties>
-    <jetty.version>9.4.20.v20190813</jetty.version>
-    <jna.version>5.4.0</jna.version>
+    <jetty.version>9.4.38.v20210224</jetty.version>
+    <jna.version>5.8.0</jna.version>
   </properties>
 
   <build>

--- a/features/karaf/openhab-tp/pom.xml
+++ b/features/karaf/openhab-tp/pom.xml
@@ -15,7 +15,7 @@
   <name>openHAB Core :: Features :: Karaf :: Target Platform</name>
 
   <properties>
-    <jetty.version>9.4.20.v20190813</jetty.version>
+    <jetty.version>9.4.38.v20210224</jetty.version>
   </properties>
 
   <build>


### PR DESCRIPTION
These versions should also have been updated in https://github.com/openhab/openhab-core/pull/2264.