### PR TITLE
Upgrade jamod (to get rid of case with fragmented packets)

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>[1.3.2.OH]</version>
+      <version>1.3.2.OH</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>[1.3.0.OH,1.3.1.OH]</version>
+      <version>[1.3.2.OH]</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This PR bumps version of jamod modbus library to include fix for case with fragmented modbus packets received via TCP connection (discussed here https://github.com/openhab/jamod/pull/11)