### PR TITLE
[static-code-analysis] Use SAT release version 0.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <eea.version>2.3.0</eea.version>
     <karaf.compile.version>4.3.0</karaf.compile.version>
     <karaf.tooling.version>4.3.1</karaf.tooling.version>
-    <sat.version>0.10.0</sat.version>
+    <sat.version>0.11.1</sat.version>
     <slf4j.version>1.7.21</slf4j.version>
     <xtext.version>2.25.0</xtext.version>
     <spotless.version>2.0.3</spotless.version>

--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -9,6 +9,7 @@
     <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|MissingJavadocFilterCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|MissingJavadocFilterCheck"/>
     <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationCheck"/>
+    <suppress files=".+[\\/]OH-INF[\\/].+\.xml" checks="OhInfXmlLabelCheck"/>
 
     <!-- All generated files will skip the author tag check -->
     <suppress files=".+[\\/]gen[\\/].+\.java" checks="AuthorTagCheck"/>


### PR DESCRIPTION
- Use SAT release version 0.11.1
- Added suppression for new OhInfXmlLabelCheck (PR https://github.com/openhab/static-code-analysis/pull/360)


Release notes:
https://github.com/openhab/static-code-analysis/releases/tag/0.11.0
https://github.com/openhab/static-code-analysis/releases/tag/0.11.1

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>