### PR TITLE
Remove trailing space from update-canceled in firmware.properties

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/firmware.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/firmware.properties
@@ -2,4 +2,4 @@ unexpected-handler-error=An unexpected error occurred during firmware update.
 timeout-error=A timeout occurred during firmware update.
 unexpected-handler-error-during-cancel=An unexpected error occurred during canceling of firmware update.
 timeout-error-during-cancel=A timeout occurred during canceling of firmware update.
-update-canceled=The firmware update was canceled. 
+update-canceled=The firmware update was canceled.


### PR DESCRIPTION
Signed-off-by: Wouter Born <github@maindrain.net>