### PR TITLE
Fix Crowdin translation filename mismatch

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,4 +6,4 @@ files:
   - source: /bundles/**/src/main/resources/*.properties
     ignore:
       - /bundles/**/src/main/resources/*_*.properties
-    translation: /%original_path%/messages_%two_letters_code%.properties
+    translation: /%original_path%/%file_name%_%two_letters_code%.properties


### PR DESCRIPTION
Looks like this is the root cause of the generated translation filenames not matching the original filename.