### PR TITLE
Ignore illegal thing status updates from REMOVING

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -120,6 +120,7 @@ import org.slf4j.LoggerFactory;
  * @author Henning Sudbrock - Consider thing type properties when migrating to new thing type
  * @author Christoph Weitkamp - Added preconfigured ChannelGroupBuilder
  * @author Yordan Zhelev - Added thing disabling mechanism
+ * @author Björn Lange - Ignore illegal thing status transitions instead of throwing IllegalArgumentException
  */
 @NonNullByDefault
 @Component(immediate = true, service = { ThingTypeMigrationService.class, ThingManager.class })
@@ -187,10 +188,11 @@ public class ThingManagerImpl
 
             if (ThingStatus.REMOVING.equals(oldStatusInfo.getStatus())
                     && !ThingStatus.REMOVED.equals(statusInfo.getStatus())) {
-                // only allow REMOVING -> REMOVED transition, all others are illegal
-                throw new IllegalArgumentException(MessageFormat.format(
-                        "Illegal status transition from REMOVING to {0}, only REMOVED would have been allowed.",
-                        statusInfo.getStatus()));
+                // only allow REMOVING -> REMOVED transition, all others are ignored because they are illegal
+                logger.warn(
+                        "Ignoring illegal status transition for thing {} from REMOVING to {}, only REMOVED would have been allowed.",
+                        thing.getUID(), statusInfo.getStatus());
+                return;
             }
 
             // update thing status and send event about new status

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -189,7 +189,7 @@ public class ThingManagerImpl
             if (ThingStatus.REMOVING.equals(oldStatusInfo.getStatus())
                     && !ThingStatus.REMOVED.equals(statusInfo.getStatus())) {
                 // only allow REMOVING -> REMOVED transition, all others are ignored because they are illegal
-                logger.warn(
+                logger.debug(
                         "Ignoring illegal status transition for thing {} from REMOVING to {}, only REMOVED would have been allowed.",
                         thing.getUID(), statusInfo.getStatus());
                 return;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -970,7 +970,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void thingManagerPreventsRestoringThingStatusFromRemoving() {
+    public void thingManagerIgnoresRestoringOfThingStatusFromRemoving() {
         class ThingHandlerState {
             ThingHandlerCallback callback;
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -111,6 +111,7 @@ import org.osgi.service.component.ComponentContext;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Wouter Born - Migrate tests from Groovy to Java
+ * @author Björn Lange - Ignore illegal thing status transitions instead of throwing IllegalArgumentException
  */
 public class ThingManagerOSGiTest extends JavaOSGiTest {
 
@@ -966,6 +967,45 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         final ThingStatusInfo removedNone = ThingStatusInfoBuilder.create(ThingStatus.REMOVED, ThingStatusDetail.NONE)
                 .build();
         expectException(() -> state.callback.statusUpdated(thing, removedNone), IllegalArgumentException.class);
+    }
+
+    @Test
+    public void thingManagerPreventsRestoringThingStatusFromRemoving() {
+        class ThingHandlerState {
+            ThingHandlerCallback callback;
+        }
+
+        final ThingHandlerState state = new ThingHandlerState();
+
+        ThingHandler thingHandler = mock(ThingHandler.class);
+
+        managedThingProvider.add(thing);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                state.callback = (ThingHandlerCallback) invocation.getArgument(0);
+                return null;
+            }
+        }).when(thingHandler).setCallback(any(ThingHandlerCallback.class));
+        when(thingHandler.getThing()).thenReturn(thing);
+
+        ThingHandlerFactory thingHandlerFactory = mock(ThingHandlerFactory.class);
+        when(thingHandlerFactory.supportsThingType(any(ThingTypeUID.class))).thenReturn(true);
+        when(thingHandlerFactory.registerHandler(any(Thing.class))).thenReturn(thingHandler);
+
+        registerService(thingHandlerFactory);
+
+        final ThingStatusInfo removingNone = ThingStatusInfoBuilder.create(ThingStatus.REMOVING, ThingStatusDetail.NONE)
+                .build();
+        final ThingStatusInfo onlineNone = ThingStatusInfoBuilder.create(ThingStatus.ONLINE, ThingStatusDetail.NONE)
+                .build();
+
+        thing.setStatusInfo(removingNone);
+
+        state.callback.statusUpdated(thing, onlineNone);
+
+        assertThat(thing.getStatusInfo(), is(removingNone));
     }
 
     private void expectException(Runnable runnable, Class<? extends Exception> exceptionType) {


### PR DESCRIPTION
Ignore illegal thing status transitions from REMOVING instead of throwing IllegalArgumentException. Feedback is appreciated, especially concerning unexpected side-effects and the added integration test.

Closes #2311