### PR TITLE
Upgrade Units of Measurement dependencies

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -157,19 +157,19 @@
     <dependency>
       <groupId>javax.measure</groupId>
       <artifactId>unit-api</artifactId>
-      <version>1.0</version>
+      <version>2.1.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>tec.uom</groupId>
-      <artifactId>uom-se</artifactId>
-      <version>1.0.10</version>
+      <groupId>si.uom</groupId>
+      <artifactId>si-units</artifactId>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>tec.uom.lib</groupId>
-      <artifactId>uom-lib-common</artifactId>
-      <version>1.0.3</version>
+      <groupId>tech.units</groupId>
+      <artifactId>indriya</artifactId>
+      <version>2.1.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -443,21 +443,40 @@
 
     <!-- Measurement -->
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.measure</groupId>
       <artifactId>unit-api</artifactId>
-      <version>1.0</version>
+      <version>2.1.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <!-- The si.uom:si-units manifest has no Export-Package entry. As workaround this OSGi-ify bundle is used. -->
+    <dependency>
+      <groupId>org.openhab.osgiify</groupId>
+      <artifactId>si.uom.si-units</artifactId>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>tec.uom</groupId>
-      <artifactId>uom-se</artifactId>
-      <version>1.0.10</version>
+      <groupId>si.uom</groupId>
+      <artifactId>si-quantity</artifactId>
+      <version>2.0.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>tec.uom.lib</groupId>
-      <artifactId>uom-lib-common</artifactId>
-      <version>1.0.3</version>
+      <groupId>tech.units</groupId>
+      <artifactId>indriya</artifactId>
+      <version>2.1.2</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -142,22 +142,22 @@ public class PersistenceExtensionsTest {
                 ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("2012.0 °C", historicItem.getState().toString());
+        assertEquals("2012 °C", historicItem.getState().toString());
 
         historicItem = PersistenceExtensions.historicState(quantityItem,
                 ZonedDateTime.of(2011, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
-        assertEquals("2011.0 °C", historicItem.getState().toString());
+        assertEquals("2011 °C", historicItem.getState().toString());
 
         historicItem = PersistenceExtensions.historicState(quantityItem,
                 ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
-        assertEquals("2011.0 °C", historicItem.getState().toString());
+        assertEquals("2011 °C", historicItem.getState().toString());
 
         historicItem = PersistenceExtensions.historicState(quantityItem,
                 ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
-        assertEquals("2000.0 °C", historicItem.getState().toString());
+        assertEquals("2000 °C", historicItem.getState().toString());
 
         // default persistence service
         historicItem = PersistenceExtensions.historicState(quantityItem,
@@ -210,19 +210,19 @@ public class PersistenceExtensionsTest {
                 ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("1.0 °C", historicItem.getState().toString());
+        assertEquals("1 °C", historicItem.getState().toString());
 
         historicItem = PersistenceExtensions.maximumSince(quantityItem,
                 ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
-        assertEquals("2012.0 °C", historicItem.getState().toString());
+        assertEquals("2012 °C", historicItem.getState().toString());
         assertEquals(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), historicItem.getTimestamp());
 
         // default persistence service
         historicItem = PersistenceExtensions.maximumSince(quantityItem,
                 ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNotNull(historicItem);
-        assertEquals("1.0 °C", historicItem.getState().toString());
+        assertEquals("1 °C", historicItem.getState().toString());
     }
 
     @Test
@@ -281,19 +281,19 @@ public class PersistenceExtensionsTest {
                 ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("5000.0 °C", historicItem.getState().toString());
+        assertEquals("5000 °C", historicItem.getState().toString());
 
         historicItem = PersistenceExtensions.minimumSince(quantityItem,
                 ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
         assertNotNull(historicItem);
-        assertEquals("2005.0 °C", historicItem.getState().toString());
+        assertEquals("2005 °C", historicItem.getState().toString());
         assertEquals(ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), historicItem.getTimestamp());
 
         // default persistence service
         historicItem = PersistenceExtensions.minimumSince(quantityItem,
                 ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNotNull(historicItem);
-        assertEquals("5000.0 °C", historicItem.getState().toString());
+        assertEquals("5000 °C", historicItem.getState().toString());
     }
 
     @Test
@@ -601,22 +601,22 @@ public class PersistenceExtensionsTest {
                 TestPersistenceService.ID);
         assertNotNull(prevStateItem);
         assertThat(prevStateItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("2012.0 °C", prevStateItem.getState().toString());
+        assertEquals("2012 °C", prevStateItem.getState().toString());
 
         quantityItem.setState(QuantityType.valueOf(4321, SIUnits.CELSIUS));
         prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012.0 °C", prevStateItem.getState().toString());
+        assertEquals("2012 °C", prevStateItem.getState().toString());
 
         quantityItem.setState(QuantityType.valueOf(2012, SIUnits.CELSIUS));
         prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012.0 °C", prevStateItem.getState().toString());
+        assertEquals("2012 °C", prevStateItem.getState().toString());
 
         quantityItem.setState(QuantityType.valueOf(3025, SIUnits.CELSIUS));
         prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012.0 °C", prevStateItem.getState().toString());
+        assertEquals("2012 °C", prevStateItem.getState().toString());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(quantityItem, false);
@@ -640,7 +640,7 @@ public class PersistenceExtensionsTest {
         quantityItem.setState(QuantityType.valueOf(2012, SIUnits.CELSIUS));
         HistoricItem prevStateItem = PersistenceExtensions.previousState(quantityItem, true, TestPersistenceService.ID);
         assertNotNull(prevStateItem);
-        assertEquals("2011.0 °C", prevStateItem.getState().toString());
+        assertEquals("2011 °C", prevStateItem.getState().toString());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(quantityItem, true);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
@@ -32,7 +32,7 @@ import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import tec.uom.se.AbstractUnit;
+import tech.units.indriya.AbstractUnit;
 
 /***
  * This is the default implementation for a {@link SystemHysteresisStateProfile}.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
@@ -32,7 +32,7 @@ import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import tec.uom.se.AbstractUnit;
+import tech.units.indriya.AbstractUnit;
 
 /***
  * This is the default implementation for a {@link SystemRangeStateProfile}.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
@@ -92,8 +92,11 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
                             sum = itemState; // initialise the sum from the first item
                             count++;
                         } else {
-                            sum = sum.add(itemState);
-                            count++;
+                            itemState = itemState.toUnit(sum.getUnit());
+                            if (itemState != null) {
+                                sum = sum.add(itemState);
+                                count++;
+                            }
                         }
                     }
                 }
@@ -131,8 +134,11 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
                     if (itemState != null) {
                         if (sum == null) {
                             sum = itemState; // initialise the sum from the first item
-                        } else if (sum.getUnit().isCompatible(itemState.getUnit())) {
-                            sum = sum.add(itemState);
+                        } else {
+                            itemState = itemState.toUnit(sum.getUnit());
+                            if (itemState != null) {
+                                sum = sum.add(itemState);
+                            }
                         }
                     }
                 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/BinaryPrefix.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/BinaryPrefix.java
@@ -20,9 +20,9 @@ import javax.measure.UnitConverter;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import tec.uom.lib.common.function.SymbolSupplier;
-import tec.uom.lib.common.function.UnitConverterSupplier;
-import tec.uom.se.function.RationalConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.uom.lib.common.function.SymbolSupplier;
+import tech.uom.lib.common.function.UnitConverterSupplier;
 
 /**
  * The binary prefixes used to derive units by specific powers of 2.
@@ -31,14 +31,14 @@ import tec.uom.se.function.RationalConverter;
  */
 @NonNullByDefault
 public enum BinaryPrefix implements SymbolSupplier, UnitConverterSupplier {
-    YOBI("Yi", new RationalConverter(BigInteger.valueOf(2).pow(80), BigInteger.ONE)),
-    ZEBI("Zi", new RationalConverter(BigInteger.valueOf(2).pow(70), BigInteger.ONE)),
-    EXBI("Ei", new RationalConverter(BigInteger.valueOf(2).pow(60), BigInteger.ONE)),
-    PEBI("Pi", new RationalConverter(BigInteger.valueOf(2).pow(50), BigInteger.ONE)),
-    TEBI("Ti", new RationalConverter(BigInteger.valueOf(2).pow(40), BigInteger.ONE)),
-    GIBI("Gi", new RationalConverter(BigInteger.valueOf(2).pow(30), BigInteger.ONE)),
-    MEBI("Mi", new RationalConverter(BigInteger.valueOf(2).pow(20), BigInteger.ONE)),
-    KIBI("Ki", new RationalConverter(BigInteger.valueOf(2).pow(10), BigInteger.ONE));
+    YOBI("Yi", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(80), BigInteger.ONE)),
+    ZEBI("Zi", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(70), BigInteger.ONE)),
+    EXBI("Ei", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(60), BigInteger.ONE)),
+    PEBI("Pi", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(50), BigInteger.ONE)),
+    TEBI("Ti", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(40), BigInteger.ONE)),
+    GIBI("Gi", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(30), BigInteger.ONE)),
+    MEBI("Mi", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(20), BigInteger.ONE)),
+    KIBI("Ki", MultiplyConverter.ofRational(BigInteger.valueOf(2).pow(10), BigInteger.ONE));
 
     /**
      * The symbol of this prefix, as returned by {@link #getSymbol}.
@@ -61,7 +61,7 @@ public enum BinaryPrefix implements SymbolSupplier, UnitConverterSupplier {
      * @param symbol the symbol of this prefix.
      * @param converter the associated unit converter.
      */
-    BinaryPrefix(String symbol, RationalConverter converter) {
+    BinaryPrefix(String symbol, MultiplyConverter converter) {
         this.symbol = symbol;
         this.converter = converter;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CustomUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CustomUnits.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.library.unit;
 
-import tec.uom.se.AbstractSystemOfUnits;
+import tech.units.indriya.AbstractSystemOfUnits;
 
 /**
  * Base class for all custom unit classes added in openHAB.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
@@ -23,13 +23,12 @@ import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import tec.uom.se.format.SimpleUnitFormat;
-import tec.uom.se.function.AddConverter;
-import tec.uom.se.function.MultiplyConverter;
-import tec.uom.se.function.RationalConverter;
-import tec.uom.se.unit.ProductUnit;
-import tec.uom.se.unit.TransformedUnit;
-import tec.uom.se.unit.Units;
+import tech.units.indriya.format.SimpleUnitFormat;
+import tech.units.indriya.function.AddConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.unit.ProductUnit;
+import tech.units.indriya.unit.TransformedUnit;
+import tech.units.indriya.unit.Units;
 
 /**
  * Imperial units used for the United States and Liberia.
@@ -45,30 +44,30 @@ public final class ImperialUnits extends CustomUnits {
 
     /** Additionally defined units to be used in openHAB **/
     public static final Unit<Pressure> INCH_OF_MERCURY = addUnit(new TransformedUnit<>("inHg", Units.PASCAL,
-            new RationalConverter(BigInteger.valueOf(3386388), BigInteger.valueOf(1000))));
+            MultiplyConverter.ofRational(BigInteger.valueOf(3386388), BigInteger.valueOf(1000))));
 
-    public static final Unit<Temperature> FAHRENHEIT = addUnit(new TransformedUnit<>("°F", Units.KELVIN,
-            new RationalConverter(BigInteger.valueOf(5), BigInteger.valueOf(9)).concatenate(new AddConverter(459.67))));
+    public static final Unit<Temperature> FAHRENHEIT = addUnit(
+            new TransformedUnit<>("°F", Units.KELVIN, MultiplyConverter
+                    .ofRational(BigInteger.valueOf(5), BigInteger.valueOf(9)).concatenate(new AddConverter(459.67))));
 
     public static final Unit<Speed> MILES_PER_HOUR = addUnit(new TransformedUnit<>("mph", Units.KILOMETRE_PER_HOUR,
-            new RationalConverter(BigInteger.valueOf(1609344), BigInteger.valueOf(1000000))));
+            MultiplyConverter.ofRational(BigInteger.valueOf(1609344), BigInteger.valueOf(1000000))));
 
     /** Length **/
     public static final Unit<Length> INCH = addUnit(new TransformedUnit<>("in", Units.METRE,
-            new RationalConverter(BigInteger.valueOf(254), BigInteger.valueOf(10000))));
+            MultiplyConverter.ofRational(BigInteger.valueOf(254), BigInteger.valueOf(10000))));
 
-    public static final Unit<Length> FOOT = addUnit(new TransformedUnit<>("ft", INCH, new MultiplyConverter(12.0)));
+    public static final Unit<Length> FOOT = addUnit(new TransformedUnit<>("ft", INCH, MultiplyConverter.of(12.0)));
 
-    public static final Unit<Length> YARD = addUnit(new TransformedUnit<>("yd", FOOT, new MultiplyConverter(3.0)));
+    public static final Unit<Length> YARD = addUnit(new TransformedUnit<>("yd", FOOT, MultiplyConverter.of(3.0)));
 
-    public static final Unit<Length> CHAIN = addUnit(new TransformedUnit<>("ch", YARD, new MultiplyConverter(22.0)));
+    public static final Unit<Length> CHAIN = addUnit(new TransformedUnit<>("ch", YARD, MultiplyConverter.of(22.0)));
 
-    public static final Unit<Length> FURLONG = addUnit(
-            new TransformedUnit<>("fur", CHAIN, new MultiplyConverter(10.0)));
+    public static final Unit<Length> FURLONG = addUnit(new TransformedUnit<>("fur", CHAIN, MultiplyConverter.of(10.0)));
 
-    public static final Unit<Length> MILE = addUnit(new TransformedUnit<>("mi", FURLONG, new MultiplyConverter(8.0)));
+    public static final Unit<Length> MILE = addUnit(new TransformedUnit<>("mi", FURLONG, MultiplyConverter.of(8.0)));
 
-    public static final Unit<Length> LEAGUE = addUnit(new TransformedUnit<>("lea", MILE, new MultiplyConverter(3.0)));
+    public static final Unit<Length> LEAGUE = addUnit(new TransformedUnit<>("lea", MILE, MultiplyConverter.of(3.0)));
 
     public static final Unit<Length> SQUARE_FOOT = addUnit(new ProductUnit<>(FOOT.multiply(FOOT)));
     public static final Unit<Length> CUBIC_FOOT = addUnit(new ProductUnit<>(SQUARE_FOOT.multiply(FOOT)));

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/MetricPrefix.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/MetricPrefix.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * The metric prefixes used to derive units by specific powers of 10. This delegates to the enum instances of
- * {@link tec.uom.se.unit.MetricPrefix}.
+ * {@link javax.measure.MetricPrefix}.
  *
  * @author Henning Treu - Initial contribution
  */
@@ -27,82 +27,82 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class MetricPrefix {
 
     public static <T extends Quantity<T>> Unit<T> YOTTA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.YOTTA(unit);
+        return javax.measure.MetricPrefix.YOTTA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> ZETTA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.ZETTA(unit);
+        return javax.measure.MetricPrefix.ZETTA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> EXA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.EXA(unit);
+        return javax.measure.MetricPrefix.EXA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> PETA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.PETA(unit);
+        return javax.measure.MetricPrefix.PETA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> TERA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.TERA(unit);
+        return javax.measure.MetricPrefix.TERA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> GIGA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.GIGA(unit);
+        return javax.measure.MetricPrefix.GIGA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> MEGA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.MEGA(unit);
+        return javax.measure.MetricPrefix.MEGA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> KILO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.KILO(unit);
+        return javax.measure.MetricPrefix.KILO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> HECTO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.HECTO(unit);
+        return javax.measure.MetricPrefix.HECTO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> DEKA(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.DEKA(unit);
+        return javax.measure.MetricPrefix.DEKA(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> DECI(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.DECI(unit);
+        return javax.measure.MetricPrefix.DECI(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> CENTI(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.CENTI(unit);
+        return javax.measure.MetricPrefix.CENTI(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> MILLI(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.MILLI(unit);
+        return javax.measure.MetricPrefix.MILLI(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> MICRO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.MICRO(unit);
+        return javax.measure.MetricPrefix.MICRO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> NANO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.NANO(unit);
+        return javax.measure.MetricPrefix.NANO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> PICO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.PICO(unit);
+        return javax.measure.MetricPrefix.PICO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> FEMTO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.FEMTO(unit);
+        return javax.measure.MetricPrefix.FEMTO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> ATTO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.ATTO(unit);
+        return javax.measure.MetricPrefix.ATTO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> ZEPTO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.ZEPTO(unit);
+        return javax.measure.MetricPrefix.ZEPTO(unit);
     }
 
     public static <T extends Quantity<T>> Unit<T> YOCTO(Unit<T> unit) {
-        return tec.uom.se.unit.MetricPrefix.YOCTO(unit);
+        return javax.measure.MetricPrefix.YOCTO(unit);
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
@@ -24,8 +24,8 @@ import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-import tec.uom.se.format.SimpleUnitFormat;
-import tec.uom.se.unit.Units;
+import tech.units.indriya.format.SimpleUnitFormat;
+import tech.units.indriya.unit.Units;
 
 /**
  * Delegate SI units to {@link Units} to hide this dependency from the rest of openHAB.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -57,16 +57,15 @@ import org.openhab.core.library.dimension.ElectricConductivity;
 import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.dimension.VolumetricFlowRate;
 
-import tec.uom.se.AbstractUnit;
-import tec.uom.se.format.SimpleUnitFormat;
-import tec.uom.se.function.ExpConverter;
-import tec.uom.se.function.LogConverter;
-import tec.uom.se.function.MultiplyConverter;
-import tec.uom.se.function.PiMultiplierConverter;
-import tec.uom.se.function.RationalConverter;
-import tec.uom.se.unit.AlternateUnit;
-import tec.uom.se.unit.ProductUnit;
-import tec.uom.se.unit.TransformedUnit;
+import si.uom.NonSI;
+import tech.units.indriya.AbstractUnit;
+import tech.units.indriya.format.SimpleUnitFormat;
+import tech.units.indriya.function.ExpConverter;
+import tech.units.indriya.function.LogConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.unit.AlternateUnit;
+import tech.units.indriya.unit.ProductUnit;
+import tech.units.indriya.unit.TransformedUnit;
 
 /**
  * Delegate common units to {@link Units} to hide this dependency from the rest of openHAB.
@@ -82,109 +81,112 @@ public final class Units extends CustomUnits {
 
     // Alphabetical ordered by Unit.
     public static final Unit<Acceleration> METRE_PER_SQUARE_SECOND = addUnit(
-            tec.uom.se.unit.Units.METRE_PER_SQUARE_SECOND);
+            tech.units.indriya.unit.Units.METRE_PER_SQUARE_SECOND);
     public static final Unit<Acceleration> STANDARD_GRAVITY = addUnit(METRE_PER_SQUARE_SECOND.multiply(9.80665));
-    public static final Unit<AmountOfSubstance> MOLE = addUnit(tec.uom.se.unit.Units.MOLE);
+    public static final Unit<AmountOfSubstance> MOLE = addUnit(tech.units.indriya.unit.Units.MOLE);
+    public static final Unit<Volume> LITRE = addUnit(tech.units.indriya.unit.Units.LITRE);
     @SuppressWarnings("unchecked")
-    public static final Unit<AmountOfSubstance> DEUTSCHE_HAERTE = addUnit(
-            new TransformedUnit<>("°dH", (Unit<AmountOfSubstance>) MetricPrefix.MILLI(tec.uom.se.unit.Units.MOLE)
-                    .divide(tec.uom.se.unit.Units.LITRE), RationalConverter.of(5.6, 1)));
-    public static final Unit<Angle> DEGREE_ANGLE = addUnit(new TransformedUnit<>(tec.uom.se.unit.Units.RADIAN,
-            new PiMultiplierConverter().concatenate(new RationalConverter(BigInteger.ONE, BigInteger.valueOf(180)))));
-    public static final Unit<Angle> RADIAN = addUnit(tec.uom.se.unit.Units.RADIAN);
-    public static final Unit<ArealDensity> DOBSON_UNIT = addUnit(new ProductUnit<ArealDensity>(MetricPrefix
-            .MILLI(tec.uom.se.unit.Units.MOLE).multiply(0.4462).divide(tec.uom.se.unit.Units.SQUARE_METRE)));
-    public static final Unit<CatalyticActivity> KATAL = addUnit(tec.uom.se.unit.Units.KATAL);
-    public static final Unit<Density> KILOGRAM_PER_CUBICMETRE = addUnit(
-            new ProductUnit<Density>(tec.uom.se.unit.Units.KILOGRAM.divide(tec.uom.se.unit.Units.CUBIC_METRE)));
+    public static final Unit<AmountOfSubstance> DEUTSCHE_HAERTE = addUnit(new TransformedUnit<>("°dH",
+            (Unit<AmountOfSubstance>) MetricPrefix.MILLI(Units.MOLE).divide(Units.LITRE), MultiplyConverter.of(5.6)));
+    public static final Unit<Angle> DEGREE_ANGLE = addUnit(NonSI.DEGREE_ANGLE);
+    public static final Unit<Angle> RADIAN = addUnit(tech.units.indriya.unit.Units.RADIAN);
+    public static final Unit<ArealDensity> DOBSON_UNIT = addUnit(
+            new ProductUnit<ArealDensity>(MetricPrefix.MILLI(tech.units.indriya.unit.Units.MOLE).multiply(0.4462)
+                    .divide(tech.units.indriya.unit.Units.SQUARE_METRE)));
+    public static final Unit<CatalyticActivity> KATAL = addUnit(tech.units.indriya.unit.Units.KATAL);
+    public static final Unit<Density> KILOGRAM_PER_CUBICMETRE = addUnit(new ProductUnit<Density>(
+            tech.units.indriya.unit.Units.KILOGRAM.divide(tech.units.indriya.unit.Units.CUBIC_METRE)));
     public static final Unit<Density> MICROGRAM_PER_CUBICMETRE = addUnit(new TransformedUnit<>(KILOGRAM_PER_CUBICMETRE,
-            new RationalConverter(BigInteger.ONE, BigInteger.valueOf(1000000000))));
+            MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(1000000000))));
     public static final Unit<Dimensionless> ONE = addUnit(AbstractUnit.ONE);
-    public static final Unit<Dimensionless> PERCENT = addUnit(tec.uom.se.unit.Units.PERCENT);
+    public static final Unit<Dimensionless> PERCENT = addUnit(tech.units.indriya.unit.Units.PERCENT);
     public static final Unit<Dimensionless> PARTS_PER_BILLION = addUnit(
-            new TransformedUnit<>(ONE, new RationalConverter(BigInteger.ONE, BigInteger.valueOf(1000000000))));
+            new TransformedUnit<>(ONE, MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(1000000000))));
     public static final Unit<Dimensionless> PARTS_PER_MILLION = addUnit(
-            new TransformedUnit<>(ONE, new RationalConverter(BigInteger.ONE, BigInteger.valueOf(1000000))));
+            new TransformedUnit<>(ONE, MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(1000000))));
     public static final Unit<Dimensionless> DECIBEL = addUnit(ONE.transform(
-            new LogConverter(10).inverse().concatenate(new RationalConverter(BigInteger.ONE, BigInteger.TEN))));
-    public static final Unit<ElectricCurrent> AMPERE = addUnit(tec.uom.se.unit.Units.AMPERE);
-    public static final Unit<ElectricCapacitance> FARAD = addUnit(tec.uom.se.unit.Units.FARAD);
-    public static final Unit<ElectricCharge> COULOMB = addUnit(tec.uom.se.unit.Units.COULOMB);
-    public static final Unit<ElectricCharge> AMPERE_HOUR = addUnit(tec.uom.se.unit.Units.COULOMB.multiply(3600));
+            new LogConverter(10).inverse().concatenate(MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.TEN))));
+    public static final Unit<ElectricCurrent> AMPERE = addUnit(tech.units.indriya.unit.Units.AMPERE);
+    public static final Unit<ElectricCapacitance> FARAD = addUnit(tech.units.indriya.unit.Units.FARAD);
+    public static final Unit<ElectricCharge> COULOMB = addUnit(tech.units.indriya.unit.Units.COULOMB);
+    public static final Unit<ElectricCharge> AMPERE_HOUR = addUnit(
+            tech.units.indriya.unit.Units.COULOMB.multiply(3600));
     public static final Unit<ElectricCharge> MILLIAMPERE_HOUR = addUnit(MetricPrefix.MILLI(AMPERE_HOUR));
-    public static final Unit<ElectricConductance> SIEMENS = addUnit(tec.uom.se.unit.Units.SIEMENS);
-    public static final Unit<ElectricConductivity> SIEMENS_PER_METRE = addUnit(
-            new ProductUnit<ElectricConductivity>(tec.uom.se.unit.Units.SIEMENS.divide(tec.uom.se.unit.Units.METRE)));
-    public static final Unit<ElectricInductance> HENRY = addUnit(tec.uom.se.unit.Units.HENRY);
-    public static final Unit<ElectricPotential> VOLT = addUnit(tec.uom.se.unit.Units.VOLT);
-    public static final Unit<ElectricResistance> OHM = addUnit(tec.uom.se.unit.Units.OHM);
-    public static final Unit<Energy> JOULE = addUnit(tec.uom.se.unit.Units.JOULE);
+    public static final Unit<ElectricConductance> SIEMENS = addUnit(tech.units.indriya.unit.Units.SIEMENS);
+    public static final Unit<ElectricConductivity> SIEMENS_PER_METRE = addUnit(new ProductUnit<ElectricConductivity>(
+            tech.units.indriya.unit.Units.SIEMENS.divide(tech.units.indriya.unit.Units.METRE)));
+    public static final Unit<ElectricInductance> HENRY = addUnit(tech.units.indriya.unit.Units.HENRY);
+    public static final Unit<ElectricPotential> VOLT = addUnit(tech.units.indriya.unit.Units.VOLT);
+    public static final Unit<ElectricResistance> OHM = addUnit(tech.units.indriya.unit.Units.OHM);
+    public static final Unit<Energy> JOULE = addUnit(tech.units.indriya.unit.Units.JOULE);
     public static final Unit<Energy> WATT_SECOND = addUnit(
-            new ProductUnit<>(tec.uom.se.unit.Units.WATT.multiply(tec.uom.se.unit.Units.SECOND)));
+            new ProductUnit<>(tech.units.indriya.unit.Units.WATT.multiply(tech.units.indriya.unit.Units.SECOND)));
     public static final Unit<Energy> WATT_HOUR = addUnit(
-            new ProductUnit<>(tec.uom.se.unit.Units.WATT.multiply(tec.uom.se.unit.Units.HOUR)));
+            new ProductUnit<>(tech.units.indriya.unit.Units.WATT.multiply(tech.units.indriya.unit.Units.HOUR)));
     public static final Unit<Energy> KILOWATT_HOUR = addUnit(MetricPrefix.KILO(WATT_HOUR));
     public static final Unit<Energy> MEGAWATT_HOUR = addUnit(MetricPrefix.MEGA(WATT_HOUR));
-    public static final Unit<Power> VAR = addUnit(new AlternateUnit<>(tec.uom.se.unit.Units.WATT, "var"));
+    public static final Unit<Power> VAR = addUnit(new AlternateUnit<>(tech.units.indriya.unit.Units.WATT, "var"));
     public static final Unit<Power> KILOVAR = addUnit(MetricPrefix.KILO(VAR));
-    public static final Unit<Energy> VAR_HOUR = addUnit(new ProductUnit<>(VAR.multiply(tec.uom.se.unit.Units.HOUR)),
-            Energy.class);
+    public static final Unit<Energy> VAR_HOUR = addUnit(
+            new ProductUnit<>(VAR.multiply(tech.units.indriya.unit.Units.HOUR)), Energy.class);
     public static final Unit<Energy> KILOVAR_HOUR = addUnit(MetricPrefix.KILO(VAR_HOUR));
-    public static final Unit<Power> VOLT_AMPERE = addUnit(new AlternateUnit<>(tec.uom.se.unit.Units.WATT, "VA"));
+    public static final Unit<Power> VOLT_AMPERE = addUnit(
+            new AlternateUnit<>(tech.units.indriya.unit.Units.WATT, "VA"));
+    public static final Unit<Power> KILOVOLT_AMPERE = addUnit(MetricPrefix.KILO(VOLT_AMPERE));
     public static final Unit<Energy> VOLT_AMPERE_HOUR = addUnit(
-            new ProductUnit<>(VOLT_AMPERE.multiply(tec.uom.se.unit.Units.HOUR)), Energy.class);
-    public static final Unit<Force> NEWTON = addUnit(tec.uom.se.unit.Units.NEWTON);
-    public static final Unit<Frequency> HERTZ = addUnit(tec.uom.se.unit.Units.HERTZ);
+            new ProductUnit<>(VOLT_AMPERE.multiply(tech.units.indriya.unit.Units.HOUR)), Energy.class);
+    public static final Unit<Force> NEWTON = addUnit(tech.units.indriya.unit.Units.NEWTON);
+    public static final Unit<Frequency> HERTZ = addUnit(tech.units.indriya.unit.Units.HERTZ);
     public static final Unit<Intensity> IRRADIANCE = addUnit(
-            new ProductUnit<>(tec.uom.se.unit.Units.WATT.divide(tec.uom.se.unit.Units.SQUARE_METRE)));
+            new ProductUnit<>(tech.units.indriya.unit.Units.WATT.divide(tech.units.indriya.unit.Units.SQUARE_METRE)));
     public static final Unit<Intensity> MICROWATT_PER_SQUARE_CENTIMETRE = addUnit(
-            new TransformedUnit<>(IRRADIANCE, new RationalConverter(BigInteger.ONE, BigInteger.valueOf(100))));
-    public static final Unit<Illuminance> LUX = addUnit(tec.uom.se.unit.Units.LUX);
-    public static final Unit<LuminousFlux> LUMEN = addUnit(tec.uom.se.unit.Units.LUMEN);
-    public static final Unit<LuminousIntensity> CANDELA = addUnit(tec.uom.se.unit.Units.CANDELA);
-    public static final Unit<MagneticFlux> WEBER = addUnit(tec.uom.se.unit.Units.WEBER);
-    public static final Unit<MagneticFluxDensity> TESLA = addUnit(tec.uom.se.unit.Units.TESLA);
-    public static final Unit<Power> WATT = addUnit(tec.uom.se.unit.Units.WATT);
+            new TransformedUnit<>(IRRADIANCE, MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(100))));
+    public static final Unit<Illuminance> LUX = addUnit(tech.units.indriya.unit.Units.LUX);
+    public static final Unit<LuminousFlux> LUMEN = addUnit(tech.units.indriya.unit.Units.LUMEN);
+    public static final Unit<LuminousIntensity> CANDELA = addUnit(tech.units.indriya.unit.Units.CANDELA);
+    public static final Unit<MagneticFlux> WEBER = addUnit(tech.units.indriya.unit.Units.WEBER);
+    public static final Unit<MagneticFluxDensity> TESLA = addUnit(tech.units.indriya.unit.Units.TESLA);
+    public static final Unit<Power> WATT = addUnit(tech.units.indriya.unit.Units.WATT);
     public static final Unit<Power> DECIBEL_MILLIWATTS = new TransformedUnit<>("dBm", MetricPrefix.MILLI(WATT),
-            new ExpConverter(10.0).concatenate(new MultiplyConverter(0.1)));
+            new ExpConverter(10.0).concatenate(MultiplyConverter.of(0.1)));
     public static final Unit<Pressure> MILLIMETRE_OF_MERCURY = addUnit(
-            new TransformedUnit<>("mmHg", tec.uom.se.unit.Units.PASCAL,
-                    new RationalConverter(BigInteger.valueOf(133322368), BigInteger.valueOf(1000000))));
-    public static final Unit<Pressure> BAR = addUnit(new TransformedUnit<>("bar", tec.uom.se.unit.Units.PASCAL,
-            new RationalConverter(BigInteger.valueOf(100000), BigInteger.ONE)));
+            new TransformedUnit<>("mmHg", tech.units.indriya.unit.Units.PASCAL,
+                    MultiplyConverter.ofRational(BigInteger.valueOf(133322368), BigInteger.valueOf(1000000))));
+    public static final Unit<Pressure> BAR = addUnit(new TransformedUnit<>("bar", tech.units.indriya.unit.Units.PASCAL,
+            MultiplyConverter.ofRational(BigInteger.valueOf(100000), BigInteger.ONE)));
     public static final Unit<Pressure> MILLIBAR = addUnit(MetricPrefix.MILLI(BAR));
-    public static final Unit<Radioactivity> BECQUEREL = addUnit(tec.uom.se.unit.Units.BECQUEREL);
-    public static final Unit<Density> BECQUEREL_PER_CUBIC_METRE = addUnit(
-            new ProductUnit<>(tec.uom.se.unit.Units.BECQUEREL.divide(tec.uom.se.unit.Units.CUBIC_METRE)));
-    public static final Unit<RadiationDoseAbsorbed> GRAY = addUnit(tec.uom.se.unit.Units.GRAY);
-    public static final Unit<RadiationDoseEffective> SIEVERT = addUnit(tec.uom.se.unit.Units.SIEVERT);
+    public static final Unit<Radioactivity> BECQUEREL = addUnit(tech.units.indriya.unit.Units.BECQUEREL);
+    public static final Unit<Density> BECQUEREL_PER_CUBIC_METRE = addUnit(new ProductUnit<>(
+            tech.units.indriya.unit.Units.BECQUEREL.divide(tech.units.indriya.unit.Units.CUBIC_METRE)));
+    public static final Unit<RadiationDoseAbsorbed> GRAY = addUnit(tech.units.indriya.unit.Units.GRAY);
+    public static final Unit<RadiationDoseEffective> SIEVERT = addUnit(tech.units.indriya.unit.Units.SIEVERT);
     public static final Unit<Speed> MILLIMETRE_PER_HOUR = addUnit(
-            new TransformedUnit<>("mm/h", tec.uom.se.unit.Units.KILOMETRE_PER_HOUR,
-                    new RationalConverter(BigInteger.ONE, BigInteger.valueOf(1000000))));
+            new TransformedUnit<>("mm/h", tech.units.indriya.unit.Units.KILOMETRE_PER_HOUR,
+                    MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(1000000))));
     public static final Unit<Speed> INCHES_PER_HOUR = addUnit(new TransformedUnit<>("in/h",
-            ImperialUnits.MILES_PER_HOUR, new RationalConverter(BigInteger.ONE, BigInteger.valueOf(63360))));
-    public static final Unit<Speed> METRE_PER_SECOND = addUnit(tec.uom.se.unit.Units.METRE_PER_SECOND);
-    public static final Unit<Speed> KNOT = addUnit(new TransformedUnit<>("kn", tec.uom.se.unit.Units.KILOMETRE_PER_HOUR,
-            new RationalConverter(BigInteger.valueOf(1852), BigInteger.valueOf(1000))));
-    public static final Unit<SolidAngle> STERADIAN = addUnit(tec.uom.se.unit.Units.STERADIAN);
-    public static final Unit<Temperature> KELVIN = addUnit(tec.uom.se.unit.Units.KELVIN);
-    public static final Unit<Time> SECOND = addUnit(tec.uom.se.unit.Units.SECOND);
-    public static final Unit<Time> MINUTE = addUnit(tec.uom.se.unit.Units.MINUTE);
-    public static final Unit<Time> HOUR = addUnit(tec.uom.se.unit.Units.HOUR);
-    public static final Unit<Time> DAY = addUnit(tec.uom.se.unit.Units.DAY);
-    public static final Unit<Time> WEEK = addUnit(tec.uom.se.unit.Units.WEEK);
-    public static final Unit<Time> YEAR = addUnit(tec.uom.se.unit.Units.YEAR);
-    public static final Unit<Volume> LITRE = addUnit(tec.uom.se.unit.Units.LITRE);
-    public static final Unit<VolumetricFlowRate> LITRE_PER_MINUTE = addUnit(
-            new ProductUnit<VolumetricFlowRate>(tec.uom.se.unit.Units.LITRE.divide(tec.uom.se.unit.Units.MINUTE)));
+            ImperialUnits.MILES_PER_HOUR, MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.valueOf(63360))));
+    public static final Unit<Speed> METRE_PER_SECOND = addUnit(tech.units.indriya.unit.Units.METRE_PER_SECOND);
+    public static final Unit<Speed> KNOT = addUnit(
+            new TransformedUnit<>("kn", tech.units.indriya.unit.Units.KILOMETRE_PER_HOUR,
+                    MultiplyConverter.ofRational(BigInteger.valueOf(1852), BigInteger.valueOf(1000))));
+    public static final Unit<SolidAngle> STERADIAN = addUnit(tech.units.indriya.unit.Units.STERADIAN);
+    public static final Unit<Temperature> KELVIN = addUnit(tech.units.indriya.unit.Units.KELVIN);
+    public static final Unit<Time> SECOND = addUnit(tech.units.indriya.unit.Units.SECOND);
+    public static final Unit<Time> MINUTE = addUnit(tech.units.indriya.unit.Units.MINUTE);
+    public static final Unit<Time> HOUR = addUnit(tech.units.indriya.unit.Units.HOUR);
+    public static final Unit<Time> DAY = addUnit(tech.units.indriya.unit.Units.DAY);
+    public static final Unit<Time> WEEK = addUnit(tech.units.indriya.unit.Units.WEEK);
+    public static final Unit<Time> YEAR = addUnit(tech.units.indriya.unit.Units.YEAR);
+    public static final Unit<VolumetricFlowRate> LITRE_PER_MINUTE = addUnit(new ProductUnit<VolumetricFlowRate>(
+            tech.units.indriya.unit.Units.LITRE.divide(tech.units.indriya.unit.Units.MINUTE)));
     public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_SECOND = addUnit(new ProductUnit<VolumetricFlowRate>(
-            tec.uom.se.unit.Units.CUBIC_METRE.divide(tec.uom.se.unit.Units.SECOND)));
+            tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.SECOND)));
     public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_MINUTE = addUnit(new ProductUnit<VolumetricFlowRate>(
-            tec.uom.se.unit.Units.CUBIC_METRE.divide(tec.uom.se.unit.Units.MINUTE)));
-    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_HOUR = addUnit(
-            new ProductUnit<VolumetricFlowRate>(tec.uom.se.unit.Units.CUBIC_METRE.divide(tec.uom.se.unit.Units.HOUR)));
-    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_DAY = addUnit(
-            new ProductUnit<VolumetricFlowRate>(tec.uom.se.unit.Units.CUBIC_METRE.divide(tec.uom.se.unit.Units.DAY)));
+            tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.MINUTE)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_HOUR = addUnit(new ProductUnit<VolumetricFlowRate>(
+            tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.HOUR)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_DAY = addUnit(new ProductUnit<VolumetricFlowRate>(
+            tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.DAY)));
     public static final Unit<DataAmount> BIT = addUnit(new AlternateUnit<>(ONE, "bit"));
     public static final Unit<DataAmount> KILOBIT = addUnit(MetricPrefix.KILO(BIT));
     public static final Unit<DataAmount> MEGABIT = addUnit(MetricPrefix.MEGA(BIT));
@@ -209,7 +211,7 @@ public final class Units extends CustomUnits {
     public static final Unit<DataAmount> TEBIOCTET = addUnit(BinaryPrefix.TEBI(OCTET));
     public static final Unit<DataAmount> PEBIOCTET = addUnit(BinaryPrefix.PEBI(OCTET));
     public static final Unit<DataTransferRate> BIT_PER_SECOND = addUnit(
-            new ProductUnit<DataTransferRate>(BIT.divide(tec.uom.se.unit.Units.SECOND)));
+            new ProductUnit<DataTransferRate>(BIT.divide(tech.units.indriya.unit.Units.SECOND)));
     public static final Unit<DataTransferRate> KILOBIT_PER_SECOND = addUnit(MetricPrefix.KILO(BIT_PER_SECOND));
     public static final Unit<DataTransferRate> MEGABIT_PER_SECOND = addUnit(MetricPrefix.MEGA(BIT_PER_SECOND));
     public static final Unit<DataTransferRate> GIGABIT_PER_SECOND = addUnit(MetricPrefix.GIGA(BIT_PER_SECOND));
@@ -249,6 +251,7 @@ public final class Units extends CustomUnits {
         SimpleUnitFormat.getInstance().label(KILOBIT_PER_SECOND, "kbit/s");
         SimpleUnitFormat.getInstance().label(KILOVAR, "kvar");
         SimpleUnitFormat.getInstance().label(KILOVAR_HOUR, "kvarh");
+        SimpleUnitFormat.getInstance().label(KILOVOLT_AMPERE, "kVA");
         SimpleUnitFormat.getInstance().label(KILOWATT_HOUR, "kWh");
         SimpleUnitFormat.getInstance().label(KNOT, KNOT.getSymbol());
         SimpleUnitFormat.getInstance().label(LITRE_PER_MINUTE, "l/min");

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.measure.MetricPrefix;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.UnitConverter;
@@ -36,9 +37,9 @@ import org.openhab.core.library.unit.Units;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import tec.uom.se.quantity.Quantities;
-import tec.uom.se.unit.MetricPrefix;
-import tec.uom.se.unit.TransformedUnit;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.quantity.Quantities;
+import tech.units.indriya.unit.TransformedUnit;
 
 /**
  * A utility for parsing dimensions to interface classes of {@link Quantity} and parsing units from format strings.
@@ -54,10 +55,11 @@ public class UnitUtils {
     public static final String UNIT_PERCENT_FORMAT_STRING = "%%";
 
     private static final String JAVAX_MEASURE_QUANTITY_PREFIX = "javax.measure.quantity.";
+    private static final String SI_DIMENSION_PREFIX = "si.uom.quantity.";
     private static final String FRAMEWORK_DIMENSION_PREFIX = "org.openhab.core.library.dimension.";
 
     private static final Collection<Class<? extends SystemOfUnits>> ALL_SYSTEM_OF_UNITS = Arrays.asList(SIUnits.class,
-            ImperialUnits.class, Units.class, tec.uom.se.unit.Units.class);
+            ImperialUnits.class, Units.class, tech.units.indriya.unit.Units.class);
 
     static {
         UnitInitializer.init();
@@ -84,8 +86,12 @@ public class UnitUtils {
             try {
                 return dimensionClass(JAVAX_MEASURE_QUANTITY_PREFIX, dimension);
             } catch (ClassNotFoundException e2) {
-                throw new IllegalArgumentException(
-                        "Error creating a dimension Class instance for name '" + dimension + "'.");
+                try {
+                    return dimensionClass(SI_DIMENSION_PREFIX, dimension);
+                } catch (ClassNotFoundException e3) {
+                    throw new IllegalArgumentException(
+                            "Error creating a dimension Class instance for name '" + dimension + "'.");
+                }
             }
         }
     }
@@ -201,7 +207,7 @@ public class UnitUtils {
 
     private static boolean isMetricConversion(UnitConverter converter) {
         for (MetricPrefix mp : MetricPrefix.values()) {
-            if (mp.getConverter().equals(converter)) {
+            if (MultiplyConverter.ofPrefix(mp).equals(converter)) {
                 return true;
             }
         }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/VolumetricFlowRateTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/VolumetricFlowRateTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.library.dimension;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.IsCloseTo.closeTo;
 
 import java.util.stream.Stream;
 
@@ -26,8 +27,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.util.UnitUtils;
 
-import tec.uom.se.ComparableQuantity;
-import tec.uom.se.quantity.Quantities;
+import tech.units.indriya.ComparableQuantity;
+import tech.units.indriya.quantity.Quantities;
 
 /**
  * Test for volumentric flow rate constants defined in {@link Units}.
@@ -56,7 +57,8 @@ public class VolumetricFlowRateTest {
 
         ComparableQuantity<VolumetricFlowRate> convertedQuantity = quantity.to(BASE_UNIT);
 
-        assertThat(convertedQuantity, is(equalTo(quantityInBase)));
+        assertThat(convertedQuantity.getValue().doubleValue(),
+                is(closeTo(quantityInBase.getValue().doubleValue(), 1e-10)));
     }
 
     /**
@@ -76,6 +78,6 @@ public class VolumetricFlowRateTest {
                 Arguments.of(Units.CUBICMETRE_PER_SECOND, "m³/s", 100.0, 360000.0),
                 Arguments.of(Units.CUBICMETRE_PER_MINUTE, "m³/min", 100.0, 6000.0),
                 Arguments.of(Units.CUBICMETRE_PER_HOUR, "m³/h", 100.0, 100.0),
-                Arguments.of(Units.CUBICMETRE_PER_DAY, "m³/d", 100.0, 4.166666666666667));
+                Arguments.of(Units.CUBICMETRE_PER_DAY, "m³/d", 100.0, 4.166666666666666666666666666666667));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -119,7 +119,7 @@ public class QuantityTypeArithmeticGroupFunctionTest {
         function = new QuantityTypeArithmeticGroupFunction.Avg(Temperature.class);
         State state = function.calculate(items);
 
-        assertEquals(new QuantityType<>("55.33 °C"), state);
+        assertEquals(new QuantityType<>("55.33333333333333333333333333333334 °C"), state);
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.text.DecimalFormatSymbols;
 
+import javax.measure.format.MeasurementParseException;
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Energy;
 import javax.measure.quantity.Length;
@@ -40,7 +41,7 @@ import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.util.UnitUtils;
 
-import tec.uom.se.quantity.QuantityDimension;
+import tech.units.indriya.unit.UnitDimension;
 
 /**
  * @author Gaël L'hopital - Initial contribution
@@ -57,14 +58,14 @@ public class QuantityTypeTest {
         new QuantityType<>("57%");
 
         QuantityType<Dimensionless> dt0 = new QuantityType<>("12");
-        assertTrue(dt0.getUnit().getDimension() == QuantityDimension.NONE);
+        assertTrue(dt0.getUnit().getDimension() == UnitDimension.NONE);
         dt0 = new QuantityType<>("2rad");
-        assertTrue(dt0.getUnit().getDimension() == QuantityDimension.NONE);
+        assertTrue(dt0.getUnit().getDimension() == UnitDimension.NONE);
     }
 
     @Test
     public void testKnownInvalidConstructors() {
-        assertThrows(IllegalArgumentException.class, () -> new QuantityType<>("123 Hello World"));
+        assertThrows(MeasurementParseException.class, () -> new QuantityType<>("123 Hello World"));
     }
 
     @Test
@@ -78,7 +79,6 @@ public class QuantityTypeTest {
         new QuantityType<>("1084 hPa");
         new QuantityType<>("0E-22 m");
         new QuantityType<>("10E-3");
-        new QuantityType<>("10E+3");
         new QuantityType<>("10E3");
         QuantityType.valueOf("2m");
     }
@@ -94,13 +94,13 @@ public class QuantityTypeTest {
     public void testUnits() {
         QuantityType<Length> dt2 = new QuantityType<>("2 m");
         // Check that the unit has correctly been identified
-        assertEquals(dt2.getDimension(), QuantityDimension.LENGTH);
+        assertEquals(dt2.getDimension(), UnitDimension.LENGTH);
         assertEquals(dt2.getUnit(), SIUnits.METRE);
         assertEquals("2 m", dt2.toString());
 
         QuantityType<Length> dt1 = new QuantityType<>("2.1cm");
         // Check that the unit has correctly been identified
-        assertEquals(dt1.getDimension(), QuantityDimension.LENGTH);
+        assertEquals(dt1.getDimension(), UnitDimension.LENGTH);
         assertEquals(dt1.getUnit(), CENTI(SIUnits.METRE));
         assertEquals("2.1 cm", dt1.toString());
 
@@ -255,19 +255,16 @@ public class QuantityTypeTest {
 
     @Test
     public void testDivideZero() {
-        assertThrows(ArithmeticException.class, () -> new QuantityType<>("4 m").divide(QuantityType.ZERO));
+        assertThrows(IllegalArgumentException.class, () -> new QuantityType<>("4 m").divide(QuantityType.ZERO));
     }
 
     @Test
     public void testExponentials() {
         QuantityType<Length> exponential = new QuantityType<>("10E-2 m");
-        assertEquals(exponential, new QuantityType<>("10 cm"));
-
-        exponential = new QuantityType<>("10E+3 m");
-        assertEquals(exponential, new QuantityType<>("10 km"));
+        assertEquals(new QuantityType<>("10 cm"), exponential);
 
         exponential = new QuantityType<>("10E3 m");
-        assertEquals(exponential, new QuantityType<>("10 km"));
+        assertEquals(new QuantityType<>("10 km"), exponential);
     }
 
     @Test

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -27,9 +27,14 @@
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.12.0</bundle>
 
 		<!-- Measurement -->
-		<bundle dependency="true">mvn:javax.measure/unit-api/1.0</bundle>
-		<bundle dependency="true">mvn:tec.uom/uom-se/1.0.10</bundle>
-		<bundle dependency="true">mvn:tec.uom.lib/uom-lib-common/1.0.3</bundle>
+		<bundle dependency="true">mvn:jakarta.annotation/jakarta.annotation-api/2.0.0</bundle>
+		<bundle dependency="true">mvn:jakarta.inject/jakarta.inject-api/2.0.0</bundle>
+		<bundle dependency="true">mvn:javax.measure/unit-api/2.1.2</bundle>
+		<!-- The si.uom:si-units manifest has no Export-Package entry. As workaround this OSGi-ify bundle is used. -->
+		<bundle dependency="true">mvn:org.openhab.osgiify/si.uom.si-units/2.0.1</bundle>
+		<bundle dependency="true">mvn:si.uom/si-quantity/2.0.1</bundle>
+		<bundle dependency="true">mvn:tech.units/indriya/2.1.2</bundle>
+		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.1</bundle>
 
 		<!-- TODO: Unbundled libraries -->
 		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.15</bundle>

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -54,4 +51,13 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.eclipse.jetty.websocket.common;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -49,4 +46,12 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -50,4 +47,12 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.automation.module.script
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -50,4 +47,12 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -50,4 +47,12 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.automation
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -50,4 +47,12 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -3,19 +3,20 @@
 Bundle-SymbolicName: ${project.artifactId}
 Fragment-Host: org.openhab.core.binding.xml
 
--runrequires: bnd.identity;id='org.openhab.core.binding.xml.tests'
+-runblacklist: \
+	bnd.identity;id='org.osgi.service.cm'
+
+-runrequires: \
+	bnd.identity;id='org.openhab.core.binding.xml.tests'
 
 #
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.eclipse.jdt.annotation;version='[2.2.100,2.2.101)',\
@@ -48,4 +49,12 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -10,13 +10,10 @@ Fragment-Host: org.openhab.core.config.core
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -48,4 +45,12 @@ Fragment-Host: org.openhab.core.config.core
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -50,4 +47,13 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -11,13 +11,10 @@ Fragment-Host: org.openhab.core.config.discovery
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -57,4 +54,13 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -9,12 +9,9 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
@@ -54,5 +51,14 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'
 

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -19,13 +19,10 @@ Provide-Capability: \
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -62,4 +59,13 @@ Provide-Capability: \
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.config.dispatch
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -44,4 +41,13 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -9,12 +9,9 @@ Fragment-Host: org.openhab.core.config.xml
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
@@ -45,4 +42,12 @@ Fragment-Host: org.openhab.core.config.xml
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -15,13 +15,10 @@ feature.openhab-config: \
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -54,4 +51,12 @@ feature.openhab-config: \
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 #
 -runbundles: \
 	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	net.minidev.accessors-smart;version='[1.2.0,1.2.1)',\
 	net.minidev.json-smart;version='[2.3.0,2.3.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
@@ -19,8 +18,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -89,4 +86,12 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.objectweb.asm.tree.analysis;version='[9.0.0,9.0.1)',\
 	org.objectweb.asm.util;version='[9.0.0,9.0.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	stax2-api;version='[4.2.1,4.2.2)'
+	stax2-api;version='[4.2.1,4.2.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -10,7 +10,6 @@ Fragment-Host: org.openhab.core.model.core
 #
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
@@ -18,8 +17,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -69,7 +66,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
 	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
 	org.eclipse.jetty.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.http;version='[9.4.38,9.4.39)',\
@@ -83,7 +79,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.jetty.websocket.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.xml;version='[9.4.38,9.4.39)',\
-	org.openhab.core.model.item.runtime;version='[3.1.0,3.1.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.13,7.3.14)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.13,7.3.14)',\
@@ -104,4 +99,13 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.xtext.xbase.lib;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -12,7 +12,6 @@ Fragment-Host: org.openhab.core.model.item
 #
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
@@ -20,8 +19,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -67,7 +64,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
 	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
 	org.eclipse.jetty.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.http;version='[9.4.38,9.4.39)',\
@@ -101,4 +97,13 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.xtext.xbase.lib;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -12,20 +12,15 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 #
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -71,7 +66,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
 	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
 	org.eclipse.jetty.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.http;version='[9.4.38,9.4.39)',\
@@ -105,5 +99,14 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.xtext.xbase.lib;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -3,16 +3,18 @@
 Bundle-SymbolicName: ${project.artifactId}
 Fragment-Host: org.openhab.core.model.script
 
+-runblacklist: \
+	bnd.identity;id='org.osgi.service.cm'
+
 -runrequires: \
-    bnd.identity;id='org.openhab.core.model.script.tests',\
-    bnd.identity;id='org.openhab.core.model.script.runtime'
+	bnd.identity;id='org.openhab.core.model.script.tests',\
+	bnd.identity;id='org.openhab.core.model.script.runtime'
 
 #
 # done
 #
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.glassfish.hk2.external.aopalliance-repackaged;version='[2.4.0,2.4.1)',\
@@ -20,8 +22,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -80,7 +80,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.jetty.websocket.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.websocket.common;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.xml;version='[9.4.38,9.4.39)',\
-	org.openhab.core.model.item.runtime;version='[3.1.0,3.1.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.ops4j.pax.web.pax-web-api;version='[7.3.13,7.3.14)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.13,7.3.14)',\
@@ -101,4 +100,12 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.xtext.xbase.lib;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.openhab.core.model.thing.runtime;version='[3.1.0,3.1.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
@@ -117,7 +117,7 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
         State numberState = itemRegistry.get(NUMBER_ITEM_TEMPERATURE).getState();
         assertNotNull(numberState);
         assertEquals("org.openhab.core.library.types.QuantityType", numberState.getClass().getName());
-        assertEquals("20.0 °C", numberState.toString());
+        assertEquals("20 °C", numberState.toString());
     }
 
     @SuppressWarnings("null")

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -14,7 +14,6 @@ Fragment-Host: org.openhab.core.model.thing
 #
 -runbundles: \
 	com.google.inject;version='[3.0.0,3.0.1)',\
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.antlr.runtime;version='[3.2.0,3.2.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -22,8 +21,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	io.github.classgraph;version='[4.8.35,4.8.36)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
@@ -80,7 +77,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.semantics;version='[3.1.0,3.1.1)',\
 	biz.aQute.tester.junit-platform;version='[5.3.0,5.3.1)',\
 	com.google.gson;version='[2.8.6,2.8.7)',\
-	org.apache.felix.configadmin;version='[1.9.20,1.9.21)',\
 	org.apache.felix.scr;version='[2.1.26,2.1.27)',\
 	org.eclipse.jetty.client;version='[9.4.38,9.4.39)',\
 	org.eclipse.jetty.http;version='[9.4.38,9.4.39)',\
@@ -114,4 +110,12 @@ Fragment-Host: org.openhab.core.model.thing
 	org.eclipse.xtext.xbase.lib;version='[2.25.0,2.25.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core.storage.json
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -44,4 +41,12 @@ Fragment-Host: org.openhab.core.storage.json
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -9,13 +9,10 @@ Fragment-Host: org.openhab.core
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -47,4 +44,12 @@ Fragment-Host: org.openhab.core
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -67,7 +67,7 @@ import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
-import tec.uom.se.unit.Units;
+import tech.units.indriya.unit.Units;
 
 /**
  * @author Stefan Triller - Initial contribution

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -3,22 +3,22 @@
 Bundle-SymbolicName: ${project.artifactId}
 Fragment-Host: org.openhab.core.thing
 
+-runblacklist: \
+	bnd.identity;id='org.osgi.service.cm'
+
 -runrequires: \
-    bnd.identity;id='org.openhab.core.thing.tests',\
-    bnd.identity;id='org.openhab.core.config.xml',\
-    bnd.identity;id='org.openhab.core.thing.xml'
+	bnd.identity;id='org.openhab.core.thing.tests',\
+	bnd.identity;id='org.openhab.core.config.xml',\
+	bnd.identity;id='org.openhab.core.thing.xml'
 
 #
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -57,4 +57,12 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -11,13 +11,10 @@ Fragment-Host: org.openhab.core.thing.xml
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -51,4 +48,12 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.eclipse.jetty.util.ajax;version='[9.4.38,9.4.39)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.8,2.0.9)',\
 	org.osgi.util.function;version='[1.1.0,1.1.1)',\
-	org.osgi.util.promise;version='[1.1.1,1.1.2)'
+	org.osgi.util.promise;version='[1.1.1,1.1.2)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -3,19 +3,20 @@
 Bundle-SymbolicName: ${project.artifactId}
 Fragment-Host: org.openhab.core.voice
 
--runrequires: bnd.identity;id='org.openhab.core.voice.tests'
+-runblacklist: \
+	bnd.identity;id='org.osgi.service.cm'
+
+-runrequires: \
+	bnd.identity;id='org.openhab.core.voice.tests'
 
 #
 # done
 #
 -runbundles: \
-	javax.measure.unit-api;version='[1.0.0,1.0.1)',\
 	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
-	tec.uom.lib.uom-lib-common;version='[1.0.3,1.0.4)',\
-	tec.uom.se;version='[1.0.10,1.0.11)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
@@ -60,4 +61,12 @@ Fragment-Host: org.openhab.core.voice
 	org.apache.xbean.finder;version='[4.18.0,4.18.1)',\
 	org.objectweb.asm;version='[9.1.0,9.1.1)',\
 	org.objectweb.asm.commons;version='[9.0.0,9.0.1)',\
-	org.objectweb.asm.tree;version='[9.0.0,9.0.1)'
+	org.objectweb.asm.tree;version='[9.0.0,9.0.1)',\
+	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
+	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
+	javax.measure.unit-api;version='[2.1.2,2.1.3)',\
+	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
+	si-units;version='[2.0.1,2.0.2)',\
+	si.uom.si-quantity;version='[2.0.1,2.0.2)',\
+	tech.units.indriya;version='[2.1.2,2.1.3)',\
+	uom-lib-common;version='[2.1.0,2.1.1)'


### PR DESCRIPTION
Based on #1664
Depends on openhab/openhab-osgiify#19

---


Upgrades UoM dependencies to:

* javax.measure 2.1.2
* si-units 2.0.1
* indriya 2.1.2

An openHAB OSGi-ified si-units bundle is used as runtime dependency, because the latest si-units release is still missing proper OSGi manifest headers.

Notable changes:

* Quantity not longer implements an `equals` method, so the unit tests had to be adjusted. This should have any impact outside of the unit tests though since the rest of openHAB should be using QuantityType instead.
* RationalConverter is not package private, so instances of it much be created through the MultiplyConverter static functions.
* Quantities.getQuantity can no longer parse values without units like `100`. A workaround has been implemented.
* The unicode greek `mu` letter is now returned for unit prefixes instead of the unicode `micro` character. These characters are visually identical but the unit tests had to be adjusted. The new library seems to parse both types just fine.