### PR TITLE
Remove commons-io and commons-codec dependencies

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -60,12 +60,6 @@
 
     <!-- Apache Commons -->
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -374,12 +374,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -22,8 +22,6 @@
 		<feature>eventadmin</feature>
 
 		<!-- Apache Commons -->
-		<bundle dependency="true">mvn:commons-codec/commons-codec/1.6</bundle>
-		<bundle dependency="true">mvn:commons-io/commons-io/2.2</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.12.0</bundle>
 
 		<!-- Measurement -->


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-addons/pull/10614, https://github.com/openhab/openhab-webui/pull/1028
Related to openhab/openhab-addons#7722
Replaces #2321, #2322
