### PR TITLE
[modbus] clearer error messages

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>net.wimpi</groupId>
       <artifactId>jamod</artifactId>
-      <version>1.3.3.OH</version>
+      <version>1.3.4.OH</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Bumping jamod to 1.3.4.OH

Pending https://github.com/openhab/jamod/pull/16 and release

Signed-off-by: Sami Salonen <ssalonen@gmail.com>