### PR TITLE
[i18n] Added i18n feature for labels of ConfigurableServices

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/resources/OH-INF/i18n/audio.properties
+++ b/bundles/org.openhab.core.audio/src/main/resources/OH-INF/i18n/audio.properties
@@ -2,3 +2,5 @@ system.config.audio.defaultSource.label = Default Source
 system.config.audio.defaultSource.description = The default audio source to use if no other is specified.
 system.config.audio.defaultSink.label = Default Sink
 system.config.audio.defaultSink.description = The default audio sink to use if no other is specified.
+
+service.system.audio.label = Audio

--- a/bundles/org.openhab.core.config.discovery/src/main/resources/OH-INF/i18n/inbox.properties
+++ b/bundles/org.openhab.core.config.discovery/src/main/resources/OH-INF/i18n/inbox.properties
@@ -2,3 +2,5 @@ system.config.inbox.autoIgnore.label = Auto Ignore
 system.config.inbox.autoIgnore.description = If enabled, an Inbox result matching an existing thing is automatically ignored.<br>If set to false, the Inbox may contain results although identical things already exist.
 system.config.inbox.autoApprove.label = Auto Approve
 system.config.inbox.autoApprove.description = If enabled, Inbox results are automatically approved, unless they were marked as ignored.
+
+service.system.inbox.label = Inbox

--- a/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/i18n/ephemeris.properties
+++ b/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/i18n/ephemeris.properties
@@ -6,3 +6,5 @@ system.config.ephemeris.region.label = Region
 system.config.ephemeris.region.description = Get the holidays for a specific state (e.g. New York = "ny").
 system.config.ephemeris.city.label = City
 system.config.ephemeris.city.description = Get the holidays for a specific city (e.g. New York City = "nyc").
+
+service.system.ephemeris.label = Ephemeris

--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/i18n/restauth.properties
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/i18n/restauth.properties
@@ -4,3 +4,5 @@ system.config.restauth.cacheExpiration.label = Cache Expiration Time
 system.config.restauth.cacheExpiration.description = When basic authentication is activated, credentials are put in a cache in order to speed up request authorization. The entries in the cache expire after a while in order to not keep credentials in memory indefinitely. This value defines the expiration time in hours. Set it to 0 for disabling the cache.
 system.config.restauth.implicitUserRole.label = Implicit User Role
 system.config.restauth.implicitUserRole.description = By default, operations requiring the "user" role are available when unauthenticated. Disabling this option will enforce authorization for these operations. Warning: This causes clients that do not support authentication to break.
+
+service.system.restauth.label = API Security

--- a/bundles/org.openhab.core.karaf/src/main/resources/OH-INF/i18n/addons.properties
+++ b/bundles/org.openhab.core.karaf/src/main/resources/OH-INF/i18n/addons.properties
@@ -1,2 +1,4 @@
 system.config.addons.remote.label = Access Remote Repository
 system.config.addons.remote.description = Defines whether openHAB should access the remote repository for add-on installation.
+
+service.system.addons.label = Add-on Management

--- a/bundles/org.openhab.core.persistence/src/main/resources/OH-INF/i18n/persistence.properties
+++ b/bundles/org.openhab.core.persistence/src/main/resources/OH-INF/i18n/persistence.properties
@@ -1,2 +1,4 @@
 system.config.persistence.default.label = Default Service
 system.config.persistence.default.description = The persistence service to use if no other is specified.
+
+service.system.persistence.label = Persistence

--- a/bundles/org.openhab.core.storage.json/src/main/resources/OH-INF/i18n/jsonStorage.properties
+++ b/bundles/org.openhab.core.storage.json/src/main/resources/OH-INF/i18n/jsonStorage.properties
@@ -4,3 +4,5 @@ system.config.json_storage.write_delay.label = Write Delay
 system.config.json_storage.write_delay.description = Sets the time to wait before writing changes to disk. This can reduce the number of writes when many changes are being introduced within a short period. Time is defined in milliseconds.
 system.config.json_storage.max_defer_delay.label = Maximum Write Delay
 system.config.json_storage.max_defer_delay.description = Sets the maximum period the service will wait to write data to disk in the event that many changes are happening continually.
+
+service.system.json_storage.label = Json Storage

--- a/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/chart.properties
+++ b/bundles/org.openhab.core.ui/src/main/resources/OH-INF/i18n/chart.properties
@@ -6,3 +6,5 @@ system.config.chart.scale.label = Scale
 system.config.chart.scale.description = Defines the scale to apply to the requested chart height (0.5 to divide by 2 for example).
 system.config.chart.maxWidth.label = Maximum Width
 system.config.chart.maxWidth.description = Defines the maximum width in pixels for the chart to build.
+
+service.system.chart.label = Charts

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
@@ -12,3 +12,5 @@ system.config.voice.keyword.label = Magic Word
 system.config.voice.keyword.description = The magic word to spot before initiating a dialog.
 system.config.voice.listeningItem.label = Listening Switch
 system.config.voice.listeningItem.description = If provided, the item will be switched on during the period when the dialog processor has spotted the keyword and is listening for commands.
+
+service.system.voice.label = Voice

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
@@ -14,3 +14,5 @@ system.config.i18n.measurementSystem.label = Measurement System
 system.config.i18n.measurementSystem.description = The measurement system is used for unit conversion.
 system.config.i18n.measurementSystem.option.SI = Metric
 system.config.i18n.measurementSystem.option.US = Imperial (US)
+
+service.system.i18n.label = Regional Settings

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/network.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/network.properties
@@ -6,3 +6,5 @@ system.config.network.useOnlyOneAddress.label = Single IP Address per Interface
 system.config.network.useOnlyOneAddress.description = Use only one IP address per interface and family.
 system.config.network.useIPv6.label = Use IPv6
 system.config.network.useIPv6.description = Use IPv6 Addresses if available.
+
+service.system.network.label = Network Settings


### PR DESCRIPTION
- Added i18n feature for labels of ConfigurableServices

Notation is either ` service.<uri>.label = ...` (`:` has to be replaced by `.` in the `<uri>` part) or `@text/<key>`.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>