### PR TITLE
[automation] match on complete channel UID

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
@@ -25,6 +25,7 @@ import org.openhab.core.automation.handler.TriggerHandlerCallback;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.events.ChannelTriggeredEvent;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -47,7 +48,7 @@ public class ChannelEventTriggerHandler extends BaseTriggerModuleHandler impleme
     private final Logger logger = LoggerFactory.getLogger(ChannelEventTriggerHandler.class);
 
     private final String eventOnChannel;
-    private final String channelUID;
+    private final ChannelUID channelUID;
     private final Set<String> types = new HashSet<>();
     private final BundleContext bundleContext;
 
@@ -58,7 +59,7 @@ public class ChannelEventTriggerHandler extends BaseTriggerModuleHandler impleme
         super(module);
 
         this.eventOnChannel = (String) module.getConfiguration().get(CFG_CHANNEL_EVENT);
-        this.channelUID = (String) module.getConfiguration().get(CFG_CHANNEL);
+        this.channelUID = new ChannelUID((String) module.getConfiguration().get(CFG_CHANNEL));
         this.bundleContext = bundleContext;
         this.types.add("ChannelTriggeredEvent");
 
@@ -88,7 +89,7 @@ public class ChannelEventTriggerHandler extends BaseTriggerModuleHandler impleme
         boolean eventMatches = false;
         if (event instanceof ChannelTriggeredEvent) {
             ChannelTriggeredEvent cte = (ChannelTriggeredEvent) event;
-            if (cte.getTopic().contains(this.channelUID)) {
+            if (cte.getChannel().equals(channelUID)) {
                 logger.trace("->FILTER: {}:{}", cte.getEvent(), eventOnChannel);
                 eventMatches = true;
                 if (eventOnChannel != null && !eventOnChannel.isEmpty() && !eventOnChannel.equals(cte.getEvent())) {

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandlerTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.events.ThingEventFactory;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Basic test cases for {@link ChannelEventTriggerHandler}
+ *
+ * @author Thomas Weißschuh - Initial contribution
+ */
+@NonNullByDefault
+class ChannelEventTriggerHandlerTest {
+    private @NonNullByDefault({}) ChannelEventTriggerHandler handler;
+    private @NonNullByDefault({}) Trigger moduleMock;
+    private @NonNullByDefault({}) BundleContext contextMock;
+
+    @BeforeEach
+    public void setUp() {
+        moduleMock = mock(Trigger.class);
+        contextMock = mock(BundleContext.class);
+    }
+
+    @Test
+    public void testExactlyMatchingChannelIsApplied() {
+        when(moduleMock.getConfiguration())
+                .thenReturn(new Configuration(Map.of(ChannelEventTriggerHandler.CFG_CHANNEL, "foo:bar:baz:quux")));
+        handler = new ChannelEventTriggerHandler(moduleMock, contextMock);
+
+        assertTrue(handler.apply(ThingEventFactory.createTriggerEvent("PRESSED", new ChannelUID("foo:bar:baz:quux"))));
+    }
+
+    @Test
+    public void testSubstringMatchingChannelIsNotApplied() {
+        when(moduleMock.getConfiguration())
+                .thenReturn(new Configuration(Map.of(ChannelEventTriggerHandler.CFG_CHANNEL, "foo:bar:baz:q")));
+        handler = new ChannelEventTriggerHandler(moduleMock, contextMock);
+
+        assertFalse(handler.apply(ThingEventFactory.createTriggerEvent("PRESSED", new ChannelUID("foo:bar:baz:quux"))));
+    }
+}


### PR DESCRIPTION
Matching only on "topic.contains(channelUID)" will lead to false
positivies.

This was reported for the linuxinput binding, where pressing the "left"
key would also trigger rules for the "l" key.

The channels for these are
`linuxinput:input-device:test:keypresses#KEY_L` and
`linuxinput:input-device:test:keypresses#KEY_LEFT`

Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>