### PR TITLE
Display raw item state when formatting fails

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -152,7 +152,8 @@ public class SseItemStatesEventBuilder {
                             try {
                                 displayState = state.format(pattern);
                             } catch (IllegalArgumentException e) {
-                                logger.info("Unable to format value '{}' of item {} with format '{}': {}, displaying raw state",
+                                logger.info(
+                                        "Unable to format value '{}' of item {} with format '{}': {}, displaying raw state",
                                         state, item.getName(), pattern, e.getMessage());
                                 displayState = state.toString();
                             }

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -152,9 +152,9 @@ public class SseItemStatesEventBuilder {
                             try {
                                 displayState = state.format(pattern);
                             } catch (IllegalArgumentException e) {
-                                logger.warn("Exception while formatting value '{}' of item {} with format '{}': {}",
+                                logger.info("Unable to format value '{}' of item {} with format '{}': {}, displaying raw state",
                                         state, item.getName(), pattern, e.getMessage());
-                                displayState = new String("Err");
+                                displayState = state.toString();
                             }
                         }
                     }

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -152,7 +152,7 @@ public class SseItemStatesEventBuilder {
                             try {
                                 displayState = state.format(pattern);
                             } catch (IllegalArgumentException e) {
-                                logger.info(
+                                logger.debug(
                                         "Unable to format value '{}' of item {} with format '{}': {}, displaying raw state",
                                         state, item.getName(), pattern, e.getMessage());
                                 displayState = state.toString();


### PR DESCRIPTION
With the addition of Profiles, there are situations where a Channel sends format information that
does not match the type. For example, "Timestamp on update" always sends a DateTime, but the channel
may specify a different format (e.g., if it is a battery level, "%.0f %%"). In such a case, we
attempt to format the DateTime according to the pattern, it (predictably and correctly) fails, and
this results in an error in the UI and a warning in the log.

While this is an expected error if a user uses an incorrect format code in an Item's metadata (user
error), it is somewhat unexpected if a user is choosing an option as presented in the UI. Because
this is purely a formatting issue, one solution is to direct users to add a formatting code if they
see an error. However, the disadvantage of this approach is that it doesn't work "out of the box."

This patch attempts to address the issue by displaying the raw Item state when formatting fails
instead of displaying "Err". This should provide a more balanced approach with a predictable
outcome. In addition, when a user is intentionally changing the pattern via metadata and gets it
wrong, they should still see info in the log that helps them get to the root of the problem, but
I've changed it from warn to info so it will be a little less noisy for those who choose to ignore
it.

This solution was discussed in https://github.com/openhab/openhab-core/issues/2037 and
https://community.openhab.org/t/timestamps-not-rendering-consistently-in-ui-3-0-2/121891/2

Thank you to @Rossko57 and @cweitkamp for their help in figuring it out, and in suggesting the
solution.

Fixes #2037

Signed-off-by: Brian Warner <brian@bdwarner.com>