### PR TITLE
Update jose4j to 0.7.7

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -314,7 +314,7 @@
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.7</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -896,7 +896,7 @@
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
-      <version>0.7.0</version>
+      <version>0.7.7</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -176,9 +176,9 @@
 	</feature>
 
 	<feature name="openhab.tp-jose4j" description="jose4j JWT library" version="${project.version}">
-		<capability>openhab.tp;feature=jose4j;version=0.7.0</capability>
+		<capability>openhab.tp;feature=jose4j;version=0.7.7</capability>
 		<bundle start-level="10">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.2.1/1.2.1_3</bundle>
-		<bundle>mvn:org.bitbucket.b_c/jose4j/0.7.0</bundle>
+		<bundle>mvn:org.bitbucket.b_c/jose4j/0.7.7</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">


### PR DESCRIPTION
Updates jose4j from 0.7.0 to 0.7.7.

For release notes, see:

https://bitbucket.org/b_c/jose4j/wiki/Release%20Notes