### PR TITLE
Update Swagger to 2.1.9

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <jetty.version>9.4.38.v20210224</jetty.version>
-    <swagger.version>2.1.7</swagger.version>
+    <swagger.version>2.1.9</swagger.version>
   </properties>
 
   <dependencies>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -20,7 +20,7 @@
     <jetty.version>9.4.38.v20210224</jetty.version>
     <pax.logging.version>2.0.8</pax.logging.version>
     <pax.web.version>7.3.13</pax.web.version>
-    <swagger.version>2.1.7</swagger.version>
+    <swagger.version>2.1.9</swagger.version>
   </properties>
 
   <dependencyManagement>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -259,14 +259,14 @@
 	</feature>
 
 	<feature name="openhab.tp-swagger-jaxrs" description="JAX-RS Whiteboard Swagger Support" version="${project.version}">
-		<capability>openhab.tp;feature=swagger-jaxrs;version=2.1.7</capability>
+		<capability>openhab.tp;feature=swagger-jaxrs;version=2.1.9</capability>
 		<feature dependency="true">openhab.tp-jax-rs-whiteboard</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.1.7</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.1.7</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.7</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.7</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.7</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.1.9</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.1.9</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.9</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.9</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.9</bundle>
 		<bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/2.0.2</bundle>
 		<bundle dependency="true">mvn:org.javassist/javassist/3.27.0-GA</bundle>
 	</feature>


### PR DESCRIPTION
Updates Swagger from 2.1.7 to 2.1.9.

For release notes, see:

* https://github.com/swagger-api/swagger-core/releases/tag/v2.1.8
* https://github.com/swagger-api/swagger-core/releases/tag/v2.1.9