### PR TITLE
Fix JavaDoc build by upgrading plexus-java dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,14 @@ Import-Package: \\
               ]]>
             </bottom>
           </configuration>
+          <dependencies>
+            <!-- This newer version fixes issues with resolving tech.units:indriya packages -->
+            <dependency>
+              <groupId>org.codehaus.plexus</groupId>
+              <artifactId>plexus-java</artifactId>
+              <version>1.0.7</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This fixes the issue that the `tech.units.indriya` packages cannot be resolved in the JavaDoc build.

See: [openHAB JavaDoc down](https://community.openhab.org/t/openhab-javadoc-down/122223?u=wborn)