### PR TITLE
Expose Channel Type UIDs of default System Channel Types

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.LocalizedKey;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeBuilder;
@@ -56,12 +57,51 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
 
     static final String BINDING_ID = "system";
 
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_SIGNAL_STRENGTH = new ChannelTypeUID(BINDING_ID,
+            "signal-strength");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_LOW_BATTERY = new ChannelTypeUID(BINDING_ID,
+            "low-battery");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL = new ChannelTypeUID(BINDING_ID,
+            "battery-level");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_TRIGGER = new ChannelTypeUID(BINDING_ID, "trigger");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON = new ChannelTypeUID(BINDING_ID, "rawbutton");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_BUTTON = new ChannelTypeUID(BINDING_ID, "button");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_RAWROCKER = new ChannelTypeUID(BINDING_ID, "rawrocker");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_POWER = new ChannelTypeUID(BINDING_ID, "power");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_LOCATION = new ChannelTypeUID(BINDING_ID, "location");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MOTION = new ChannelTypeUID(BINDING_ID, "motion");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_BRIGHTNESS = new ChannelTypeUID(BINDING_ID,
+            "brightness");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_COLOR = new ChannelTypeUID(BINDING_ID, "color");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE = new ChannelTypeUID(BINDING_ID,
+            "color-temperature");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS = new ChannelTypeUID(BINDING_ID,
+            "color-temperature-abs");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_VOLUME = new ChannelTypeUID(BINDING_ID, "volume");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MUTE = new ChannelTypeUID(BINDING_ID, "mute");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MEDIA_CONTROL = new ChannelTypeUID(BINDING_ID,
+            "media-control");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MEDIA_TITLE = new ChannelTypeUID(BINDING_ID,
+            "media-title");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MEDIA_ARTIST = new ChannelTypeUID(BINDING_ID,
+            "media-artist");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION = new ChannelTypeUID(BINDING_ID,
+            "wind-direction");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_WIND_SPEED = new ChannelTypeUID(BINDING_ID,
+            "wind-speed");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_OUTDOOR_TEMPERATURE = new ChannelTypeUID(BINDING_ID,
+            "outdoor-temperature");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY = new ChannelTypeUID(BINDING_ID,
+            "atmospheric-humidity");
+    public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_BAROMETRIC_PRESSURE = new ChannelTypeUID(BINDING_ID,
+            "barometric-pressure");
+
     /**
      * Signal strength default system wide {@link ChannelType}. Represents signal strength of a device as a number
      * with values 0, 1, 2, 3 or 4, 0 being worst strength and 4 being best strength.
      */
     public static final ChannelType SYSTEM_CHANNEL_SIGNAL_STRENGTH = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "signal-strength"), "Signal Strength", "Number")
+            .state(SYSTEM_CHANNEL_TYPE_UID_SIGNAL_STRENGTH, "Signal Strength", CoreItemFactory.NUMBER)
             .withCategory("QualityOfService")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(4)).withStep(BigDecimal.ONE).withReadOnly(Boolean.TRUE)
@@ -76,14 +116,16 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * on (low battery) and off (battery ok).
      */
     public static final ChannelType SYSTEM_CHANNEL_LOW_BATTERY = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "low-battery"), "Low Battery", "Switch").withCategory("LowBattery")
+            .state(SYSTEM_CHANNEL_TYPE_UID_LOW_BATTERY, "Low Battery", CoreItemFactory.SWITCH)
+            .withCategory("LowBattery")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true).build()).build();
 
     /**
      * Battery level default system wide {@link ChannelType}. Represents the battery level as a percentage.
      */
     public static final ChannelType SYSTEM_CHANNEL_BATTERY_LEVEL = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "battery-level"), "Battery Level", "Number").withCategory("Battery")
+            .state(SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL, "Battery Level", CoreItemFactory.NUMBER)
+            .withCategory("Battery")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(100)).withStep(BigDecimal.ONE).withReadOnly(true).withPattern("%.0f %%")
                     .build())
@@ -93,13 +135,13 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * System wide trigger {@link ChannelType} without event options.
      */
     public static final ChannelType SYSTEM_TRIGGER = ChannelTypeBuilder
-            .trigger(new ChannelTypeUID(BINDING_ID, "trigger"), "Trigger").build();
+            .trigger(SYSTEM_CHANNEL_TYPE_UID_TRIGGER, "Trigger").build();
 
     /**
      * System wide trigger {@link ChannelType} which triggers "PRESSED" and "RELEASED" events.
      */
     public static final ChannelType SYSTEM_RAWBUTTON = ChannelTypeBuilder
-            .trigger(new ChannelTypeUID(BINDING_ID, "rawbutton"), "Raw Button")
+            .trigger(SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON, "Raw Button")
             .withEventDescription(new EventDescription(List.of(new EventOption(CommonTriggerEvents.PRESSED, null),
                     new EventOption(CommonTriggerEvents.RELEASED, null))))
             .build();
@@ -108,8 +150,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * System wide trigger {@link ChannelType} which triggers "SHORT_PRESSED", "DOUBLE_PRESSED" and "LONG_PRESSED"
      * events.
      */
-    public static final ChannelType SYSTEM_BUTTON = ChannelTypeBuilder
-            .trigger(new ChannelTypeUID(BINDING_ID, "button"), "Button")
+    public static final ChannelType SYSTEM_BUTTON = ChannelTypeBuilder.trigger(SYSTEM_CHANNEL_TYPE_UID_BUTTON, "Button")
             .withEventDescription(new EventDescription(List.of(new EventOption(CommonTriggerEvents.SHORT_PRESSED, null),
                     new EventOption(CommonTriggerEvents.DOUBLE_PRESSED, null),
                     new EventOption(CommonTriggerEvents.LONG_PRESSED, null))))
@@ -120,7 +161,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * "DIR2_RELEASED" events.
      */
     public static final ChannelType SYSTEM_RAWROCKER = ChannelTypeBuilder
-            .trigger(new ChannelTypeUID(BINDING_ID, "rawrocker"), "Raw Rocker Button")
+            .trigger(SYSTEM_CHANNEL_TYPE_UID_RAWROCKER, "Raw Rocker Button")
             .withEventDescription(new EventDescription(List.of(new EventOption(CommonTriggerEvents.DIR1_PRESSED, null),
                     new EventOption(CommonTriggerEvents.DIR1_RELEASED, null),
                     new EventOption(CommonTriggerEvents.DIR2_PRESSED, null),
@@ -131,14 +172,14 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Power: default system wide {@link ChannelType} which allows turning off (potentially on) a device
      */
     public static final ChannelType SYSTEM_POWER = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "power"), "Power", "Switch")
+            .state(SYSTEM_CHANNEL_TYPE_UID_POWER, "Power", CoreItemFactory.SWITCH)
             .withDescription("Device is operable when channel has state ON").withCategory("Switch").build();
 
     /**
      * Location: default system wide {@link ChannelType} which displays a location
      */
     public static final ChannelType SYSTEM_LOCATION = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "location"), "Location", "Location")
+            .state(SYSTEM_CHANNEL_TYPE_UID_LOCATION, "Location", CoreItemFactory.LOCATION)
             .withDescription("Location in lat./lon./height coordinates")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true)
                     .withPattern("%2$s°N %3$s°E %1$sm").build())
@@ -148,7 +189,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Motion: default system wide {@link ChannelType} which indications whether motion was detected (state ON)
      */
     public static final ChannelType SYSTEM_MOTION = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "motion"), "Motion", "Switch")
+            .state(SYSTEM_CHANNEL_TYPE_UID_MOTION, "Motion", CoreItemFactory.SWITCH)
             .withDescription("Motion detected by the device").withCategory("Motion")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true).build()).build();
 
@@ -156,7 +197,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Brightness: default system wide {@link ChannelType} which allows changing the brightness from 0-100%
      */
     public static final ChannelType SYSTEM_BRIGHTNESS = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "brightness"), "Brightness", "Dimmer")
+            .state(SYSTEM_CHANNEL_TYPE_UID_BRIGHTNESS, "Brightness", CoreItemFactory.DIMMER)
             .withDescription("Controls the brightness and switches the light on and off").withCategory("Light")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(100)).withPattern("%d %%").build())
@@ -166,14 +207,14 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Color: default system wide {@link ChannelType} which allows changing the color
      */
     public static final ChannelType SYSTEM_COLOR = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color"), "Color", "Color")
+            .state(SYSTEM_CHANNEL_TYPE_UID_COLOR, "Color", CoreItemFactory.COLOR)
             .withDescription("Controls the color of the light").withCategory("ColorLight").build();
 
     /**
      * Color-temperature: default system wide {@link ChannelType} which allows changing the color temperature in percent
      */
     public static final ChannelType SYSTEM_COLOR_TEMPERATURE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color-temperature"), "Color Temperature", "Dimmer")
+            .state(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE, "Color Temperature", CoreItemFactory.DIMMER)
             .withDescription("Controls the color temperature of the light from 0 (cold) to 100 (warm)")
             .withCategory("ColorLight").withStateDescriptionFragment(StateDescriptionFragmentBuilder.create()
                     .withMinimum(BigDecimal.ZERO).withMaximum(new BigDecimal(100)).withPattern("%.0f").build())
@@ -183,7 +224,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Color-temperature: default system wide {@link ChannelType} which allows changing the color temperature in Kelvin
      */
     public static final ChannelType SYSTEM_COLOR_TEMPERATURE_ABS = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color-temperature-abs"), "Color Temperature", "Number")
+            .state(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS, "Color Temperature", CoreItemFactory.NUMBER)
             .withDescription("Controls the color temperature of the light in Kelvin").withCategory("ColorLight")
             .isAdvanced(true).withStateDescriptionFragment(StateDescriptionFragmentBuilder.create()
                     .withMinimum(new BigDecimal(1000)).withMaximum(new BigDecimal(10000)).withPattern("%.0f K").build())
@@ -195,7 +236,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Volume: default system wide {@link ChannelType} which allows changing the audio volume from 0-100%
      */
     public static final ChannelType SYSTEM_VOLUME = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "volume"), "Volume", "Dimmer")
+            .state(SYSTEM_CHANNEL_TYPE_UID_VOLUME, "Volume", CoreItemFactory.DIMMER)
             .withDescription("Change the sound volume of a device")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(100)).withPattern("%d %%").build())
@@ -205,21 +246,21 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Mute: default system wide {@link ChannelType} which allows muting and un-muting audio
      */
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "mute"), "Mute", "Switch").withDescription("Mute audio of the device")
-            .withCategory("SoundVolume").build();
+            .state(SYSTEM_CHANNEL_TYPE_UID_MUTE, "Mute", CoreItemFactory.SWITCH)
+            .withDescription("Mute audio of the device").withCategory("SoundVolume").build();
 
     /**
      * Media-control: system wide {@link ChannelType} which controls a media player
      */
     public static final ChannelType SYSTEM_MEDIA_CONTROL = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-control"), "Media Control", "Player")
+            .state(SYSTEM_CHANNEL_TYPE_UID_MEDIA_CONTROL, "Media Control", CoreItemFactory.PLAYER)
             .withCategory("MediaControl").build();
 
     /**
      * Media-title: default system wide {@link ChannelType} which displays the title of a (played) song
      */
     public static final ChannelType SYSTEM_MEDIA_TITLE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-title"), "Media Title", "String")
+            .state(SYSTEM_CHANNEL_TYPE_UID_MEDIA_TITLE, "Media Title", CoreItemFactory.STRING)
             .withDescription("Title of a (played) media file")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true).build()).build();
 
@@ -227,7 +268,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Media-artist: default system wide {@link ChannelType} which displays the artist of a (played) song
      */
     public static final ChannelType SYSTEM_MEDIA_ARTIST = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "media-artist"), "Media Artist", "String")
+            .state(SYSTEM_CHANNEL_TYPE_UID_MEDIA_ARTIST, "Media Artist", CoreItemFactory.STRING)
             .withDescription("Artist of a (played) media file")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withReadOnly(true).build()).build();
 
@@ -237,7 +278,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Wind-direction: system wide {@link ChannelType} which shows the wind direction in degrees 0-360
      */
     public static final ChannelType SYSTEM_WIND_DIRECTION = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "wind-direction"), "Wind Direction", "Number:Angle")
+            .state(SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION, "Wind Direction", "Number:Angle")
             .withDescription("Current wind direction expressed as an angle").withCategory("Wind")
             .withStateDescriptionFragment(StateDescriptionFragmentBuilder.create().withMinimum(BigDecimal.ZERO)
                     .withMaximum(new BigDecimal(360)).withReadOnly(true).withPattern("%.0f %unit%").build())
@@ -247,7 +288,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Wind-speed: system wide {@link ChannelType} which shows the wind speed
      */
     public static final ChannelType SYSTEM_WIND_SPEED = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "wind-speed"), "Wind Speed", "Number:Speed")
+            .state(SYSTEM_CHANNEL_TYPE_UID_WIND_SPEED, "Wind Speed", "Number:Speed")
             .withDescription("Current wind speed").withCategory("Wind")
             .withStateDescriptionFragment(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.1f %unit%").build())
@@ -257,7 +298,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Outdoor-temperature: system wide {@link ChannelType} which shows the outdoor temperature
      */
     public static final ChannelType SYSTEM_OUTDOOR_TEMPERATURE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "outdoor-temperature"), "Outdoor Temperature", "Number:Temperature")
+            .state(SYSTEM_CHANNEL_TYPE_UID_OUTDOOR_TEMPERATURE, "Outdoor Temperature", "Number:Temperature")
             .withDescription("Current outdoor temperature").withCategory("Temperature")
             .withStateDescriptionFragment(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.1f %unit%").build())
@@ -267,8 +308,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Atmospheric-humidity: system wide {@link ChannelType} which shows the atmospheric humidity
      */
     public static final ChannelType SYSTEM_ATMOSPHERIC_HUMIDITY = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "atmospheric-humidity"), "Atmospheric Humidity",
-                    "Number:Dimensionless")
+            .state(SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY, "Atmospheric Humidity", "Number:Dimensionless")
             .withDescription("Current atmospheric relative humidity").withCategory("Humidity")
             .withStateDescriptionFragment(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.0f %%").build())
@@ -278,7 +318,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      * Barometric-pressure: system wide {@link ChannelType} which shows the barometric pressure
      */
     public static final ChannelType SYSTEM_BAROMETRIC_PRESSURE = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "barometric-pressure"), "Barometric Pressure", "Number:Pressure")
+            .state(SYSTEM_CHANNEL_TYPE_UID_BAROMETRIC_PRESSURE, "Barometric Pressure", "Number:Pressure")
             .withDescription("Current barometric pressure").withCategory("Pressure")
             .withStateDescriptionFragment(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.3f %unit%").build())

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/SystemWideChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/SystemWideChannelTypesTest.java
@@ -13,7 +13,7 @@
 package org.openhab.core.thing;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.BINDING_ID;
+import static org.openhab.core.thing.DefaultSystemChannelTypeProvider.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.thing.type.ChannelTypeProvider;
-import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.StateOption;
 
 /**
@@ -35,40 +34,6 @@ import org.openhab.core.types.StateOption;
 public class SystemWideChannelTypesTest extends JavaOSGiTest {
 
     private static final int NUMBER_OF_SYSTEM_WIDE_CHANNEL_TYPES = 24;
-
-    private static final ChannelTypeUID SIGNAL_STRENGTH_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "signal-strength");
-    private static final ChannelTypeUID LOW_BATTERY_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "low-battery");
-    private static final ChannelTypeUID BATTERY_LEVEL_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "battery-level");
-    private static final ChannelTypeUID TRIGGER_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "trigger");
-    private static final ChannelTypeUID RAWBUTTON_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "rawbutton");
-    private static final ChannelTypeUID BUTTON_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "button");
-    private static final ChannelTypeUID RAWROCKER_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "rawrocker");
-    private static final ChannelTypeUID POWER_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "power");
-    private static final ChannelTypeUID LOCATION_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "location");
-    private static final ChannelTypeUID MOTION_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "motion");
-    private static final ChannelTypeUID BRIGHTNESS_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "brightness");
-    private static final ChannelTypeUID COLOR_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "color");
-    private static final ChannelTypeUID COLOR_TEMPERATURE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "color-temperature");
-    private static final ChannelTypeUID COLOR_TEMPERATURE_ABS_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "color-temperature-abs");
-    private static final ChannelTypeUID VOLUME_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "volume");
-    private static final ChannelTypeUID MUTE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "mute");
-    private static final ChannelTypeUID MEDIA_CONTROL_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "media-control");
-    private static final ChannelTypeUID MEDIA_TITLE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "media-title");
-    private static final ChannelTypeUID MEDIA_ARTIST_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "media-artist");
-    private static final ChannelTypeUID WIND_DIRECTION_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "wind-direction");
-    private static final ChannelTypeUID WIND_SPEED_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID, "wind-speed");
-    private static final ChannelTypeUID OUTDOOR_TEMPERATURE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "outdoor-temperature");
-    private static final ChannelTypeUID ATMOSPHERIC_HUMIDITY_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "atmospheric-humidity");
-    private static final ChannelTypeUID BAROMETRIC_PRESSURE_CHANNEL_TYPE_UID = new ChannelTypeUID(BINDING_ID,
-            "barometric-pressure");
 
     private ChannelTypeProvider systemChannelTypeProvider;
 
@@ -84,30 +49,30 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         Collection<ChannelType> sytemChannelTypes = systemChannelTypeProvider.getChannelTypes(null);
         assertEquals(NUMBER_OF_SYSTEM_WIDE_CHANNEL_TYPES, sytemChannelTypes.size());
 
-        assertNotNull(systemChannelTypeProvider.getChannelType(SIGNAL_STRENGTH_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(LOW_BATTERY_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(BATTERY_LEVEL_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(TRIGGER_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(RAWBUTTON_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(BUTTON_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(RAWROCKER_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(POWER_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(LOCATION_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(MOTION_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(BRIGHTNESS_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(COLOR_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(COLOR_TEMPERATURE_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(COLOR_TEMPERATURE_ABS_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(VOLUME_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(MUTE_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(MEDIA_CONTROL_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(MEDIA_TITLE_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(MEDIA_ARTIST_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(WIND_DIRECTION_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(WIND_SPEED_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(OUTDOOR_TEMPERATURE_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(ATMOSPHERIC_HUMIDITY_CHANNEL_TYPE_UID, null));
-        assertNotNull(systemChannelTypeProvider.getChannelType(BAROMETRIC_PRESSURE_CHANNEL_TYPE_UID, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_SIGNAL_STRENGTH, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_LOW_BATTERY, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_TRIGGER, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_BUTTON, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_RAWROCKER, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_POWER, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_LOCATION, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MOTION, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_BRIGHTNESS, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_VOLUME, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MUTE, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_CONTROL, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_TITLE, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_ARTIST, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_WIND_SPEED, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_OUTDOOR_TEMPERATURE, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY, null));
+        assertNotNull(systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_BAROMETRIC_PRESSURE, null));
     }
 
     @Test
@@ -116,7 +81,7 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         assertEquals(NUMBER_OF_SYSTEM_WIDE_CHANNEL_TYPES, localizedChannelTypes.size());
 
         ChannelType signalStrengthChannelType = systemChannelTypeProvider
-                .getChannelType(SIGNAL_STRENGTH_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_SIGNAL_STRENGTH, Locale.GERMAN);
         assertNotNull(signalStrengthChannelType);
         assertEquals("Signalstärke", signalStrengthChannelType.getLabel());
         assertNull(signalStrengthChannelType.getDescription());
@@ -145,122 +110,125 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         assertNotNull(excellentOption);
         assertEquals("Ausgezeichnet", excellentOption.getLabel());
 
-        ChannelType lowBatteryChannelType = systemChannelTypeProvider.getChannelType(LOW_BATTERY_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType lowBatteryChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_LOW_BATTERY, Locale.GERMAN);
         assertNotNull(lowBatteryChannelType);
         assertEquals("Niedriger Batteriestatus", lowBatteryChannelType.getLabel());
         assertNull(lowBatteryChannelType.getDescription());
 
-        ChannelType batteryLevelChannelType = systemChannelTypeProvider.getChannelType(BATTERY_LEVEL_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType batteryLevelChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_BATTERY_LEVEL, Locale.GERMAN);
         assertNotNull(batteryLevelChannelType);
         assertEquals("Batterieladung", batteryLevelChannelType.getLabel());
         assertNull(batteryLevelChannelType.getDescription());
 
-        ChannelType powerChannelType = systemChannelTypeProvider.getChannelType(POWER_CHANNEL_TYPE_UID, Locale.GERMAN);
+        ChannelType powerChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_POWER,
+                Locale.GERMAN);
         assertNotNull(powerChannelType);
         assertEquals("Betrieb", powerChannelType.getLabel());
         assertEquals(
                 "Ermöglicht die Steuerung der Betriebsbereitschaft. Das Gerät ist betriebsbereit, wenn \"Betrieb\" den Status ON hat.",
                 powerChannelType.getDescription());
 
-        ChannelType locationChannelType = systemChannelTypeProvider.getChannelType(LOCATION_CHANNEL_TYPE_UID,
+        ChannelType locationChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_LOCATION,
                 Locale.GERMAN);
         assertNotNull(locationChannelType);
         assertEquals("Ort", locationChannelType.getLabel());
         assertEquals("Ort in geographischen Koordinaten (Breitengrad/Längengrad/Höhe).",
                 locationChannelType.getDescription());
 
-        ChannelType motionChannelType = systemChannelTypeProvider.getChannelType(MOTION_CHANNEL_TYPE_UID,
+        ChannelType motionChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MOTION,
                 Locale.GERMAN);
         assertNotNull(motionChannelType);
         assertEquals("Bewegung", motionChannelType.getLabel());
         assertEquals("Zeigt eine erkannte Bewegung an.", motionChannelType.getDescription());
 
-        ChannelType brightnessChannelType = systemChannelTypeProvider.getChannelType(BRIGHTNESS_CHANNEL_TYPE_UID,
+        ChannelType brightnessChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_BRIGHTNESS,
                 Locale.GERMAN);
         assertNotNull(brightnessChannelType);
         assertEquals("Helligkeit", brightnessChannelType.getLabel());
         assertEquals("Steuert die Helligkeit und schaltet das Licht ein und aus.",
                 brightnessChannelType.getDescription());
 
-        ChannelType colorChannelType = systemChannelTypeProvider.getChannelType(COLOR_CHANNEL_TYPE_UID, Locale.GERMAN);
+        ChannelType colorChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR,
+                Locale.GERMAN);
         assertNotNull(colorChannelType);
         assertEquals("Farbe", colorChannelType.getLabel());
         assertEquals("Steuert die Lichtfarbe.", colorChannelType.getDescription());
 
         ChannelType colorTemperatureChannelType = systemChannelTypeProvider
-                .getChannelType(COLOR_TEMPERATURE_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE, Locale.GERMAN);
         assertNotNull(colorTemperatureChannelType);
         assertEquals("Farbtemperatur", colorTemperatureChannelType.getLabel());
         assertEquals("Steuert die Farbtemperatur des Lichts von 0 (kalt) bis 100 (warm).",
                 colorTemperatureChannelType.getDescription());
 
         ChannelType colorTemperatureAbsChannelType = systemChannelTypeProvider
-                .getChannelType(COLOR_TEMPERATURE_ABS_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_COLOR_TEMPERATURE_ABS, Locale.GERMAN);
         assertNotNull(colorTemperatureAbsChannelType);
         assertEquals("Farbtemperatur", colorTemperatureAbsChannelType.getLabel());
         assertEquals("Steuert die Farbtemperatur des Lichts in Kelvin.",
                 colorTemperatureAbsChannelType.getDescription());
 
-        ChannelType volumeChannelType = systemChannelTypeProvider.getChannelType(VOLUME_CHANNEL_TYPE_UID,
+        ChannelType volumeChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_VOLUME,
                 Locale.GERMAN);
         assertNotNull(volumeChannelType);
         assertEquals("Lautstärke", volumeChannelType.getLabel());
         assertEquals("Ermöglicht die Steuerung der Lautstärke.", volumeChannelType.getDescription());
 
-        ChannelType muteChannelType = systemChannelTypeProvider.getChannelType(MUTE_CHANNEL_TYPE_UID, Locale.GERMAN);
+        ChannelType muteChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_MUTE,
+                Locale.GERMAN);
         assertNotNull(muteChannelType);
         assertEquals("Stumm schalten", muteChannelType.getLabel());
         assertEquals("Ermöglicht die Lautstärke auf stumm zu schalten.", muteChannelType.getDescription());
 
-        ChannelType mediaControlChannelType = systemChannelTypeProvider.getChannelType(MEDIA_CONTROL_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType mediaControlChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_CONTROL, Locale.GERMAN);
         assertNotNull(mediaControlChannelType);
         assertEquals("Fernbedienung", mediaControlChannelType.getLabel());
         assertNull(mediaControlChannelType.getDescription());
 
-        ChannelType mediaTitleChannelType = systemChannelTypeProvider.getChannelType(MEDIA_TITLE_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType mediaTitleChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_TITLE, Locale.GERMAN);
         assertNotNull(mediaTitleChannelType);
         assertEquals("Titel", mediaTitleChannelType.getLabel());
         assertEquals("Zeigt den Titel der (aktuell abgespielten) Video- oder Audiodatei an.",
                 mediaTitleChannelType.getDescription());
 
-        ChannelType mediaArtistChannelType = systemChannelTypeProvider.getChannelType(MEDIA_ARTIST_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType mediaArtistChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_MEDIA_ARTIST, Locale.GERMAN);
         assertNotNull(mediaArtistChannelType);
         assertEquals("Künstler", mediaArtistChannelType.getLabel());
         assertEquals("Zeigt den Künstler der (aktuell abgespielten) Video- oder Audiodatei an.",
                 mediaArtistChannelType.getDescription());
 
-        ChannelType windDirectionChannelType = systemChannelTypeProvider.getChannelType(WIND_DIRECTION_CHANNEL_TYPE_UID,
-                Locale.GERMAN);
+        ChannelType windDirectionChannelType = systemChannelTypeProvider
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_WIND_DIRECTION, Locale.GERMAN);
         assertNotNull(windDirectionChannelType);
         assertEquals("Windrichtung", windDirectionChannelType.getLabel());
         assertEquals("Aktuelle Windrichtung ausgedrückt als Winkel.", windDirectionChannelType.getDescription());
 
-        ChannelType windSpeedChannelType = systemChannelTypeProvider.getChannelType(WIND_SPEED_CHANNEL_TYPE_UID,
+        ChannelType windSpeedChannelType = systemChannelTypeProvider.getChannelType(SYSTEM_CHANNEL_TYPE_UID_WIND_SPEED,
                 Locale.GERMAN);
         assertNotNull(windSpeedChannelType);
         assertEquals("Windgeschwindigkeit", windSpeedChannelType.getLabel());
         assertEquals("Aktuelle Windgeschwindigkeit.", windSpeedChannelType.getDescription());
 
         ChannelType outdoorTemperatureChannelType = systemChannelTypeProvider
-                .getChannelType(OUTDOOR_TEMPERATURE_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_OUTDOOR_TEMPERATURE, Locale.GERMAN);
         assertNotNull(outdoorTemperatureChannelType);
         assertEquals("Außentemperatur", outdoorTemperatureChannelType.getLabel());
         assertEquals("Aktuelle Außentemperatur.", outdoorTemperatureChannelType.getDescription());
 
         ChannelType atmosphericHumidityChannelType = systemChannelTypeProvider
-                .getChannelType(ATMOSPHERIC_HUMIDITY_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_ATMOSPHERIC_HUMIDITY, Locale.GERMAN);
         assertNotNull(atmosphericHumidityChannelType);
         assertEquals("Luftfeuchtigkeit", atmosphericHumidityChannelType.getLabel());
         assertEquals("Aktuelle atmosphärische relative Luftfeuchtigkeit.",
                 atmosphericHumidityChannelType.getDescription());
 
         ChannelType barometricPressureChannelType = systemChannelTypeProvider
-                .getChannelType(BAROMETRIC_PRESSURE_CHANNEL_TYPE_UID, Locale.GERMAN);
+                .getChannelType(SYSTEM_CHANNEL_TYPE_UID_BAROMETRIC_PRESSURE, Locale.GERMAN);
         assertNotNull(barometricPressureChannelType);
         assertEquals("Luftdruck", barometricPressureChannelType.getLabel());
         assertEquals("Aktueller Luftdruck.", barometricPressureChannelType.getDescription());


### PR DESCRIPTION
- Expose Channel Type UIDs of default System Channel Types

https://github.com/openhab/openhab-addons/blob/e1a76505a07f9d329f046a7e3f41ddf9a6360247/bundles/org.openhab.binding.deconz/src/main/java/org/openhab/binding/deconz/internal/handler/SensorBaseThingHandler.java#L186-L191

The advantage of this is that bindings do not need to create the `ChannelTypeUID`s on there own but can reuse the exposed constants. Additionally bundles can use them for defining Profiles.

https://github.com/openhab/openhab-core/blob/a8f469e5e78ba86c5d648b85a0054b5a978c6ee9/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeBuilder.java#L111

https://github.com/openhab/openhab-core/blob/a8f469e5e78ba86c5d648b85a0054b5a978c6ee9/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeBuilder.java#L122

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>