### PR TITLE
Support parsing localized strings with DecimalType, PercentType and QuantityType

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -13,7 +13,11 @@
 package org.openhab.core.library.types;
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParsePosition;
 import java.util.IllegalFormatConversionException;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -53,7 +57,18 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     }
 
     public DecimalType(String value) {
-        this.value = new BigDecimal(value);
+        this(value, Locale.ENGLISH);
+    }
+
+    public DecimalType(String value, Locale locale) {
+        DecimalFormat df = (DecimalFormat) NumberFormat.getInstance(locale);
+        df.setParseBigDecimal(true);
+        ParsePosition position = new ParsePosition(0);
+        BigDecimal parsedValue = (BigDecimal) df.parseObject(value, position);
+        if (parsedValue == null || position.getErrorIndex() != -1 || position.getIndex() < value.length()) {
+            throw new IllegalArgumentException("Invalid BigDecimal value: " + value);
+        }
+        this.value = parsedValue;
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
@@ -14,6 +14,7 @@ package org.openhab.core.library.types;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -43,7 +44,11 @@ public class PercentType extends DecimalType {
     }
 
     public PercentType(String value) {
-        super(value);
+        this(value, Locale.ENGLISH);
+    }
+
+    public PercentType(String value, Locale locale) {
+        super(value, locale);
         validateValue(this.value);
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemStateConverterImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemStateConverterImplTest.java
@@ -49,15 +49,15 @@ public class ItemStateConverterImplTest {
     private @NonNullByDefault({}) ItemStateConverterImpl itemStateConverter;
 
     /**
-     * Locales having a different decimal separator to test string parsing and generation.
+     * Locales having a different decimal and grouping separators to test string parsing and generation.
      */
     static Stream<Locale> locales() {
         return Stream.of(
-                // ٫ (Arabic, Egypt)
+                // ٫٬ (Arabic, Egypt)
                 Locale.forLanguageTag("ar-EG"),
-                // , (German, Germany)
+                // ,. (German, Germany)
                 Locale.forLanguageTag("de-DE"),
-                // . (English, United States)
+                // ., (English, United States)
                 Locale.forLanguageTag("en-US"));
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -50,15 +50,15 @@ public class QuantityTypeArithmeticGroupFunctionTest {
     private @NonNullByDefault({}) @Mock UnitProvider unitProvider;
 
     /**
-     * Locales having a different decimal separator to test string parsing and generation.
+     * Locales having a different decimal and grouping separators to test string parsing and generation.
      */
     static Stream<Locale> locales() {
         return Stream.of(
-                // ٫ (Arabic, Egypt)
+                // ٫٬ (Arabic, Egypt)
                 Locale.forLanguageTag("ar-EG"),
-                // , (German, Germany)
+                // ,. (German, Germany)
                 Locale.forLanguageTag("de-DE"),
-                // . (English, United States)
+                // ., (English, United States)
                 Locale.forLanguageTag("en-US"));
     }
 


### PR DESCRIPTION
Adds constructors with a Locale parameter for parsing localized string to DecimalType, PercentType and QuantityType.
This allows for parsing locale specific group and decimal seperators in strings.

Also fixes:
* IllegalArgumentException not being thrown if numbers in strings are only partially parsed as QuantityType
* MeasurementParseException not caught and rethrown as IllegalArgumentException

Several new unit tests cover the new functionality and fixed regressions.

---

Further improves https://github.com/openhab/openhab-core/pull/2362