### PR TITLE
[UoM] Catch MeasurementParseException in UnitUtils.parseUnit(String) method

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.types.util;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -21,11 +19,13 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.measure.MetricPrefix;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.UnitConverter;
+import javax.measure.format.MeasurementParseException;
 import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -165,7 +165,7 @@ public class UnitUtils {
             try {
                 Quantity<?> quantity = Quantities.getQuantity("1 " + unitSymbol);
                 return quantity.getUnit();
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | MeasurementParseException e) {
                 // we expect this exception in case the extracted string does not match any known unit
                 LOGGER.debug("Unknown unit from pattern: {}", unitSymbol);
             }
@@ -195,8 +195,8 @@ public class UnitUtils {
 
         // Compare the unit symbols. For product units (e.g. 1km / 1h) the equality is not given in the Sets above.
         if (!differentSystems) {
-            Set<String> siSymbols = siUnits.stream().map(Unit::getSymbol).collect(toSet());
-            Set<String> usSymbols = usUnits.stream().map(Unit::getSymbol).collect(toSet());
+            Set<String> siSymbols = siUnits.stream().map(Unit::getSymbol).collect(Collectors.toSet());
+            Set<String> usSymbols = usUnits.stream().map(Unit::getSymbol).collect(Collectors.toSet());
 
             differentSystems = (siSymbols.contains(thisUnit.getSymbol()) && usSymbols.contains(thatUnit.getSymbol())) //
                     || (siSymbols.contains(thatUnit.getSymbol()) && usSymbols.contains(thisUnit.getSymbol()));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/util/UnitUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/util/UnitUtilsTest.java
@@ -97,6 +97,12 @@ public class UnitUtilsTest {
     }
 
     @Test
+    public void testParseUnknownUnit() {
+        assertNull(UnitUtils.parseUnit("123 Hello World"));
+        assertNull(UnitUtils.parseUnit("Lux"));
+    }
+
+    @Test
     public void testGetDimensionName() {
         assertThat(UnitUtils.getDimensionName(SIUnits.CELSIUS), is(Temperature.class.getSimpleName()));
         assertThat(UnitUtils.getDimensionName(Units.KILOWATT_HOUR), is(Energy.class.getSimpleName()));


### PR DESCRIPTION
- Catch `MeasurementParseException` in `UnitUtils.parseUnit(String)` method

Related to #2319

Avoids regressions when trying to parse an unknown unit:

```
17:46:20.356 [WARN ] [ue.internal.handler.HueBridgeHandler] - An unexpected error occurred: Parse Error
javax.measure.format.MeasurementParseException: Parse Error
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.check(SimpleUnitFormat.java:631) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parseSingleUnit(SimpleUnitFormat.java:486) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parseProductUnit(SimpleUnitFormat.java:505) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat.parseObject(SimpleUnitFormat.java:293) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:834) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:829) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:825) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.CommonFormatter.parseMixed(CommonFormatter.java:109) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.CommonFormatter.parseMixedAsLeading(CommonFormatter.java:138) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleQuantityFormat.parse(SimpleQuantityFormat.java:207) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.format.SimpleQuantityFormat.parse(SimpleQuantityFormat.java:224) ~[indriya-2.1.2.jar:2.1.2]
	at tech.units.indriya.quantity.Quantities.getQuantity(Quantities.java:85) ~[indriya-2.1.2.jar:2.1.2]
	at org.openhab.core.types.util.UnitUtils.parseUnit(UnitUtils.java:166) ~[org.openhab.core-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.internal.items.ItemStateConverterImpl.parseItemUnit(ItemStateConverterImpl.java:129) ~[?:?]
	at org.openhab.core.internal.items.ItemStateConverterImpl.convertToAcceptedState(ItemStateConverterImpl.java:79) ~[?:?]
	at org.openhab.core.thing.internal.profiles.ProfileCallbackImpl.sendUpdate(ProfileCallbackImpl.java:121) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.internal.profiles.SystemDefaultProfile.onStateUpdateFromHandler(SystemDefaultProfile.java:53) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.internal.CommunicationManager.lambda$11(CommunicationManager.java:531) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.internal.CommunicationManager.lambda$13(CommunicationManager.java:551) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at org.openhab.core.thing.internal.CommunicationManager.handleCallFromHandler(CommunicationManager.java:547) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.internal.CommunicationManager.stateUpdated(CommunicationManager.java:529) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.internal.ThingManagerImpl$1.stateUpdated(ThingManagerImpl.java:176) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.binding.BaseThingHandler.updateState(BaseThingHandler.java:231) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.core.thing.binding.BaseThingHandler.updateState(BaseThingHandler.java:250) ~[org.openhab.core.thing-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.binding.hue.internal.handler.sensors.LightLevelHandler.doSensorStateChanged(LightLevelHandler.java:77) ~[org.openhab.binding.hue-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.binding.hue.internal.handler.HueSensorHandler.onSensorStateChanged(HueSensorHandler.java:255) ~[org.openhab.binding.hue-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.binding.hue.internal.handler.HueBridgeHandler$1.doConnectedRun(HueBridgeHandler.java:200) ~[org.openhab.binding.hue-3.1.0-SNAPSHOT.jar:?]
	at org.openhab.binding.hue.internal.handler.HueBridgeHandler$PollingRunnable.run(HueBridgeHandler.java:126) [org.openhab.binding.hue-3.1.0-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

or

```
17:48:10.562 [ERROR] [internal.JSONResponseExceptionMapper] - Unexpected exception occurred while processing REST request.
javax.measure.format.MeasurementParseException: Parse Error
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.check(SimpleUnitFormat.java:631) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parseSingleUnit(SimpleUnitFormat.java:486) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parseProductUnit(SimpleUnitFormat.java:505) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat.parseObject(SimpleUnitFormat.java:293) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:834) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:829) ~[?:?]
	at tech.units.indriya.format.SimpleUnitFormat$DefaultFormat.parse(SimpleUnitFormat.java:825) ~[?:?]
	at tech.units.indriya.format.CommonFormatter.parseMixed(CommonFormatter.java:109) ~[?:?]
	at tech.units.indriya.format.CommonFormatter.parseMixedAsLeading(CommonFormatter.java:138) ~[?:?]
	at tech.units.indriya.format.SimpleQuantityFormat.parse(SimpleQuantityFormat.java:207) ~[?:?]
	at tech.units.indriya.format.SimpleQuantityFormat.parse(SimpleQuantityFormat.java:224) ~[?:?]
	at tech.units.indriya.quantity.Quantities.getQuantity(Quantities.java:85) ~[?:?]
	at org.openhab.core.types.util.UnitUtils.parseUnit(UnitUtils.java:166) ~[?:?]
	at org.openhab.core.io.rest.sse.internal.SseItemStatesEventBuilder.getDisplayState(SseItemStatesEventBuilder.java:132) ~[?:?]
	at org.openhab.core.io.rest.sse.internal.SseItemStatesEventBuilder.buildEvent(SseItemStatesEventBuilder.java:77) ~[?:?]
	at org.openhab.core.io.rest.sse.SseResource.updateTrackedItems(SseResource.java:220) ~[?:?]
	at jdk.internal.reflect.GeneratedMethodAccessor40.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.apache.cxf.service.invoker.AbstractInvoker.performInvocation(AbstractInvoker.java:179) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.service.invoker.AbstractInvoker.invoke(AbstractInvoker.java:96) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:201) ~[cxf-rt-frontend-jaxrs-3.4.3.jar:3.4.3]
	at org.apache.cxf.jaxrs.JAXRSInvoker.invoke(JAXRSInvoker.java:104) ~[cxf-rt-frontend-jaxrs-3.4.3.jar:3.4.3]
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor$1.run(ServiceInvokerInterceptor.java:59) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.interceptor.ServiceInvokerInterceptor.handleMessage(ServiceInvokerInterceptor.java:96) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:308) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.ChainInitiationObserver.onMessage(ChainInitiationObserver.java:121) ~[cxf-core-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.http.AbstractHTTPDestination.invoke(AbstractHTTPDestination.java:265) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.ServletController.invokeDestination(ServletController.java:234) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:208) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.ServletController.invoke(ServletController.java:160) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.CXFNonSpringServlet.invoke(CXFNonSpringServlet.java:225) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.handleRequest(AbstractHTTPServlet.java:298) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.doPost(AbstractHTTPServlet.java:217) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:644) ~[org.apache.felix.http.servlet-api-1.1.2.jar:?]
	at org.apache.cxf.transport.servlet.AbstractHTTPServlet.service(AbstractHTTPServlet.java:273) ~[cxf-rt-transports-http-3.4.3.jar:3.4.3]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:791) ~[jetty-servlet-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550) ~[jetty-servlet-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.ops4j.pax.web.service.jetty.internal.HttpServiceServletHandler.doHandle(HttpServiceServletHandler.java:71) ~[pax-web-jetty-7.3.13.jar:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:602) ~[jetty-security-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1435) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.ops4j.pax.web.service.jetty.internal.HttpServiceContext.doHandle(HttpServiceContext.java:294) ~[pax-web-jetty-7.3.13.jar:?]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501) ~[jetty-servlet-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerHandlerCollection.handle(JettyServerHandlerCollection.java:82) ~[pax-web-jetty-7.3.13.jar:?]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388) ~[jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633) [jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380) [jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:279) [jetty-server-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) [jetty-io-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) [jetty-io-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) [jetty-io-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036) [jetty-util-9.4.38.v20210224.jar:9.4.38.v20210224]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>