### PR TITLE
Upgrade XStream to 1.4.17

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -257,7 +257,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.15</version>
+      <version>1.4.17</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -500,7 +500,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.15</version>
+      <version>1.4.17</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -35,7 +35,7 @@
 		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.1</bundle>
 
 		<!-- TODO: Unbundled libraries -->
-		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.15</bundle>
+		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.17</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.openhab.core.config.core;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.test;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -57,4 +56,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.openhab.core.test;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing.xml;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -63,4 +62,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -23,7 +23,6 @@ Fragment-Host: org.openhab.core.config.xml
 	org.openhab.core.config.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.config.xml.tests;version='[3.1.0,3.1.1)',\
 	org.openhab.core.test;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -50,4 +49,5 @@ Fragment-Host: org.openhab.core.config.xml
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -32,7 +32,6 @@ feature.openhab-config: \
 	org.openhab.core.ephemeris;version='[3.1.0,3.1.1)',\
 	org.openhab.core.ephemeris.tests;version='[3.1.0,3.1.1)',\
 	org.openhab.core.test;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -59,4 +58,5 @@ feature.openhab-config: \
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -107,4 +107,5 @@ Fragment-Host: org.openhab.core.model.core
 	org.ops4j.pax.web.pax-web-api;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.16,7.3.17)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)',\
+	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -105,4 +105,5 @@ Fragment-Host: org.openhab.core.model.item
 	org.ops4j.pax.web.pax-web-api;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.16,7.3.17)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)',\
+	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -107,4 +107,5 @@ Fragment-Host: org.openhab.core.model.script
 	org.ops4j.pax.web.pax-web-api;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.16,7.3.17)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)',\
+	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -61,7 +61,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.thing.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.transform;version='[3.1.0,3.1.1)',\
 	org.openhab.core.voice;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-jupiter-params;version='[5.7.0,5.7.1)',\
@@ -118,4 +117,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-api;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.16,7.3.17)',\
-	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)'
+	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)',\
+	org.openhab.core.model.rule.runtime;version='[3.1.0,3.1.1)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.core.thing
 	org.openhab.core.thing;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing.tests;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing.xml;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -65,4 +64,5 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.openhab.core.thing;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing.xml;version='[3.1.0,3.1.1)',\
 	org.openhab.core.thing.xml.tests;version='[3.1.0,3.1.1)',\
-	xstream;version='[1.4.15,1.4.16)',\
 	junit-jupiter-api;version='[5.7.0,5.7.1)',\
 	junit-jupiter-engine;version='[5.7.0,5.7.1)',\
 	junit-platform-commons;version='[1.7.0,1.7.1)',\
@@ -56,4 +55,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.eclipse.jetty.servlet;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
+	xstream;version='[1.4.17,1.4.18)'


### PR DESCRIPTION
Upgrades XStream from 1.4.15 to 1.4.17

Prevents the following vulnerabilities when using XStream instances with an uninitialized security framework:

* CVE-2021-21341
* CVE-2021-21342
* CVE-2021-21343
* CVE-2021-21344
* CVE-2021-21345
* CVE-2021-21346
* CVE-2021-21347
* CVE-2021-21348
* CVE-2021-21349
* CVE-2021-21350
* CVE-2021-21351
* CVE-2021-29505


See: http://x-stream.github.io/changes.html#1.4.17

Related to: #2250, #2251