### PR TITLE
[automation] Remove readOnly flag on script type parameter

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -107,7 +107,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
             parameterOptionsList.add(new ParameterOption(entry.getKey(), entry.getValue()));
         }
         final ConfigDescriptionParameter scriptType = ConfigDescriptionParameterBuilder.create("type", Type.TEXT)
-                .withRequired(true).withReadOnly(true).withMultiple(false).withLabel("Script Type")
+                .withRequired(true).withMultiple(false).withLabel("Script Type")
                 .withDescription("the scripting language used").withOptions(parameterOptionsList)
                 .withLimitToOptions(true).build();
         final ConfigDescriptionParameter script = ConfigDescriptionParameterBuilder.create("script", Type.TEXT)


### PR DESCRIPTION
Not sure if there's a good rationale behind it being read-only (maybe because it's not supposed to change after having been set) but removing it will fix https://github.com/openhab/openhab-webui/issues/1061.

Signed-off-by: Yannick Schaus <github@schaus.net>