### PR TITLE
[automation] Fixed default value definition for module configuration parameters

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/EphemerisConditions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/EphemerisConditions.json
@@ -10,7 +10,7 @@
 					"type": "INTEGER",
 					"label": "Offset",
 					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
-					"default": 0,
+					"defaultValue": 0,
 					"stepsize": 1,
 					"required": false
 				}
@@ -26,7 +26,7 @@
 					"type": "INTEGER",
 					"label": "Offset",
 					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
-					"default": 0,
+					"defaultValue": 0,
 					"stepsize": 1,
 					"required": false
 				}
@@ -42,7 +42,7 @@
 					"type": "INTEGER",
 					"label": "Offset",
 					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
-					"default": 0,
+					"defaultValue": 0,
 					"stepsize": 1,
 					"required": false
 				}
@@ -58,7 +58,7 @@
 					"type": "INTEGER",
 					"label": "Offset",
 					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
-					"default": 0,
+					"defaultValue": 0,
 					"stepsize": 1,
 					"required": false
 				}
@@ -81,7 +81,7 @@
 					"type": "INTEGER",
 					"label": "Offset",
 					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
-					"default": 0,
+					"defaultValue": 0,
 					"stepsize": 1,
 					"required": false
 				}

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericConditions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericConditions.json
@@ -66,7 +66,7 @@
 					"type": "TEXT",
 					"description": "the compare operator, allowed are <,>,=,!=,>=,<= matches",
 					"required": true,
-					"default": "="
+					"defaultValue": "="
 				}
 			],
 			"inputs": [

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/GenericTriggers.json
@@ -12,23 +12,21 @@
 					"label": "Topic",
 					"description": "This is the topic, the trigger will listen to: >>openhab/*<<",
 					"required": true,
-					"default": "openhab/*"
+					"defaultValue": "openhab/*"
 				},
 				{
 					"name": "eventSource",
 					"type": "TEXT",
 					"label": "Source",
 					"description": "This is the source of the event (eg. item name)",
-					"required": true,
-					"default": ""
+					"required": true
 				},
 				{
 					"name": "eventTypes",
 					"type": "TEXT",
 					"label": "Event Type",
 					"description": "the event type, the trigger should listen to. Multiple types can be specified comma-separated",
-					"required": true,
-					"default": ""
+					"required": true
 				}
 			],
 			"outputs": [

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemConditions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemConditions.json
@@ -18,8 +18,6 @@
 					"type": "TEXT",
 					"label": "Operator",
 					"description": "the compare operator (one of =,<,>,!=,>=,<=)",
-					"required": false,
-					"limitToOptions": true,
 					"options": [
 						{
 							"label": "=",
@@ -46,7 +44,7 @@
 							"value": "<="
 						}
 					],
-					"default": "="
+					"defaultValue": "="
 				},
 				{
 					"name": "state",

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/RunRuleAction.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/RunRuleAction.json
@@ -20,7 +20,7 @@
 					"label": "Consider Conditions",
 					"description": "Specifies whether the conditions of the target rule(s) to be executed should be considered or not.",
 					"required": true,
-					"default": true,
+					"defaultValue": true,
 					"options": [
 						{
 							"label": "Yes",


### PR DESCRIPTION
- Fixed default value definition for module configuration parameters

The field is called "defaultValue" in `ConfigDescriptionParameterDTO` and was not parsed before.

Related to #2148

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>