### PR TITLE
[automation] add tags to item modules

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
@@ -107,14 +107,16 @@ public class ItemCommandActionHandler extends BaseActionModuleHandler {
                 Item item = itemRegistry.getItem(itemName);
 
                 Command commandObj = null;
-                Object cmd = inputs.get(COMMAND);
-
-                if (cmd instanceof Command) {
-                    if (item.getAcceptedCommandTypes().contains(cmd.getClass())) {
-                        commandObj = (Command) cmd;
-                    }
-                } else {
+                if (command != null) {
                     commandObj = TypeParser.parseCommand(item.getAcceptedCommandTypes(), command);
+                } else {
+                    Object cmd = inputs.get(COMMAND);
+
+                    if (cmd instanceof Command) {
+                        if (item.getAcceptedCommandTypes().contains(cmd.getClass())) {
+                            commandObj = (Command) cmd;
+                        }
+                    }
                 }
                 if (commandObj != null) {
                     ItemCommandEvent itemCommandEvent = ItemEventFactory.createCommandEvent(itemName, commandObj);
@@ -122,7 +124,7 @@ public class ItemCommandActionHandler extends BaseActionModuleHandler {
                             itemCommandEvent.getItemName(), itemCommandEvent.getItemCommand());
                     eventPublisher.post(itemCommandEvent);
                 } else {
-                    logger.warn("Command '{}' is not valid for item '{}'.", command, itemName);
+                    logger.debug("Command '{}' is not valid for item '{}'.", command, itemName);
                 }
             } catch (ItemNotFoundException e) {
                 logger.error("Item with name {} not found in ItemRegistry.", itemName);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
@@ -65,14 +65,17 @@ public class ItemStateUpdateActionHandler extends BaseActionModuleHandler {
                 Item item = itemRegistry.getItem(itemName);
 
                 State stateObj = null;
-                final Object st = inputs.get(STATE);
 
-                if (st instanceof State) {
-                    if (item.getAcceptedDataTypes().contains(st.getClass())) {
-                        stateObj = (State) st;
-                    }
-                } else {
+                if (state != null) {
                     stateObj = TypeParser.parseState(item.getAcceptedDataTypes(), state);
+                } else {
+                    final Object st = inputs.get(STATE);
+
+                    if (st instanceof State) {
+                        if (item.getAcceptedDataTypes().contains(st.getClass())) {
+                            stateObj = (State) st;
+                        }
+                    }
                 }
                 if (stateObj != null) {
                     final ItemStateEvent itemStateEvent = (ItemStateEvent) ItemEventFactory.createStateEvent(itemName,
@@ -81,7 +84,7 @@ public class ItemStateUpdateActionHandler extends BaseActionModuleHandler {
                             itemStateEvent.getItemState());
                     eventPublisher.post(itemStateEvent);
                 } else {
-                    logger.warn("State '{}' is not valid for item '{}'.", state, itemName);
+                    logger.debug("State '{}' is not valid for item '{}'.", state, itemName);
                 }
             } catch (ItemNotFoundException e) {
                 logger.error("Item with name {} not found in ItemRegistry.", itemName);

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
@@ -53,7 +53,10 @@
 					"name": "command",
 					"type": "command",
 					"label": "Command",
-					"description": "command that will be sent to the item."
+					"description": "command that will be sent to the item.",
+					"tags": [
+						"command"
+					]
 				}
 			]
 		},
@@ -110,7 +113,10 @@
 					"name": "state",
 					"type": "state",
 					"label": "State",
-					"description": "state that the item will be set to."
+					"description": "state that the item will be set to.",
+					"tags": [
+						"state"
+					]
 				}
 			]
 		}

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
@@ -17,8 +17,8 @@
 					"name": "command",
 					"type": "TEXT",
 					"label": "Command",
-					"description": "the default command to be sent if none is passed as an input value",
-					"required": true,
+					"description": "the command to be sent (overrides a potential input value)",
+					"required": false,
 					"limitToOptions": false,
 					"options": [
 						{
@@ -77,8 +77,8 @@
 					"name": "state",
 					"type": "TEXT",
 					"label": "State",
-					"description": "the default state to be used to update the item if none is passed as an input value",
-					"required": true,
+					"description": "the state to update the item to (overrides a potential input value)",
+					"required": false,
 					"limitToOptions": false,
 					"options": [
 						{
@@ -113,7 +113,7 @@
 					"name": "state",
 					"type": "state",
 					"label": "State",
-					"description": "state that the item will be set to.",
+					"description": "state that the item will be set to",
 					"tags": [
 						"state"
 					]

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
@@ -117,7 +117,10 @@
 					"name": "state",
 					"type": "state",
 					"description": "the item state",
-					"label": "State"
+					"label": "State",
+					"tags": [
+						"state"
+					]
 				},
 				{
 					"name": "event",
@@ -215,7 +218,10 @@
 					"name": "newState",
 					"type": "state",
 					"description": "the new item state",
-					"label": "New State"
+					"label": "New State",
+					"tags": [
+						"state"
+					]
 				},
 				{
 					"name": "oldState",
@@ -285,13 +291,19 @@
 					"name": "triggeringItem",
 					"type": "org.openhab.core.items.Item",
 					"description": "the member of the group that received the command",
-					"label": "Triggering Item"
+					"label": "Triggering Item",
+					"tags": [
+						"item"
+					]
 				},
 				{
 					"name": "command",
 					"type": "command",
 					"description": "the received command",
-					"label": "Command"
+					"label": "Command",
+					"tags": [
+						"command"
+					]
 				},
 				{
 					"name": "event",
@@ -355,13 +367,19 @@
 					"name": "triggeringItem",
 					"type": "org.openhab.core.items.Item",
 					"description": "the member of the group that updated its state",
-					"label": "Triggering Item"
+					"label": "Triggering Item",
+					"tags": [
+						"item"
+					]
 				},
 				{
 					"name": "state",
 					"type": "state",
 					"description": "the item state",
-					"label": "State"
+					"label": "State",
+					"tags": [
+						"state"
+					]
 				},
 				{
 					"name": "event",
@@ -459,13 +477,19 @@
 					"name": "triggeringItem",
 					"type": "org.openhab.core.items.Item",
 					"description": "the member of the group that changed its state",
-					"label": "Triggering Item"
+					"label": "Triggering Item",
+					"tags": [
+						"item"
+					]
 				},
 				{
 					"name": "newState",
 					"type": "state",
 					"description": "the new item state",
-					"label": "New State"
+					"label": "New State",
+					"tags": [
+						"state"
+					]
 				},
 				{
 					"name": "oldState",

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemTriggers.json
@@ -53,7 +53,10 @@
 					"name": "command",
 					"type": "command",
 					"description": "the received command",
-					"label": "Command"
+					"label": "Command",
+					"tags": [
+						"command"
+					]
 				},
 				{
 					"name": "event",


### PR DESCRIPTION
Tags are required to enable auto-mapping of inputs and outputs of modules in a rule, see https://github.com/openhab/openhab-addons/pull/10205#discussion_r636433332.

Also made command/state config params optional and being regarded, if they are set. This way it is avoided that auto-wiring prevents users from defining dedicated values in the actions.

Signed-off-by: Kai Kreuzer <kai@openhab.org>