### PR TITLE
[config] Changed 'ConfigDescriptionParameterDTO' field serialization 'defaultValue' -> 'default'

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
@@ -50,4 +50,42 @@ public class FilterCriteria {
     public String toString() {
         return this.getClass().getSimpleName() + " [name=\"" + name + "\", value=\"" + value + "\"]";
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        FilterCriteria other = (FilterCriteria) obj;
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOMapper.java
@@ -17,10 +17,12 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroupBuilder;
 import org.openhab.core.config.core.FilterCriteria;
 import org.openhab.core.config.core.ParameterOption;
 
@@ -31,6 +33,7 @@ import org.openhab.core.config.core.ParameterOption;
  * @author Dennis Nobel - Initial contribution
  * @author Ana Dimova - converting ConfigDescriptionParameterDTO to ConfigDescriptionParameter
  */
+@NonNullByDefault
 public class ConfigDescriptionDTOMapper {
 
     /**
@@ -64,9 +67,23 @@ public class ConfigDescriptionDTOMapper {
                     .withPattern(parameter.pattern).withReadOnly(parameter.readOnly).withMultiple(parameter.multiple)
                     .withMultipleLimit(parameter.multipleLimit).withGroupName(parameter.groupName)
                     .withAdvanced(parameter.advanced).withVerify(parameter.verify)
-                    .withLimitToOptions(parameter.limitToOptions).withUnit(parameter.unitLabel)
+                    .withLimitToOptions(parameter.limitToOptions).withUnit(parameter.unit)
                     .withUnitLabel(parameter.unitLabel).withOptions(mapOptionsDTO(parameter.options))
                     .withFilterCriteria(mapFilterCriteriaDTO(parameter.filterCriteria)).build());
+        }
+        return result;
+    }
+
+    public static List<ConfigDescriptionParameterGroup> mapParameterGroupsDTO(
+            List<ConfigDescriptionParameterGroupDTO> parameterGroups) {
+        if (parameterGroups == null) {
+            return null;
+        }
+        final List<ConfigDescriptionParameterGroup> result = new ArrayList<>(parameterGroups.size());
+        for (ConfigDescriptionParameterGroupDTO parameterGroup : parameterGroups) {
+            result.add(ConfigDescriptionParameterGroupBuilder.create(parameterGroup.name)
+                    .withAdvanced(parameterGroup.advanced).withContext(parameterGroup.context)
+                    .withDescription(parameterGroup.description).withLabel(parameterGroup.label).build());
         }
         return result;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
@@ -17,9 +17,10 @@ import java.util.List;
 
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
- * This is a data transfer object that is used to serialize parameter of a
- * configuration description.
+ * This is a data transfer object that is used to serialize parameter of a configuration description.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Alex Tugarev - Extended for options and filter criteria
@@ -29,6 +30,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 public class ConfigDescriptionParameterDTO {
 
     public String context;
+    @SerializedName(value = "default")
     public String defaultValue;
     public String description;
     public String label;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
@@ -30,7 +30,7 @@ import com.google.gson.annotations.SerializedName;
 public class ConfigDescriptionParameterDTO {
 
     public String context;
-    @SerializedName(value = "default")
+    @SerializedName(value = "default", alternate = "defaultValue")
     public String defaultValue;
     public String description;
     public String label;

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core.dto;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+import org.openhab.core.config.core.ConfigDescriptionParameter;
+import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroup;
+import org.openhab.core.config.core.ConfigDescriptionParameterGroupBuilder;
+import org.openhab.core.config.core.FilterCriteria;
+import org.openhab.core.config.core.ParameterOption;
+
+/**
+ * This is the test class for {@link ConfigDescriptionDTO}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+class ConfigDescriptionDTOTest {
+
+    private static final String CONFIG_DESCRIPTION_SYSTEM_I18N_URI = "system:i18n";
+
+    private static final String PARAM_NAME = "name";
+    private static final String PARAMETER_NAME_CONTEXT_NETWORK_ADDRESS = "network-address";
+    private static final String PARAMETER_NAME_DEFAULT_VALUE = "test";
+    private static final String PARAMETER_NAME_DESCRIPTION = "description";
+    private static final List<FilterCriteria> PARAMETER_NAME_FILTER = List.of(new FilterCriteria("name", "value"));
+    private static final String PARAMETER_NAME_GROUP = "group";
+    private static final String PARAMETER_NAME_LABEL = "label";
+    private static final List<ParameterOption> PARAMETER_NAME_OPTIONS = List.of(new ParameterOption("value", "label"));
+    private static final String PARAMETER_NAME_PATTERN = "%.1f";
+    private static final String PARAMETER_NAME_UNIT = "ms";
+    private static final String PARAMETER_NAME_UNIT_LABEL = "milliseconds";
+
+    private static final String PARAMETER_GROUP_NAME = "name";
+    private static final String PARAMETER_GROUP_CONTEXT = "context";
+    private static final String PARAMETER_GROUP_DESCRIPTION = "description";
+    private static final String PARAMETER_GROUP_LABEL = "label";
+
+    @Test
+    public void testConfigDescriptionDTOMappingContainsDecodedURIString() throws URISyntaxException {
+        final URI systemI18nURI = new URI(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
+        ConfigDescription subject = ConfigDescriptionBuilder.create(systemI18nURI).build();
+
+        ConfigDescriptionDTO result = ConfigDescriptionDTOMapper.map(subject);
+
+        assertThat(result.uri, is(CONFIG_DESCRIPTION_SYSTEM_I18N_URI));
+    }
+
+    @Test
+    public void testConfigDescriptionParameterDTOMappingIsBidirectional() {
+        List<ConfigDescriptionParameter> subject = List.of(ConfigDescriptionParameterBuilder
+                .create(PARAM_NAME, Type.INTEGER).withAdvanced(true).withContext(PARAMETER_NAME_CONTEXT_NETWORK_ADDRESS)
+                .withDefault(PARAMETER_NAME_DEFAULT_VALUE).withDescription(PARAMETER_NAME_DESCRIPTION)
+                .withFilterCriteria(PARAMETER_NAME_FILTER).withGroupName(PARAMETER_NAME_GROUP)
+                .withLabel(PARAMETER_NAME_LABEL).withLimitToOptions(false).withMaximum(BigDecimal.TEN)
+                .withMinimum(BigDecimal.ZERO).withMultiple(true).withMultipleLimit(Integer.valueOf(3))
+                .withOptions(PARAMETER_NAME_OPTIONS).withPattern(PARAMETER_NAME_PATTERN).withReadOnly(false)
+                .withRequired(true).withStepSize(BigDecimal.ONE).withUnit(PARAMETER_NAME_UNIT)
+                .withUnitLabel(PARAMETER_NAME_UNIT_LABEL).withVerify(true).build());
+
+        List<ConfigDescriptionParameter> result = ConfigDescriptionDTOMapper
+                .map(ConfigDescriptionDTOMapper.mapParameters(subject));
+        assertThat(result, hasSize(1));
+
+        ConfigDescriptionParameter parameter = result.get(0);
+        assertThat(parameter.getName(), is(PARAM_NAME));
+        assertThat(parameter.getType(), is(Type.INTEGER));
+        assertThat(parameter.isAdvanced(), is(true));
+        assertThat(parameter.getContext(), is(PARAMETER_NAME_CONTEXT_NETWORK_ADDRESS));
+        assertThat(parameter.getDefault(), is(PARAMETER_NAME_DEFAULT_VALUE));
+        assertThat(parameter.getDescription(), is(PARAMETER_NAME_DESCRIPTION));
+        assertThat(parameter.getFilterCriteria(), is(PARAMETER_NAME_FILTER));
+        assertThat(parameter.getGroupName(), is(PARAMETER_NAME_GROUP));
+        assertThat(parameter.getLabel(), is(PARAMETER_NAME_LABEL));
+        assertThat(parameter.getLimitToOptions(), is(false));
+        assertThat(parameter.getMaximum(), is(BigDecimal.TEN));
+        assertThat(parameter.getMinimum(), is(BigDecimal.ZERO));
+        assertThat(parameter.isMultiple(), is(true));
+        assertThat(parameter.getMultipleLimit(), is(Integer.valueOf(3)));
+        assertThat(parameter.getOptions(), is(PARAMETER_NAME_OPTIONS));
+        assertThat(parameter.getPattern(), is(PARAMETER_NAME_PATTERN));
+        assertThat(parameter.isReadOnly(), is(false));
+        assertThat(parameter.isRequired(), is(true));
+        assertThat(parameter.getStepSize(), is(BigDecimal.ONE));
+        assertThat(parameter.getUnit(), is(PARAMETER_NAME_UNIT));
+        assertThat(parameter.getUnitLabel(), is(PARAMETER_NAME_UNIT_LABEL));
+        assertThat(parameter.isVerifyable(), is(true));
+    }
+
+    @Test
+    public void testConfigDescriptionParameterGroupDTOMappingIsBidirectional() {
+        List<ConfigDescriptionParameterGroup> subject = List.of(ConfigDescriptionParameterGroupBuilder
+                .create(PARAMETER_GROUP_NAME).withAdvanced(true).withContext(PARAMETER_GROUP_CONTEXT)
+                .withDescription(PARAMETER_GROUP_DESCRIPTION).withLabel(PARAMETER_GROUP_LABEL).build());
+
+        List<ConfigDescriptionParameterGroup> result = ConfigDescriptionDTOMapper
+                .mapParameterGroupsDTO(ConfigDescriptionDTOMapper.mapParameterGroups(subject));
+        assertThat(result, hasSize(1));
+
+        ConfigDescriptionParameterGroup parameterGroup = result.get(0);
+        assertThat(parameterGroup.getName(), is(PARAMETER_GROUP_NAME));
+        assertThat(parameterGroup.isAdvanced(), is(true));
+        assertThat(parameterGroup.getContext(), is(PARAMETER_GROUP_CONTEXT));
+        assertThat(parameterGroup.getDescription(), is(PARAMETER_GROUP_DESCRIPTION));
+        assertThat(parameterGroup.getLabel(), is(PARAMETER_GROUP_LABEL));
+    }
+}

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -121,7 +121,8 @@ public class ConfigDescriptionResource implements RESTResource {
         URI uriObject = UriBuilder.fromPath(uri).build();
         ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(uriObject, locale);
         return configDescription != null
-                ? Response.ok(EnrichedConfigDescriptionDTOMapper.map(configDescription)).build()
+                ? JSONResponse.createResponse(Status.OK, EnrichedConfigDescriptionDTOMapper.map(configDescription),
+                        null)
                 : JSONResponse.createErrorResponse(Status.NOT_FOUND, "Configuration not found: " + uri);
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -220,7 +220,7 @@ public class ItemResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
-    @Produces({ MediaType.APPLICATION_JSON })
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getItemByName", summary = "Gets a single item.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedItemDTO.class))),
             @ApiResponse(responseCode = "404", description = "Item not found") })

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
@@ -71,7 +71,6 @@ public class EnrichedConfigDescriptionDTOMapperTest {
         assertThat(ecdpdto.defaultValues, is(nullValue()));
     }
 
-    @SuppressWarnings("null")
     @Test
     public void testThatDefaultValuesAreAList() {
         ConfigDescriptionParameter configDescriptionParameter = ConfigDescriptionParameterBuilder

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.core.internal.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
+import org.openhab.core.config.core.ConfigDescriptionRegistry;
+import org.openhab.core.io.rest.LocaleService;
+
+/**
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class ConfigDescriptionResourceTest {
+
+    private static final String PARAM_NAME = "name";
+    private static final String PARAMETER_NAME_DEFAULT_VALUE = "test";
+    private static final String PARAM_COUNTRY = "country";
+
+    private static final String CONFIG_DESCRIPTION_SYSTEM_I18N_URI = "system:i18n";
+
+    private ConfigDescriptionResource resource;
+
+    private @Mock ConfigDescriptionRegistry mockedConfigDescriptionRegistry;
+    private @Mock LocaleService mockedLocaleService;
+
+    @BeforeEach
+    public void beforeEach() throws URISyntaxException {
+        final URI systemI18nURI = new URI(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
+        final ConfigDescription systemI18n = ConfigDescriptionBuilder.create(systemI18nURI)
+                .withParameter(ConfigDescriptionParameterBuilder.create(PARAM_NAME, Type.TEXT)
+                        .withDefault(PARAMETER_NAME_DEFAULT_VALUE).build())
+                .build();
+        final ConfigDescription systemEphemeris = ConfigDescriptionBuilder.create(new URI("system:ephemeris"))
+                .withParameter(ConfigDescriptionParameterBuilder.create(PARAM_COUNTRY, Type.TEXT).build()).build();
+        when(mockedConfigDescriptionRegistry.getConfigDescriptions(any()))
+                .thenReturn(List.of(systemI18n, systemEphemeris));
+        when(mockedConfigDescriptionRegistry.getConfigDescription(eq(systemI18nURI), any())).thenReturn(systemI18n);
+
+        resource = new ConfigDescriptionResource(mockedConfigDescriptionRegistry, mockedLocaleService);
+    }
+
+    @Test
+    public void shouldReturnAllConfigDescriptions() throws IOException {
+        Response response = resource.getAll(null, null);
+        assertThat(response.getStatus(), is(200));
+        assertThat(new String(((InputStream) response.getEntity()).readAllBytes(), StandardCharsets.UTF_8), is(
+                "[{\"uri\":\"system:i18n\",\"parameters\":[{\"default\":\"test\",\"name\":\"name\",\"required\":false,\"type\":\"TEXT\",\"readOnly\":false,\"multiple\":false,\"advanced\":false,\"verify\":false,\"limitToOptions\":true,\"options\":[],\"filterCriteria\":[]}],\"parameterGroups\":[]},{\"uri\":\"system:ephemeris\",\"parameters\":[{\"name\":\"country\",\"required\":false,\"type\":\"TEXT\",\"readOnly\":false,\"multiple\":false,\"advanced\":false,\"verify\":false,\"limitToOptions\":true,\"options\":[],\"filterCriteria\":[]}],\"parameterGroups\":[]}]"));
+    }
+
+    @Test
+    public void shouldReturnAConfigDescription() throws IOException {
+        Response response = resource.getByURI(null, CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
+        assertThat(response.getStatus(), is(200));
+        assertThat(new String(((InputStream) response.getEntity()).readAllBytes(), StandardCharsets.UTF_8), is(
+                "{\"uri\":\"system:i18n\",\"parameters\":[{\"default\":\"test\",\"name\":\"name\",\"required\":false,\"type\":\"TEXT\",\"readOnly\":false,\"multiple\":false,\"advanced\":false,\"verify\":false,\"limitToOptions\":true,\"options\":[],\"filterCriteria\":[]}],\"parameterGroups\":[]}"));
+    }
+
+    @Test
+    public void shouldReturnStatus404() {
+        Response response = resource.getByURI(null, "uri:invalid");
+        assertThat(response.getStatus(), is(404));
+    }
+}

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -209,13 +209,17 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
                     .filter(o -> "customActionOutput3".equals(o.getName())).findFirst();
             assertThat(output3.isPresent(), is(true));
             assertThat(output3.get().getDefaultValue(), is("{\"command\":\"OFF\"}"));
+            Optional<ConfigDescriptionParameter> configDescription = moduleType3.getConfigurationDescriptions().stream()
+                    .filter(o -> "offset".equals(o.getName())).findFirst();
+            assertThat(configDescription.isPresent(), is(true));
+            assertThat(configDescription.get().getDefault(), is("1"));
 
             assertThat(moduleType4.getInputs(), is(notNullValue()));
             Optional<Input> input = moduleType4.getInputs().stream()
                     .filter(o -> "customActionInput".equals(o.getName())).findFirst();
             assertThat(input.isPresent(), is(true));
             assertThat(input.get().getDefaultValue(), is("5"));
-            Optional<ConfigDescriptionParameter> configDescription = moduleType4.getConfigurationDescriptions().stream()
+            configDescription = moduleType4.getConfigurationDescriptions().stream()
                     .filter(o -> "offset".equals(o.getName())).findFirst();
             assertThat(configDescription.isPresent(), is(true));
             assertThat(configDescription.get().getDefault(), is("0"));

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -43,6 +42,7 @@ import org.openhab.core.automation.type.ModuleTypeRegistry;
 import org.openhab.core.automation.type.Output;
 import org.openhab.core.automation.type.TriggerType;
 import org.openhab.core.common.registry.ProviderChangeListener;
+import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventPublisher;
@@ -101,20 +101,12 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
 
             @Override
             public Collection<Item> getAll() {
-                Set<Item> items = new HashSet<>();
-                items.add(new SwitchItem("myMotionItem"));
-                items.add(new SwitchItem("myPresenceItem"));
-                items.add(new SwitchItem("myLampItem"));
-                items.add(new SwitchItem("myMotionItem2"));
-                items.add(new SwitchItem("myPresenceItem2"));
-                items.add(new SwitchItem("myLampItem2"));
-                items.add(new SwitchItem("myMotionItem11"));
-                items.add(new SwitchItem("myLampItem11"));
-                items.add(new SwitchItem("myMotionItem3"));
-                items.add(new SwitchItem("templ_MotionItem"));
-                items.add(new SwitchItem("templ_LampItem"));
-
-                return items;
+                return Set.of(new SwitchItem("myMotionItem"), new SwitchItem("myPresenceItem"),
+                        new SwitchItem("myLampItem"), new SwitchItem("myMotionItem2"),
+                        new SwitchItem("myPresenceItem2"), new SwitchItem("myLampItem2"),
+                        new SwitchItem("myMotionItem11"), new SwitchItem("myLampItem11"),
+                        new SwitchItem("myMotionItem3"), new SwitchItem("templ_MotionItem"),
+                        new SwitchItem("templ_LampItem"));
             }
 
             @Override
@@ -212,17 +204,21 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
             assertThat(output2.isPresent(), is(true));
             assertThat(output2.get().getDefaultValue(), is("event"));
 
-            assertThat(moduleType4.getInputs(), is(notNullValue()));
-            Optional<Input> input = moduleType4.getInputs().stream()
-                    .filter(o -> "customActionInput".equals(o.getName())).findFirst();
-            assertThat(input.isPresent(), is(true));
-            assertThat(input.get().getDefaultValue(), is("5"));
-
             assertThat(moduleType3.getOutputs(), is(notNullValue()));
             Optional<Output> output3 = moduleType3.getOutputs().stream()
                     .filter(o -> "customActionOutput3".equals(o.getName())).findFirst();
             assertThat(output3.isPresent(), is(true));
             assertThat(output3.get().getDefaultValue(), is("{\"command\":\"OFF\"}"));
+
+            assertThat(moduleType4.getInputs(), is(notNullValue()));
+            Optional<Input> input = moduleType4.getInputs().stream()
+                    .filter(o -> "customActionInput".equals(o.getName())).findFirst();
+            assertThat(input.isPresent(), is(true));
+            assertThat(input.get().getDefaultValue(), is("5"));
+            Optional<ConfigDescriptionParameter> configDescription = moduleType4.getConfigurationDescriptions().stream()
+                    .filter(o -> "offset".equals(o.getName())).findFirst();
+            assertThat(configDescription.isPresent(), is(true));
+            assertThat(configDescription.get().getDefault(), is("0"));
         }, 10000, 200);
     }
 

--- a/itests/org.openhab.core.automation.integration.tests/src/main/resources/OH-INF/automation/moduletypes/CustomActionsTypeDefinition.json
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/resources/OH-INF/automation/moduletypes/CustomActionsTypeDefinition.json
@@ -26,6 +26,17 @@
 					"defaultValue": 5,
 					"required": false
 				}
+			],
+			"configDescriptions": [
+				{
+					"name": "offset",
+					"type": "INTEGER",
+					"label": "Offset",
+					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
+					"default": 0,
+					"stepsize": 1,
+					"required": false
+				}
 			]
 		}
 	]

--- a/itests/org.openhab.core.automation.integration.tests/src/main/resources/OH-INF/automation/moduletypes/CustomActionsTypeDefinition.json
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/resources/OH-INF/automation/moduletypes/CustomActionsTypeDefinition.json
@@ -12,6 +12,17 @@
 					"defaultValue": "{\"command\":\"OFF\"}",
 					"required": false
 				}
+			],
+			"configDescriptions": [
+				{
+					"name": "offset",
+					"type": "INTEGER",
+					"label": "Offset",
+					"description": "Today +/- offset days (+1 = tomorrow, -1 = yesterday).",
+					"defaultValue": 1,
+					"stepsize": 1,
+					"required": false
+				}
 			]
 		},
 		{


### PR DESCRIPTION
- Changed `ConfigDescriptionParameterDTO` field serialization: "defaultValue" -> "default"
- Fixed a minor bug in `ConfigDescriptionDTOMapper` for field "unit"
- Added unit tests for `ConfigDescriptionDTOMapper`, `ConfigDescriptionResource` and `AutomationIntegrationJsonTest`

Supersedes #2376
Related to #2148

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>