### PR TITLE
Fix group member links from rest/items/{itemname}

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -236,7 +236,8 @@ public class ItemResource implements RESTResource {
 
         // if it exists
         if (item != null) {
-            EnrichedItemDTO dto = EnrichedItemDTOMapper.map(item, true, null, uriBuilder(uriInfo, httpHeaders), locale);
+            UriBuilder uriBuilder = uriBuilder(uriInfo, httpHeaders).replacePath("rest/items/{itemName}");
+            EnrichedItemDTO dto = EnrichedItemDTOMapper.map(item, true, null, uriBuilder, locale);
             addMetadata(dto, namespaces, null);
             dto.editable = isEditable(dto.name);
             return JSONResponse.createResponse(Status.OK, dto, null);


### PR DESCRIPTION
Signed-off-by: Anders Alfredsson <andersb86@gmail.com>

Not really happy with hardcoding the path for the UriBuilder, but couldn't find a cleaner way.

The problem is that the UriBuilder is created without templates when creating it from the UriInfo, which caused it to always return the requested path, regardless of what arguments was passed to the `.build()` method.

Fixes #2252 