### PR TITLE
[REST][Docs] Corrects the docs for security requirement for the ThingResource (in the openapi specification)

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -289,7 +289,7 @@ public class ThingResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getThings", summary = "Get all available things.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedThingDTO.class), uniqueItems = true))) })
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedThingDTO.class), uniqueItems = true))) })
     public Response getAll(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("summary") @Parameter(description = "summary fields only") @Nullable Boolean summary) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -287,7 +287,8 @@ public class ThingResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.ADMIN })
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(operationId = "getThings", summary = "Get all available things.", responses = {
+    @Operation(operationId = "getThings", summary = "Get all available things.", security = {
+            @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedThingDTO.class), uniqueItems = true))) })
     public Response getAll(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,


### PR DESCRIPTION
**Problem:**

At the moment, the openapi specification generator for the rest api of openhab generates the following block for the api in the endpoint (GET) /things:

 ```yaml
 /things:
    get:
      tags:
        - things
      summary: Get all available things.
      operationId: getThings
      parameters:
        - name: Accept-Language
          in: header
          description: language
          schema:
            type: string
        - name: summary
          in: query
          description: summary fields only
          schema:
            type: boolean
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                uniqueItems: true
                type: array
                items:
                  $ref: '#/components/schemas/EnrichedThingDTO'
```

However, this is incorrect because the getThings function requires authentication (admin level). The output should therefore be as follows:

 ```yaml
 /things:
    get:
      tags:
        - things
      summary: Get all available things.
      operationId: getThings
      parameters:
        - name: Accept-Language
          in: header
          description: language
          schema:
            type: string
        - name: summary
          in: query
          description: summary fields only
          schema:
            type: boolean
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                uniqueItems: true
                type: array
                items:
                  $ref: '#/components/schemas/EnrichedThingDTO'
      security:
        - oauth2:
            - admin
```


**Solution:**

Add the annotation `@SecurityRequirement` to the function `ThingResource::getAll`.
The annotation marks the function for the generator so that it also outputs the security block.

---

More info see this issue and my comment:
https://github.com/openhab/openhab-core/pull/2402
