### PR TITLE
[REST][Docs] Corrects the docs for security requirement for the PersistenceResource (in the openapi specification)

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -199,9 +199,10 @@ public class PersistenceResource implements RESTResource {
     @RolesAllowed({ Role.ADMIN })
     @Path("/items/{itemname: [a-zA-Z_0-9]+}")
     @Produces({ MediaType.APPLICATION_JSON })
-    @Operation(operationId = "storeItemDataInPersistenceService", summary = "Stores item persistence data into the persistence service.", responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "404", description = "Unknown Item or persistence service") })
+    @Operation(operationId = "storeItemDataInPersistenceService", summary = "Stores item persistence data into the persistence service.", security = {
+            @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "404", description = "Unknown Item or persistence service") })
     public Response httpPutPersistenceItemData(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId,
             @Parameter(description = "The item name.") @PathParam("itemname") String itemName,


### PR DESCRIPTION
**Problem:**

At the moment, the openapi specification generator for the rest api of openhab generates the following block for the api in the endpoint (GET) /things:

```yaml
    put:
      tags:
        - persistence
      summary: Stores item persistence data into the persistence service.
      operationId: storeItemDataInPersistenceService
      parameters:
        - name: serviceId
          in: query
          description: >-
            Id of the persistence service. If not provided the default service
            will be used
          schema:
            type: string
        - name: itemname
          in: path
          description: The item name.
          required: true
          schema:
            type: string
        - name: time
          in: query
          description: >-
            Time of the data to be stored. Will default to current time.
            [yyyy-MM-dd'T'HH:mm:ss.SSSZ]
          required: true
          schema:
            type: string
        - name: state
          in: query
          description: The state to store.
          required: true
          schema:
            type: string
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ItemHistoryDTO'
        '404':
          description: Unknown Item or persistence service

```
However, this is incorrect because the `httpPutPersistenceItemData `function requires authentication (admin level). The output should therefore be as follows:

```yaml
    put:
      tags:
        - persistence
      summary: Stores item persistence data into the persistence service.
      operationId: storeItemDataInPersistenceService
      parameters:
        - name: serviceId
          in: query
          description: >-
            Id of the persistence service. If not provided the default service
            will be used
          schema:
            type: string
        - name: itemname
          in: path
          description: The item name.
          required: true
          schema:
            type: string
        - name: time
          in: query
          description: >-
            Time of the data to be stored. Will default to current time.
            [yyyy-MM-dd'T'HH:mm:ss.SSSZ]
          required: true
          schema:
            type: string
        - name: state
          in: query
          description: The state to store.
          required: true
          schema:
            type: string
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ItemHistoryDTO'
        '404':
          description: Unknown Item or persistence service
     security:
       - oauth2:
           - admin
```

**Solution:**

Add the annotation @SecurityRequirement to the function PersistenceResource::httpPutPersistenceItemData.
The annotation marks the function for the generator so that it also outputs the security block.

---

More info see this issue and my comment:
#2402 and my other pr #2404