### PR TITLE
[automation] Ignore relative lib directories for scripts

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptLibraryWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptLibraryWatcher.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 
-import org.openhab.core.OpenHAB;
 import org.openhab.core.service.AbstractWatchService;
 
 /**
@@ -28,11 +27,8 @@ import org.openhab.core.service.AbstractWatchService;
  */
 abstract class ScriptLibraryWatcher extends AbstractWatchService {
 
-    public static final String LIB_PATH = String.join(File.separator, OpenHAB.getConfigFolder(), "automation", "lib",
-            "javascript");
-
-    ScriptLibraryWatcher() {
-        super(LIB_PATH);
+    ScriptLibraryWatcher(String libPath) {
+        super(libPath);
     }
 
     @Override


### PR DESCRIPTION
ScriptFileWatcher can now be configured to ignore specific, relative directories. This is used so that it can ignore "node_modules" which is what JS is hardcoded to use as a library path.

(Note that this also disables generic library tracking, and instead leaves specific enablement up to script engine providers. I will re-enable this in the JS add-on.)

This change is required to allow JS scripts to use relative paths for libraries, to allow general support for 3rd party libraries and tooling.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>