### PR TITLE
[profiles] Add Incoming and Outgoing profiles.

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemIncomingProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemIncomingProfile.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.thing.profiles.SystemProfiles;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+
+/**
+ * Incoming only profile.
+ *
+ * Posts events from the {@link ThingHandler} to the event bus for state updates.
+ *
+ * @author James Hewitt - Initial contribution
+ */
+@NonNullByDefault
+public class SystemIncomingProfile implements StateProfile {
+
+    private final ProfileCallback callback;
+
+    public SystemIncomingProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.INCOMING;
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        callback.sendUpdate(state);
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        callback.sendCommand(command);
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOutgoingProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOutgoingProfile.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.thing.profiles.SystemProfiles;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+
+/**
+ * Outgoing only profile.
+ *
+ * Forwards commands to the {@link ThingHandler}.
+ *
+ * @author James Hewitt - Initial contribution
+ */
+@NonNullByDefault
+public class SystemOutgoingProfile implements StateProfile {
+
+    private final ProfileCallback callback;
+
+    public SystemOutgoingProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.OUTGOING;
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand(command);
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
@@ -62,15 +62,15 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     private final ChannelTypeRegistry channelTypeRegistry;
 
-    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Set.of(DEFAULT_TYPE, FOLLOW_TYPE, HYSTERESIS_TYPE,
-            OFFSET_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
-            RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE,
-            RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
+    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Set.of(DEFAULT_TYPE, FOLLOW_TYPE, INCOMING_TYPE,
+            OUTGOING_TYPE, HYSTERESIS_TYPE, OFFSET_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE,
+            RAWBUTTON_TOGGLE_PLAYER_TYPE, RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE,
+            RAWROCKER_DIMMER_TYPE, RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
             RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE,
             TIMESTAMP_OFFSET_TYPE, TIMESTAMP_TRIGGER_TYPE, TIMESTAMP_UPDATE_TYPE);
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(DEFAULT, FOLLOW, HYSTERESIS, OFFSET,
-            RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(DEFAULT, FOLLOW, INCOMING, OUTGOING,
+            HYSTERESIS, OFFSET, RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
             RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE,
             RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_OFFSET,
             TIMESTAMP_TRIGGER, TIMESTAMP_UPDATE);
@@ -96,6 +96,10 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemDefaultProfile(callback);
         } else if (FOLLOW.equals(profileTypeUID)) {
             return new SystemFollowProfile(callback);
+        } else if (INCOMING.equals(profileTypeUID)) {
+            return new SystemIncomingProfile(callback);
+        } else if (OUTGOING.equals(profileTypeUID)) {
+            return new SystemOutgoingProfile(callback);
         } else if (HYSTERESIS.equals(profileTypeUID)) {
             return new SystemHysteresisStateProfile(callback, context);
         } else if (OFFSET.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
@@ -28,6 +28,8 @@ public interface SystemProfiles {
 
     public static final ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
     public static final ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
+    public static final ProfileTypeUID INCOMING = new ProfileTypeUID(SYSTEM_SCOPE, "incoming");
+    public static final ProfileTypeUID OUTGOING = new ProfileTypeUID(SYSTEM_SCOPE, "outgoing");
     public static final ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
     public static final ProfileTypeUID HYSTERESIS = new ProfileTypeUID(SYSTEM_SCOPE, "hysteresis");
     public static final ProfileTypeUID RANGE = new ProfileTypeUID(SYSTEM_SCOPE, "range");
@@ -57,6 +59,10 @@ public interface SystemProfiles {
     static final ProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
     static final ProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
+
+    static final ProfileType INCOMING_TYPE = ProfileTypeBuilder.newState(INCOMING, "Incoming").build();
+
+    static final ProfileType OUTGOING_TYPE = ProfileTypeBuilder.newState(OUTGOING, "Outgoing").build();
 
     static final ProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
@@ -1,6 +1,8 @@
 profile-type.system.default.label = Default
 profile-type.system.follow.label = Follow
 profile-type.system.offset.label = Offset
+profile-type.system.incoming.label = Incoming
+profile-type.system.outgoing.label = Outgoing
 profile.config.system.offset.offset.label = Offset
 profile.config.system.offset.offset.description = Offset (plain number or number with unit) to be applied on the state towards the item. The negative offset will be applied in the reverse direction.
 profile-type.system.hysteresis.label = Hysteresis

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemIncomingProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemIncomingProfileTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+
+/**
+ *
+ * @author James Hewitt - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+public class SystemIncomingProfileTest {
+
+    private @Mock ProfileCallback mockCallback;
+
+    @Test
+    public void testOnCommand() {
+        SystemIncomingProfile profile = new SystemIncomingProfile(mockCallback);
+
+        profile.onCommandFromItem(OnOffType.ON);
+
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testOnUpdate() {
+        SystemIncomingProfile profile = new SystemIncomingProfile(mockCallback);
+        profile.onStateUpdateFromItem(OnOffType.ON);
+
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testStateUpdated() {
+        SystemIncomingProfile profile = new SystemIncomingProfile(mockCallback);
+        profile.onStateUpdateFromHandler(OnOffType.ON);
+
+        verify(mockCallback).sendUpdate(eq(OnOffType.ON));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testPostCommand() {
+        SystemIncomingProfile profile = new SystemIncomingProfile(mockCallback);
+        profile.onCommandFromHandler(OnOffType.ON);
+
+        verify(mockCallback).sendCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(mockCallback);
+    }
+}

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOutcomingProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOutcomingProfileTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+
+/**
+ *
+ * @author James Hewitt - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+public class SystemOutcomingProfileTest {
+
+    private @Mock ProfileCallback mockCallback;
+
+    @Test
+    public void testOnCommand() {
+        SystemOutgoingProfile profile = new SystemOutgoingProfile(mockCallback);
+
+        profile.onCommandFromItem(OnOffType.ON);
+
+        verify(mockCallback).handleCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testOnUpdate() {
+        SystemOutgoingProfile profile = new SystemOutgoingProfile(mockCallback);
+        profile.onStateUpdateFromItem(OnOffType.ON);
+
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testStateUpdated() {
+        SystemOutgoingProfile profile = new SystemOutgoingProfile(mockCallback);
+        profile.onStateUpdateFromHandler(OnOffType.ON);
+
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void testPostCommand() {
+        SystemOutgoingProfile profile = new SystemOutgoingProfile(mockCallback);
+        profile.onCommandFromHandler(OnOffType.ON);
+
+        verifyNoMoreInteractions(mockCallback);
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -71,7 +71,7 @@ public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
     @Test
     public void systemProfileTypesAndUidsShouldBeAvailable() {
         Collection<ProfileTypeUID> systemProfileTypeUIDs = profileFactory.getSupportedProfileTypeUIDs();
-        assertThat(systemProfileTypeUIDs, hasSize(20));
+        assertThat(systemProfileTypeUIDs, hasSize(22));
 
         Collection<ProfileType> systemProfileTypes = profileFactory.getProfileTypes(null);
         assertThat(systemProfileTypes, hasSize(systemProfileTypeUIDs.size()));


### PR DESCRIPTION
Specific use case that triggered this is that I have a wall switch that controls two lights over RF (no openhab involvement). I'd like to link the switch to the lights in openhab so that when the switch is pressed, the status is updated correctly. But if I then turn on one of the lights individually, the link posts the wall switch command to the channel, and rfxcom transmits the message, so the other light also turns on.

The Incoming profile allows me to use the switch to keep track of the state of the lights without linking them together, without having to resort to writing rules.

The Outgoing profile... was for the yin and yang of it really. But I tested it and it works.