### PR TITLE
[item] Create a deep copy of the first found fragment before merging other fragments into it

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/StateDescriptionServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/StateDescriptionServiceImpl.java
@@ -75,7 +75,8 @@ public class StateDescriptionServiceImpl implements StateDescriptionService {
 
             // we pick up the first valid StateDescriptionFragment here:
             if (result == null) {
-                result = (StateDescriptionFragmentImpl) fragment;
+                // create a deep copy of the first found fragment before merging other fragments into it
+                result = new StateDescriptionFragmentImpl((StateDescriptionFragmentImpl) fragment);
             } else {
                 result.merge(fragment);
             }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
@@ -114,7 +114,7 @@ public class StateDescriptionServiceImplTest {
 
         StateDescription stateDescription = item.getStateDescription();
 
-        assertThat(stateDescription.isReadOnly(), is(stateDescriptionFragment1.isReadOnly()));
+        assertThat(stateDescription.isReadOnly(), is(stateDescriptionFragment2.isReadOnly()));
     }
 
     @Test
@@ -167,8 +167,7 @@ public class StateDescriptionServiceImplTest {
                 .withMinimum(BigDecimal.ZERO) //
                 .withMaximum(BigDecimal.TEN) //
                 .withPattern("pattern") //
-                .withReadOnly(Boolean.TRUE) //
-                .withOptions(options).build();
+                .withReadOnly(Boolean.TRUE).build();
         registerStateDescriptionFragmentProvider(stateDescriptionFragment1, -1);
 
         StateDescriptionFragment stateDescriptionFragment2 = StateDescriptionFragmentBuilder.create()
@@ -187,6 +186,8 @@ public class StateDescriptionServiceImplTest {
         assertThat(stateDescription.getPattern(), is("pattern"));
         assertThat(stateDescription.isReadOnly(), is(true));
         assertThat(stateDescription.getOptions(), is(options));
+        // check that fragement2 is not merged into fragement1
+        assertThat(stateDescriptionFragment1.getOptions().size(), is(0));
     }
 
     private void registerStateDescriptionFragmentProvider(StateDescriptionFragment stateDescriptionFragment,


### PR DESCRIPTION
- Create a deep copy of the first found fragment before merging other fragments into it

Fixes #2409

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>