### PR TITLE
Add chart theme with transparent background

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
@@ -24,5 +24,5 @@ public class RESTConstants {
 
     public static final String JAX_RS_NAME = "openhab";
 
-    public static final String API_VERSION = "4";
+    public static final String API_VERSION = "5";
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDarkTransparent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDarkTransparent.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.ui.internal.chart.defaultchartprovider;
+
+import java.awt.*;
+
+/**
+ * Implementation of the dark {@link ChartTheme chart theme} with transparent background.
+ */
+public class ChartThemeDarkTransparent extends ChartThemeDark {
+
+    private static final String THEME_NAME = "dark_transparent";
+
+    @Override
+    public String getThemeName() {
+        return THEME_NAME;
+    }
+
+    @Override
+    public Color getPlotBackgroundColor() {
+        return new Color(0, 0, 0, 0);
+    }
+
+    @Override
+    public Color getChartBackgroundColor() {
+        return new Color(0, 0, 0, 0);
+    }
+}

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -77,7 +77,7 @@ public class DefaultChartProvider implements ChartProvider {
     private int legendPosition = 0;
 
     private static final ChartTheme[] CHART_THEMES_AVAILABLE = { new ChartThemeWhite(), new ChartThemeBright(),
-            new ChartThemeDark(), new ChartThemeBlack() };
+            new ChartThemeDark(), new ChartThemeBlack(), new ChartThemeDarkTransparent() };
     public static final String CHART_THEME_DEFAULT_NAME = "bright";
     private Map<String, ChartTheme> chartThemes = null;
 


### PR DESCRIPTION
Currently the background of the dark theme differs from the background
color of the Android app. With a transparent background, it'll be the
same.
The version bump is required so the app can use the current `dark` theme
for older versions of the server.

Closes #1183

PS: AFAIK this is my first PR here and I'm still having issues setting up my IDE. The build doesn't work for me locally, so I want to see if the CI here passes.