### PR TITLE
RuleResource: Add schema specification for "Location" header

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -173,7 +173,7 @@ public class RuleResource implements RESTResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "createRule", summary = "Creates a rule.", responses = {
-            @ApiResponse(responseCode = "201", description = "Created", headers = @Header(name = "Location", description = "Newly created Rule")),
+            @ApiResponse(responseCode = "201", description = "Created", headers = @Header(name = "Location", description = "Newly created Rule", schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "409", description = "Creation of the rule is refused. Rule with the same UID already exists."),
             @ApiResponse(responseCode = "400", description = "Creation of the rule is refused. Missing required parameter.") })
     public Response create(@Parameter(description = "rule data", required = true) RuleDTO rule) throws IOException {


### PR DESCRIPTION
Openapi requires either a `schema` or `content` property for `/rules.post.responses.201.headers.Location`. 
See openapi documentation [Description of Responses](https://swagger.io/docs/specification/describing-responses/#headers) for details. 


The code 
```java
final Rule newRule = ruleRegistry.add(RuleDTOMapper.map(rule));
return Response.status(Status.CREATED)
    .header("location", "rules/" + URLEncoder.encode(newRule.getUID(), StandardCharsets.UTF_8)).build();
```
tells us that the "Location" header is a string with the url to the newly created rule.

We should add the schema specification for the header as a string by extending the annotation `@Header` within the `@ApiResponse` with `schema = @Schema(implementation = String.class)`.