### PR TITLE
OpenApiResource: Remove name from OAuth SecurityScheme to make it OpenAPI3 compliant

### DIFF
--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/OpenApiResource.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/OpenApiResource.java
@@ -159,7 +159,6 @@ public class OpenApiResource implements RESTResource {
         flows.setAuthorizationCode(authorizationCode);
 
         SecurityScheme securityScheme = new SecurityScheme();
-        securityScheme.setName("oauth2");
         securityScheme.setType(SecurityScheme.Type.OAUTH2);
         securityScheme.setFlows(flows);
 


### PR DESCRIPTION
**The problem:**

Right now, the output OpenAPI3 specification for openHAB (from /rest/spec) lists the OAuth2 SecurityScheme with properties `type` and `name`.
```json
// Other schemes and such ...
{
   "securitySchemes":{
      "oauth2":{
         "type":"oauth2",
         "name":"oauth2",
         "flows":{
            "authorizationCode":{
               "authorizationUrl":"/auth/authorize",
               "tokenUrl":"/rest/auth/token",
               "scopes":{
                  "admin":"Administration operations"
               }
            }
         }
      }
   }
}
```

OpenAPI3 only requires the type, but not the name of the SecurityScheme if its type is OAuth2.
In fact, it is even forbidden to specify the name here and it causes an error when validating the specification.

See the OAuth2 example:
```json
{
   "type":"oauth2",
   "flows":{
      "implicit":{
         "authorizationUrl":"https://example.com/api/oauth/dialog",
         "scopes":{
            "write:pets":"modify pets in your account",
            "read:pets":"read your pets"
         }
      }
   }
}
```
taken from the [official OpenAPI3 (3.0.3) OAuth2 sample](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#implicit-oauth2-sample).
And see the official specification on [SecuritySchemes ](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#securitySchemeObject) for more information.


The Swagger API dependency we use automatically outputs the name attribute. This is caused by the implementation of the `SecurityScheme` class from [io.swagger.core.v3:swagger-models](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java), which simply outputs all set properties in JSON format. This is basically what we want, but not in this case.

**Suggestion:**

To fix the output, we would need to remove the name property. There are two ways to do this:
- **A)** Change the code of `SecurityScheme` from `io.swagger.core.v3:swagger-models` so that the property name is only output if the type is apiKey, respectively if the type is not OAuth2.
- **B)** Remove the name (by removing the call `securityScheme.setName("oauth2");`) on the side of openHAB.

I think option **B)** is faster and easier, so I did it in this pr ;-)