### PR TITLE
Use exec:exec instead of exec:java goal to avoid classloaders leak

### DIFF
--- a/bundles/org.openhab.core.model.item/pom.xml
+++ b/bundles/org.openhab.core.model.item/pom.xml
@@ -47,19 +47,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/GenerateItems.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -72,11 +69,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>

--- a/bundles/org.openhab.core.model.persistence/pom.xml
+++ b/bundles/org.openhab.core.model.persistence/pom.xml
@@ -52,19 +52,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/persistence/GeneratePersistence.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -77,11 +74,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>

--- a/bundles/org.openhab.core.model.rule/pom.xml
+++ b/bundles/org.openhab.core.model.rule/pom.xml
@@ -47,19 +47,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/rule/GenerateRules.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -72,11 +69,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>

--- a/bundles/org.openhab.core.model.script/pom.xml
+++ b/bundles/org.openhab.core.model.script/pom.xml
@@ -78,19 +78,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/script/GenerateScript.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -103,11 +100,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>

--- a/bundles/org.openhab.core.model.sitemap/pom.xml
+++ b/bundles/org.openhab.core.model.sitemap/pom.xml
@@ -47,19 +47,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/sitemap/GenerateSitemap.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -72,11 +69,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>

--- a/bundles/org.openhab.core.model.thing/pom.xml
+++ b/bundles/org.openhab.core.model.thing/pom.xml
@@ -70,19 +70,16 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.4.0</version>
         <configuration>
-          <includeProjectDependencies>true</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
+          <executable>java</executable>
           <classpathScope>compile</classpathScope>
-          <mainClass>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</mainClass>
-          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
+            <argument>-classpath</argument>
+            <classpath/>
+            <argument>org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher</argument>
             <argument>file://${project.basedir}/src/org/openhab/core/model/thing/GenerateThing.mwe2</argument>
             <argument>-p</argument>
             <argument>rootPath=/${project.basedir}/..</argument>
           </arguments>
-          <additionalClasspathElements>
-            <additionalClasspathElement>/${basedir}/../antlr-generator-3.2.0-patch.jar</additionalClasspathElement>
-          </additionalClasspathElements>
         </configuration>
         <dependencies>
           <dependency>
@@ -95,11 +92,18 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.6.4</version>
           </dependency>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>3.2</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../antlr-generator-3.2.0-patch.jar</systemPath>
+          </dependency>
         </dependencies>
         <executions>
           <execution>
             <goals>
-              <goal>java</goal>
+              <goal>exec</goal>
             </goals>
             <phase>generate-sources</phase>
           </execution>


### PR DESCRIPTION
This should help a lot as a workaround to https://github.com/mvndaemon/mvnd/issues/440 which has no real fix.