### PR TITLE
Rework system:restauth config parameters

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/restauth.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/restauth.xml
@@ -5,7 +5,15 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="system:restauth">
+		<parameter name="implicitUserRole" type="boolean">
+			<label>Implicit User Role</label>
+			<description>By default, operations requiring the "user" role are available when unauthenticated. Disabling this
+				option will enforce authorization for these operations. Warning: This causes clients that do not support
+				authentication to break.</description>
+			<default>true</default>
+		</parameter>
 		<parameter name="allowBasicAuth" type="boolean">
+			<advanced>true</advanced>
 			<label>Allow Basic Authentication</label>
 			<description>Allow the use of Basic authentication to access protected API resources, in addition to access tokens
 				and API tokens.</description>
@@ -18,14 +26,6 @@
 				authorization. The entries in the cache expire after a while in order to not keep credentials in memory
 				indefinitely. This value defines the expiration time in hours. Set it to 0 for disabling the cache.</description>
 			<default>6</default>
-		</parameter>
-		<parameter name="implicitUserRole" type="boolean">
-			<advanced>true</advanced>
-			<label>Implicit User Role</label>
-			<description>By default, operations requiring the "user" role are available when unauthenticated. Disabling this
-				option will enforce authorization for these operations. Warning: This causes clients that do not support
-				authentication to break.</description>
-			<default>true</default>
 		</parameter>
 	</config-description>
 


### PR DESCRIPTION
Following the discussion in #2476, I believe the order and "advanced" status of config parameters in API Security (`system:restauth`) should be changed.
This promotes "Implicit User Role" to a non-advanced option (even if it can break some clients, it is clearly stated in the description), and demotes "Allow Basic Authentication" to an advanced option (API Tokens can be used to authenticate to the API as a better alternative to Basic).

Signed-off-by: Yannick Schaus <github@schaus.net>