### PR TITLE
[metrics] Catch any Throwable during initialization

### DIFF
--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/DefaultMetricsRegistration.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/DefaultMetricsRegistration.java
@@ -83,21 +83,31 @@ public class DefaultMetricsRegistration implements ReadyService.ReadyTracker, Me
     }
 
     private void registerMeters() {
-        logger.debug("Registering meters...");
-        Set<Tag> tags = Set.of(OH_CORE_METRIC_TAG);
-        meters.add(new JVMMetric(tags));
-        meters.add(new ThreadPoolMetric(tags));
-        meters.add(new BundleStateMetric(bundleContext, tags));
-        meters.add(new ThingStateMetric(bundleContext, thingRegistry, tags));
-        meters.add(new EventCountMetric(bundleContext, tags));
-        meters.add(new RuleMetric(bundleContext, tags, ruleRegistry));
-        meters.add(new ThreadPoolMetric(tags));
+        try {
+            logger.debug("Registering meters...");
+            Set<Tag> tags = Set.of(OH_CORE_METRIC_TAG);
+            meters.add(new JVMMetric(tags));
+            meters.add(new ThreadPoolMetric(tags));
+            meters.add(new BundleStateMetric(bundleContext, tags));
+            meters.add(new ThingStateMetric(bundleContext, thingRegistry, tags));
+            meters.add(new EventCountMetric(bundleContext, tags));
+            meters.add(new RuleMetric(bundleContext, tags, ruleRegistry));
+            meters.add(new ThreadPoolMetric(tags));
 
-        meters.forEach(m -> m.bindTo(registry));
+            meters.forEach(m -> m.bindTo(registry));
+        } catch (Throwable e) {
+            // handle exceptions gracefully to not break StartLevelService run
+            logger.error("Exception caught during meter registration", e);
+        }
     }
 
     private void unregisterMeters() {
-        this.meters.forEach(OpenhabCoreMeterBinder::unbind);
+        try {
+            meters.forEach(OpenhabCoreMeterBinder::unbind);
+        } catch (Throwable e) {
+            // handle exceptions gracefully to not break StartLevelService run
+            logger.error("Exception caught during meter de-registration", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Workaround for #2389

Catches `Throwable`, because a `NoClassDefFoundError` is thrown.

Signed-off-by: Fabian Wolter <github@fabian-wolter.de>