### PR TITLE
Upgrade XStream to 1.4.18

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -257,7 +257,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.17</version>
+      <version>1.4.18</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -500,7 +500,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.17</version>
+      <version>1.4.18</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -35,7 +35,7 @@
 		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.1</bundle>
 
 		<!-- TODO: Unbundled libraries -->
-		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.17</bundle>
+		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.18</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -51,7 +51,7 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.binding.xml;version='[3.2.0,3.2.1)',\
 	org.openhab.core.binding.xml.tests;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -54,7 +54,7 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.discovery;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -45,7 +45,7 @@ Fragment-Host: org.openhab.core.config.xml
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.xml;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -53,7 +53,7 @@ feature.openhab-config: \
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.xml;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -89,7 +89,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[7.3.16,7.3.17)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.3.16,7.3.17)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.audio;version='[3.2.0,3.2.1)',\
 	org.openhab.core.automation;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -57,7 +57,7 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.xml;version='[3.2.0,3.2.1)',\

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -47,7 +47,7 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.eclipse.jetty.util;version='[9.4.40,9.4.41)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.40,9.4.41)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.9,2.0.10)',\
-	xstream;version='[1.4.17,1.4.18)',\
+	xstream;version='[1.4.18,1.4.19)',\
 	org.openhab.core;version='[3.2.0,3.2.1)',\
 	org.openhab.core.binding.xml;version='[3.2.0,3.2.1)',\
 	org.openhab.core.config.core;version='[3.2.0,3.2.1)',\


### PR DESCRIPTION
For release notes, see:

https://x-stream.github.io/changes.html#1.4.18

---

There were already PRs some time ago to properly initialize the XStream security framework in all code that uses XStream.