### PR TITLE
Metrics improvements and fixes

### DIFF
--- a/bundles/org.openhab.core.io.monitor/bnd.bnd
+++ b/bundles/org.openhab.core.io.monitor/bnd.bnd
@@ -7,6 +7,8 @@ Import-Package: \
  org.osgi.service.*,\
  org.slf4j.*,\
  com.google.gson.*;version="[2.8,3)"
-Export-Package: io.micrometer.core.*;-split-package:=merge-first,\
+Export-Package: \
+ com.codahale.metrics.*;-split-package:=merge-first,\
+ io.micrometer.core.*;-split-package:=merge-first,\
  org.HdrHistogram.*;-split-package:=merge-first,\
  org.LatencyUtils.*;-split-package:=merge-first

--- a/bundles/org.openhab.core.io.monitor/pom.xml
+++ b/bundles/org.openhab.core.io.monitor/pom.xml
@@ -26,6 +26,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>4.0.7</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <version>1.6.3</version>

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/BundleStateMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/BundleStateMetric.java
@@ -42,8 +42,7 @@ public class BundleStateMetric implements OpenhabCoreMeterBinder, BundleListener
     private static final String BUNDLE_TAG_NAME = "bundle";
     private final Meter.Id commonMeterId;
     private final Map<Meter.Id, AtomicInteger> registeredMeters = new HashMap<>();
-    @Nullable
-    private MeterRegistry meterRegistry = null;
+    private @Nullable MeterRegistry meterRegistry;
     private final BundleContext bundleContext;
 
     public BundleStateMetric(BundleContext bundleContext, Collection<Tag> tags) {
@@ -87,12 +86,13 @@ public class BundleStateMetric implements OpenhabCoreMeterBinder, BundleListener
 
     @Override
     public void unbind() {
+        MeterRegistry meterRegistry = this.meterRegistry;
         if (meterRegistry == null) {
             return;
         }
         bundleContext.removeBundleListener(this);
         registeredMeters.keySet().forEach(meterRegistry::remove);
         registeredMeters.clear();
-        meterRegistry = null;
+        this.meterRegistry = null;
     }
 }

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/JVMMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/JVMMetric.java
@@ -39,8 +39,7 @@ public class JVMMetric implements OpenhabCoreMeterBinder {
     private final Logger logger = LoggerFactory.getLogger(JVMMetric.class);
     private static final Tag CORE_JVM_METRIC_TAG = Tag.of("metric", "openhab.core.metric.jvm");
     private final Set<Tag> tags = new HashSet<>();
-    @Nullable
-    private MeterRegistry meterRegistry;
+    private @Nullable MeterRegistry meterRegistry;
 
     public JVMMetric(Collection<Tag> tags) {
         this.tags.addAll(tags);
@@ -61,6 +60,7 @@ public class JVMMetric implements OpenhabCoreMeterBinder {
 
     @Override
     public void unbind() {
+        MeterRegistry meterRegistry = this.meterRegistry;
         if (meterRegistry == null) {
             return;
         }
@@ -69,6 +69,6 @@ public class JVMMetric implements OpenhabCoreMeterBinder {
                 meterRegistry.remove(meter);
             }
         }
-        meterRegistry = null;
+        this.meterRegistry = null;
     }
 }

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetric.java
@@ -74,7 +74,7 @@ public class ThingStateMetric implements OpenhabCoreMeterBinder, EventSubscriber
                 thing -> createOrUpdateMetricForBundleState(thing.getUID().getId(), thing.getStatus().ordinal()));
         Dictionary<String, Object> properties = new Hashtable<>();
         properties.put("event.topics", "openhab/things/*");
-        this.eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
+        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
                 properties);
     }
 
@@ -92,16 +92,20 @@ public class ThingStateMetric implements OpenhabCoreMeterBinder, EventSubscriber
 
     @Override
     public void unbind() {
+        MeterRegistry meterRegistry = this.meterRegistry;
         if (meterRegistry == null) {
             return;
         }
+
+        ServiceRegistration<?> eventSubscriberRegistration = this.eventSubscriberRegistration;
         if (eventSubscriberRegistration != null) {
             eventSubscriberRegistration.unregister();
-            eventSubscriberRegistration = null;
+            this.eventSubscriberRegistration = null;
         }
         registeredMeters.keySet().forEach(meterRegistry::remove);
         registeredMeters.clear();
-        meterRegistry = null;
+
+        this.meterRegistry = null;
     }
 
     @Override

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThreadPoolMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThreadPoolMetric.java
@@ -38,8 +38,7 @@ public class ThreadPoolMetric implements OpenhabCoreMeterBinder {
     public static final Tag CORE_THREADPOOL_METRIC_TAG = Tag.of("metric", "openhab.core.metric.threadpools");
     private static final String POOLNAME_TAG_NAME = "pool";
     private final Set<Tag> tags = new HashSet<>();
-    @Nullable
-    private MeterRegistry meterRegistry;
+    private @Nullable MeterRegistry meterRegistry;
 
     public ThreadPoolMetric(Collection<Tag> tags) {
         this.tags.addAll(tags);
@@ -70,6 +69,7 @@ public class ThreadPoolMetric implements OpenhabCoreMeterBinder {
 
     @Override
     public void unbind() {
+        MeterRegistry meterRegistry = this.meterRegistry;
         if (meterRegistry == null) {
             return;
         }
@@ -78,6 +78,6 @@ public class ThreadPoolMetric implements OpenhabCoreMeterBinder {
                 meterRegistry.remove(meter);
             }
         }
-        meterRegistry = null;
+        this.meterRegistry = null;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.common;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -166,10 +167,10 @@ public class ThreadPoolManager {
 
     protected static int getConfig(String poolName) {
         Integer cfg = configs.get(poolName);
-        return (cfg != null) ? cfg : DEFAULT_THREAD_POOL_SIZE;
+        return cfg != null ? cfg : DEFAULT_THREAD_POOL_SIZE;
     }
 
     public static Set<String> getPoolNames() {
-        return pools.keySet();
+        return new HashSet<>(pools.keySet());
     }
 }


### PR DESCRIPTION
* Fix `StringIndexOutOfBoundsException` when using rules file name that starts with 'state' (#2472)
* Null annotations fixes/improvements
* Add transitive `com.codahale.metrics` dependency which is used by `io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry`. This fixes a `NoClassDefFoundError` when implementing metrics exporters that use a `MeterRegistry` extending `DropwizardMeterRegistry` (e.g. `JmxMeterRegistry`).
* Prevent `ConcurrentModificationException` in `ThreadPoolMetric` at startup

Fixes #2472