### PR TITLE
[Marketplace] Add option to include unpublished entries

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -72,6 +72,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
     // constants for the configuration properties
     static final String CONFIG_URI = "system:marketplace";
     static final String CONFIG_API_KEY = "apiKey";
+    static final String CONFIG_SHOW_UNPUBLISHED_ENTRIES_KEY = "showUnpublished";
 
     private final Logger logger = LoggerFactory.getLogger(CommunityMarketplaceAddonService.class);
 
@@ -102,6 +103,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
     private final Set<MarketplaceAddonHandler> addonHandlers = new HashSet<>();
     private EventPublisher eventPublisher;
     private String apiKey = null;
+    private boolean showUnpublished = false;
 
     @Activate
     protected void activate(Map<String, Object> config) {
@@ -118,6 +120,9 @@ public class CommunityMarketplaceAddonService implements AddonService {
     void modified(@Nullable Map<String, Object> config) {
         if (config != null) {
             this.apiKey = (String) config.get(CONFIG_API_KEY);
+            Object showUnpublishedConfigValue = config.get(CONFIG_SHOW_UNPUBLISHED_ENTRIES_KEY);
+            this.showUnpublished = showUnpublishedConfigValue != null
+                    && "true".equals(showUnpublishedConfigValue.toString());
         }
     }
 
@@ -182,7 +187,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
 
             List<DiscourseUser> users = pages.stream().flatMap(p -> Stream.of(p.users)).collect(Collectors.toList());
             return pages.stream().flatMap(p -> Stream.of(p.topic_list.topics))
-                    .filter(t -> Arrays.asList(t.tags).contains(PUBLISHED_TAG))
+                    .filter(t -> showUnpublished || Arrays.asList(t.tags).contains(PUBLISHED_TAG))
                     .map(t -> convertTopicItemToAddon(t, users)).collect(Collectors.toList());
         } catch (Exception e) {
             logger.error("Unable to retrieve marketplace add-ons", e);

--- a/bundles/org.openhab.core.addon.marketplace/src/main/resources/OH-INF/config/marketplace.xml
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/resources/OH-INF/config/marketplace.xml
@@ -6,7 +6,14 @@
 		https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="system:marketplace">
+		<parameter name="showUnpublished" type="boolean">
+			<label>Show Unpublished Entries</label>
+			<default>false</default>
+			<description>Include entries which have not been tagged as published. Warning: this may include entries that are not
+				ready and might not work or harm your installation. Enable at your own risk, for testing purposes only.</description>
+		</parameter>
 		<parameter name="apiKey" type="text">
+			<advanced>true</advanced>
 			<label>API Key for community.openhab.org</label>
 			<description>Specify the API key to use on the community forum (for staff and curators - this allows for instance to
 				see content which is not yet reviewed or otherwise hidden from the general public). Leave blank if you don't have


### PR DESCRIPTION
Add a config parameter to bypass the filtering of Dicourse topics
to include those which don't have the "published" tag.

Set the API key parameter as advanced (irrelevant to most users).

Signed-off-by: Yannick Schaus <github@schaus.net>