### PR TITLE
Prevent NSEE when there is no AddonService

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -275,13 +275,9 @@ public class AddonResource implements RESTResource {
         eventPublisher.post(event);
     }
 
-    private AddonService getDefaultService() {
-        for (AddonService addonService : addonServices) {
-            if (addonService.getId().equals(DEFAULT_ADDON_SERVICE)) {
-                return addonService;
-            }
-        }
-        return addonServices.iterator().next();
+    private @Nullable AddonService getDefaultService() {
+        return addonServices.stream().filter(addonService -> DEFAULT_ADDON_SERVICE.equals(addonService.getId()))
+                .findFirst().orElse(addonServices.stream().findFirst().orElse(null));
     }
 
     private Stream<Addon> getAllAddons(Locale locale) {


### PR DESCRIPTION
The code was already prepared for a nullable default service and then returns a 404 not found.

Fixes #2491