### PR TITLE
Use CoreItemFactory item type constants in tests

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.io.rest.LocaleServiceImpl;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.profiles.ProfileTypeRegistry;
 import org.openhab.core.thing.profiles.TriggerProfileType;
 import org.openhab.core.thing.type.ChannelType;
@@ -74,7 +75,7 @@ public class ChannelTypeResourceTest {
 
         TriggerProfileType profileType = mock(TriggerProfileType.class);
         when(profileType.getSupportedChannelTypeUIDs()).thenReturn(List.of(channelTypeUID));
-        when(profileType.getSupportedItemTypes()).thenReturn(List.of("Switch", "Dimmer"));
+        when(profileType.getSupportedItemTypes()).thenReturn(List.of(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER));
 
         when(profileTypeRegistry.getProfileTypes()).thenReturn(List.of(profileType));
 
@@ -83,6 +84,7 @@ public class ChannelTypeResourceTest {
         verify(channelTypeRegistry).getChannelType(channelTypeUID);
         verify(profileTypeRegistry).getProfileTypes();
         assertThat(response.getStatus(), is(200));
-        assertThat((Set<String>) response.getEntity(), IsIterableContaining.hasItems("Switch", "Dimmer"));
+        assertThat((Set<String>) response.getEntity(),
+                IsIterableContaining.hasItems(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
@@ -29,6 +29,7 @@ import org.openhab.core.items.GroupFunction;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemFactory;
+import org.openhab.core.library.CoreItemFactory;
 
 /**
  *
@@ -51,10 +52,10 @@ public class ItemBuilderTest {
     public void testMinimal() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
 
-        Item res = itemBuilderFactory.newItemBuilder("String", "test").build();
+        Item res = itemBuilderFactory.newItemBuilder(CoreItemFactory.STRING, "test").build();
 
         assertSame(mockItem, res);
-        verify(mockFactory).createItem(eq("String"), eq("test"));
+        verify(mockFactory).createItem(eq(CoreItemFactory.STRING), eq("test"));
         verify(mockItem).setLabel(isNull());
         verify(mockItem).setCategory(isNull());
         verify(mockItem).addGroupNames(eq(Collections.emptyList()));
@@ -78,14 +79,14 @@ public class ItemBuilderTest {
     public void testFull() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
 
-        Item res = itemBuilderFactory.newItemBuilder("String", "test") //
+        Item res = itemBuilderFactory.newItemBuilder(CoreItemFactory.STRING, "test") //
                 .withCategory("category") //
                 .withGroups(List.of("a", "b")) //
                 .withLabel("label") //
                 .build();
 
         assertSame(mockItem, res);
-        verify(mockFactory).createItem(eq("String"), eq("test"));
+        verify(mockFactory).createItem(eq(CoreItemFactory.STRING), eq("test"));
         verify(mockItem).setCategory(eq("category"));
         verify(mockItem).addGroupNames(eq(List.of("a", "b")));
         verify(mockItem).setLabel(eq("label"));
@@ -157,20 +158,21 @@ public class ItemBuilderTest {
     @Test
     public void testNoFactory() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(null);
-        assertThrows(IllegalStateException.class, () -> itemBuilderFactory.newItemBuilder("String", "test").build());
+        assertThrows(IllegalStateException.class,
+                () -> itemBuilderFactory.newItemBuilder(CoreItemFactory.STRING, "test").build());
     }
 
     @Test
     public void testFunctionOnNonGroupItem() {
         GroupFunction mockFunction = mock(GroupFunction.class);
-        assertThrows(IllegalArgumentException.class,
-                () -> itemBuilderFactory.newItemBuilder("String", "test").withGroupFunction(mockFunction));
+        assertThrows(IllegalArgumentException.class, () -> itemBuilderFactory
+                .newItemBuilder(CoreItemFactory.STRING, "test").withGroupFunction(mockFunction));
     }
 
     @Test
     public void testBaseItemOnNonGroupItem() {
         Item mockItem = mock(Item.class);
         assertThrows(IllegalArgumentException.class,
-                () -> itemBuilderFactory.newItemBuilder("String", "test").withBaseItem(mockItem));
+                () -> itemBuilderFactory.newItemBuilder(CoreItemFactory.STRING, "test").withBaseItem(mockItem));
     }
 }

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -50,6 +50,7 @@ import org.openhab.core.items.MetadataKey;
 import org.openhab.core.items.MetadataProvider;
 import org.openhab.core.items.dto.GroupItemDTO;
 import org.openhab.core.items.dto.MetadataDTO;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
@@ -151,13 +152,14 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
 
     @Test
     public void shouldFilterItemsByType() throws Exception {
-        Response response = itemResource.getItems(uriInfo, httpHeaders, null, "Switch", null, null, false, null);
+        Response response = itemResource.getItems(uriInfo, httpHeaders, null, CoreItemFactory.SWITCH, null, null, false,
+                null);
         assertThat(readItemNamesFromResponse(response), hasItems(ITEM_NAME1, ITEM_NAME2));
 
-        response = itemResource.getItems(uriInfo, httpHeaders, null, "Dimmer", null, null, false, null);
+        response = itemResource.getItems(uriInfo, httpHeaders, null, CoreItemFactory.DIMMER, null, null, false, null);
         assertThat(readItemNamesFromResponse(response), hasItems(ITEM_NAME3));
 
-        response = itemResource.getItems(uriInfo, httpHeaders, null, "Color", null, null, false, null);
+        response = itemResource.getItems(uriInfo, httpHeaders, null, CoreItemFactory.COLOR, null, null, false, null);
         assertThat(readItemNamesFromResponse(response), hasSize(0));
     }
 
@@ -222,13 +224,13 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
 
         GroupItemDTO item1DTO = new GroupItemDTO();
         item1DTO.name = "item1";
-        item1DTO.type = "Switch";
+        item1DTO.type = CoreItemFactory.SWITCH;
         item1DTO.label = "item1Label";
         itemList.add(item1DTO);
 
         GroupItemDTO item2DTO = new GroupItemDTO();
         item2DTO.name = "item2";
-        item2DTO.type = "Rollershutter";
+        item2DTO.type = CoreItemFactory.ROLLERSHUTTER;
         item2DTO.label = "item2Label";
         itemList.add(item2DTO);
 

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResourceTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResourceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openhab.core.io.rest.LocaleService;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.profiles.ProfileType;
 import org.openhab.core.thing.profiles.ProfileTypeBuilder;
@@ -55,8 +56,8 @@ public class ProfileTypeResourceTest extends JavaTest {
     // UIDs for state profile types
     private final ProfileTypeUID stateProfileTypeUID1 = new ProfileTypeUID("my:stateProfile1");
     private final ChannelTypeUID pt1ChannelType1UID = new ChannelTypeUID("my:channel1");
-    private final ChannelType pt1ChannelType1 = ChannelTypeBuilder.state(pt1ChannelType1UID, "channel1", "Switch")
-            .build();
+    private final ChannelType pt1ChannelType1 = ChannelTypeBuilder
+            .state(pt1ChannelType1UID, "channel1", CoreItemFactory.SWITCH).build();
 
     private final ProfileTypeUID stateProfileTypeUID2 = new ProfileTypeUID("my:stateProfile2");
 
@@ -70,7 +71,7 @@ public class ProfileTypeResourceTest extends JavaTest {
     // some other channel types for testing
     private final ChannelTypeUID otherStateChannelTypeUID = new ChannelTypeUID("other:stateChannel1");
     private final ChannelType otherStateChannelType = ChannelTypeBuilder
-            .state(otherStateChannelTypeUID, "channelState1", "Number").build();
+            .state(otherStateChannelTypeUID, "channelState1", CoreItemFactory.NUMBER).build();
     private final ChannelTypeUID otherTriggerChannelTypeUID = new ChannelTypeUID("other:triggerChannel1");
     private final ChannelType otherTriggerChannelType = ChannelTypeBuilder
             .trigger(otherTriggerChannelTypeUID, "channel1").build();
@@ -85,7 +86,8 @@ public class ProfileTypeResourceTest extends JavaTest {
 
         List<ProfileType> profileTypes = new ArrayList<>();
         ProfileType pt1 = ProfileTypeBuilder.newState(stateProfileTypeUID1, "profile1")
-                .withSupportedChannelTypeUIDs(pt1ChannelType1UID).withSupportedItemTypesOfChannel("Switch").build();
+                .withSupportedChannelTypeUIDs(pt1ChannelType1UID)
+                .withSupportedItemTypesOfChannel(CoreItemFactory.SWITCH).build();
         ProfileType pt2 = ProfileTypeBuilder.newState(stateProfileTypeUID2, "profile2").build();
         ProfileType pt3 = ProfileTypeBuilder.newTrigger(triggerProfileTypeUID1, "profile3")
                 .withSupportedChannelTypeUIDs(pt3ChannelType1UID).build();

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.thing.internal.GenericItemChannelLinkProvider;
 import org.openhab.core.test.java.JavaOSGiTest;
@@ -150,7 +151,8 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
         }
 
         provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL, new Configuration());
+        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, CoreItemFactory.NUMBER, ITEM, CHANNEL,
+                new Configuration());
         provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
         assertThat(provider.getAll().size(), is(1));
         assertThat(provider.getAll().iterator().next().toString(), is(LINK));
@@ -158,7 +160,8 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
 
         reset(localListenerMock);
         provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL, new Configuration());
+        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, CoreItemFactory.NUMBER, ITEM, CHANNEL,
+                new Configuration());
         provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
         assertThat(provider.getAll().size(), is(1));
         assertThat(provider.getAll().iterator().next().toString(), is(LINK));

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.Bridge;
@@ -125,7 +126,8 @@ public class GenericThingProviderTest extends JavaOSGiTest {
             assertThat(c.getUID().toString(),
                     anyOf(is("hue:LCT001:myBridge:bulb1:notification"), is("hue:LCT001:myBridge:bulb1:color"),
                             is("hue:LCT001:myBridge:bulb1:color_temperature"), is("hue:TEST:bulb4")));
-            assertThat(c.getAcceptedItemType(), anyOf(is("Switch"), is("Color"), is("Dimmer")));
+            assertThat(c.getAcceptedItemType(),
+                    anyOf(is(CoreItemFactory.SWITCH), is(CoreItemFactory.COLOR), is(CoreItemFactory.DIMMER)));
         });
         assertThat(bulb1.getBridgeUID(), is(bridge1.getUID()));
         assertThat(bulb1.getConfiguration().values().size(), is(1));
@@ -149,7 +151,7 @@ public class GenericThingProviderTest extends JavaOSGiTest {
         Channel firstChannel = bulb3.getChannels().stream()
                 .filter(c -> "hue:LCT001:bulb3:notification".equals(c.getUID().toString())).findFirst().get();
         assertThat(firstChannel.getUID().toString(), is("hue:LCT001:bulb3:notification"));
-        assertThat(firstChannel.getAcceptedItemType(), is("Switch"));
+        assertThat(firstChannel.getAcceptedItemType(), is(CoreItemFactory.SWITCH));
         assertThat(firstChannel.getConfiguration().values().size(), is(1));
         assertThat(firstChannel.getConfiguration().get("duration"), is("5"));
         assertThat(bulb3.getBridgeUID(), is(nullValue()));
@@ -222,7 +224,7 @@ public class GenericThingProviderTest extends JavaOSGiTest {
         assertThat(bulb2.getChannels().size(), is(2));
         Channel firstChannel = bulb2.getChannels().get(0);
         assertThat(firstChannel.getUID().toString(), is("hue:LCT001:bulb2:color"));
-        assertThat(firstChannel.getAcceptedItemType(), is("Color"));
+        assertThat(firstChannel.getAcceptedItemType(), is(CoreItemFactory.COLOR));
         assertThat(bulb2.getBridgeUID(), is(nullValue()));
         assertThat(bulb2.getConfiguration().values().size(), is(1));
         assertThat(bulb2.getConfiguration().get("lightId"), is("2"));

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
@@ -33,6 +33,7 @@ import org.openhab.core.config.core.ConfigDescriptionBuilder;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.thing.testsupport.hue.DumbThingHandlerFactory;
 import org.openhab.core.test.java.JavaOSGiTest;
@@ -125,7 +126,8 @@ public class GenericThingProviderTest3 extends JavaOSGiTest {
         // now become smart again...
         dumbThingHandlerFactory.setDumb(false);
         ChannelType channelType1 = ChannelTypeBuilder
-                .state(new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1"), "Channel 1", "String")
+                .state(new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1"), "Channel 1",
+                        CoreItemFactory.STRING)
                 .build();
 
         ChannelTypeProvider channelTypeProvider = mock(ChannelTypeProvider.class);

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueChannelTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueChannelTypeProvider.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.thing.type.ChannelDefinitionBuilder;
 import org.openhab.core.thing.type.ChannelGroupType;
 import org.openhab.core.thing.type.ChannelGroupTypeBuilder;
@@ -49,21 +50,21 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider, ChannelG
 
     public TestHueChannelTypeProvider() {
         try {
-            ChannelType ctColor = ChannelTypeBuilder.state(COLOR_CHANNEL_TYPE_UID, "colorLabel", "Color")
+            ChannelType ctColor = ChannelTypeBuilder.state(COLOR_CHANNEL_TYPE_UID, "colorLabel", CoreItemFactory.COLOR)
                     .withDescription("description").withConfigDescriptionURI(new URI("hue", "LCT001:color", null))
                     .build();
 
             ChannelType ctColorTemperature = ChannelTypeBuilder
-                    .state(COLOR_TEMP_CHANNEL_TYPE_UID, "colorTemperatureLabel", "Dimmer")
+                    .state(COLOR_TEMP_CHANNEL_TYPE_UID, "colorTemperatureLabel", CoreItemFactory.DIMMER)
                     .withDescription("description")
                     .withConfigDescriptionURI(new URI("hue", "LCT001:color_temperature", null)).build();
 
-            ChannelType ctColorX = ChannelTypeBuilder.state(COLORX_CHANNEL_TYPE_UID, "colorLabel", "Color")
-                    .withDescription("description").withConfigDescriptionURI(new URI("Xhue", "XLCT001:Xcolor", null))
-                    .build();
+            ChannelType ctColorX = ChannelTypeBuilder
+                    .state(COLORX_CHANNEL_TYPE_UID, "colorLabel", CoreItemFactory.COLOR).withDescription("description")
+                    .withConfigDescriptionURI(new URI("Xhue", "XLCT001:Xcolor", null)).build();
 
             ChannelType ctColorTemperatureX = ChannelTypeBuilder
-                    .state(COLORX_TEMP_CHANNEL_TYPE_UID, "colorTemperatureLabel", "Dimmer")
+                    .state(COLORX_TEMP_CHANNEL_TYPE_UID, "colorTemperatureLabel", CoreItemFactory.DIMMER)
                     .withDescription("description")
                     .withConfigDescriptionURI(new URI("Xhue", "XLCT001:Xcolor_temperature", null)).build();
 

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -120,7 +120,7 @@ public class ItemRegistryImplTest extends JavaTest {
 
     @Test
     public void assertGetItemsOfTypeReturnsItemFromRegisteredItemProvider() {
-        List<Item> items = new ArrayList<>(itemRegistry.getItemsOfType("Switch"));
+        List<Item> items = new ArrayList<>(itemRegistry.getItemsOfType(CoreItemFactory.SWITCH));
         assertThat(items.size(), is(3));
         assertThat(items.get(0).getName(), is(equalTo(ITEM_NAME)));
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
@@ -40,6 +40,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Channel;
@@ -226,12 +227,12 @@ public class ThingFactoryTest extends JavaOSGiTest {
     @Test
     public void createThingWithChannels() {
         ChannelType channelType1 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("bindingId:channelTypeId1"), "channelLabel", "Color")
+                .state(new ChannelTypeUID("bindingId:channelTypeId1"), "channelLabel", CoreItemFactory.COLOR)
                 .withTags(Stream.of("tag1", "tag2").collect(toSet())).build();
 
         ChannelType channelType2 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("bindingId:channelTypeId2"), "channelLabel2", "Dimmer").withTag("tag3")
-                .build();
+                .state(new ChannelTypeUID("bindingId:channelTypeId2"), "channelLabel2", CoreItemFactory.DIMMER)
+                .withTag("tag3").build();
 
         registerChannelTypes(Set.of(channelType1, channelType2), emptyList());
 
@@ -247,7 +248,7 @@ public class ThingFactoryTest extends JavaOSGiTest {
 
         assertThat(thing.getChannels().size(), is(2));
         assertThat(thing.getChannels().get(0).getUID().toString(), is(equalTo("bindingId:thingType:thingId:ch1")));
-        assertThat(thing.getChannels().get(0).getAcceptedItemType(), is(equalTo("Color")));
+        assertThat(thing.getChannels().get(0).getAcceptedItemType(), is(equalTo(CoreItemFactory.COLOR)));
         assertThat(thing.getChannels().get(0).getDefaultTags().contains("tag1"), is(true));
         assertThat(thing.getChannels().get(0).getDefaultTags().contains("tag2"), is(true));
         assertThat(thing.getChannels().get(0).getDefaultTags().contains("tag3"), is(false));
@@ -259,12 +260,12 @@ public class ThingFactoryTest extends JavaOSGiTest {
     @Test
     public void createThingWithChannelsGroups() {
         ChannelType channelType1 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("bindingId:channelTypeId1"), "channelLabel", "Color")
+                .state(new ChannelTypeUID("bindingId:channelTypeId1"), "channelLabel", CoreItemFactory.COLOR)
                 .withTags(Set.of("tag1", "tag2")).build();
 
         ChannelType channelType2 = ChannelTypeBuilder
-                .state(new ChannelTypeUID("bindingId:channelTypeId2"), "channelLabel2", "Dimmer").withTag("tag3")
-                .build();
+                .state(new ChannelTypeUID("bindingId:channelTypeId2"), "channelLabel2", CoreItemFactory.DIMMER)
+                .withTag("tag3").build();
 
         ChannelDefinition channelDef1 = new ChannelDefinitionBuilder("ch1", channelType1.getUID()).build();
         ChannelDefinition channelDef2 = new ChannelDefinitionBuilder("ch2", channelType2.getUID()).build();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -42,6 +42,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyService;
 import org.openhab.core.storage.Storage;
@@ -137,8 +138,9 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         configDescriptionChannel = new URI("test:channel");
         configDescriptionThing = new URI("test:test");
         thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(List.of( //
-                ChannelBuilder.create(CHANNEL_UID, "Switch").withLabel("Test Label").withDescription("Test Description")
-                        .withType(CHANNEL_TYPE_UID).withDefaultTags(Set.of("Test Tag")).build() //
+                ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.SWITCH).withLabel("Test Label")
+                        .withDescription("Test Description").withType(CHANNEL_TYPE_UID)
+                        .withDefaultTags(Set.of("Test Tag")).build() //
         )).build();
         registerVolatileStorageService();
 
@@ -304,7 +306,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         assertNotNull(channel);
         assertEquals("Test Label", channel.getLabel());
         assertEquals("Test Description", channel.getDescription());
-        assertEquals("Switch", channel.getAcceptedItemType());
+        assertEquals(CoreItemFactory.SWITCH, channel.getAcceptedItemType());
         assertEquals(CHANNEL_TYPE_UID, channel.getChannelTypeUID());
         assertNotNull(channel.getDefaultTags());
         assertEquals(1, channel.getDefaultTags().size());
@@ -315,7 +317,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         assertNotNull(channel);
         assertEquals("Test Label Overridden", channel.getLabel());
         assertEquals("Test Description Overridden", channel.getDescription());
-        assertEquals("Switch", channel.getAcceptedItemType());
+        assertEquals(CoreItemFactory.SWITCH, channel.getAcceptedItemType());
         assertEquals(CHANNEL_TYPE_UID, channel.getChannelTypeUID());
         assertNotNull(channel.getDefaultTags());
         assertEquals(1, channel.getDefaultTags().size());
@@ -998,8 +1000,8 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         Configuration configChannel = new Configuration(propsChannel);
 
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(List.of( //
-                ChannelBuilder.create(CHANNEL_UID, "Switch").withType(CHANNEL_TYPE_UID).withConfiguration(configChannel)
-                        .build() //
+                ChannelBuilder.create(CHANNEL_UID, CoreItemFactory.SWITCH).withType(CHANNEL_TYPE_UID)
+                        .withConfiguration(configChannel).build() //
         )).withConfiguration(configThing).build();
 
         managedThingProvider.add(thing);
@@ -1035,7 +1037,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     }
 
     private void registerChannelTypeProvider() throws Exception {
-        ChannelType channelType = ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "Test Label", "Switch")
+        ChannelType channelType = ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "Test Label", CoreItemFactory.SWITCH)
                 .withDescription("Test Description").withCategory("Test Category").withTag("Test Tag")
                 .withConfigDescriptionURI(new URI("test:channel")).build();
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -141,7 +141,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         channelTypeProvider = mock(ChannelTypeProvider.class);
         when(channelTypeProvider.getChannelType(any(ChannelTypeUID.class), nullable(Locale.class)))
-                .thenReturn(ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "label", "Switch").build());
+                .thenReturn(ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "label", CoreItemFactory.SWITCH).build());
         registerService(channelTypeProvider);
 
         managedItemChannelLinkProvider = getService(ManagedItemChannelLinkProvider.class);

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.binding.ThingTypeProvider;
 import org.openhab.core.thing.type.BridgeType;
@@ -150,7 +151,7 @@ public class ThingTypesTest extends JavaOSGiTest {
             assertThat(alarmChannelType, is(notNullValue()));
 
             assertThat(alarmChannelType.toString(), is("hue:alarm"));
-            assertThat(alarmChannelType.getItemType(), is("Number"));
+            assertThat(alarmChannelType.getItemType(), is(CoreItemFactory.NUMBER));
             assertThat(alarmChannelType.getLabel(), is("Alarm System"));
             assertThat(alarmChannelType.getDescription(), is("The light blinks if alarm is set."));
 


### PR DESCRIPTION
This prevents typos and using the constants makes it easier to find out what other items types are accepted.
It also makes it easier to see that these values are item types and not labels or descriptions.
