### PR TITLE
Bump Netty.io library to 4.1.68.Final

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -131,21 +131,21 @@
 	</feature>
 
 	<feature name="openhab.tp-netty" description="Netty bundles" version="${project.version}">
-		<capability>openhab.tp;feature=netty;version=4.1.63.Final</capability>
-		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-common/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.63.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.63.Final</bundle>
+		<capability>openhab.tp;feature=netty;version=4.1.68.Final</capability>
+		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-common/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.68.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.68.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">


### PR DESCRIPTION
Update to latest Netty which has 2 security fixes in it.

Change log here:
https://netty.io/news/2021/09/09/4-1-68-Final.html

Also this PR is also needed see here:
https://github.com/openhab/openhab-addons/pull/11326

Signed-off-by: Matthew Skinner <matt@pcmus.com>