### PR TITLE
add item name to ScriptBusEvent log messages

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEvent.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEvent.java
@@ -94,7 +94,7 @@ public class ScriptBusEvent {
                 if (command != null) {
                     eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
                 } else {
-                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("Command '{}' cannot be parsed.", commandString);
+                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("Command '{}' cannot be parsed for item '{}'.", commandString, item);
                 }
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(ScriptBusEvent.class).warn("Item '{}' does not exist.", itemName);
@@ -158,7 +158,7 @@ public class ScriptBusEvent {
                 if (state != null) {
                     eventPublisher.post(ItemEventFactory.createStateEvent(itemName, state));
                 } else {
-                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("State '{}' cannot be parsed.", stateString);
+                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("State '{}' cannot be parsed for item '{}'.", stateString, itemName);
                 }
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(ScriptBusEvent.class).warn("Item '{}' does not exist.", itemName);

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEvent.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEvent.java
@@ -94,7 +94,8 @@ public class ScriptBusEvent {
                 if (command != null) {
                     eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
                 } else {
-                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("Command '{}' cannot be parsed for item '{}'.", commandString, item);
+                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("Command '{}' cannot be parsed for item '{}'.",
+                            commandString, item);
                 }
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(ScriptBusEvent.class).warn("Item '{}' does not exist.", itemName);
@@ -158,7 +159,8 @@ public class ScriptBusEvent {
                 if (state != null) {
                     eventPublisher.post(ItemEventFactory.createStateEvent(itemName, state));
                 } else {
-                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("State '{}' cannot be parsed for item '{}'.", stateString, itemName);
+                    LoggerFactory.getLogger(ScriptBusEvent.class).warn("State '{}' cannot be parsed for item '{}'.",
+                            stateString, itemName);
                 }
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(ScriptBusEvent.class).warn("Item '{}' does not exist.", itemName);


### PR DESCRIPTION
Currently the item name is missing and it is nearly impossible to find the cause of the warning as there is no hint which rule sent the wrong update/command. Now at least the item name is shown which helps to identify the offending rule.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>