### PR TITLE
Fix add-on type inconsistencies

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     private static final Path KAR_CACHE_PATH = Path.of(OpenHAB.getUserDataFolder(), "marketplace", "kar");
-    private static final List<String> SUPPORTED_EXT_TYPES = List.of("automation", "binding", "io", "persistence",
+    private static final List<String> SUPPORTED_EXT_TYPES = List.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
     private static final String KAR_DOWNLOAD_URL_PROPERTY = "kar_download_url";
     private static final String KAR_EXTENSION = ".kar";

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -40,7 +40,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(immediate = true)
 @NonNullByDefault
 public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller implements MarketplaceAddonHandler {
-    private static final List<String> SUPPORTED_EXT_TYPES = List.of("automation", "binding", "io", "persistence",
+    private static final List<String> SUPPORTED_EXT_TYPES = List.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
     private static final String JAR_DOWNLOAD_URL_PROPERTY = "jar_download_url";
 

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -100,11 +100,11 @@ public class CommunityMarketplaceAddonService implements AddonService {
     private static final Map<String, AddonType> TAG_ADDON_TYPE_MAP = Map.of( //
             "automation", new AddonType("automation", "Automation"), //
             "binding", new AddonType("binding", "Bindings"), //
-            "io", new AddonType("io", "I/O Services"), //
-            "persistence", new AddonType("persistence", "Persistence Services"), //
+            "io", new AddonType("misc", "Misc"), //
+            "persistence", new AddonType("persistence", "Persistence"), //
             "transformation", new AddonType("transformation", "Transformations"), //
             "ui", new AddonType("ui", "User Interfaces"), //
-            "voice", new AddonType("voice", "Voices"));
+            "voice", new AddonType("voice", "Voice"));
 
     private final Logger logger = LoggerFactory.getLogger(CommunityMarketplaceAddonService.class);
     private final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").create();
@@ -336,7 +336,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
 
         String maturity = tags.stream().filter(CODE_MATURITY_LEVELS::contains).findAny().orElse(null);
 
-        HashMap<String, Object> properties = new HashMap<>(10);
+        Map<String, Object> properties = new HashMap<>(10);
         properties.put("created_at", createdDate);
         properties.put("like_count", likeCount);
         properties.put("views", views);
@@ -386,7 +386,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
 
         String maturity = tags.stream().filter(CODE_MATURITY_LEVELS::contains).findAny().orElse(null);
 
-        HashMap<String, Object> properties = new HashMap<>(10);
+        Map<String, Object> properties = new HashMap<>(10);
         properties.put("created_at", createdDate);
         properties.put("updated_at", updatedDate);
         properties.put("last_posted", lastPostedDate);


### PR DESCRIPTION
This makes the CommunityMarketplaceAddonService return the same add-on type responses as the KarafAddonService.
This allows for add-ons tagged with "io" in the Marketplace to show up in the UI.

Fixes #2507