### PR TITLE
Remove deprecated XStream.setupDefaultSecurity call

### DIFF
--- a/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/util/XmlDocumentReader.java
+++ b/bundles/org.openhab.core.config.xml/src/main/java/org/openhab/core/config/xml/util/XmlDocumentReader.java
@@ -73,7 +73,6 @@ public abstract class XmlDocumentReader<@NonNull T> {
      * @see https://x-stream.github.io/security.html
      */
     protected void configureSecurity(XStream xstream) {
-        XStream.setupDefaultSecurity(xstream);
         xstream.allowTypesByWildcard(DEFAULT_ALLOWED_TYPES_WILDCARD);
     }
 


### PR DESCRIPTION
The XStream.setupDefaultSecurity method is deprecated since XStream 1.4.18.
It no longer does anything, because this is the default in newer XStream versions.