### PR TITLE
Add image_link field to community marketplace invididual add-ons

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -434,7 +434,7 @@ public class CommunityMarketplaceAddonService implements AddonService {
                 .anyMatch(handler -> handler.supports(type, contentType) && handler.isInstalled(id));
 
         return Addon.create(id).withType(type).withContentType(contentType).withLabel(topic.title)
-                .withLink(COMMUNITY_TOPIC_URL + topic.id.toString())
+                .withImageLink(topic.image_url).withLink(COMMUNITY_TOPIC_URL + topic.id.toString())
                 .withAuthor(topic.post_stream.posts[0].display_username).withMaturity(maturity)
                 .withDetailedDescription(detailedDescription).withInstalled(installed).withProperties(properties)
                 .build();

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
@@ -27,6 +27,7 @@ public class DiscourseTopicResponseDTO {
 
     public String title;
     public Integer posts_count;
+    public String image_url;
 
     public Date created_at;
     public Date updated_at;


### PR DESCRIPTION
When I wrote the code from the HABPanel gallery which was also
based on Discourse topics, the image_url field that was present on
topic lists wasn't replicated on single topic entries, but now it is:

See:
- https://meta.discourse.org/t/single-topic-api-endpoint-should-contain-image-url/131020
- https://github.com/discourse/discourse/commit/3201613f138bf574577d77631f8214098e22b7e3

I have confirmed the field is present on community.openhab.org.
So this should help moving the "primary image" to the place where
the logo should be in the UI.

We can prevent the same image from being displayed twice with some
measures on the Discourse posts themselves (like have it between `<details></details>`).

![image](https://user-images.githubusercontent.com/2004147/137378924-169be246-86b6-43ed-a83d-91840857ea6d.png)

Signed-off-by: Yannick Schaus <github@schaus.net>