### PR TITLE
Configure default timeout of 15 minutes for all testable and lifecycle methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,11 @@ Import-Package: \\
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
+          <configuration>
+            <systemPropertyVariables>
+              <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This helps to identify what tests cause builds to fail and it will more quickly end builds.

For instance the `WebClientFactoryImplTest` currently often hangs on my local builds.
With this configuration in place it is easy to see and it will timeout after 15 minutes:

```
[ERROR] Tests run: 5, Failures: 0, Errors: 1, Skipped: 4, Time elapsed: 900.207 s <<< FAILURE! - in org.openhab.core.io.net.http.internal.WebClientFactoryImplTest
[ERROR] org.openhab.core.io.net.http.internal.WebClientFactoryImplTest.testGetClients  Time elapsed: 900.194 s  <<< ERROR!
java.util.concurrent.TimeoutException: tearDown() timed out after 15 minutes
```

See: https://junit.org/junit5/docs/current/user-guide/#writing-tests-declarative-timeouts