### PR TITLE
WebClientFactoryImpl deprecation and blocking test fixes

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -277,14 +277,16 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
                 public WebSocketClient run() {
                     logger.debug("creating web socket client for consumer {}", consumerName);
 
-                    WebSocketClient webSocketClient = new WebSocketClient(createSslContextFactory());
+                    HttpClient httpClient = new HttpClient(createSslContextFactory());
                     if (threadPool != null) {
-                        webSocketClient.setExecutor(threadPool);
+                        httpClient.setExecutor(threadPool);
                     } else {
                         final QueuedThreadPool queuedThreadPool = createThreadPool(consumerName, minThreadsCustom,
                                 maxThreadsCustom, keepAliveTimeoutCustom);
-                        webSocketClient.setExecutor(queuedThreadPool);
+                        httpClient.setExecutor(queuedThreadPool);
                     }
+
+                    WebSocketClient webSocketClient = new WebSocketClient(httpClient);
 
                     if (startClient) {
                         try {

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -65,8 +65,13 @@ public class WebClientFactoryImplTest {
     }
 
     @AfterEach
-    public void tearDown() {
-        webClientFactory.deactivate();
+    public void tearDown() throws InterruptedException {
+        // Sometimes a java.nio.channels.ClosedSelectorException occurs when the commonWebSocketClient
+        // is stopped while its threads are still starting. This would cause webClientFactory.deactivate()
+        // to block forever so continue if it has not completed after 2 seconds.
+        Thread deactivateThread = new Thread(() -> webClientFactory.deactivate());
+        deactivateThread.start();
+        deactivateThread.join(2000);
     }
 
     @Test


### PR DESCRIPTION
* Update the `WebClientFactoryImpl` so it no longer uses a deprecated `WebSocketClient` constructor.
* Use a workaround so `WebClientFactoryImplTest.tearDown()` cannot block forever when the commonWebSocketClient is stopped when it has not yet been fully started.

---

When the commonWebSocketClient has not yet fully started, this exception occurs when stopping it:

```
[OH-httpClient-common-20] WARN org.eclipse.jetty.io.ManagedSelector - java.nio.channels.ClosedSelectorException
```

When this exception occurs, the blocking thread would have a stack trace like this:

```
"main" #1 prio=5 os_prio=0 cpu=2079,48ms elapsed=270,59s tid=0x00007eff6c029000 nid=0xbfb20 waiting on condition  [0x00007eff729a0000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@11.0.13/Native Method)
        - parking to wait for  <0x0000000628621670> (a java.util.concurrent.CountDownLatch$Sync)
        at java.util.concurrent.locks.LockSupport.park(java.base@11.0.13/LockSupport.java:194)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(java.base@11.0.13/AbstractQueuedSynchronizer.java:885)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(java.base@11.0.13/AbstractQueuedSynchronizer.java:1039)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(java.base@11.0.13/AbstractQueuedSynchronizer.java:1345)
        at java.util.concurrent.CountDownLatch.await(java.base@11.0.13/CountDownLatch.java:232)
        at org.eclipse.jetty.io.ManagedSelector.doStop(ManagedSelector.java:140)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        - locked <0x0000000628ba8960> (a java.lang.Object)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.io.SelectorManager.doStop(SelectorManager.java:281)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        - locked <0x0000000628ba7420> (a java.lang.Object)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.client.AbstractConnectorHttpClientTransport.doStop(AbstractConnectorHttpClientTransport.java:70)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        - locked <0x0000000628cefb18> (a java.lang.Object)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.client.HttpClient.doStop(HttpClient.java:279)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        - locked <0x0000000628cefbe0> (a java.lang.Object)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.stop(ContainerLifeCycle.java:180)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStop(ContainerLifeCycle.java:201)
        at org.eclipse.jetty.websocket.client.WebSocketClient.doStop(WebSocketClient.java:429)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94)
        - locked <0x0000000628cf0188> (a java.lang.Object)
        at org.openhab.core.io.net.http.internal.WebClientFactoryImpl.deactivate(WebClientFactoryImpl.java:116)
        at org.openhab.core.io.net.http.internal.WebClientFactoryImplTest.tearDown(WebClientFactoryImplTest.java:69)
...
```