### PR TITLE
Add feature to sort group members with metadata configuration

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
@@ -198,6 +198,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         if (item instanceof GenericItem) {
             GenericItem genericItem = (GenericItem) item;
             genericItem.setEventPublisher(getEventPublisher());
+            genericItem.setMetadataRegistry(metadataRegistry);
             genericItem.setStateDescriptionService(stateDescriptionService);
             genericItem.setCommandDescriptionService(commandDescriptionService);
             genericItem.setUnitProvider(unitProvider);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -62,6 +62,8 @@ public abstract class GenericItem implements ActiveItem {
 
     protected @Nullable EventPublisher eventPublisher;
 
+    protected @Nullable MetadataRegistry metadataRegistry;
+
     protected Set<StateChangeListener> listeners = new CopyOnWriteArraySet<>(
             Collections.newSetFromMap(new WeakHashMap<>()));
 
@@ -172,16 +174,21 @@ public abstract class GenericItem implements ActiveItem {
      * member order in case this item is exchanged in a group.
      */
     public void dispose() {
-        this.listeners.clear();
-        this.eventPublisher = null;
-        this.stateDescriptionService = null;
-        this.commandDescriptionService = null;
-        this.unitProvider = null;
-        this.itemStateConverter = null;
+        listeners.clear();
+        eventPublisher = null;
+        metadataRegistry = null;
+        stateDescriptionService = null;
+        commandDescriptionService = null;
+        unitProvider = null;
+        itemStateConverter = null;
     }
 
     public void setEventPublisher(@Nullable EventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
+    }
+
+    public void setMetadataRegistry(@Nullable MetadataRegistry metadataRegistry) {
+        this.metadataRegistry = metadataRegistry;
     }
 
     public void setStateDescriptionService(@Nullable StateDescriptionService stateDescriptionService) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.items;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -40,6 +41,16 @@ import org.openhab.core.types.UnDefType;
  */
 @NonNullByDefault
 public interface Item extends Identifiable<String> {
+
+    /**
+     * Default state {@link Comparator}: values are sorted in ascending alphabetical order
+     */
+    public static final Comparator<Item> DEFAULT_STATE_COMPARATOR = new Comparator<Item>() {
+        @Override
+        public int compare(Item a, Item b) {
+            return a.getState().toFullString().compareTo(b.getState().toFullString());
+        }
+    };
 
     /**
      * returns the current state of the item
@@ -174,4 +185,13 @@ public interface Item extends Identifiable<String> {
      * @return command description (can be null)
      */
     public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale);
+
+    /**
+     * Returns a default {@link Comparator} for the item to compare its {@link State}.
+     *
+     * @return comparator to compare item states
+     */
+    public default Comparator<Item> getDefaultStateComparator() {
+        return DEFAULT_STATE_COMPARATOR;
+    }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
@@ -13,8 +13,6 @@
 package org.openhab.core.items;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -42,14 +40,13 @@ public final class Metadata implements Identifiable<MetadataKey> {
     Metadata() {
         key = new MetadataKey("", "");
         value = "";
-        configuration = Collections.emptyMap();
+        configuration = Map.of();
     }
 
     public Metadata(MetadataKey key, String value, @Nullable Map<String, Object> configuration) {
         this.key = key;
         this.value = value;
-        this.configuration = configuration != null ? Collections.unmodifiableMap(new HashMap<>(configuration))
-                : Collections.emptyMap();
+        this.configuration = configuration != null ? Map.copyOf(configuration) : Map.of();
     }
 
     @Override
@@ -95,10 +92,7 @@ public final class Metadata implements Identifiable<MetadataKey> {
             return false;
         }
         Metadata other = (Metadata) obj;
-        if (!key.equals(other.key)) {
-            return false;
-        }
-        return true;
+        return key.equals(other.key);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -12,10 +12,12 @@
  */
 package org.openhab.core.library.items;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.items.GenericItem;
+import org.openhab.core.items.Item;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.types.Command;
@@ -36,6 +38,22 @@ public class DateTimeItem extends GenericItem {
             UnDefType.class);
     private static final List<Class<? extends Command>> ACCEPTED_COMMAND_TYPES = List.of(DateTimeType.class,
             RefreshType.class);
+    /**
+     * Chronological {@link Comparator}: DateTime values are sorted in ascending chronological order, if state is
+     * DateTimeType, UnDefType at the beginning
+     */
+    public static final Comparator<Item> DATE_TIME_COMPARATOR = new Comparator<Item>() {
+        @Override
+        public int compare(Item a, Item b) {
+            final State stateA = a.getState().as(DateTimeType.class);
+            final State stateB = b.getState().as(DateTimeType.class);
+            if (stateA != null && stateB != null) {
+                return ((DateTimeType) stateA).compareTo((DateTimeType) stateB);
+            } else {
+                return stateA == null ? -1 : 1;
+            }
+        }
+    };
 
     public DateTimeItem(String name) {
         super(CoreItemFactory.DATETIME, name);
@@ -53,6 +71,11 @@ public class DateTimeItem extends GenericItem {
 
     public void send(DateTimeType command) {
         internalSend(command);
+    }
+
+    @Override
+    public Comparator<Item> getDefaultStateComparator() {
+        return DATE_TIME_COMPARATOR;
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
@@ -12,9 +12,11 @@
  */
 package org.openhab.core.library.items;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.items.Item;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
@@ -38,6 +40,22 @@ public class DimmerItem extends SwitchItem {
             UnDefType.class);
     private static final List<Class<? extends Command>> ACCEPTED_COMMAND_TYPES = List.of(PercentType.class,
             OnOffType.class, IncreaseDecreaseType.class, RefreshType.class);
+    /**
+     * Numerical {@link Comparator}: Number values are sorted in ascending numerical order, if state is PercentType or
+     * OnOffType, UnDefType at the beginning
+     */
+    public static final Comparator<Item> DIMMER_COMPARATOR = new Comparator<Item>() {
+        @Override
+        public int compare(Item a, Item b) {
+            final State stateA = a.getState().as(PercentType.class);
+            final State stateB = b.getState().as(PercentType.class);
+            if (stateA != null && stateB != null) {
+                return ((PercentType) stateA).compareTo((PercentType) stateB);
+            } else {
+                return stateA == null ? -1 : 1;
+            }
+        }
+    };
 
     public DimmerItem(String name) {
         super(CoreItemFactory.DIMMER, name);
@@ -45,10 +63,6 @@ public class DimmerItem extends SwitchItem {
 
     /* package */ DimmerItem(String type, String name) {
         super(type, name);
-    }
-
-    public void send(PercentType command) {
-        internalSend(command);
     }
 
     @Override
@@ -59,6 +73,15 @@ public class DimmerItem extends SwitchItem {
     @Override
     public List<Class<? extends Command>> getAcceptedCommandTypes() {
         return ACCEPTED_COMMAND_TYPES;
+    }
+
+    public void send(PercentType command) {
+        internalSend(command);
+    }
+
+    @Override
+    public Comparator<Item> getDefaultStateComparator() {
+        return DIMMER_COMPARATOR;
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.library.items;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
@@ -22,6 +23,7 @@ import javax.measure.Unit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
+import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemUtil;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
@@ -49,6 +51,22 @@ public class NumberItem extends GenericItem {
             QuantityType.class, UnDefType.class);
     private static final List<Class<? extends Command>> ACCEPTED_COMMAND_TYPES = List.of(DecimalType.class,
             QuantityType.class, RefreshType.class);
+    /**
+     * Numerical {@link Comparator}: Number values are sorted in ascending numerical order, if state is DecimalType or
+     * QuantityType, UnDefType at the beginning
+     */
+    public static final Comparator<Item> NUMBER_COMPARATOR = new Comparator<Item>() {
+        @Override
+        public int compare(Item a, Item b) {
+            final State stateA = a.getState().as(DecimalType.class);
+            final State stateB = b.getState().as(DecimalType.class);
+            if (stateA != null && stateB != null) {
+                return ((DecimalType) stateA).compareTo((DecimalType) stateB);
+            } else {
+                return stateA == null ? -1 : 1;
+            }
+        }
+    };
 
     @Nullable
     private Class<? extends Quantity<?>> dimension;
@@ -92,6 +110,11 @@ public class NumberItem extends GenericItem {
             }
         }
         return stateDescription;
+    }
+
+    @Override
+    public Comparator<Item> getDefaultStateComparator() {
+        return NUMBER_COMPARATOR;
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.library.items;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -63,9 +62,7 @@ public class StringItem extends GenericItem {
 
     @Override
     public <T extends State> @Nullable T getStateAs(Class<T> typeClass) {
-        List<Class<? extends State>> list = new ArrayList<>();
-        list.add(typeClass);
-        State convertedState = TypeParser.parseState(list, state.toString());
+        State convertedState = TypeParser.parseState(List.of(typeClass), state.toString());
         if (typeClass.isInstance(convertedState)) {
             return typeClass.cast(convertedState);
         } else {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -39,7 +39,7 @@ import org.openhab.core.types.State;
  * @author Gaël L'hopital - added ability to use second and milliseconds unix time
  */
 @NonNullByDefault
-public class DateTimeType implements PrimitiveType, State, Command {
+public class DateTimeType implements PrimitiveType, State, Command, Comparable<DateTimeType> {
 
     // external format patterns for output
     public static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
@@ -216,6 +216,11 @@ public class DateTimeType implements PrimitiveType, State, Command {
         }
         DateTimeType other = (DateTimeType) obj;
         return zonedDateTime.compareTo(other.zonedDateTime) == 0;
+    }
+
+    @Override
+    public int compareTo(DateTimeType o) {
+        return zonedDateTime.compareTo(o.zonedDateTime);
     }
 
     private ZonedDateTime parse(String value) throws DateTimeParseException {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -61,7 +61,6 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
      * The English locale is used to determine (decimal/grouping) separator characters.
      *
      * @param value the non null value representing a number
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      */
     public DecimalType(String value) {
@@ -73,7 +72,6 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
      *
      * @param value the non null value representing a number
      * @param locale the locale used to determine (decimal/grouping) separator characters
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      */
     public DecimalType(String value, Locale locale) {
@@ -102,7 +100,6 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
      *
      * @param value the non null value representing a number
      * @return a new {@link DecimalType}
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      */
     public static DecimalType valueOf(String value) {
@@ -192,7 +189,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         } else if (target == UpDownType.class) {
             if (equals(ZERO)) {
                 return target.cast(UpDownType.UP);
-            } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
+            } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
                 return target.cast(UpDownType.DOWN);
             } else {
                 return null;
@@ -200,7 +197,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
                 return target.cast(OpenClosedType.CLOSED);
-            } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
+            } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
                 return target.cast(OpenClosedType.OPEN);
             } else {
                 return null;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
@@ -45,7 +45,6 @@ public class PercentType extends DecimalType {
      * Creates a new {@link PercentType} with the given value.
      *
      * @param value the value representing a percentage
-     *
      * @throws IllegalArgumentException when the value is not between 0 and 100
      */
     public PercentType(int value) {
@@ -58,7 +57,6 @@ public class PercentType extends DecimalType {
      * The English locale is used to determine (decimal/grouping) separator characters.
      *
      * @param value the non null value representing a percentage
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      * @throws IllegalArgumentException when the value is not between 0 and 100
      */
@@ -71,7 +69,6 @@ public class PercentType extends DecimalType {
      *
      * @param value the non null value representing a percentage
      * @param locale the locale used to determine (decimal/grouping) separator characters
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      * @throws IllegalArgumentException when the value is not between 0 and 100
      */
@@ -84,7 +81,6 @@ public class PercentType extends DecimalType {
      * Creates a new {@link PercentType} with the given value.
      *
      * @param value the value representing a percentage.
-     *
      * @throws IllegalArgumentException when the value is not between 0 and 100
      */
     public PercentType(BigDecimal value) {
@@ -103,7 +99,6 @@ public class PercentType extends DecimalType {
      *
      * @param value the non null value representing a percentage
      * @return new {@link PercentType}
-     *
      * @throws NumberFormatException when the number could not be parsed to a {@link BigDecimal}
      * @throws IllegalArgumentException when the value is not between 0 and 100
      */

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -99,7 +99,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
      * The English locale is used to determine (decimal/grouping) separator characters.
      *
      * @param value the non null value representing a quantity with an optional unit.
-     *
      * @throws NumberFormatException when a quantity without a unit could not be parsed
      * @throws IllegalArgumentException when a quantity with a unit could not be parsed
      */
@@ -113,7 +112,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
      *
      * @param value the non null value representing a quantity with an optional unit.
      * @param locale the locale used to determine (decimal/grouping) separator characters.
-     *
      * @throws NumberFormatException when a quantity without a unit could not be parsed
      * @throws IllegalArgumentException when a quantity with a unit could not be parsed
      */
@@ -201,7 +199,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
      *
      * @param value the non null value representing a quantity with an optional unit
      * @return a new {@link QuantityType}
-     *
      * @throws NumberFormatException when a quantity without a unit could not be parsed
      * @throws IllegalArgumentException when a quantity with a unit could not be parsed
      */

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/UnDefType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/UnDefType.java
@@ -30,7 +30,7 @@ public enum UnDefType implements PrimitiveType, State {
 
     @Override
     public String format(String pattern) {
-        return String.format(pattern, this.toString());
+        return String.format(pattern, toString());
     }
 
     @Override

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GroupItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GroupItemTest.java
@@ -1,0 +1,331 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.items;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.library.items.DimmerItem;
+import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.StringItem;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+class GroupItemTest {
+
+    private @Mock MetadataRegistry metadataRegistry;
+
+    @Test
+    public void testInvalidMetadataConfiguration() {
+        GroupItem rootGroupItem = new GroupItem("root");
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "INVALID", Map.of()));
+
+        TestItem member3 = new TestItem("member3");
+        rootGroupItem.addMember(member3);
+
+        TestItem member1 = new TestItem("member1");
+        rootGroupItem.addMember(member1);
+
+        TestItem member2 = new TestItem("member2");
+        rootGroupItem.addMember(member2);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(3));
+
+        List<Item> expected = List.of(member3, member1, member2);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByNameAscending() {
+        GroupItem rootGroupItem = new GroupItem("root");
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "NAME", Map.of()));
+
+        TestItem member3 = new TestItem("member3");
+        rootGroupItem.addMember(member3);
+
+        TestItem member1 = new TestItem("member1");
+        rootGroupItem.addMember(member1);
+
+        TestItem member2 = new TestItem("member2");
+        rootGroupItem.addMember(member2);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(3));
+
+        List<Item> expected = List.of(member1, member2, member3);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByNameDescending() {
+        GroupItem rootGroupItem = new GroupItem("root");
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "NAME", Map.of("ordering", "DESCENDING")));
+
+        TestItem member3 = new TestItem("member3");
+        rootGroupItem.addMember(member3);
+
+        TestItem member1 = new TestItem("member1");
+        rootGroupItem.addMember(member1);
+
+        TestItem member2 = new TestItem("member2");
+        rootGroupItem.addMember(member2);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(3));
+
+        List<Item> expected = List.of(member3, member2, member1);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByLabelAscending() {
+        GroupItem rootGroupItem = new GroupItem("root");
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "LABEL", Map.of("ordering", "ASCENDING")));
+
+        TestItem member1 = new TestItem("member1");
+        member1.setLabel("C");
+        rootGroupItem.addMember(member1);
+
+        TestItem member2 = new TestItem("member2");
+        member2.setLabel("A");
+        rootGroupItem.addMember(member2);
+
+        TestItem member3 = new TestItem("member3");
+        member3.setLabel("B");
+        rootGroupItem.addMember(member3);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(3));
+
+        List<Item> expected = List.of(member2, member3, member1);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByStringTypeStateAscending() {
+        GroupItem rootGroupItem = new GroupItem("root", new StringItem("baseItem"));
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "STATE", Map.of("ordering", "ASCENDING")));
+
+        StringItem member1 = new StringItem("member1");
+        member1.setState(new StringType("C"));
+        rootGroupItem.addMember(member1);
+
+        StringItem member2 = new StringItem("member2");
+        member2.setState(new StringType("A"));
+        rootGroupItem.addMember(member2);
+
+        StringItem member3 = new StringItem("member3");
+        member3.setState(new StringType("B"));
+        rootGroupItem.addMember(member3);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(3));
+
+        List<Item> expected = List.of(member2, member3, member1);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersWithoutBaseItemAscending() {
+        GroupItem rootGroupItem = new GroupItem("root");
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "STATE", Map.of("ordering", "ASCENDING")));
+
+        NumberItem member1 = new NumberItem("member1");
+        member1.setState(DecimalType.valueOf("1"));
+        rootGroupItem.addMember(member1);
+
+        NumberItem member2 = new NumberItem("member2");
+        member2.setState(new QuantityType<>("2 °C"));
+        rootGroupItem.addMember(member2);
+
+        NumberItem member3 = new NumberItem("member3");
+        member3.setState(DecimalType.valueOf("0.5"));
+        rootGroupItem.addMember(member3);
+
+        NumberItem member4 = new NumberItem("member4");
+        member4.setState(DecimalType.valueOf("-1"));
+        rootGroupItem.addMember(member4);
+
+        NumberItem member5 = new NumberItem("member5");
+        member5.setState(UnDefType.UNDEF);
+        rootGroupItem.addMember(member5);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(5));
+
+        List<Item> expected = List.of(member4, member3, member1, member2, member5);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByDecimalTypeStateAscending() {
+        GroupItem rootGroupItem = new GroupItem("root", new NumberItem("baseItem"));
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "STATE", Map.of("ordering", "ASCENDING")));
+
+        NumberItem member1 = new NumberItem("member1");
+        member1.setState(DecimalType.valueOf("1"));
+        rootGroupItem.addMember(member1);
+
+        NumberItem member2 = new NumberItem("member2");
+        member2.setState(new QuantityType<>("2 °C"));
+        rootGroupItem.addMember(member2);
+
+        NumberItem member3 = new NumberItem("member3");
+        member3.setState(DecimalType.valueOf("0.5"));
+        rootGroupItem.addMember(member3);
+
+        NumberItem member4 = new NumberItem("member4");
+        member4.setState(DecimalType.valueOf("-1"));
+        rootGroupItem.addMember(member4);
+
+        NumberItem member5 = new NumberItem("member5");
+        member5.setState(UnDefType.UNDEF);
+        rootGroupItem.addMember(member5);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(5));
+
+        List<Item> expected = List.of(member5, member4, member3, member1, member2);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByDecimalTypeStateDescending() {
+        GroupItem rootGroupItem = new GroupItem("root", new NumberItem("baseItem"));
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "STATE", Map.of("ordering", "DESCENDING")));
+
+        NumberItem member1 = new NumberItem("member1");
+        member1.setState(DecimalType.valueOf("1"));
+        rootGroupItem.addMember(member1);
+
+        NumberItem member2 = new NumberItem("member2");
+        member2.setState(new QuantityType<>("2 °C"));
+        rootGroupItem.addMember(member2);
+
+        NumberItem member3 = new NumberItem("member3");
+        member3.setState(DecimalType.valueOf("0.5"));
+        rootGroupItem.addMember(member3);
+
+        NumberItem member4 = new NumberItem("member4");
+        member4.setState(DecimalType.valueOf("-1"));
+        rootGroupItem.addMember(member4);
+
+        NumberItem member5 = new NumberItem("member5");
+        member5.setState(UnDefType.UNDEF);
+        rootGroupItem.addMember(member5);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(5));
+
+        List<Item> expected = List.of(member2, member1, member3, member4, member5);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+
+    @Test
+    public void testGetSortedMembersByPercentTypeStateAscending() {
+        GroupItem rootGroupItem = new GroupItem("root", new DimmerItem("baseItem"));
+        rootGroupItem.setMetadataRegistry(metadataRegistry);
+
+        MetadataKey key = new MetadataKey("sortBy", "root");
+        when(metadataRegistry.get(key)).thenReturn(new Metadata(key, "STATE", Map.of("ordering", "ASCENDING")));
+
+        DimmerItem member1 = new DimmerItem("member1");
+        member1.setState(PercentType.valueOf("1"));
+        rootGroupItem.addMember(member1);
+
+        DimmerItem member2 = new DimmerItem("member2");
+        member2.setState(PercentType.HUNDRED);
+        rootGroupItem.addMember(member2);
+
+        DimmerItem member3 = new DimmerItem("member3");
+        member3.setState(PercentType.ZERO);
+        rootGroupItem.addMember(member3);
+
+        DimmerItem member4 = new DimmerItem("member4");
+        member4.setState(OnOffType.ON);
+        rootGroupItem.addMember(member4);
+
+        DimmerItem member5 = new DimmerItem("member5");
+        member5.setState(UnDefType.UNDEF);
+        rootGroupItem.addMember(member5);
+
+        List<Item> members = rootGroupItem.getSortedMembers();
+        assertThat(members, hasSize(5));
+
+        List<Item> expected = List.of(member5, member3, member1, member2, member4);
+        for (int i = 0; i < members.size(); i++) {
+            assertEquals(expected.get(i).getName(), members.get(i).getName());
+        }
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/TestItem.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/TestItem.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.items;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -38,11 +37,11 @@ public class TestItem extends GenericItem {
 
     @Override
     public List<Class<? extends State>> getAcceptedDataTypes() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public List<Class<? extends Command>> getAcceptedCommandTypes() {
-        return Collections.emptyList();
+        return List.of();
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
@@ -309,7 +309,7 @@ public class UnitsTest {
 
     @Test
     public void testBar2Pascal() {
-        Quantity<Pressure> bar = Quantities.getQuantity(BigDecimal.valueOf(1), Units.BAR);
+        Quantity<Pressure> bar = Quantities.getQuantity(BigDecimal.ONE, Units.BAR);
         assertThat(bar.to(SIUnits.PASCAL), is(Quantities.getQuantity(100000, SIUnits.PASCAL)));
     }
 

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -89,6 +89,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
     private final GroupFunctionHelper groupFunctionHelper = new GroupFunctionHelper();
     private ItemStateConverter itemStateConverter;
 
+    @SuppressWarnings("null")
     @BeforeEach
     public void beforeEach() {
         registerVolatileStorageService();
@@ -148,7 +149,6 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(change.getItem().label, is("secondLabel"));
     }
 
-    @SuppressWarnings("unchecked")
     @Test()
     public void assertAcceptedCommandTypesOnGroupItemsReturnsSubsetOfCommandTypesSupportedByAllMembers() {
         SwitchItem switchItem = new SwitchItem("switch");
@@ -293,6 +293,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(members.size(), is(2));
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testGetMembersFilteringGroups() {
         GroupItem rootGroupItem = new GroupItem("root");
@@ -314,6 +315,7 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         assertThat(members.size(), is(1));
     }
 
+    @SuppressWarnings("null")
     @Test
     public void testGetMembersFilteringGroupsTransient() {
         GroupItem rootGroupItem = new GroupItem("root");

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -366,12 +366,14 @@ public class ItemRegistryImplTest extends JavaTest {
         itemProvider.add(item);
 
         assertNotNull(item.eventPublisher);
+        assertNotNull(item.metadataRegistry);
         assertNotNull(item.itemStateConverter);
         assertNotNull(item.unitProvider);
 
         itemProvider.update(new SwitchItem("Item1"));
 
         assertNull(item.eventPublisher);
+        assertNull(item.metadataRegistry);
         assertNull(item.itemStateConverter);
         assertNull(item.unitProvider);
         assertEquals(0, item.listeners.size());

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/TestItem.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/TestItem.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.items;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -38,11 +37,11 @@ public class TestItem extends GenericItem {
 
     @Override
     public List<Class<? extends State>> getAcceptedDataTypes() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public List<Class<? extends Command>> getAcceptedCommandTypes() {
-        return Collections.emptyList();
+        return List.of();
     }
 }


### PR DESCRIPTION
- Added feature to sort group members with metadata configuration

See https://github.com/openhab/openhab-core/pull/2123#issuecomment-765904668

This is an initial draft on sorting group members with metadata configuration. Items in groups can be sorted by name, label or state. Default ordering is ascending.

demo.items
```java
Group:Number testGroup "Test Group" {
    sortBy="STATE" [ ordering="DESCENDING" ]
}
```

Allowed values for `sortBy`: `LABEL`, `NAME` and `STATE`.
Allowed values for `ordering`: `DESCENDING`, otherwise ascending ordering will be used. Configuration of `ordering` is optional.

Sort members by state picks up a `Comparator` from items, which can be implemented individually for each item type. `Item` class provides a default `Comparator` to sort states in alphabetically order by applying `toFullString()` on the state first.

UIs and other services have to be changed afterwards to benefit from this feature.

@openhab/core-maintainers wdyt?
// CC @ghys @rkoshak

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>