### PR TITLE
Suppress bnd warnings for unused imports/exports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,8 +142,12 @@ Import-Package: \\
 -noimportjava: true
 -sources: false
 -contract: *
--includeresource: -${.}/NOTICE, -${.}/*.xsd]]></bnd>
+-includeresource: -${.}/NOTICE, -${.}/*.xsd
+-fixupmessages: \\
+  'Unused Import-Package instructions';is:=ignore,\\
+  'Unused Export-Package instructions';is:=ignore]]></bnd>
             <!-- Bundle-SymbolicName: ${project.groupId}.${project.artifactId} -->
+            <skipIfEmpty>true</skipIfEmpty>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
Ignores warnings like:

```
Warning:  /home/runner/work/openhab-addons/openhab-addons/bom/runtime-index/pom.xml [0:0]: Unused Export-Package instructions: [org.openhab.*]
Warning:  /home/runner/work/openhab-addons/openhab-addons/bom/runtime-index/pom.xml [0:0]: Unused Import-Package instructions: [io.swagger.v3.oas.annotations.*,
```

These are safe to ignore because the import/export packages are globally defined and not every bundle imports/exports all these packages.

The `skipIfEmpty` configuration furthermore prevents warnings when the bnd-maven-plugin runs on projects that don't have any code like BOMs.

More important compiler/SAT warnings standout more when there are fewer useless warnings.