### PR TITLE
Use POM packaging with index BOMs

### DIFF
--- a/bom/openhab-core-index/pom.xml
+++ b/bom/openhab-core-index/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>org.openhab.core.bom.openhab-core-index</artifactId>
+  <packaging>pom</packaging>
 
   <name>openHAB Core :: BOM :: openHAB Core Index</name>
 

--- a/bom/runtime-index/pom.xml
+++ b/bom/runtime-index/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>org.openhab.core.bom.runtime-index</artifactId>
+  <packaging>pom</packaging>
 
   <name>openHAB Core :: BOM :: Runtime Index</name>
 

--- a/bom/test-index/pom.xml
+++ b/bom/test-index/pom.xml
@@ -11,6 +11,7 @@
   </parent>
 
   <artifactId>org.openhab.core.bom.test-index</artifactId>
+  <packaging>pom</packaging>
 
   <name>openHAB Core :: BOM :: Test Index</name>
 


### PR DESCRIPTION
Looks like only the POM dependencies are used by the indexer, so the JAR is unused and useless as this warning correctly indicates when you build them:

```
[WARNING] JAR will be empty - no content was marked for inclusion!
```