### PR TITLE
Fix NPE in WatchQueueReader

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
@@ -337,8 +337,11 @@ public class WatchQueueReader implements Runnable {
         Path baseWatchedDir = null;
         Path registeredPath = null;
         synchronized (this) {
-            baseWatchedDir = keyToService.get(key).getSourcePath();
-            registeredPath = registeredKeys.get(key);
+            AbstractWatchService service = keyToService.get(key);
+            if (service != null) {
+                baseWatchedDir = service.getSourcePath();
+                registeredPath = registeredKeys.get(key);
+            }
         }
         if (registeredPath != null) {
             // If the path has been registered in the watch service it relative path can be resolved


### PR DESCRIPTION
Fix NPE in WatchQueueReader. The NPE would cause the watch queue to stop being watched, and script files will no longer be reloaded when changed.

This seems to occur when files were created and quickly removed within the watched directories. It should resolve #2537 and #2535 