### PR TITLE
[marketplace] avoid collisions with multiple AddonProviders

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -33,6 +33,7 @@ import org.openhab.core.OpenHAB;
 import org.openhab.core.addon.Addon;
 import org.openhab.core.addon.marketplace.MarketplaceAddonHandler;
 import org.openhab.core.addon.marketplace.MarketplaceHandlerException;
+import org.openhab.core.util.UIDUtils;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -169,7 +170,7 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     private void ensureCachedKarsAreInstalled() {
         try {
             if (Files.isDirectory(KAR_CACHE_PATH)) {
-                Files.list(KAR_CACHE_PATH).filter(Files::isDirectory).map(p -> "marketplace:" + p.getFileName())
+                Files.list(KAR_CACHE_PATH).filter(Files::isDirectory).map(this::addonIdFromPath)
                         .filter(addonId -> !isInstalled(addonId)).forEach(addonId -> {
                             logger.info("Reinstalling missing marketplace KAR: {}", addonId);
                             try {
@@ -184,12 +185,14 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
         }
     }
 
+    private String addonIdFromPath(Path path) {
+        String pathName = UIDUtils.decode(path.getFileName().toString());
+        return pathName.contains(":") ? pathName : "marketplace:";
+    }
+
     private Path getAddonCacheDirectory(String addonId) {
-        if (addonId.startsWith("marketplace:")) {
-            return KAR_CACHE_PATH.resolve(addonId.replace("marketplace:", ""));
-        } else if (addonId.contains(":")) {
-            return KAR_CACHE_PATH.resolve(addonId.replaceAll(":", File.separator));
-        }
-        return KAR_CACHE_PATH.resolve(addonId);
+        String dir = addonId.startsWith("marketplace:") ? addonId.replace("marketplace:", "")
+                : UIDUtils.encode(addonId);
+        return KAR_CACHE_PATH.resolve(dir);
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -185,6 +185,11 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     }
 
     private Path getAddonCacheDirectory(String addonId) {
-        return KAR_CACHE_PATH.resolve(addonId.replace("marketplace:", ""));
+        if (addonId.startsWith("marketplace:")) {
+            return KAR_CACHE_PATH.resolve(addonId.replace("marketplace:", ""));
+        } else if (addonId.contains(":")) {
+            return KAR_CACHE_PATH.resolve(addonId.replaceAll(":", File.separator));
+        }
+        return KAR_CACHE_PATH.resolve(addonId);
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
@@ -164,6 +164,11 @@ public abstract class MarketplaceBundleInstaller {
     }
 
     private Path getAddonCacheDirectory(String addonId) {
-        return BUNDLE_CACHE_PATH.resolve(addonId.replace("marketplace:", ""));
+        if (addonId.startsWith("marketplace:")) {
+            return BUNDLE_CACHE_PATH.resolve(addonId.replace("marketplace:", ""));
+        } else if (addonId.contains(":")) {
+            return BUNDLE_CACHE_PATH.resolve(addonId.replaceAll(":", File.separator));
+        }
+        return BUNDLE_CACHE_PATH.resolve(addonId);
     }
 }


### PR DESCRIPTION
The current implementation could result in collision of file-path and failed in determining the installation status if other AddonProviders re-use the marketplace addon handlers.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>