### PR TITLE
Make LifecycleScriptExtensionProvider and its Disposable interface public

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LifecycleScriptExtensionProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LifecycleScriptExtensionProvider.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.internal.defaultscope;
+package org.openhab.core.automation.module.script;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.ScriptExtensionProvider;
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -98,7 +97,7 @@ public class LifecycleScriptExtensionProvider implements ScriptExtensionProvider
     }
 
     @FunctionalInterface
-    interface Disposable {
+    public interface Disposable {
         void dispose();
     }
 }


### PR DESCRIPTION
LifecycleScriptExtensionProvider's Disposable interface is package-private which caused scriptry engines, e.g. JRuby unable to create a hook needed by the LifecycleTracker.addDisposeHook(). The hook is implemented from the `Disposable` functional interface which was not public.

Just making Disposable public without moving LifecycleScriptExtensionProvide out of the internal package wasn't enough.

Resolve #2287 

See https://github.com/boc-tothefuture/openhab-jruby/issues/366

