### PR TITLE
Add Timer.isCancelled() method

### DIFF
--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/internal/actions/TimerImplTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/internal/actions/TimerImplTest.java
@@ -52,24 +52,29 @@ public class TimerImplTest {
     public void testTimerIsActiveAndCancel() {
         assertThat(subject.isActive(), is(true));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
 
         subject.cancel();
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
+        assertThat(subject.isCancelled(), is(true));
 
         subject.reschedule(ZonedDateTime.now().plusSeconds(DEFAULT_TIMEOUT_SECONDS));
         assertThat(subject.isActive(), is(true));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
     }
 
     @Test
     public void testTimerIsActiveAndTerminate() throws InterruptedException {
         assertThat(subject.isActive(), is(true));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
+        assertThat(subject.isCancelled(), is(false));
     }
 
     @Test
@@ -77,28 +82,34 @@ public class TimerImplTest {
         Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
+        assertThat(subject.isCancelled(), is(false));
      
         subject.reschedule(ZonedDateTime.now().plusSeconds(DEFAULT_TIMEOUT_SECONDS));
         assertThat(subject.isActive(), is(true));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
+        assertThat(subject.isCancelled(), is(false));
     }
 
     @Test
     public void testTimerIsRunning() throws InterruptedException {
         assertThat(subject.isRunning(), is(false));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS) + 500);
         assertThat(subject.isRunning(), is(true));
         assertThat(subject.hasTerminated(), is(false));
+        assertThat(subject.isCancelled(), is(false));
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_RUNTIME_SECONDS + 1));
         assertThat(subject.isRunning(), is(false));
         assertThat(subject.hasTerminated(), is(true));
+        assertThat(subject.isCancelled(), is(false));
     }
 
     private Timer createTimer(ZonedDateTime instant, SchedulerRunnable runnable) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
@@ -45,6 +45,13 @@ public interface Timer {
     public boolean isActive();
 
     /**
+     * Determines whether the timer has been cancelled
+     *
+     * @return true, if the timer has been cancelled, false otherwise
+     */
+    public boolean isCancelled();
+
+    /**
      * Determines whether the scheduled code is currently executed.
      *
      * @return true, if the code is being executed, false otherwise


### PR DESCRIPTION
I found the need for Timer.isCancelled() inside a long running timer that self-reschedules itself.

Example:

```java
var timer = null

rule "Long running timer"
when
    System started
then
    timer = createTimer(now.plusSeconds(1), [|
        downloadFile() // do something that takes a long time here, e.g. a http get from a large source            
        timer.reschedule(now.plusSeconds(1))
    ])
end

rule "Cancel the timer"
when
    Item Switch1 received command ON
then
    timer.cancel()
end
```

When Switch1 received a command ON while `downloadFile()` is executing, the timer got cancelled, but the currently running task is still continuing, it will reschedule the timer and therefore the timer continues to run despite having been "cancelled".

In this case, the timer code can check with `isCancelled()` before calling `reschedule` as such:
```java
rule "Long running timer"
when
    System started
then
    timer = createTimer(now.plusSeconds(1), [|
        downloadFile() // do something that takes a long time here, e.g. a http get from a large source
        if (!timer.isCancelled())  {
            timer.reschedule(now.plusSeconds(1))
        }
    ])
end
```