### PR TITLE
Use Maven 3.8.4 in GHA CI builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         java: [ '11' ]
-        maven: [ '3.8.3']
+        maven: [ '3.8.4']
         os: [ 'ubuntu-20.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This new version fixes a few regressions, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12350685