### PR TITLE
Add i18n-maven-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,6 +540,12 @@ Import-Package: \\
         </plugin>
 
         <plugin>
+          <groupId>org.openhab.core.tools</groupId>
+          <artifactId>i18n-maven-plugin</artifactId>
+          <version>${project.version}</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.openhab.tools.sat</groupId>
           <artifactId>sat-plugin</artifactId>
           <version>${sat.version}</version>
@@ -562,6 +568,7 @@ Import-Package: \\
             </execution>
           </executions>
         </plugin>
+
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
@@ -584,6 +591,7 @@ Import-Package: \\
             </execution>
           </executions>
         </plugin>
+
         <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
When the plugin dependency is managed you can also use the plugin without adding GAV parameters to commands.

E.g. it allows for using it with:

```
mvn i18n:generate-default-translations
```

Related to #2544