### PR TITLE
[automation] Added basic time-related classes for usage in script and rules

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
@@ -17,6 +17,10 @@ import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -147,11 +151,17 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements.put("PointType", PointType.class);
         elements.put("StringType", StringType.class);
 
-        elements.put("SIUnits", SIUnits.class);
         elements.put("ImperialUnits", ImperialUnits.class);
         elements.put("MetricPrefix", MetricPrefix.class);
+        elements.put("SIUnits", SIUnits.class);
         elements.put("Units", Units.class);
         elements.put("BinaryPrefix", BinaryPrefix.class);
+
+        // date time static functions
+        elements.put("ChronoUnit", ChronoUnit.class);
+        elements.put("Duration", Duration.class);
+        elements.put("ZoneId", ZoneId.class);
+        elements.put("ZonedDateTime", ZonedDateTime.class);
 
         // services
         elements.put("items", new ItemRegistryDelegate(itemRegistry));

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -15,7 +15,10 @@ package org.openhab.core.model.script.scoping;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URLEncoder;
+import java.time.Duration;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -100,6 +103,9 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(BinaryPrefix.class);
 
         // date time static functions
+        result.add(ChronoUnit.class);
+        result.add(Duration.class);
+        result.add(ZoneId.class);
         result.add(ZonedDateTime.class);
 
         result.addAll(getActionClasses());


### PR DESCRIPTION
- Added basic time-related classes for usage in script and rules

This allows to use DateTime functions a lot easier for users without defining additional imports. We have public methods in different types which makes use of these classes e.g.

https://github.com/openhab/openhab-core/blob/a9504bfced5054bb8c7a864876f66df27c69c661/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java#L170

https://github.com/openhab/openhab-core/blob/a9504bfced5054bb8c7a864876f66df27c69c661/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java#L76

`org.joda.time` API has a method `DateTime.now().withTimeAtStartOfDay()` which was used by many users. The replacement is `ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS)`.

`Duration` class allows easy calculation of differences between two timestamps (`Duration.between(Temporal startInclusive, Temporal endExclusive)` - `ZonedDateTime` implemets `Temporal` interface).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>