### PR TITLE
Fixed nullness anotations for TriggerHandlerCallback

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandlerCallback.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandlerCallback.java
@@ -54,5 +54,5 @@ public interface TriggerHandlerCallback extends ModuleHandlerCallback {
     /**
      * @return the scheduler of this rule
      */
-    public @Nullable ScheduledExecutorService getScheduler();
+    public ScheduledExecutorService getScheduler();
 }


### PR DESCRIPTION
- Fixed nullness anotations for `TriggerHandlerCallback`

It looks like I made a wrong assumption regarding the `getScheduler()` method of `TriggerHandlerCallback` in https://github.com/openhab/openhab-core/pull/2586.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>