### PR TITLE
[automation] Script file watchers now reusable for language-specific versions

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DefaultScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DefaultScriptFileWatcher.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+
+import java.io.File;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.automation.module.script.rulesupport.loader.ScriptFileWatcher;
+import org.openhab.core.service.ReadyService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link DefaultScriptFileWatcher} watches the jsr223 directory for files. If a new/modified file is detected, the
+ * script is read and passed to the {@link ScriptEngineManager}.
+ *
+ * @author Jonathan Gilbert - initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true)
+public class DefaultScriptFileWatcher extends ScriptFileWatcher {
+
+    private static final String FILE_DIRECTORY = "automation" + File.separator + "jsr223";
+
+    @Activate
+    public DefaultScriptFileWatcher(final @Reference ScriptEngineManager manager,
+            final @Reference ReadyService readyService) {
+        super(manager, null, readyService, FILE_DIRECTORY);
+    }
+
+    @Activate
+    @Override
+    public void activate() {
+        super.activate();
+    }
+
+    @Deactivate
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptLibraryWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptLibraryWatcher.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 
-import org.openhab.core.OpenHAB;
 import org.openhab.core.service.AbstractWatchService;
 
 /**
@@ -26,12 +25,10 @@ import org.openhab.core.service.AbstractWatchService;
  *
  * @author Jonathan Gilbert - Initial contribution
  */
-abstract class ScriptLibraryWatcher extends AbstractWatchService {
+public abstract class ScriptLibraryWatcher extends AbstractWatchService {
 
-    public static final String LIB_PATH = String.join(File.separator, OpenHAB.getConfigFolder(), "automation", "lib");
-
-    ScriptLibraryWatcher() {
-        super(LIB_PATH);
+    public ScriptLibraryWatcher(final String libraryPath) {
+        super(libraryPath);
     }
 
     @Override
@@ -58,5 +55,5 @@ abstract class ScriptLibraryWatcher extends AbstractWatchService {
         }
     }
 
-    abstract void updateFile(String filePath);
+    protected abstract void updateFile(String filePath);
 }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileReference.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+package org.openhab.core.automation.module.script.rulesupport.loader;
 
 import java.net.URISyntaxException;
 import java.net.URL;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.internal.loader;
+package org.openhab.core.automation.module.script.rulesupport.loader;
 
 import static java.nio.file.StandardWatchEventKinds.*;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -35,6 +35,7 @@ import org.mockito.InOrder;
 import org.openhab.core.automation.module.script.ScriptDependencyListener;
 import org.openhab.core.automation.module.script.ScriptEngineContainer;
 import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.automation.module.script.rulesupport.internal.loader.DelegatingScheduledExecutorService;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyService;
 import org.openhab.core.service.StartLevelService;
@@ -60,7 +61,8 @@ class ScriptFileWatcherTest {
         scriptEngineManager = mock(ScriptEngineManager.class);
         dependencyTracker = mock(DependencyTracker.class);
         readyService = mock(ReadyService.class);
-        scriptFileWatcher = new ScriptFileWatcher(scriptEngineManager, dependencyTracker, readyService);
+        scriptFileWatcher = new ScriptFileWatcher(scriptEngineManager, dependencyTracker, readyService,
+                "automation" + File.separator + "jsr223");
         scriptFileWatcher.activate();
     }
 


### PR DESCRIPTION
Extracted reusable parts of script watching to allow language-specific instantiations:

- Moved to non-internal package
- Extracted logic into non-osgi-component classes
- Added back in basic osgi-component versions

This change is specifically to prepare for JS-specific scripts to operate as standard NodeJS which is slightly different to the existing openHAB mechanism, as discussed with @kaikreuzer. No functionality change to core with this change, except the creation of the script directory if not already present. PR to use this functionality in openhab-addons to follow. 

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>