### PR TITLE
[UI] Added item name to error message

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -372,7 +372,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 }
             }
         } catch (ItemNotFoundException e) {
-            logger.error("Cannot retrieve item for widget {}", w.eClass().getInstanceTypeName());
+            logger.error("Cannot retrieve item '{}' for widget {}", itemName, w.eClass().getInstanceTypeName());
         }
 
         boolean considerTransform = false;


### PR DESCRIPTION
- Added item name to error message

There are three places logging the item name and one does not.
```
2021-12-07 14:38:13.858 [ERROR] [ui.internal.items.ItemUIRegistryImpl] - Cannot retrieve item for widget org.openhab.core.model.sitemap.sitemap.Text
2021-12-07 14:38:13.861 [ERROR] [ui.internal.items.ItemUIRegistryImpl] - Cannot retrieve item 'sensorTerraceEnergyCostsProfile' for widget org.openhab.core.model.sitemap.sitemap.Text
2021-12-07 14:38:13.864 [ERROR] [ui.internal.items.ItemUIRegistryImpl] - Cannot retrieve item 'sensorTerraceEnergyCostsProfile' for widget org.openhab.core.model.sitemap.sitemap.Text
2021-12-07 14:38:13.868 [ERROR] [ui.internal.items.ItemUIRegistryImpl] - Cannot retrieve item 'sensorTerraceEnergyCostsProfile' for widget org.openhab.core.model.sitemap.sitemap.Text
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>