### PR TITLE
Use the mime types provided by the ScriptEngineFactory

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -150,7 +150,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
             ScriptEngine scriptEngine = engineFactory.createScriptEngine(scriptTypes.get(0));
             if (scriptEngine != null) {
                 javax.script.ScriptEngineFactory factory = scriptEngine.getFactory();
-                parameterOptions.put(getPreferredMimeType(factory), getLanguageName(factory));
+                parameterOptions.put(getPreferredMimeType(engineFactory), getLanguageName(factory));
                 logger.trace("ParameterOptions: {}", parameterOptions);
             } else {
                 logger.trace("setScriptEngineFactory: engine was null");
@@ -165,8 +165,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
         if (!scriptTypes.isEmpty()) {
             ScriptEngine scriptEngine = engineFactory.createScriptEngine(scriptTypes.get(0));
             if (scriptEngine != null) {
-                javax.script.ScriptEngineFactory factory = scriptEngine.getFactory();
-                parameterOptions.remove(getPreferredMimeType(factory));
+                parameterOptions.remove(getPreferredMimeType(engineFactory));
                 logger.trace("ParameterOptions: {}", parameterOptions);
             } else {
                 logger.trace("unsetScriptEngineFactory: engine was null");
@@ -176,10 +175,10 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
         }
     }
 
-    private String getPreferredMimeType(javax.script.ScriptEngineFactory factory) {
-        List<String> mimeTypes = new ArrayList<>(factory.getMimeTypes());
+    private String getPreferredMimeType(ScriptEngineFactory factory) {
+        List<String> mimeTypes = new ArrayList<>(factory.getScriptTypes());
         mimeTypes.removeIf(mimeType -> !mimeType.contains("application") || mimeType.contains("x-"));
-        return mimeTypes.isEmpty() ? factory.getMimeTypes().get(0) : mimeTypes.get(0);
+        return mimeTypes.isEmpty() ? factory.getScriptTypes().get(0) : mimeTypes.get(0);
     }
 
     private String getLanguageName(javax.script.ScriptEngineFactory factory) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -149,8 +149,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
         if (!scriptTypes.isEmpty()) {
             ScriptEngine scriptEngine = engineFactory.createScriptEngine(scriptTypes.get(0));
             if (scriptEngine != null) {
-                javax.script.ScriptEngineFactory factory = scriptEngine.getFactory();
-                parameterOptions.put(getPreferredMimeType(engineFactory), getLanguageName(factory));
+                parameterOptions.put(getPreferredMimeType(engineFactory), getLanguageName(scriptEngine.getFactory()));
                 logger.trace("ParameterOptions: {}", parameterOptions);
             } else {
                 logger.trace("setScriptEngineFactory: engine was null");


### PR DESCRIPTION
Use the mime types provided by the ScriptEngineFactory and not the underlying script engines they provide. This allows mutliple versions of script engines to co-exist, like Nashorn and GraalVM .

Signed-off-by: Dan Cunningham <dan@digitaldan.com>