### PR TITLE
[openhab.core] DecimalType-ctor with Number argument

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -41,19 +41,27 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     protected BigDecimal value;
 
     public DecimalType() {
-        this.value = BigDecimal.ZERO;
+        this(BigDecimal.ZERO);
+    }
+
+    public DecimalType(Number value) {
+        this(bigDecimal(value));
+    }
+
+    private static BigDecimal bigDecimal(Number value) {
+        if (value instanceof QuantityType) {
+            return ((QuantityType<?>) value).toBigDecimal();
+        }
+
+        if (value instanceof HSBType) {
+            return ((HSBType) value).toBigDecimal();
+        }
+
+        return new BigDecimal(value.toString());
     }
 
     public DecimalType(BigDecimal value) {
         this.value = value;
-    }
-
-    public DecimalType(long value) {
-        this.value = BigDecimal.valueOf(value);
-    }
-
-    public DecimalType(double value) {
-        this.value = BigDecimal.valueOf(value);
     }
 
     /**

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
@@ -13,7 +13,10 @@
 package org.openhab.core.library.types;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormatSymbols;
 import java.util.IllegalFormatConversionException;
 import java.util.Locale;
@@ -22,8 +25,10 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openhab.core.library.unit.Units;
 
 /**
  * @author Thomas Eichstaedt-Engelen - Initial contribution
@@ -214,5 +219,30 @@ public class DecimalTypeTest {
     public void testConversionToPointType() {
         // should not be possible => null
         assertNull(new DecimalType("0.23").as(PointType.class));
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> testNumberConstructor() {
+        return Stream.of(arguments((byte) 42, "42", 42f, 42d), arguments((short) 42, "42", 42f, 42d),
+                arguments(42, "42", 42f, 42d), arguments(42L, "42", 42f, 42d),
+                arguments(new BigInteger("42"), "42", 42f, 42d), arguments(new PercentType(42), "42", 42f, 42d),
+                arguments(new HSBType(DecimalType.ZERO, PercentType.ZERO, new PercentType(42)), "42", 42f, 42d),
+                // 4.2 is an example of a float value, which cannot converted to a double value directly:
+                // (float) 4.2 ==> (double) 4.199999809265137
+                arguments(4.2f, "4.2", 4.2f, 4.2d), arguments(4.2d, "4.2", 4.2f, 4.2d),
+                arguments(new BigDecimal("4.2"), "4.2", 4.2f, 4.2d),
+                arguments(new DecimalType("4.2"), "4.2", 4.2f, 4.2d),
+                arguments(new QuantityType<>(4.2f, Units.WATT), "4.2", 4.2f, 4.2d),
+                arguments(new QuantityType<>(4.2d, Units.WATT), "4.2", 4.2f, 4.2d));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testNumberConstructor(Number val, String strVal, float floatVal, double doubleVal) {
+        assertEquals(new DecimalType(strVal), new DecimalType(val));
+        assertEquals(doubleVal, new DecimalType(val).doubleValue());
+        assertEquals(floatVal, new DecimalType(val).floatValue());
+        assertEquals(new BigDecimal(strVal), new DecimalType(val).toBigDecimal());
+        assertEquals(strVal, new DecimalType(val).toString());
     }
 }


### PR DESCRIPTION
The expectation is, that when a `DecimalType` was constructed with a
`float` value, the precision of its `doubleValue()`, `floatValue()`,
`toBigDecimal()` and `toString()` is preserved. But there are `float`
values like `4.2f` or `37.1f` that cannot directly converted to `double`
without precision loss.

This commit replaces all the numerical constructors of `DecimalType`
with a single constructor with a `Number` argument, so that all `float`
values can be used without precision loss.

NOTE: There is some special handling needed for `QuantityType` and
`HSBType` because these types have a special none conventional `toString`
implementation.