### PR TITLE
Downgrade Aries JAX-RS Whiteboard from 2.0.1 to 2.0.0

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.apache.aries.jax.rs</groupId>
       <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.aries.jax.rs</groupId>
       <artifactId>org.apache.aries.jax.rs.whiteboard</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -96,7 +96,7 @@
 	</feature>
 
 	<feature name="openhab.tp-jax-rs-whiteboard" description="Aries JAX-RS Whiteboard" version="${project.version}">
-		<capability>openhab.tp;feature=jax-rs-whiteboard;version=2.0.1</capability>
+		<capability>openhab.tp;feature=jax-rs-whiteboard;version=2.0.0</capability>
 		<feature>http-whiteboard</feature>
 		<feature dependency="true">openhab.tp-cxf</feature>
 		<feature dependency="true">openhab.tp-jaxb</feature>
@@ -104,7 +104,7 @@
 		<bundle dependency="true">mvn:org.osgi/org.osgi.util.promise/1.1.1</bundle>
 		<bundle dependency="true">mvn:org.osgi/org.osgi.service.jaxrs/1.0.0</bundle>
 		<bundle>mvn:org.apache.aries.component-dsl/org.apache.aries.component-dsl.component-dsl/1.2.2</bundle>
-		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/2.0.1</bundle>
+		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/2.0.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-cxf" description="Apache CXF" version="${project.version}">

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -74,7 +74,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.ops4j.pax.web.pax-web-api;version='[7.3.19,7.3.20)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[7.3.19,7.3.20)',\
 	org.ops4j.pax.web.pax-web-spi;version='[7.3.19,7.3.20)',\
-	org.apache.aries.jax.rs.whiteboard;version='[2.0.1,2.0.2)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.2.6,6.2.7)',\
 	org.apache.cxf.cxf-core;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.4.5,3.4.6)',\
@@ -94,4 +93,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
 	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
 	org.objenesis;version='[3.2.0,3.2.1)',\
-	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)'
+	biz.aQute.tester.junit-platform;version='[6.1.0,6.1.1)',\
+	org.apache.aries.jax.rs.whiteboard;version='[2.0.0,2.0.1)'


### PR DESCRIPTION
It causes unneccessary bundle refreshes whenever add-ons are installed/uninstalled.
As a result the UI does not get properly notified of installation changes.

Fixes #2580
Reverts the Aries JAX-RS Whiteboard upgrade of #2532