### PR TITLE
[marketplace] fix re-installation of marketplace addons

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -186,7 +186,7 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
 
     private String addonIdFromPath(Path path) {
         String pathName = UIDUtils.decode(path.getFileName().toString());
-        return pathName.contains(":") ? pathName : "marketplace:";
+        return pathName.contains(":") ? pathName : "marketplace:" + pathName;
     }
 
     private Path getAddonCacheDirectory(String addonId) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
@@ -166,7 +166,7 @@ public abstract class MarketplaceBundleInstaller {
 
     private String addonIdFromPath(Path path) {
         String pathName = UIDUtils.decode(path.getFileName().toString());
-        return pathName.contains(":") ? pathName : "marketplace:";
+        return pathName.contains(":") ? pathName : "marketplace:" + pathName;
     }
 
     private Path getAddonCacheDirectory(String addonId) {


### PR DESCRIPTION
Fixes #2614 

Unfortunately the (full) addonId created from a path missed the addonId when the addon was installed from the community marketplace.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>