### PR TITLE
UIRegistry now extensible, like other Registries

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedPageProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedPageProvider.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.ui.internal.components;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed page provider which uses storage layer to keep defined pages.
+ *
+ * @author Łukasz Dywicki - initial contribution.
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedPageProvider extends UIComponentProvider {
+    @Activate
+    public ManagedPageProvider(@Reference StorageService storageService) {
+        super("ui:page", storageService);
+    }
+}

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedPageProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedPageProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * A managed page provider which uses storage layer to keep defined pages.
  *
- * @author Łukasz Dywicki - initial contribution.
+ * @author Łukasz Dywicki - Initial contribution
  */
 @NonNullByDefault
 @Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedWidgetProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedWidgetProvider.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.ui.internal.components;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed widget provider which stores their definition in storage layer.
+ *
+ * @author Łukasz Dywicki - initial contribution
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedWidgetProvider extends UIComponentProvider {
+    @Activate
+    public ManagedWidgetProvider(@Reference StorageService storageService) {
+        super("ui:widget", storageService);
+    }
+}

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedWidgetProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedWidgetProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * A managed widget provider which stores their definition in storage layer.
  *
- * @author Łukasz Dywicki - initial contribution
+ * @author Łukasz Dywicki - Initial contribution
  */
 @NonNullByDefault
 @Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentProvider.java
@@ -31,7 +31,7 @@ import org.openhab.core.ui.components.RootUIComponent;
  */
 @NonNullByDefault
 public class UIComponentProvider extends AbstractProvider<RootUIComponent>
-        implements ManagedProvider<RootUIComponent, String> {
+        implements ManagedProvider<RootUIComponent, String>, UIProvider {
 
     private String namespace;
     private volatile Storage<RootUIComponent> storage;
@@ -106,5 +106,10 @@ public class UIComponentProvider extends AbstractProvider<RootUIComponent>
             throw new IllegalArgumentException("Invalid UID");
         }
         return storage.get(key);
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryFactoryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryFactoryImpl.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.ManagedProvider;
 import org.openhab.core.ui.components.RootUIComponent;
 import org.openhab.core.ui.components.UIComponentRegistryFactory;
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Łukasz Dywicki - Removed explicit dependency on storage providers.
  * @author Jonathan Gilbert - Made providers' collections immutable.
  */
+@NonNullByDefault
 @Component(service = UIComponentRegistryFactory.class, immediate = true)
 public class UIComponentRegistryFactoryImpl implements UIComponentRegistryFactory {
     Map<String, UIComponentRegistryImpl> registries = new ConcurrentHashMap<>();
@@ -44,11 +45,11 @@ public class UIComponentRegistryFactoryImpl implements UIComponentRegistryFactor
         UIComponentRegistryImpl registry = registries.get(namespace);
         if (registry == null) {
             Set<UIProvider> namespaceProviders = this.providers.get(namespace);
-            ManagedProvider<@NonNull RootUIComponent, @NonNull String> managedProvider = null;
+            ManagedProvider<RootUIComponent, String> managedProvider = null;
             if (namespaceProviders != null) {
                 for (UIProvider provider : namespaceProviders) {
                     if (provider instanceof ManagedProvider) {
-                        managedProvider = (ManagedProvider<@NonNull RootUIComponent, @NonNull String>) provider;
+                        managedProvider = (ManagedProvider<RootUIComponent, String>) provider;
                         break;
                     }
                 }
@@ -61,15 +62,17 @@ public class UIComponentRegistryFactoryImpl implements UIComponentRegistryFactor
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     void addProvider(UIProvider provider) {
-        if (registries.containsKey(provider.getNamespace())) {
-            registries.get(provider.getNamespace()).addProvider(provider);
+        UIComponentRegistryImpl registry = registries.get(provider.getNamespace());
+        if (registry != null) {
+            registry.addProvider(provider);
         }
         registerProvider(provider);
     }
 
     void removeProvider(UIProvider provider) {
-        if (registries.containsKey(provider.getNamespace())) {
-            registries.get(provider.getNamespace()).removeProvider(provider);
+        UIComponentRegistryImpl registry = registries.get(provider.getNamespace());
+        if (registry != null) {
+            registry.removeProvider(provider);
         }
         deregisterProvider(provider);
     }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
@@ -27,13 +27,11 @@ import org.openhab.core.ui.components.UIComponentRegistry;
  * It is instantiated by the {@link UIComponentRegistryFactoryImpl}.
  *
  * @author Yannick Schaus - Initial contribution
- * @author Łukasz Dywicki - Support for dynamic registartion of providers.
+ * @author Łukasz Dywicki - Support for dynamic registration of providers
  */
 @NonNullByDefault
 public class UIComponentRegistryImpl extends AbstractRegistry<RootUIComponent, String, UIComponentProvider>
         implements UIComponentRegistry {
-
-    private final String namespace;
 
     /**
      * Constructs a UI component registry for the specified namespace.
@@ -43,8 +41,6 @@ public class UIComponentRegistryImpl extends AbstractRegistry<RootUIComponent, S
     public UIComponentRegistryImpl(String namespace, @Nullable ManagedProvider<RootUIComponent, String> managedProvider,
             @Nullable Set<UIProvider> providers) {
         super(null);
-        this.namespace = namespace;
-
         if (managedProvider != null) {
             setManagedProvider(managedProvider);
         }
@@ -55,10 +51,12 @@ public class UIComponentRegistryImpl extends AbstractRegistry<RootUIComponent, S
         }
     }
 
+    @Override
     public void addProvider(Provider<RootUIComponent> provider) {
         super.addProvider(provider);
     }
 
+    @Override
     public void removeProvider(Provider<RootUIComponent> provider) {
         super.removeProvider(provider);
     }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
@@ -12,9 +12,13 @@
  */
 package org.openhab.core.ui.internal.components;
 
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.AbstractRegistry;
-import org.openhab.core.storage.StorageService;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
 import org.openhab.core.ui.components.RootUIComponent;
 import org.openhab.core.ui.components.UIComponentRegistry;
 
@@ -23,26 +27,39 @@ import org.openhab.core.ui.components.UIComponentRegistry;
  * It is instantiated by the {@link UIComponentRegistryFactoryImpl}.
  *
  * @author Yannick Schaus - Initial contribution
+ * @author Łukasz Dywicki - Support for dynamic registartion of providers.
  */
 @NonNullByDefault
 public class UIComponentRegistryImpl extends AbstractRegistry<RootUIComponent, String, UIComponentProvider>
         implements UIComponentRegistry {
 
-    String namespace;
-    StorageService storageService;
+    private final String namespace;
 
     /**
      * Constructs a UI component registry for the specified namespace.
      *
      * @param namespace UI components namespace of this registry
-     * @param storageService supporting storage service
      */
-    public UIComponentRegistryImpl(String namespace, StorageService storageService) {
+    public UIComponentRegistryImpl(String namespace, @Nullable ManagedProvider<RootUIComponent, String> managedProvider,
+            @Nullable Set<UIProvider> providers) {
         super(null);
         this.namespace = namespace;
-        this.storageService = storageService;
-        UIComponentProvider provider = new UIComponentProvider(namespace, storageService);
-        addProvider(provider);
-        setManagedProvider(provider);
+
+        if (managedProvider != null) {
+            setManagedProvider(managedProvider);
+        }
+        if (providers != null && !providers.isEmpty()) {
+            for (Provider<RootUIComponent> provider : providers) {
+                addProvider(provider);
+            }
+        }
+    }
+
+    public void addProvider(Provider<RootUIComponent> provider) {
+        super.addProvider(provider);
+    }
+
+    public void removeProvider(Provider<RootUIComponent> provider) {
+        super.removeProvider(provider);
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIProvider.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.ui.internal.components;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.ui.components.RootUIComponent;
+
+/**
+ * Provides components (pages, widgets, etc.) at runtime.
+ *
+ * @author Łukasz Dywicki - initial controbution.
+ */
+@NonNullByDefault
+public interface UIProvider extends Provider<RootUIComponent> {
+    String getNamespace();
+}

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -19,7 +19,7 @@ import org.openhab.core.ui.components.RootUIComponent;
 /**
  * Provides components (pages, widgets, etc.) at runtime.
  *
- * @author Łukasz Dywicki - initial controbution.
+ * @author Łukasz Dywicki - Initial contribution
  */
 @NonNullByDefault
 public interface UIProvider extends Provider<RootUIComponent> {


### PR DESCRIPTION
This is to allow the UI registry & providers to follow the standard extensible pattern to allow osgi to supply other widgets and pages.

Fixes #2513 

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>