### PR TITLE
[addonservices] fix JsonAddonService

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -204,7 +204,6 @@ public class JsonAddonService implements AddonService {
                     }
                     return;
                 }
-                return;
             }
         }
         postFailureEvent(id, "Add-on not known.");

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -181,7 +181,6 @@ public class JsonAddonService implements AddonService {
                     }
                     return;
                 }
-                return;
             }
         }
         postFailureEvent(id, "Add-on not known.");


### PR DESCRIPTION
This fixes a regression introduced by #2605 which results in addon installation exiting early if the first `MarketplaceAddonHandler` does not support the addon.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>