### PR TITLE
Improve logic to choose a script engine preferred MIME type

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -176,7 +176,7 @@ public class ScriptModuleTypeProvider implements ModuleTypeProvider {
 
     private String getPreferredMimeType(ScriptEngineFactory factory) {
         List<String> mimeTypes = new ArrayList<>(factory.getScriptTypes());
-        mimeTypes.removeIf(mimeType -> !mimeType.contains("application") || mimeType.contains("x-"));
+        mimeTypes.removeIf(mimeType -> !mimeType.contains("application") || "application/python".equals(mimeType));
         return mimeTypes.isEmpty() ? factory.getScriptTypes().get(0) : mimeTypes.get(0);
     }
 


### PR DESCRIPTION
As discussed in https://github.com/openhab/openhab-addons/issues/11818.
This should select `application/x-python` for Jython (instead of `application/python` currently)
and allow other script engines to advertise their MIME type:
- JRuby: `application/x-ruby`
- Groovy: `application/x-groovy`

Signed-off-by: Yannick Schaus <github@schaus.net>