### PR TITLE
Bump netty to 4.1.72.Final for log4j2 2.15.0 fix

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -131,21 +131,21 @@
 	</feature>
 
 	<feature name="openhab.tp-netty" description="Netty bundles" version="${project.version}">
-		<capability>openhab.tp;feature=netty;version=4.1.68.Final</capability>
-		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-common/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.68.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.68.Final</bundle>
+		<capability>openhab.tp;feature=netty;version=4.1.72.Final</capability>
+		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-common/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.72.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -147,6 +147,7 @@
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-tcnative/2.0.46.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -147,7 +147,7 @@
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-tcnative/2.0.46.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-tcnative-classes/2.0.46.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -146,6 +146,7 @@
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.72.Final</bundle>
 		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.72.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.72.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">


### PR DESCRIPTION
Nettys news/change log is here:
https://netty.io/news/2021/12/13/4-1-72-Final.html

Contains an update to log4j2 2.15.0 to fix security issue.

Also have made a PR here for the addons repo changes..
https://github.com/openhab/openhab-addons/pull/11826

Signed-off-by: Matthew Skinner <matt@pcmus.com>