### PR TITLE
[discovery.mdns] Devices may apply a grace period for removal from the Inbox

### DIFF
--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -68,14 +68,14 @@ public interface MDNSDiscoveryParticipant {
     ThingUID getThingUID(ServiceInfo service);
 
     /**
-     * Some openHAB bindings handle devices that can sometimes be a bit late in updating their mDns announcements, which
+     * Some openHAB bindings handle devices that can sometimes be a bit late in updating their mDNS announcements, which
      * means that such devices are repeatedly removed from, and (re)added to, the Inbox.
      *
-     * To prevent this, a binding that implements an MDnsDiscoveryParticipant may OPTIONALLY implement this method to
+     * To prevent this, a binding that implements an MDNSDiscoveryParticipant may OPTIONALLY implement this method to
      * specify an additional delay period (grace period) to wait before the device is removed from the Inbox.
      *
-     * @param service the mDns ServiceInfo describing the device on the network
-     * @return the additional grace period delay in seconds before the device will be removed from the Inbox
+     * @param service the mDNS ServiceInfo describing the device on the network.
+     * @return the additional grace period delay in seconds before the device will be removed from the Inbox.
      */
     default long getRemovalGracePeriodSeconds(ServiceInfo service) {
         return 0;

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -66,4 +66,18 @@ public interface MDNSDiscoveryParticipant {
      */
     @Nullable
     ThingUID getThingUID(ServiceInfo service);
+
+    /**
+     * Some openHAB bindings handle devices that can sometimes be a bit late in updating their mDns announcements, which
+     * means that such devices are repeatedly removed from, and (re)added to, the Inbox.
+     *
+     * To prevent this, a binding that implements an MDnsDiscoveryParticipant may OPTIONALLY implement this method to
+     * specify an additional delay period (grace period) to wait before the device is removed from the Inbox.
+     *
+     * @param service the mDns ServiceInfo describing the device on the network
+     * @return the additional grace period delay in seconds before the device will be removed from the Inbox
+     */
+    default long getRemovalGracePeriodSeconds(ServiceInfo service) {
+        return 0;
+    }
 }

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -74,10 +74,10 @@ public interface MDNSDiscoveryParticipant {
      * To prevent this, a binding that implements an MDNSDiscoveryParticipant may OPTIONALLY implement this method to
      * specify an additional delay period (grace period) to wait before the device is removed from the Inbox.
      *
-     * @param service the mDNS ServiceInfo describing the device on the network.
+     * @param serviceInfo the mDNS ServiceInfo describing the device on the network.
      * @return the additional grace period delay in seconds before the device will be removed from the Inbox.
      */
-    default long getRemovalGracePeriodSeconds(ServiceInfo service) {
+    default long getRemovalGracePeriodSeconds(ServiceInfo serviceInfo) {
         return 0;
     }
 }

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -66,7 +66,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
 
     private final MDNSClient mdnsClient;
 
-    /*
+    /**
      * Map of scheduled tasks to remove devices from the Inbox.
      */
     private Map<String, ScheduledFuture<?>> deviceRemovalTasks = new ConcurrentHashMap<>();
@@ -238,12 +238,9 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
                     try {
                         DiscoveryResult result = participant.createResult(serviceEvent.getInfo());
                         if (result != null) {
+                            cancelRemovalTask(serviceEvent.getInfo());
                             final DiscoveryResult resultNew = getLocalizedDiscoveryResult(result,
                                     FrameworkUtil.getBundle(participant.getClass()));
-                            final ServiceInfo service = serviceEvent.getInfo();
-                            if (participant.getRemovalGracePeriodSeconds(service) > 0) {
-                                cancelRemovalTask(service);
-                            }
                             thingDiscovered(resultNew);
                         }
                     } catch (Exception e) {
@@ -254,11 +251,11 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
         }
     }
 
-    /*
+    /**
      * If the device has been scheduled to be removed, cancel its respective removal task.
      */
-    private void cancelRemovalTask(ServiceInfo service) {
-        ScheduledFuture<?> deviceRemovalTask = deviceRemovalTasks.remove(service.getQualifiedName());
+    private void cancelRemovalTask(ServiceInfo serviceInfo) {
+        ScheduledFuture<?> deviceRemovalTask = deviceRemovalTasks.remove(serviceInfo.getQualifiedName());
         if (deviceRemovalTask != null) {
             deviceRemovalTask.cancel(false);
         }

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -67,7 +67,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
     private final MDNSClient mdnsClient;
 
     /*
-     * Map of scheduled tasks to remove devices from the Inbox
+     * Map of scheduled tasks to remove devices from the Inbox.
      */
     private Map<String, ScheduledFuture<?>> deviceRemovalTasks = new ConcurrentHashMap<>();
 
@@ -255,7 +255,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
     }
 
     /*
-     * If the device has been scheduled to be removed, cancel its respective removal task
+     * If the device has been scheduled to be removed, cancel its respective removal task.
      */
     private void cancelRemovalTask(ServiceInfo service) {
         ScheduledFuture<?> deviceRemovalTask = deviceRemovalTasks.remove(service.getQualifiedName());


### PR DESCRIPTION
**BACKGROUND**

Some types of OpenHAB bindings have devices that can sometimes be a bit late in sending their mDNS renewal announcements, which means that such devices are repeatedly removed from, and (re)added to, the InBox. This leads to confusion in the UI, and repeated logger messages. This is an exact analog to the UPNP Discovery issue that was solved by https://github.com/openhab/openhab-core/pull/2144

**SOLUTION**

The solution is an exact analog to the solution in https://github.com/openhab/openhab-core/pull/2144
Resolves #1835

**DOCUMENTATION**

The binding developer guide will also be updated via this PR https://github.com/openhab/openhab-docs/pull/1708

Signed-off-by: Andrew Fiddian-Green software@whitebear.ch