### PR TITLE
[discovery.mdns] MDNSDiscoveryParticipant: Fix wrong argument names in Javadoc.

### DIFF
--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -50,7 +50,7 @@ public interface MDNSDiscoveryParticipant {
     /**
      * Creates a discovery result for a mDNS service
      *
-     * @param device the mDNS service found on the network
+     * @param service the mDNS service found on the network
      * @return the according discovery result or <code>null</code>, if device is not
      *         supported by this participant
      */
@@ -60,7 +60,7 @@ public interface MDNSDiscoveryParticipant {
     /**
      * Returns the thing UID for a mDNS service
      *
-     * @param device the mDNS service on the network
+     * @param service the mDNS service on the network
      * @return a thing UID or <code>null</code>, if device is not supported
      *         by this participant
      */


### PR DESCRIPTION
Signed-off-by: Jacob Laursen <jacob-github@vindvejr.dk>

See:
- https://www.openhab.org/javadoc/latest/org/openhab/core/config/discovery/mdns/mdnsdiscoveryparticipant#createResult(javax.jmdns.ServiceInfo)
- https://www.openhab.org/javadoc/latest/org/openhab/core/config/discovery/mdns/mdnsdiscoveryparticipant#getThingUID(javax.jmdns.ServiceInfo)

![image](https://user-images.githubusercontent.com/19519842/146996831-24d8356c-872f-4579-a600-3753bcea6d18.png)
