### PR TITLE
[audio] Fix hardcoded value for WAV file

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -147,6 +147,11 @@ public class AudioFormat {
     private final @Nullable Long frequency;
 
     /**
+     * Channels number
+     */
+    private final @Nullable Integer channels;
+
+    /**
      * Constructs an instance with the specified properties.
      *
      * Note that any properties that are null indicate that
@@ -173,6 +178,39 @@ public class AudioFormat {
         this.bitDepth = bitDepth;
         this.bitRate = bitRate;
         this.frequency = frequency;
+        this.channels = 1;
+    }
+
+    /**
+     * Constructs an instance with the specified properties.
+     *
+     * Note that any properties that are null indicate that
+     * the corresponding AudioFormat allows any value for
+     * the property.
+     *
+     * Concretely this implies that if, for example, one
+     * passed null for the value of frequency, this would
+     * mean the created AudioFormat allowed for any valid
+     * frequency.
+     *
+     * @param container The container for the audio
+     * @param codec The audio codec
+     * @param bigEndian If the audo data is big endian
+     * @param bitDepth The bit depth of the audo data
+     * @param bitRate The bit rate of the audio
+     * @param frequency The frequency at which the audio was sampled
+     * @param channels The number of channels
+     */
+    public AudioFormat(@Nullable String container, @Nullable String codec, @Nullable Boolean bigEndian,
+            @Nullable Integer bitDepth, @Nullable Integer bitRate, @Nullable Long frequency,
+            @Nullable Integer channels) {
+        this.container = container;
+        this.codec = codec;
+        this.bigEndian = bigEndian;
+        this.bitDepth = bitDepth;
+        this.bitRate = bitRate;
+        this.frequency = frequency;
+        this.channels = channels;
     }
 
     /**
@@ -229,6 +267,15 @@ public class AudioFormat {
      */
     public @Nullable Long getFrequency() {
         return frequency;
+    }
+
+    /**
+     * Gets channel number
+     *
+     * @return The frequency
+     */
+    public @Nullable Integer getChannels() {
+        return channels;
     }
 
     /**
@@ -345,10 +392,12 @@ public class AudioFormat {
                 continue;
             }
 
+            Integer channel = format.getChannels() == null ? Integer.valueOf(1) : format.getChannels();
+
             // If required set BigEndian, BitDepth, BitRate, and Frequency to default values
             if (null == format.isBigEndian()) {
                 format = new AudioFormat(format.getContainer(), format.getCodec(), Boolean.TRUE, format.getBitDepth(),
-                        format.getBitRate(), format.getFrequency());
+                        format.getBitRate(), format.getFrequency(), channel);
             }
             if (null == format.getBitDepth() || null == format.getBitRate() || null == format.getFrequency()) {
                 // Define default values
@@ -379,7 +428,7 @@ public class AudioFormat {
                 }
 
                 format = new AudioFormat(format.getContainer(), format.getCodec(), format.isBigEndian(), bitDepth,
-                        bitRate, frequency);
+                        bitRate, frequency, channel);
             }
 
             // Return preferred AudioFormat
@@ -414,7 +463,9 @@ public class AudioFormat {
                     : getFrequency().equals(format.getFrequency()))) {
                 return false;
             }
-            return true;
+            if (!(null == getChannels() ? null == format.getChannels() : getChannels().equals(format.getChannels()))) {
+                return false;
+            }
         }
         return super.equals(obj);
     }
@@ -429,6 +480,7 @@ public class AudioFormat {
         result = prime * result + ((codec == null) ? 0 : codec.hashCode());
         result = prime * result + ((container == null) ? 0 : container.hashCode());
         result = prime * result + ((frequency == null) ? 0 : frequency.hashCode());
+        result = prime * result + ((channels == null) ? 0 : channels.hashCode());
         return result;
     }
 
@@ -439,6 +491,7 @@ public class AudioFormat {
                 + (bigEndian != null ? "bigEndian=" + bigEndian + ", " : "")
                 + (bitDepth != null ? "bitDepth=" + bitDepth + ", " : "")
                 + (bitRate != null ? "bitRate=" + bitRate + ", " : "")
-                + (frequency != null ? "frequency=" + frequency : "") + "]";
+                + (frequency != null ? "frequency=" + frequency : "") + (channels != null ? "channels=" + channels : "")
+                + "]";
     }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -149,7 +149,7 @@ public class AudioFormat {
     /**
      * Channels number
      */
-    private @Nullable Integer channels;
+    private final @Nullable Integer channels;
 
     /**
      * Constructs an instance with the specified properties.
@@ -172,13 +172,7 @@ public class AudioFormat {
      */
     public AudioFormat(@Nullable String container, @Nullable String codec, @Nullable Boolean bigEndian,
             @Nullable Integer bitDepth, @Nullable Integer bitRate, @Nullable Long frequency) {
-        this.container = container;
-        this.codec = codec;
-        this.bigEndian = bigEndian;
-        this.bitDepth = bitDepth;
-        this.bitRate = bitRate;
-        this.frequency = frequency;
-        this.channels = 1;
+        this(container, codec, bigEndian, bitDepth, bitRate, frequency, 1);
     }
 
     /**
@@ -204,7 +198,12 @@ public class AudioFormat {
     public AudioFormat(@Nullable String container, @Nullable String codec, @Nullable Boolean bigEndian,
             @Nullable Integer bitDepth, @Nullable Integer bitRate, @Nullable Long frequency,
             @Nullable Integer channels) {
-        this(container, codec, bigEndian, bitDepth, bitRate, frequency);
+        this.container = container;
+        this.codec = codec;
+        this.bigEndian = bigEndian;
+        this.bitDepth = bitDepth;
+        this.bitRate = bitRate;
+        this.frequency = frequency;
         this.channels = channels;
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -149,7 +149,7 @@ public class AudioFormat {
     /**
      * Channels number
      */
-    private final @Nullable Integer channels;
+    private @Nullable Integer channels;
 
     /**
      * Constructs an instance with the specified properties.
@@ -204,12 +204,7 @@ public class AudioFormat {
     public AudioFormat(@Nullable String container, @Nullable String codec, @Nullable Boolean bigEndian,
             @Nullable Integer bitDepth, @Nullable Integer bitRate, @Nullable Long frequency,
             @Nullable Integer channels) {
-        this.container = container;
-        this.codec = codec;
-        this.bigEndian = bigEndian;
-        this.bitDepth = bitDepth;
-        this.bitRate = bitRate;
-        this.frequency = frequency;
+        this(container, codec, bigEndian, bitDepth, bitRate, frequency);
         this.channels = channels;
     }
 
@@ -272,7 +267,7 @@ public class AudioFormat {
     /**
      * Gets channel number
      *
-     * @return The frequency
+     * @return The number of channels
      */
     public @Nullable Integer getChannels() {
         return channels;

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioWaveUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioWaveUtils.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.sound.sampled.AudioFormat.Encoding;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+
+/**
+ * Some utility methods for parsing and cleaning wav files
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ *
+ */
+public class AudioWaveUtils {
+
+    private static final AudioFormat DEFAULT_WAVE_AUDIO_FORMAT = new AudioFormat(AudioFormat.CONTAINER_WAVE,
+            AudioFormat.CODEC_PCM_SIGNED, false, 16, 705600, 44100L, 1);
+
+    /**
+     *
+     * @param InputStream an inputStream of a wav file to analyze. The InputStream must have a fmt header
+     *            and support the mark/reset method
+     * @return The audio format, or the default audio format if an error occured
+     * @throws IOException If i/o exception occurs, or if the InputStream doesn't support the mark/reset
+     */
+    public static AudioFormat parseWavFormat(InputStream inputStream) throws IOException {
+        try {
+            inputStream.mark(200); // arbitrary amount, also used by the underlying parsing package from Sun
+            javax.sound.sampled.AudioFormat format = AudioSystem.getAudioInputStream(inputStream).getFormat();
+            String javaSoundencoding = format.getEncoding().toString();
+            String codecPCMSignedOrUnsigned;
+            if (javaSoundencoding.equals(Encoding.PCM_SIGNED.toString())) {
+                codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_SIGNED;
+            } else if (javaSoundencoding.equals(Encoding.PCM_UNSIGNED.toString())) {
+                codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_UNSIGNED;
+            } else if (javaSoundencoding.equals(Encoding.ULAW.toString())) {
+                codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_ULAW;
+            } else if (javaSoundencoding.equals(Encoding.ALAW.toString())) {
+                codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_ALAW;
+            } else {
+                codecPCMSignedOrUnsigned = null;
+            }
+            Integer bitRate = Math.round(format.getFrameRate() * format.getFrameSize()) * format.getChannels();
+            Long frequency = Float.valueOf(format.getSampleRate()).longValue();
+            return new AudioFormat(AudioFormat.CONTAINER_WAVE, codecPCMSignedOrUnsigned, format.isBigEndian(),
+                    format.getSampleSizeInBits(), bitRate, frequency, format.getChannels());
+
+        } catch (UnsupportedAudioFileException e) {
+            // do not throw exception and assume default format to let a chance for the sink to play the stream.
+            return DEFAULT_WAVE_AUDIO_FORMAT;
+        } finally {
+            inputStream.reset();
+        }
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.audio.utils.AudioStreamUtils;
+import org.openhab.core.audio.utils.AudioWaveUtils;
 
 /**
  * This is an AudioStream from an audio file

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
@@ -137,7 +137,6 @@ public class AudioPlayer extends Thread {
         final int sampleSizeInBits = bitDepth.intValue();
 
         final int channels = audioFormat.getChannels() == null ? Integer.valueOf(1) : audioFormat.getChannels();
-        ;
 
         final int frameSize = channels * sampleSizeInBits / 8;
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
@@ -136,11 +136,12 @@ public class AudioPlayer extends Thread {
         }
         final int sampleSizeInBits = bitDepth.intValue();
 
-        final int channels = 1;
+        final int channels = audioFormat.getChannels() == null ? Integer.valueOf(1) : audioFormat.getChannels();
+        ;
 
-        final int frameSize = sampleSizeInBits / 8;
+        final int frameSize = channels * sampleSizeInBits / 8;
 
-        final float frameRate = sampleRate / frameSize;
+        final float frameRate = channels * sampleRate / frameSize;
 
         final Boolean bigEndian = audioFormat.isBigEndian();
         if (bigEndian == null) {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.audio;
+package org.openhab.core.audio.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,12 +19,16 @@ import javax.sound.sampled.AudioFormat.Encoding;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.audio.AudioFormat;
+
 /**
  * Some utility methods for parsing and cleaning wav files
  *
  * @author Gwendal Roulleau - Initial contribution
  *
  */
+@NonNullByDefault
 public class AudioWaveUtils {
 
     private static final AudioFormat DEFAULT_WAVE_AUDIO_FORMAT = new AudioFormat(AudioFormat.CONTAINER_WAVE,
@@ -41,15 +45,15 @@ public class AudioWaveUtils {
         try {
             inputStream.mark(200); // arbitrary amount, also used by the underlying parsing package from Sun
             javax.sound.sampled.AudioFormat format = AudioSystem.getAudioInputStream(inputStream).getFormat();
-            String javaSoundencoding = format.getEncoding().toString();
+            Encoding javaSoundencoding = format.getEncoding();
             String codecPCMSignedOrUnsigned;
-            if (javaSoundencoding.equals(Encoding.PCM_SIGNED.toString())) {
+            if (Encoding.PCM_SIGNED.equals(javaSoundencoding)) {
                 codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_SIGNED;
-            } else if (javaSoundencoding.equals(Encoding.PCM_UNSIGNED.toString())) {
+            } else if (Encoding.PCM_UNSIGNED.equals(javaSoundencoding)) {
                 codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_UNSIGNED;
-            } else if (javaSoundencoding.equals(Encoding.ULAW.toString())) {
+            } else if (Encoding.ULAW.equals(javaSoundencoding)) {
                 codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_ULAW;
-            } else if (javaSoundencoding.equals(Encoding.ALAW.toString())) {
+            } else if (Encoding.ALAW.equals(javaSoundencoding)) {
                 codecPCMSignedOrUnsigned = AudioFormat.CODEC_PCM_ALAW;
             } else {
                 codecPCMSignedOrUnsigned = null;
@@ -58,7 +62,6 @@ public class AudioWaveUtils {
             Long frequency = Float.valueOf(format.getSampleRate()).longValue();
             return new AudioFormat(AudioFormat.CONTAINER_WAVE, codecPCMSignedOrUnsigned, format.isBigEndian(),
                     format.getSampleSizeInBits(), bitRate, frequency, format.getChannels());
-
         } catch (UnsupportedAudioFileException e) {
             // do not throw exception and assume default format to let a chance for the sink to play the stream.
             return DEFAULT_WAVE_AUDIO_FORMAT;


### PR DESCRIPTION
This pull request aims to replace hardcoded value by values extracted from the wav file itself, for the System speaker audio sink to play correctly some files.

Things I'm not sure about : 
- I added a new AudioFormat constructor, instead of adding a parameter to the already existing one, because I'm not confortable with introducing a breaking change.
- The values I compute (bitrate, framerate and framesize). I'm not proficient in audio, and honestly I don't really know what I'm doing. But it works when I test it. If someone using other audio sinks (compatible with WAV) could test it would be great.

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>