### PR TITLE
"System reached start level XX" trigger for DSL rules

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -51,6 +51,7 @@ import org.openhab.core.model.rule.rules.GroupMemberUpdateEventTrigger;
 import org.openhab.core.model.rule.rules.RuleModel;
 import org.openhab.core.model.rule.rules.SystemOnShutdownTrigger;
 import org.openhab.core.model.rule.rules.SystemOnStartupTrigger;
+import org.openhab.core.model.rule.rules.SystemStartlevelTrigger;
 import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger;
 import org.openhab.core.model.rule.rules.ThingStateUpdateEventTrigger;
 import org.openhab.core.model.rule.rules.TimerTrigger;
@@ -292,6 +293,12 @@ public class DSLRuleProvider
         if (t instanceof SystemOnStartupTrigger) {
             Configuration cfg = new Configuration();
             cfg.put("startlevel", 20);
+            return TriggerBuilder.create().withId(Integer.toString(triggerId++))
+                    .withTypeUID("core.SystemStartlevelTrigger").withConfiguration(cfg).build();
+        } else if (t instanceof SystemStartlevelTrigger) {
+            SystemStartlevelTrigger slTrigger = (SystemStartlevelTrigger) t;
+            Configuration cfg = new Configuration();
+            cfg.put("startlevel", slTrigger.getLevel());
             return TriggerBuilder.create().withId(Integer.toString(triggerId++))
                     .withTypeUID("core.SystemStartlevelTrigger").withConfiguration(cfg).build();
         } else if (t instanceof SystemOnShutdownTrigger) {

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -76,12 +76,18 @@ TimerTrigger:
 
 SystemTrigger:
 	SystemOnStartupTrigger |
+        SystemStartlevelTrigger |
 	SystemOnShutdownTrigger
 ;
 
 SystemOnStartupTrigger:
 	{SystemOnStartupTrigger}
 	'System' 'started'
+;
+
+SystemStartlevelTrigger:
+        {SystemStartlevelTrigger}
+        'System' 'reached start level' level=INT
 ;
 
 SystemOnShutdownTrigger:


### PR DESCRIPTION
This implements a way to trigger dsl-based rules on various start levels, like it is already possible with ui-based rules.