### PR TITLE
Use ZonedDateTime instead of Date in ModifiablePersistenceService interface

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -15,7 +15,6 @@ package org.openhab.core.io.rest.core.internal.persistence;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -507,7 +506,7 @@ public class PersistenceResource implements RESTResource {
 
         ModifiablePersistenceService mService = (ModifiablePersistenceService) service;
 
-        mService.store(item, Date.from(dateTime.toInstant()), state);
+        mService.store(item, dateTime, state);
         return Response.status(Status.OK).build();
     }
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.persistence;
 
-import java.util.Date;
+import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.items.Item;
@@ -44,7 +44,7 @@ public interface ModifiablePersistenceService extends QueryablePersistenceServic
      * @param date the date of the record
      * @param state the state to be recorded
      */
-    void store(Item item, Date date, State state);
+    void store(Item item, ZonedDateTime date, State state);
 
     /**
      * Removes data associated with an item from a persistence service.


### PR DESCRIPTION
If PRs are created to implement this interface, it would be better if we can prevent the propagation of old APIs like Date.

Related to:

* https://github.com/openhab/openhab-addons/pull/11922
* https://github.com/openhab/openhab-addons/pull/11923
* https://github.com/openhab/openhab-core/issues/2618#issuecomment-1003544762