### PR TITLE
[automation] Align parsing of startlevel config

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.automation.internal;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1450,14 +1451,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     private boolean mustTrigger(Rule r) {
         for (Trigger t : r.getTriggers()) {
             if (SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID.equals(t.getTypeUID())) {
-                Object slObj = t.getConfiguration().get(SystemTriggerHandler.CFG_STARTLEVEL);
-                try {
-                    Integer sl = Integer.valueOf(slObj.toString());
-                    if (sl <= StartLevelService.STARTLEVEL_RULEENGINE) {
-                        return true;
-                    }
-                } catch (NumberFormatException e) {
-                    logger.warn("Configuration '{}' is not a valid start level!", slObj);
+                int sl = ((BigDecimal) t.getConfiguration().get(SystemTriggerHandler.CFG_STARTLEVEL)).intValue();
+                if (sl <= StartLevelService.STARTLEVEL_RULEENGINE) {
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
- Align parsing of startlevel config

We assume that configuration values are `BigDecimal` in `SystemTriggerHandler` thus it might make sense to align the parsing in the `RuleEngine`.

https://github.com/openhab/openhab-core/blob/0bdaeef789a52d637134800f3dbaf4827b543c60/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java#L62

Otherwise it might happen that we see a warning in the log:

```
2022-01-03 12:35:24.420 [WARN ] [e.automation.internal.RuleEngineImpl] - Configuration '80.0' is not a valid start level!
```

Extract from Json Storage:

```json
{
  "e8c39a6060": {
    "class": "org.openhab.core.automation.dto.RuleDTO",
    "value": {
      "triggers": [
        {
          "id": "1",
          "configuration": {
            "startlevel": 80.0
          },
          "type": "core.SystemStartlevelTrigger"
        }
      ],
      "conditions": [],
...
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>