### PR TITLE
[profiles] Do not log a warning if QuantityState has unit AbstractUnit.ONE

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
@@ -137,11 +137,13 @@ public class SystemHysteresisStateProfile implements StateProfile {
             if (Units.ONE.equals(lower.getUnit()) && Units.ONE.equals(upper.getUnit())) {
                 // allow bounds without unit -> implicitly assume its the same as the one from the state, but warn
                 // the user
+                if (!Units.ONE.equals(qtState.getUnit())) {
+                    logger.warn(
+                            "Received a QuantityType '{}' with unit, but the boundaries are defined as a plain number without units (lower={}, upper={}), please consider adding units to them.",
+                            value, lower, upper);
+                }
                 finalLower = new QuantityType<>(lower.toBigDecimal(), qtState.getUnit());
                 finalUpper = new QuantityType<>(upper.toBigDecimal(), qtState.getUnit());
-                logger.warn(
-                        "Received a QuantityType '{}' with unit, but the boundaries are defined as a plain number without units (lower={}, upper={}), please consider adding units to them.",
-                        value, lower, upper);
             } else {
                 finalLower = lower.toUnit(qtState.getUnit());
                 finalUpper = upper.toUnit(qtState.getUnit());

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -115,13 +115,13 @@ public class SystemOffsetProfile implements StateProfile {
         if (state instanceof QuantityType) {
             QuantityType qtState = (QuantityType) state;
             try {
-                if (Units.ONE.equals(finalOffset.getUnit())) {
+                if (Units.ONE.equals(finalOffset.getUnit()) && !Units.ONE.equals(qtState.getUnit())) {
                     // allow offsets without unit -> implicitly assume its the same as the one from the state, but warn
                     // the user
-                    finalOffset = new QuantityType<>(finalOffset.toBigDecimal(), qtState.getUnit());
                     logger.warn(
                             "Received a QuantityType state '{}' with unit, but the offset is defined as a plain number without unit ({}), please consider adding a unit to the profile offset.",
                             state, offset);
+                    finalOffset = new QuantityType<>(finalOffset.toBigDecimal(), qtState.getUnit());
                 }
                 // take care of temperatures because they start at offset -273°C = 0K
                 if (Units.KELVIN.equals(qtState.getUnit().getSystemUnit())) {
@@ -147,6 +147,7 @@ public class SystemOffsetProfile implements StateProfile {
         return result;
     }
 
+    @SuppressWarnings("null")
     private @Nullable QuantityType<Temperature> handleTemperature(QuantityType<Temperature> qtState,
             QuantityType<Temperature> offset) {
         // do the math in Kelvin and afterwards convert it back to the unit of the state

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
@@ -145,11 +145,13 @@ public class SystemRangeStateProfile implements StateProfile {
             if (Units.ONE.equals(lower.getUnit()) && Units.ONE.equals(upper.getUnit())) {
                 // allow bounds without unit -> implicitly assume its the same as the one from the state, but warn
                 // the user
+                if (!Units.ONE.equals(qtState.getUnit())) {
+                    logger.warn(
+                            "Received a QuantityType '{}' with unit, but the boundaries are defined as a plain number without units (lower={}, upper={}), please consider adding units to them.",
+                            value, lower, upper);
+                }
                 finalLower = new QuantityType<>(lower.toBigDecimal(), qtState.getUnit());
                 finalUpper = new QuantityType<>(upper.toBigDecimal(), qtState.getUnit());
-                logger.warn(
-                        "Received a QuantityType '{}' with unit, but the boundaries are defined as a plain number without units (lower={}, upper={}), please consider adding units to them.",
-                        value, lower, upper);
             } else {
                 finalLower = lower.toUnit(qtState.getUnit());
                 finalUpper = upper.toUnit(qtState.getUnit());

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
@@ -99,6 +99,7 @@ public class SystemHysteresisStateProfileTest {
                         BigDecimal.TEN, null) }, //
                 { new ParameterSet(List.of(QuantityType.valueOf("0 %")), List.of(OnOffType.OFF), BigDecimal.TEN,
                         null) }, //
+                { new ParameterSet(List.of(new QuantityType<>()), List.of(OnOffType.OFF), BigDecimal.TEN, null) }, //
                 // lower bound = upper bound = 10 (as QuantityType), one state update / command (QuantityType)
                 { new ParameterSet(List.of(QuantityType.valueOf("100 %")), List.of(OnOffType.ON), QUANTITY_STRING_TEN,
                         null) }, //

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
@@ -30,6 +30,7 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
 import org.openhab.core.types.Command;
@@ -78,8 +79,7 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).handleCommand(capture.capture());
 
         Command result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
+        QuantityType<?> decResult = (QuantityType<?>) result;
         assertEquals(20, decResult.intValue());
         assertEquals(SIUnits.CELSIUS, decResult.getUnit());
     }
@@ -128,8 +128,7 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).sendCommand(capture.capture());
 
         Command result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
+        QuantityType<?> decResult = (QuantityType<?>) result;
         assertEquals(26, decResult.intValue());
         assertEquals(SIUnits.CELSIUS, decResult.getUnit());
     }
@@ -146,8 +145,7 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).sendUpdate(capture.capture());
 
         State result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
+        QuantityType<?> decResult = (QuantityType<?>) result;
         assertEquals(26, decResult.intValue());
         assertEquals(SIUnits.CELSIUS, decResult.getUnit());
     }
@@ -164,14 +162,13 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).sendUpdate(capture.capture());
 
         State result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
+        QuantityType<?> decResult = (QuantityType<?>) result;
         assertThat(decResult.doubleValue(), is(closeTo(24.6666666666666666666666666666667d, 0.0000000000000001d)));
         assertEquals(SIUnits.CELSIUS, decResult.getUnit());
     }
 
     @Test
-    public void testQuantityTypeOnStateUpdateFromHandlerDecimalOffset() {
+    public void testQuantityTypeWithUnitCelsiusOnStateUpdateFromHandlerDecimalOffset() {
         ProfileCallback callback = mock(ProfileCallback.class);
         SystemOffsetProfile offsetProfile = createProfile(callback, "3");
 
@@ -182,16 +179,32 @@ public class SystemOffsetProfileTest {
         verify(callback, times(1)).sendUpdate(capture.capture());
 
         State result = capture.getValue();
-        @SuppressWarnings("unchecked")
-        QuantityType<Temperature> decResult = (QuantityType<Temperature>) result;
+        QuantityType<?> decResult = (QuantityType<?>) result;
         assertEquals(26, decResult.intValue());
         assertEquals(SIUnits.CELSIUS, decResult.getUnit());
+    }
+
+    @Test
+    public void testQuantityTypeWithUnitOneOnStateUpdateFromHandlerDecimalOffset() {
+        ProfileCallback callback = mock(ProfileCallback.class);
+        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
+
+        State state = new QuantityType<>();
+        offsetProfile.onStateUpdateFromHandler(state);
+
+        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
+        verify(callback, times(1)).sendUpdate(capture.capture());
+
+        State result = capture.getValue();
+        QuantityType<?> decResult = (QuantityType<?>) result;
+        assertEquals(3, decResult.intValue());
+        assertEquals(Units.ONE, decResult.getUnit());
     }
 
     private SystemOffsetProfile createProfile(ProfileCallback callback, String offset) {
         ProfileContext context = mock(ProfileContext.class);
         Configuration config = new Configuration();
-        config.put("offset", offset);
+        config.put(SystemOffsetProfile.OFFSET_PARAM, offset);
         when(context.getConfiguration()).thenReturn(config);
 
         return new SystemOffsetProfile(callback, context);

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
@@ -106,6 +106,8 @@ public class SystemRangeStateProfileTest {
                         BigDecimal.TEN, BIGDECIMAL_FOURTY, false) }, //
                 { new ParameterSet(List.of(QuantityType.valueOf("0 %")), List.of(OnOffType.OFF), BigDecimal.TEN,
                         BIGDECIMAL_FOURTY, false) }, //
+                { new ParameterSet(List.of(new QuantityType<>()), List.of(OnOffType.OFF), BigDecimal.TEN,
+                        BIGDECIMAL_FOURTY, false) }, //
                 // lower bound = 10, upper bound = 40 (as QuantityType), one state update / command (QuantityType), not
                 // inverted
                 { new ParameterSet(List.of(QuantityType.valueOf("100 %")), List.of(OnOffType.OFF), QUANTITY_STRING_TEN,


### PR DESCRIPTION
- Do not log a warning if `QuantityState` has unit `AbstractUnit.ONE`

I added this check to deal with dimensionless `QuantityTypes` without unit (internally `AbstractUnit.ONE`) because for them it is not possible to define a unit in the compare condition as the unit symbol is an empty string.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>