### PR TITLE
Force English locale to parse marketplace UI components timestamp

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.addon.Addon;
@@ -58,7 +59,7 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
         this.blocksRegistry = uiComponentRegistryFactory.getRegistry("ui:blocks");
         this.yamlMapper = new ObjectMapper(new YAMLFactory());
         yamlMapper.findAndRegisterModules();
-        this.yamlMapper.setDateFormat(new SimpleDateFormat("MMM d, yyyy, hh:mm:ss aa"));
+        this.yamlMapper.setDateFormat(new SimpleDateFormat("MMM d, yyyy, hh:mm:ss aa", Locale.ENGLISH));
     }
 
     @Override

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.addon.Addon;
@@ -58,7 +59,7 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
         this.widgetRegistry = uiComponentRegistryFactory.getRegistry("ui:widget");
         this.yamlMapper = new ObjectMapper(new YAMLFactory());
         yamlMapper.findAndRegisterModules();
-        this.yamlMapper.setDateFormat(new SimpleDateFormat("MMM d, yyyy, hh:mm:ss aa"));
+        this.yamlMapper.setDateFormat(new SimpleDateFormat("MMM d, yyyy, hh:mm:ss aa", Locale.ENGLISH));
     }
 
     @Override


### PR DESCRIPTION
Related to https://community.openhab.org/t/error-installing-widgets-from-community-in-user-interfaces/128729/16

When the locale is not English the timestamp might fail to be deserialized into a Date:

```
2022-01-02 21:01:42.260 [ERROR] [munity.CommunityUIWidgetAddonHandler] - Unable to parse YAML: Cannot deserialize value of type `java.util.Date` from String "Oct 2, 2021, 9:24:59 PM": not a valid representation (error: Failed to parse Date value 'Oct 2, 2021, 9:24:59 PM': Unparseable date: "Oct 2, 2021, 9:24:59 PM")

 at [Source: (StringReader); line: 36, column: 12] (through reference chain: org.openhab.core.ui.components.RootUIComponent["timestamp"])

2022-01-02 21:01:42.261 [ERROR] [munity.CommunityUIWidgetAddonHandler] - Widget from marketplace is invalid: Unable to parse YAML
```