### PR TITLE
ScriptFileWatcher subdirectory loading upon startup no longer hardcoded

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcher.java
@@ -137,9 +137,11 @@ public class ScriptFileWatcher extends AbstractWatchService implements ReadyServ
         if (file.exists()) {
             File[] files = file.listFiles();
             if (files != null) {
-                for (File f : files) {
-                    if (!f.isHidden()) {
-                        importResources(f);
+                if (watchSubDirectories()) {
+                    for (File f : files) {
+                        if (!f.isHidden()) {
+                            importResources(f);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
… to true

This matters as subclasses can override this behaviour and it was previously being ignored upon startup (only).

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>