### PR TITLE
[audio] Remove 'clac' noise when playing wave (javasound)

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
@@ -62,7 +62,7 @@ public class AudioPlayer extends Thread {
     public void run() {
         SourceDataLine line;
 
-        org.openhab.core.audio.AudioFormat openhabAudioFormat = this.audioStream.getFormat();
+        org.openhab.core.audio.AudioFormat openhabAudioFormat = audioStream.getFormat();
 
         AudioFormat audioFormat = convertAudioFormat(openhabAudioFormat);
         if (audioFormat == null) {
@@ -94,7 +94,7 @@ public class AudioPlayer extends Thread {
             // If this is a wav container, we should remove the header from the stream
             // to avoid a "clack" noise at the beginning
             if (org.openhab.core.audio.AudioFormat.CONTAINER_WAVE.equals(openhabAudioFormat.getContainer())) {
-                AudioWaveUtils.removeFMT(this.audioStream);
+                AudioWaveUtils.removeFMT(audioStream);
             }
             while (-1 != nRead) {
                 nRead = audioStream.read(abData, 0, abData.length);

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
@@ -25,6 +25,7 @@ import javax.sound.sampled.SourceDataLine;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioStream;
+import org.openhab.core.audio.utils.AudioWaveUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,10 @@ public class AudioPlayer extends Thread {
     @Override
     public void run() {
         SourceDataLine line;
-        AudioFormat audioFormat = convertAudioFormat(this.audioStream.getFormat());
+
+        org.openhab.core.audio.AudioFormat openhabAudioFormat = this.audioStream.getFormat();
+
+        AudioFormat audioFormat = convertAudioFormat(openhabAudioFormat);
         if (audioFormat == null) {
             logger.warn("Audio format is unsupported or does not have enough details in order to be played");
             return;
@@ -87,6 +91,11 @@ public class AudioPlayer extends Thread {
         int nRead = 0;
         byte[] abData = new byte[65532]; // needs to be a multiple of 4 and 6, to support both 16 and 24 bit stereo
         try {
+            // If this is a wav container, we should remove the header from the stream
+            // to avoid a "clack" noise at the beginning
+            if (org.openhab.core.audio.AudioFormat.CONTAINER_WAVE.equals(openhabAudioFormat.getContainer())) {
+                AudioWaveUtils.removeFMT(this.audioStream);
+            }
             while (-1 != nRead) {
                 nRead = audioStream.read(abData, 0, abData.length);
                 if (nRead >= 0) {


### PR DESCRIPTION
A 'clac' can be heard at the beginning of a wav file when playing on the javasound sink.

This is because the code playing the sound targets PCM. But a WAV file has an additional header (fmt). When the code tries to play this header as if it was actual sound, it outputs a "pop" noise.
This bug was first encoutered when [playing WAV from the Google TTS](https://community.openhab.org/t/oh3-google-tts-only-white-noise/112714/35), and also in my tests with the Pico TTS, and with the play action from a wav file in the sound directory.

With the fix in this PR, the code consumes (at most) 400 + 2 bytes (if it is a wav file) by trying to get to a "magic" packet that marks the beginning of the real PCM data.

I put the removal code in an utility class because every audio sink playing PCM could potentially need to remove the fmt header.


Close #2669