### PR TITLE
[config] Added nullness annotations and suppress 'ConfigStatusInfoEvent' if list of 'ConfigStatusMessage's is empty

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusCallback.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusCallback.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.core.config.core.status;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link ConfigStatusCallback} interface is a callback interface to propagate a new configuration status for an
  * entity.
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public interface ConfigStatusCallback {
 
     /**

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusInfo.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusInfo.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.status.ConfigStatusMessage.Type;
 
 /**
@@ -28,6 +30,7 @@ import org.openhab.core.config.core.status.ConfigStatusMessage.Type;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public final class ConfigStatusInfo {
 
     private final Collection<ConfigStatusMessage> configStatusMessages = new ArrayList<>();
@@ -146,7 +149,7 @@ public final class ConfigStatusInfo {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
@@ -15,6 +15,8 @@ package org.openhab.core.config.core.status;
 import java.util.Arrays;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link ConfigStatusMessage} is a domain object for a configuration status message. It contains the name
  * of the configuration parameter, the {@link ConfigStatusMessage.Type} information, the internationalized message and
@@ -74,19 +76,19 @@ public final class ConfigStatusMessage {
     public final Type type;
 
     /** The key for the message to be internalized. */
-    final transient String messageKey;
+    final transient @Nullable String messageKey;
 
     /** The arguments to be injected into the internationalized message. */
-    final transient Object[] arguments;
+    final transient Object @Nullable [] arguments;
 
     /** The corresponding internationalized status message. */
-    public final String message;
+    public final @Nullable String message;
 
     /**
      * The optional status code of the configuration status message; to be used if there are additional information to
      * be provided.
      */
-    public final Integer statusCode;
+    public final @Nullable Integer statusCode;
 
     /**
      * Package protected default constructor to allow reflective instantiation.
@@ -103,12 +105,7 @@ public final class ConfigStatusMessage {
      * @param builder the configuration status message builder
      */
     private ConfigStatusMessage(Builder builder) {
-        this.parameterName = builder.parameterName;
-        this.type = builder.type;
-        this.messageKey = builder.messageKey;
-        this.arguments = builder.arguments;
-        this.message = null;
-        this.statusCode = builder.statusCode;
+        this(builder.parameterName, builder.type, builder.messageKey, builder.arguments, null, builder.statusCode);
     }
 
     /**
@@ -119,12 +116,12 @@ public final class ConfigStatusMessage {
      * @param message the corresponding internationalized status message
      * @param statusCode the optional status code
      */
-    ConfigStatusMessage(String parameterName, Type type, String message, Integer statusCode) {
+    ConfigStatusMessage(String parameterName, Type type, String message, @Nullable Integer statusCode) {
         this(parameterName, type, null, null, message, statusCode);
     }
 
-    private ConfigStatusMessage(String parameterName, Type type, String messageKey, Object[] arguments, String message,
-            Integer statusCode) {
+    private ConfigStatusMessage(String parameterName, Type type, @Nullable String messageKey,
+            Object @Nullable [] arguments, @Nullable String message, @Nullable Integer statusCode) {
         this.parameterName = parameterName;
         this.type = type;
         this.messageKey = messageKey;
@@ -144,11 +141,11 @@ public final class ConfigStatusMessage {
 
         private final Type type;
 
-        private String messageKey;
+        private @Nullable String messageKey;
 
-        private Object[] arguments;
+        private Object @Nullable [] arguments;
 
-        private Integer statusCode;
+        private @Nullable Integer statusCode;
 
         private Builder(String parameterName, Type type) {
             Objects.requireNonNull(parameterName, "Parameter name must not be null.");
@@ -199,6 +196,17 @@ public final class ConfigStatusMessage {
         }
 
         /**
+         * Adds the given message key suffix for the creation of {@link ConfigStatusMessage#messageKey}.
+         *
+         * @param messageKeySuffix the message key suffix to be added
+         * @return the updated builder
+         */
+        public Builder withMessageKeySuffix(String messageKeySuffix) {
+            this.messageKey = CONFIG_STATUS_MSG_KEY_PREFIX + type.name().toLowerCase() + "." + messageKeySuffix;
+            return this;
+        }
+
+        /**
          * Adds the given arguments (to be injected into the internationalized message) to the builder.
          *
          * @param arguments the arguments to be added
@@ -217,17 +225,6 @@ public final class ConfigStatusMessage {
          */
         public Builder withStatusCode(Integer statusCode) {
             this.statusCode = statusCode;
-            return this;
-        }
-
-        /**
-         * Adds the given message key suffix for the creation of {@link ConfigStatusMessage#messageKey}.
-         *
-         * @param messageKeySuffix the message key suffix to be added
-         * @return the updated builder
-         */
-        public Builder withMessageKeySuffix(String messageKeySuffix) {
-            this.messageKey = CONFIG_STATUS_MSG_KEY_PREFIX + type.name().toLowerCase() + "." + messageKeySuffix;
             return this;
         }
 
@@ -253,7 +250,7 @@ public final class ConfigStatusMessage {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusEventFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusEventFactory.java
@@ -14,6 +14,8 @@ package org.openhab.core.config.core.status.events;
 
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.status.ConfigStatusInfo;
 import org.openhab.core.events.AbstractEventFactory;
 import org.openhab.core.events.Event;
@@ -26,7 +28,8 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Thomas Höfer - Initial contribution
  */
-@Component(immediate = true, service = { EventFactory.class })
+@Component(immediate = true, service = EventFactory.class)
+@NonNullByDefault
 public final class ConfigStatusEventFactory extends AbstractEventFactory {
 
     private static final Set<String> SUPPORTED_EVENT_TYPES = Set.of(ConfigStatusInfoEvent.TYPE);
@@ -48,7 +51,8 @@ public final class ConfigStatusEventFactory extends AbstractEventFactory {
     }
 
     @Override
-    protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
+    protected Event createEventByType(String eventType, String topic, String payload, @Nullable String source)
+            throws Exception {
         if (ConfigStatusInfoEvent.TYPE.equals(eventType)) {
             return createStatusInfoEvent(topic, payload);
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusInfoEvent.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusInfoEvent.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.config.core.status.events;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.status.ConfigStatusInfo;
 import org.openhab.core.events.AbstractEvent;
 
@@ -22,6 +23,7 @@ import com.google.gson.Gson;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public final class ConfigStatusInfoEvent extends AbstractEvent {
 
     static final String TYPE = "ConfigStatusInfoEvent";

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
@@ -12,16 +12,13 @@
  */
 package org.openhab.core.config.core.status;
 
-import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.status.ConfigStatusMessage.Type;
 
@@ -31,6 +28,7 @@ import org.openhab.core.config.core.status.ConfigStatusMessage.Type;
  * @author Thomas Höfer - Initial contribution
  * @author Wouter Born - Migrate tests from Groovy to Java
  */
+@NonNullByDefault
 public class ConfigStatusInfoTest {
 
     private static final String PARAM1 = "param1";
@@ -60,8 +58,7 @@ public class ConfigStatusInfoTest {
     private static final ConfigStatusMessage MSG6 = ConfigStatusMessage.Builder.pending(PARAM6)
             .withMessageKeySuffix(ERROR2).withStatusCode(1).build();
 
-    private static final List<ConfigStatusMessage> ALL = Stream.of(MSG1, MSG2, MSG3, MSG4, MSG5, MSG6)
-            .collect(toList());
+    private static final List<ConfigStatusMessage> ALL = List.of(MSG1, MSG2, MSG3, MSG4, MSG5, MSG6);
 
     @Test
     public void assertCorrectConfigErrorHandlingForEmptyResultObject() {
@@ -90,17 +87,17 @@ public class ConfigStatusInfoTest {
         assertConfigStatusInfo(info);
     }
 
-    @Test
-    public void assertNPEisThrownIfTypesAreNull() {
-        ConfigStatusInfo info = new ConfigStatusInfo();
-        assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(null, emptySet()));
-    }
-
-    @Test
-    public void assertNPEisThrownIfParameterNamesAreNull() {
-        ConfigStatusInfo info = new ConfigStatusInfo();
-        assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(emptySet(), null));
-    }
+    // @Test
+    // public void assertNPEisThrownIfTypesAreNull() {
+    // ConfigStatusInfo info = new ConfigStatusInfo();
+    // assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(null, Set.of()));
+    // }
+    //
+    // @Test
+    // public void assertNPEisThrownIfParameterNamesAreNull() {
+    // ConfigStatusInfo info = new ConfigStatusInfo();
+    // assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(Set.of(), null));
+    // }
 
     private void assertConfigStatusInfo(ConfigStatusInfo info) {
         assertThat(info.getConfigStatusMessages().size(), is(ALL.size()));

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
@@ -87,18 +87,6 @@ public class ConfigStatusInfoTest {
         assertConfigStatusInfo(info);
     }
 
-    // @Test
-    // public void assertNPEisThrownIfTypesAreNull() {
-    // ConfigStatusInfo info = new ConfigStatusInfo();
-    // assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(null, Set.of()));
-    // }
-    //
-    // @Test
-    // public void assertNPEisThrownIfParameterNamesAreNull() {
-    // ConfigStatusInfo info = new ConfigStatusInfo();
-    // assertThrows(NullPointerException.class, () -> info.getConfigStatusMessages(Set.of(), null));
-    // }
-
     private void assertConfigStatusInfo(ConfigStatusInfo info) {
         assertThat(info.getConfigStatusMessages().size(), is(ALL.size()));
         assertThat(info.getConfigStatusMessages(), hasItems(MSG1, MSG2, MSG3, MSG4, MSG5, MSG6));

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.config.core.status.ConfigStatusMessage.Type;
@@ -37,9 +39,10 @@ import org.openhab.core.util.BundleResolver;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public class ConfigStatusServiceTest extends JavaTest {
 
-    private ConfigStatusService configStatusService;
+    private @NonNullByDefault({}) ConfigStatusService configStatusService;
 
     private static final String ENTITY_ID1 = "entity1";
     private static final String ENTITY_ID2 = "entity2";
@@ -104,21 +107,17 @@ public class ConfigStatusServiceTest extends JavaTest {
         messagesEntity2En.add(buildConfigStatusMessage(PARAM3_MSG3.parameterName, PARAM3_MSG3.type,
                 MessageFormat.format(MSG3_EN, ARGS), PARAM3_MSG3.statusCode));
 
-        configStatusService = new ConfigStatusService();
-
         LocaleProvider localeProvider = mock(LocaleProvider.class);
         when(localeProvider.getLocale()).thenReturn(new Locale("en", "US"));
-        configStatusService.setLocaleProvider(localeProvider);
 
-        configStatusService.setEventPublisher(mock(EventPublisher.class));
-        configStatusService.setBundleResolver(mock(BundleResolver.class));
-        configStatusService.setTranslationProvider(getTranslationProvider());
+        configStatusService = new ConfigStatusService(mock(EventPublisher.class), localeProvider,
+                getTranslationProvider(), mock(BundleResolver.class));
         configStatusService.addConfigStatusProvider(getConfigStatusProviderMock(ENTITY_ID1));
         configStatusService.addConfigStatusProvider(getConfigStatusProviderMock(ENTITY_ID2));
     }
 
     private ConfigStatusMessage buildConfigStatusMessage(String parameterName, Type type, String msg,
-            Integer statusCode) {
+            @Nullable Integer statusCode) {
         return new ConfigStatusMessage(parameterName, type, msg, statusCode);
     }
 
@@ -142,7 +141,7 @@ public class ConfigStatusServiceTest extends JavaTest {
         assertConfigStatusInfo(info, new ConfigStatusInfo(expectedMessages));
     }
 
-    private void assertConfigStatusInfo(ConfigStatusInfo actual, ConfigStatusInfo expected) {
+    private void assertConfigStatusInfo(@Nullable ConfigStatusInfo actual, ConfigStatusInfo expected) {
         assertThat(actual, equalTo(expected));
     }
 


### PR DESCRIPTION
- Added nullness annotations
- Use constructor injection
- Suppress `ConfigStatusInfoEvent` if list of `ConfigStatusMessage`s is empty

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>