### PR TITLE
[voice] Update dialog processing

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -29,6 +29,7 @@ import org.openhab.core.voice.text.InterpretationException;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added parameter to adjust the volume
+ * @author Laurent Garnier - Updated methods startDialog and added method stopDialog
  */
 @NonNullByDefault
 public interface VoiceManager {
@@ -121,20 +122,48 @@ public interface VoiceManager {
     Voice getPreferredVoice(Set<Voice> voices);
 
     /**
-     * Starts listening for the keyword that starts a dialog
+     * Starts an infinite dialog sequence using all default services: keyword spotting on the default audio source,
+     * audio source listening to retrieve the question, speech to text conversion, interpretation, text to speech
+     * conversion and playback of the answer on the default audio sink
      *
-     * @throws IllegalStateException if required services are not available
+     * Only one dialog can be started for the default audio source.
+     *
+     * @throws IllegalStateException if required services are not available or the dialog is already started for the
+     *             default audio source
      */
-    void startDialog();
+    void startDialog() throws IllegalStateException;
 
     /**
-     * Starts listening for the keyword that starts a dialog
+     * Starts an infinite dialog sequence: keyword spotting on the audio source, audio source listening to retrieve
+     * the question, speech to text conversion, interpretation, text to speech conversion and playback of the answer
+     * on the audio sink
      *
-     * @throws IllegalStateException if required services are not available
+     * Only one dialog can be started for an audio source.
+     *
+     * @param ks the keyword spotting service to use or null to use the default service
+     * @param stt the speech-to-text service to use or null to use the default service
+     * @param tts the text-to-speech service to use or null to use the default service
+     * @param hli the human language text interpreter to use or null to use the default service
+     * @param source the audio source to use or null to use the default source
+     * @param sink the audio sink to use or null to use the default sink
+     * @param Locale the locale to use or null to use the default locale
+     * @param keyword the keyword to use during keyword spotting or null to use the default keyword
+     * @param listeningItem the item to switch ON while listening to a question
+     * @throws IllegalStateException if required services are not available or the dialog is already started for this
+     *             audio source
      */
     void startDialog(@Nullable KSService ks, @Nullable STTService stt, @Nullable TTSService tts,
             @Nullable HumanLanguageInterpreter hli, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem);
+            @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem)
+            throws IllegalStateException;
+
+    /**
+     * Stop the dialog associated to an audio source
+     *
+     * @param source the audio source or null to consider the default audio source
+     * @throws IllegalStateException if no dialog is started for the audio source
+     */
+    void stopDialog(@Nullable AudioSource source) throws IllegalStateException;
 
     /**
      * Retrieves a TTS service.

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
@@ -14,3 +14,7 @@ system.config.voice.listeningItem.label = Listening Switch
 system.config.voice.listeningItem.description = If provided, the item will be switched on during the period when the dialog processor has spotted the keyword and is listening for commands.
 
 service.system.voice.label = Voice
+
+error.ks-error = Encountered error while spotting keywords, {0}
+error.stt-error = Encountered error while recognizing text, {0}
+error.stt-exception = Error during recognition, {0}

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/HumanLanguageInterpreterStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/HumanLanguageInterpreterStub.java
@@ -30,20 +30,18 @@ import org.openhab.core.voice.text.InterpretationException;
 public class HumanLanguageInterpreterStub implements HumanLanguageInterpreter {
 
     private static final String INTERPRETED_TEXT = "Interpreted text";
-    private static final String EXCEPTION_MESSAGE = "Exception message";
+    private static final String EXCEPTION_MESSAGE = "interpretation exception";
 
     private static final String HLI_STUB_ID = "HLIStubID";
     private static final String HLI_STUB_LABEL = "HLIStubLabel";
 
-    private boolean isInterpretationExceptionExpected;
+    private boolean exceptionExpected;
+    private String question = "";
+    private String answer = "";
 
     @Override
     public String getId() {
         return HLI_STUB_ID;
-    }
-
-    public void setIsInterpretationExceptionExpected(boolean value) {
-        isInterpretationExceptionExpected = value;
     }
 
     @Override
@@ -53,10 +51,12 @@ public class HumanLanguageInterpreterStub implements HumanLanguageInterpreter {
 
     @Override
     public String interpret(Locale locale, String text) throws InterpretationException {
-        if (isInterpretationExceptionExpected) {
+        question = text;
+        if (exceptionExpected) {
             throw new InterpretationException(EXCEPTION_MESSAGE);
         } else {
-            return INTERPRETED_TEXT;
+            answer = INTERPRETED_TEXT;
+            return answer;
         }
     }
 
@@ -76,6 +76,18 @@ public class HumanLanguageInterpreterStub implements HumanLanguageInterpreter {
     public Set<String> getSupportedGrammarFormats() {
         // This method will not be used in the tests
         return null;
+    }
+
+    public void setExceptionExpected(boolean exceptionExpected) {
+        this.exceptionExpected = exceptionExpected;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public String getAnswer() {
+        return answer;
     }
 
     @Override

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/STTServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/STTServiceStub.java
@@ -23,6 +23,8 @@ import org.openhab.core.voice.STTException;
 import org.openhab.core.voice.STTListener;
 import org.openhab.core.voice.STTService;
 import org.openhab.core.voice.STTServiceHandle;
+import org.openhab.core.voice.SpeechRecognitionErrorEvent;
+import org.openhab.core.voice.SpeechRecognitionEvent;
 
 /**
  * A {@link STTService} stub used for the tests.
@@ -37,6 +39,14 @@ public class STTServiceStub implements STTService {
 
     private static final String STTSERVICE_STUB_ID = "sttServiceStubID";
     private static final String STTSERVICE_STUB_LABEL = "sttServiceStubLabel";
+
+    private static final String RECOGNIZED_TEXT = "Recognized text";
+    private static final String EXCEPTION_MESSAGE = "STT exception";
+    private static final String ERROR_MESSAGE = "STT error";
+
+    private boolean exceptionExpected;
+    private boolean errorExpected;
+    private boolean recognized;
 
     @Override
     public String getId() {
@@ -61,12 +71,34 @@ public class STTServiceStub implements STTService {
     @Override
     public STTServiceHandle recognize(STTListener sttListener, AudioStream audioStream, Locale locale,
             Set<String> grammars) throws STTException {
-        return new STTServiceHandle() {
-            // this method will not be used in the tests
-            @Override
-            public void abort() {
+        if (exceptionExpected) {
+            throw new STTException(EXCEPTION_MESSAGE);
+        } else {
+            if (errorExpected) {
+                sttListener.sttEventReceived(new SpeechRecognitionErrorEvent(ERROR_MESSAGE));
+            } else {
+                recognized = true;
+                sttListener.sttEventReceived(new SpeechRecognitionEvent(RECOGNIZED_TEXT, 0.75f));
             }
-        };
+            return new STTServiceHandle() {
+                // this method will not be used in the tests
+                @Override
+                public void abort() {
+                }
+            };
+        }
+    }
+
+    public void setExceptionExpected(boolean exceptionExpected) {
+        this.exceptionExpected = exceptionExpected;
+    }
+
+    public void setErrorExpected(boolean errorExpected) {
+        this.errorExpected = errorExpected;
+    }
+
+    public boolean isRecognized() {
+        return recognized;
     }
 
     @Override

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/TTSServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/TTSServiceStub.java
@@ -44,6 +44,7 @@ public class TTSServiceStub implements TTSService {
     private static final String TTS_SERVICE_STUB_LABEL = "ttsServiceStubLabel";
 
     private @Nullable BundleContext context;
+    private String synthesized = "";
 
     public TTSServiceStub() {
     }
@@ -88,6 +89,7 @@ public class TTSServiceStub implements TTSService {
 
     @Override
     public AudioStream synthesize(String text, Voice voice, final AudioFormat requestedFormat) throws TTSException {
+        synthesized = text;
         return new AudioStream() {
 
             @Override
@@ -101,6 +103,10 @@ public class TTSServiceStub implements TTSService {
                 return requestedFormat;
             }
         };
+    }
+
+    public String getSynthesized() {
+        return synthesized;
     }
 
     @Override

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceStub.java
@@ -43,7 +43,6 @@ public class VoiceStub implements Voice {
 
     @Override
     public Locale getLocale() {
-        // we need to return something different from null here (the real value is not important)
-        return Locale.getDefault();
+        return Locale.ENGLISH;
     }
 }

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
@@ -41,7 +41,7 @@ public class InterpretCommandTest extends VoiceConsoleCommandExtensionTest {
     private static final String CONFIG_DEFAULT_VOICE = "defaultVoice";
     private static final String SUBCMD_INTERPRET = "interpret";
     private static final String INTERPRETED_TEXT = "Interpreted text";
-    private static final String EXCEPTION_MESSAGE = "Exception message";
+    private static final String EXCEPTION_MESSAGE = "interpretation exception";
 
     private HumanLanguageInterpreterStub hliStub;
     private VoiceStub voice;
@@ -79,7 +79,7 @@ public class InterpretCommandTest extends VoiceConsoleCommandExtensionTest {
     @Test
     public void verifyThatAnInterpretationExceptionIsHandledProperly() {
         waitForAssert(() -> {
-            hliStub.setIsInterpretationExceptionExpected(true);
+            hliStub.setExceptionExpected(true);
             String[] params = new String[] { SUBCMD_INTERPRET, "text", "to", "be", "interpreted" };
             extensionService.execute(params, console);
             assertThat(console.getPrintedText(), is(EXCEPTION_MESSAGE));

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
@@ -14,15 +14,22 @@ package org.openhab.core.voice.voiceconsolecommandextension;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.voice.internal.SinkStub;
 import org.openhab.core.voice.internal.TTSServiceStub;
 import org.openhab.core.voice.internal.VoiceStub;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * A {@link VoiceConsoleCommandExtensionTest} which tests the execution of the command "voices".
@@ -31,13 +38,25 @@ import org.osgi.framework.BundleContext;
  * @author Velin Yordanov - migrated tests from groovy to java
  */
 public class VoicesCommandTest extends VoiceConsoleCommandExtensionTest {
+    private static final String CONFIG_LANGUAGE = "language";
     private static final String SUBCMD_VOICES = "voices";
+    private LocaleProvider localeProvider;
     private TTSServiceStub ttsService;
     private SinkStub sink;
     private VoiceStub voice;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
+        localeProvider = getService(LocaleProvider.class);
+        assertNotNull(localeProvider);
+
+        Dictionary<String, Object> localeConfig = new Hashtable<>();
+        localeConfig.put(CONFIG_LANGUAGE, Locale.ENGLISH.getLanguage());
+        ConfigurationAdmin configAdmin = super.getService(ConfigurationAdmin.class);
+        Configuration configuration = configAdmin.getFactoryConfiguration("org.openhab.i18n", null);
+        configuration.update(localeConfig);
+        configuration.update();
+
         BundleContext context = bundleContext;
 
         ttsService = new TTSServiceStub(context);
@@ -52,7 +71,7 @@ public class VoicesCommandTest extends VoiceConsoleCommandExtensionTest {
     @Test
     public void testVoicesCommand() {
         String[] command = new String[] { SUBCMD_VOICES };
-        Locale locale = Locale.getDefault();
+        Locale locale = localeProvider.getLocale();
         String expectedText = String.format("* %s - %s - %s (%s)", ttsService.getLabel(locale),
                 voice.getLocale().getDisplayName(locale), voice.getLabel(), voice.getUID());
         extensionService.execute(command, console);


### PR DESCRIPTION
Related to #2688

Updated methods startDialog
New method stopDialog
Null annotations added to the class DialogProcessor

Allow translation of sentences "said" by the dialog processor in case of error

2 console commands added to start and stop a dialog

Enhanced integration tests

Signed-off-by: Laurent Garnier <lg.hc@free.fr>