### PR TITLE
[config] Allow String values for other Types

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
@@ -123,7 +123,18 @@ final class TypeIntrospections {
          * @return true, if the given value can be assigned to the type of this introspection, otherwise false
          */
         boolean isAssignable(Object value) {
-            return clazz.isAssignableFrom(value.getClass());
+            return clazz.isAssignableFrom(value.getClass()) || isStringInstance(value);
+        }
+
+        /**
+         * Returns true, if the given value is a string, otherwise false.
+         *
+         * @param value the value to be analyzed
+         *
+         * @return true, if the given value is a string, otherwise false
+         */
+        final boolean isStringInstance(Object value) {
+            return value instanceof String;
         }
 
         /**

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -44,6 +44,8 @@ import org.openhab.core.config.core.validation.ConfigValidationException;
 import org.openhab.core.config.core.validation.ConfigValidationMessage;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Testing the {@link ConfigDescriptionValidator}.
@@ -52,6 +54,8 @@ import org.osgi.framework.BundleContext;
  * @author Wouter Born - Migrate tests from Groovy to Java
  */
 public class ConfigDescriptionValidatorTest {
+
+    private final Logger logger = LoggerFactory.getLogger(ConfigDescriptionValidatorTest.class);
 
     private static final int MIN_VIOLATED = 1;
     private static final int MAX_VIOLATED = 1234;
@@ -187,6 +191,14 @@ public class ConfigDescriptionValidatorTest {
 
     @Test
     public void assertValidationThrowsNoExceptionForValidConfigParameters() {
+        configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI);
+    }
+
+    @Test
+    public void assertValidationThrowsNoExceptionForValidStringConfigParameters() {
+        params.put(BOOL_PARAM_NAME, "true");
+        params.put(INT_PARAM_NAME, "1");
+        params.put(DECIMAL_PARAM_NAME, "1.0");
         configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI);
     }
 


### PR DESCRIPTION
- Allow String values for other Types

To not introduce regressions after #2682 on the type validation we should allow `String` values for all parameter types.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>