### PR TITLE
[config] make configuration value parser available for export

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -45,6 +45,8 @@ public final class ConfigParser {
             "double", Double.class, //
             "long", Long.class, //
             "int", Integer.class, //
+            "short", Short.class, //
+            "byte", Byte.class, //
             "boolean", Boolean.class);
 
     private ConfigParser() {
@@ -70,7 +72,8 @@ public final class ConfigParser {
      * @return The configuration holder object. All fields that matched a configuration option are set. If a required
      *         field is not set, null is returned.
      */
-    public static <T> @Nullable T configurationAs(Map<String, Object> properties, Class<T> configurationClass) {
+    public static <T> @Nullable T configurationAs(Map<String, @Nullable Object> properties,
+            Class<T> configurationClass) {
         T configuration;
         try {
             configuration = configurationClass.getConstructor().newInstance();
@@ -142,14 +145,14 @@ public final class ConfigParser {
     }
 
     /**
-     * Convert a value to a given type
+     * Convert a value to a given type or return default value
      *
      * @param value input value or String representation of that value
      * @param type desired target class
      * @param defaultValue default value to be used if conversion fails or input value is null
      * @return the converted value
      */
-    public static <T> T valueAs(@Nullable Object value, Class<T> type, T defaultValue) {
+    public static <T> T valueAsOrElse(@Nullable Object value, Class<T> type, T defaultValue) {
         return Objects.requireNonNullElse(valueAs(value, type), defaultValue);
     }
 
@@ -177,17 +180,27 @@ public final class ConfigParser {
                 result = bdValue.longValue();
             } else if (Integer.class.equals(typeClass)) {
                 result = bdValue.intValue();
+            } else if (Short.class.equals(typeClass)) {
+                result = bdValue.shortValue();
+            } else if (Byte.class.equals(typeClass)) {
+                result = bdValue.byteValue();
             }
         } else if (value instanceof Number) {
             Number number = (Number) value;
-            if (Long.class.equals(typeClass)) {
+            if (Float.class.equals(typeClass)) {
+                result = number.floatValue();
+            } else if (Double.class.equals(typeClass)) {
+                result = number.doubleValue();
+            } else if (Long.class.equals(typeClass)) {
                 result = number.longValue();
             } else if (Integer.class.equals(typeClass)) {
                 result = number.intValue();
-            } else if (Double.class.equals(typeClass)) {
-                result = number.doubleValue();
-            } else if (Float.class.equals(typeClass)) {
-                result = number.floatValue();
+            } else if (Short.class.equals(typeClass)) {
+                result = number.shortValue();
+            } else if (Byte.class.equals(typeClass)) {
+                result = number.byteValue();
+            } else if (BigDecimal.class.equals(typeClass)) {
+                result = new BigDecimal(number.toString());
             }
         } else if (value instanceof String && !String.class.equals(typeClass)) {
             // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean
@@ -198,10 +211,14 @@ public final class ConfigParser {
                 result = Double.valueOf(strValue);
             } else if (Long.class.equals(typeClass)) {
                 result = Long.valueOf(strValue);
-            } else if (BigDecimal.class.equals(typeClass)) {
-                result = new BigDecimal(strValue);
             } else if (Integer.class.equals(typeClass)) {
                 result = Integer.valueOf(strValue);
+            } else if (Short.class.equals(typeClass)) {
+                result = Short.valueOf(strValue);
+            } else if (Byte.class.equals(typeClass)) {
+                result = Byte.valueOf(strValue);
+            } else if (BigDecimal.class.equals(typeClass)) {
+                result = new BigDecimal(strValue);
             } else if (Boolean.class.equals(typeClass)) {
                 result = Boolean.valueOf(strValue);
             } else if (type.isEnum()) {
@@ -214,6 +231,9 @@ public final class ConfigParser {
 
         if (result != null && typeClass.isAssignableFrom(result.getClass())) {
             return (T) result;
+        } else if (value != null) {
+            LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed. Returning null", value,
+                    value.getClass(), type);
         }
 
         return null;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -173,21 +173,32 @@ public final class ConfigParser {
             } else if (Integer.class.equals(typeClass)) {
                 result = bdValue.intValue();
             }
+        } else if (value instanceof Number) {
+            Number number = (Number) value;
+            if (Long.class.equals(typeClass)) {
+                result = number.longValue();
+            } else if (Integer.class.equals(typeClass)) {
+                result = number.intValue();
+            } else if (Double.class.equals(typeClass)) {
+                result = number.doubleValue();
+            } else if (Float.class.equals(typeClass)) {
+                result = number.floatValue();
+            }
         } else if (value instanceof String && !String.class.equals(typeClass)) {
             // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean
-            String bdValue = (String) value;
+            String strValue = (String) value;
             if (Float.class.equals(typeClass)) {
-                result = Float.valueOf(bdValue);
+                result = Float.valueOf(strValue);
             } else if (Double.class.equals(typeClass)) {
-                result = Double.valueOf(bdValue);
+                result = Double.valueOf(strValue);
             } else if (Long.class.equals(typeClass)) {
-                result = Long.valueOf(bdValue);
+                result = Long.valueOf(strValue);
             } else if (BigDecimal.class.equals(typeClass)) {
-                result = new BigDecimal(bdValue);
+                result = new BigDecimal(strValue);
             } else if (Integer.class.equals(typeClass)) {
-                result = Integer.valueOf(bdValue);
+                result = Integer.valueOf(strValue);
             } else if (Boolean.class.equals(typeClass)) {
-                result = Boolean.valueOf(bdValue);
+                result = Boolean.valueOf(strValue);
             } else if (type.isEnum()) {
                 final Class<? extends Enum> enumType = (Class<? extends Enum>) typeClass;
                 result = Enum.valueOf(enumType, value.toString());

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -175,6 +175,11 @@ public final class ConfigParser {
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T> @Nullable T valueAs(@Nullable Object value, Class<T> type) {
+        if (value == null || type.isAssignableFrom(value.getClass())) {
+            // exit early if value is null or type is already compatible
+            return (T) value;
+        }
+
         // make sure primitives are converted to their respective wrapper class
         Class<?> typeClass = WRAPPER_CLASSES_MAP.getOrDefault(type.getSimpleName(), type);
 
@@ -243,10 +248,10 @@ public final class ConfigParser {
 
         if (result != null && typeClass.isAssignableFrom(result.getClass())) {
             return (T) result;
-        } else if (value != null) {
-            LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed. Returning null", value,
-                    value.getClass(), type);
         }
+
+        LOGGER.warn("Conversion of value '{}' with type '{}' to '{}' failed. Returning null", value, value.getClass(),
+                type);
 
         return null;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -101,7 +101,7 @@ public final class ConfigParser {
                 continue;
             }
 
-            // Allows to have List<int>, List<Double>, List<String> etc (and the corresponding Set<?>
+            // Allows to have List<int>, List<Double>, List<String> etc (and the corresponding Set<?>)
             if (value instanceof Collection) {
                 Class<?> innerClass = (Class<?>) ((ParameterizedType) field.getGenericType())
                         .getActualTypeArguments()[0];

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -102,8 +102,10 @@ public final class ConfigParser {
                         .getActualTypeArguments()[0];
                 final List<Object> lst = new ArrayList<>(c.size());
                 for (final Object it : c) {
-                    // the null check is done above
-                    final Object normalized = Objects.requireNonNull(valueAs(it, innerClass));
+                    final Object normalized = valueAs(it, innerClass);
+                    if (normalized == null) {
+                        continue;
+                    }
                     lst.add(normalized);
                 }
                 value = lst;
@@ -111,6 +113,9 @@ public final class ConfigParser {
 
             try {
                 value = valueAs(value, type);
+                if (value == null) {
+                    continue;
+                }
                 LOGGER.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
                         value, fieldName, configurationClass.getName());
                 field.setAccessible(true);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -62,7 +62,7 @@ public final class ConfigParser {
      * <pre>
      * {@code
      *   public void modified(Map<String, Object> properties) {
-     *     YourConfig config = ConfigMapper.as(properties, YourConfig.class);
+     *     YourConfig config = ConfigParser.configurationAs(properties, YourConfig.class);
      *   }
      * }
      * </pre>
@@ -160,7 +160,7 @@ public final class ConfigParser {
      * @param value input value or String representation of that value
      * @param type desired target class
      * @param defaultValue default value to be used if conversion fails or input value is null
-     * @return the converted value
+     * @return the converted value or the default value if value is null or conversion fails
      */
     public static <T> T valueAsOrElse(@Nullable Object value, Class<T> type, T defaultValue) {
         return Objects.requireNonNullElse(valueAs(value, type), defaultValue);
@@ -184,23 +184,8 @@ public final class ConfigParser {
         Class<?> typeClass = WRAPPER_CLASSES_MAP.getOrDefault(type.getSimpleName(), type);
 
         Object result = value;
-        // Handle the conversion case of BigDecimal to Float,Double,Long,Integer
-        if (value instanceof BigDecimal && !BigDecimal.class.equals(typeClass)) {
-            BigDecimal bdValue = (BigDecimal) value;
-            if (Float.class.equals(typeClass)) {
-                result = bdValue.floatValue();
-            } else if (Double.class.equals(typeClass)) {
-                result = bdValue.doubleValue();
-            } else if (Long.class.equals(typeClass)) {
-                result = bdValue.longValue();
-            } else if (Integer.class.equals(typeClass)) {
-                result = bdValue.intValue();
-            } else if (Short.class.equals(typeClass)) {
-                result = bdValue.shortValue();
-            } else if (Byte.class.equals(typeClass)) {
-                result = bdValue.byteValue();
-            }
-        } else if (value instanceof Number) {
+        // Handle the conversion case of Number to Float,Double,Long,Integer,Short,Byte,BigDecimal
+        if (value instanceof Number) {
             Number number = (Number) value;
             if (Float.class.equals(typeClass)) {
                 result = number.floatValue();

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.config.core.internal.ConfigMapper;
 
 /**
  * This class is a wrapper for configuration settings of {@link Thing}s.
@@ -41,7 +40,7 @@ public class Configuration {
     private final Map<String, Object> properties;
 
     public Configuration() {
-        this(emptyMap(), true);
+        this(Map.of(), true);
     }
 
     /**
@@ -53,7 +52,7 @@ public class Configuration {
      * @param configuration the configuration that should be cloned (may be null)
      */
     public Configuration(final @Nullable Configuration configuration) {
-        this(configuration == null ? emptyMap() : configuration.properties, true);
+        this(configuration == null ? Map.of() : configuration.properties, true);
     }
 
     /**
@@ -62,7 +61,7 @@ public class Configuration {
      * @param properties the properties the configuration should be filled. If null, an empty configuration is created.
      */
     public Configuration(@Nullable Map<String, Object> properties) {
-        this(properties == null ? emptyMap() : properties, false);
+        this(properties == null ? Map.of() : properties, false);
     }
 
     /**
@@ -77,7 +76,7 @@ public class Configuration {
 
     public <T> T as(Class<T> configurationClass) {
         synchronized (properties) {
-            return ConfigMapper.as(properties, configurationClass);
+            return ConfigParser.configurationAs(properties, configurationClass);
         }
     }
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.config.core;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -76,8 +77,11 @@ public class ConfigParserTest {
             // Enum
             new TestParameter<>("ENUM1", TestEnum.class, TestEnum.ENUM1), //
             // List
-            new TestParameter<>(List.of(1, 2, 3), List.class, List.of(1, 2, 3)), //
-            new TestParameter<>(List.of("1", "2", "3"), List.class, List.of("1", "2", "3")),
+            new TestParameter<>("1", List.class, List.of("1")), //
+            new TestParameter<>(List.of(1, 2, 3), List.class, List.of(1, 2, 3)),
+            // Set
+            new TestParameter<>("1", Set.class, Set.of("1")), //
+            new TestParameter<>(Set.of(1, 2, 3), Set.class, Set.of(1, 2, 3)), //
             // illegal conversion
             new TestParameter<>(1, Boolean.class, null), //
             // null input

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -71,7 +71,7 @@ public class ConfigParserTest {
             // BigDecimal
             new TestParameter<>("7.5", BigDecimal.class, BigDecimal.valueOf(7.5)), //
             new TestParameter<>(BigDecimal.valueOf(-7.5), BigDecimal.class, BigDecimal.valueOf(-7.5)), //
-            new TestParameter<>(1, BigDecimal.class, BigDecimal.valueOf(1)), //
+            new TestParameter<>(1, BigDecimal.class, BigDecimal.ONE), //
             // String
             new TestParameter<>("foo", String.class, "foo"), //
             // Enum

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.core;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The {@link ConfigParserTest} contains tests for the {@link ConfigParser}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class ConfigParserTest {
+
+    private static final List<TestParameter<?>> TEST_PARAMETERS = List.of( //
+            // int/Integer
+            new TestParameter<>("1", int.class, 1), //
+            new TestParameter<>("-1", Integer.class, -1), //
+            new TestParameter<>(-1, int.class, -1), //
+            new TestParameter<>(1, Integer.class, 1), //
+            // long/Long
+            new TestParameter<>("1", long.class, 1L), //
+            new TestParameter<>("-1", Long.class, -1L), //
+            new TestParameter<>(-1, long.class, -1L), //
+            new TestParameter<>(1, Long.class, 1L), //
+            // double/Double
+            new TestParameter<>("7.5", double.class, 7.5), //
+            new TestParameter<>("-7.5", Double.class, -7.5), //
+            new TestParameter<>(-7.5, double.class, -7.5), //
+            new TestParameter<>(7.5, Double.class, 7.5), //
+            // float/Float
+            new TestParameter<>("7.5", float.class, 7.5f), //
+            new TestParameter<>("-7.5", Float.class, -7.5f), //
+            new TestParameter<>(-7.5, float.class, -7.5f), //
+            new TestParameter<>(7.5, Float.class, 7.5f), //
+            // boolean/Boolean
+            new TestParameter<>("true", boolean.class, true), //
+            new TestParameter<>("true", Boolean.class, true), //
+            new TestParameter<>(false, boolean.class, false), //
+            new TestParameter<>(false, Boolean.class, false), //
+            // BigDecimal
+            new TestParameter<>("7.5", BigDecimal.class, BigDecimal.valueOf(7.5)), //
+            new TestParameter<>(BigDecimal.valueOf(-7.5), BigDecimal.class, BigDecimal.valueOf(-7.5)), //
+            // String
+            new TestParameter<>("foo", String.class, "foo"), //
+            // Enum
+            new TestParameter<>("ENUM1", TestEnum.class, TestEnum.ENUM1), //
+            // List
+            new TestParameter<>(List.of(1, 2, 3), List.class, List.of(1, 2, 3)), //
+            new TestParameter<>(List.of("1", "2", "3"), List.class, List.of("1", "2", "3")),
+            // illegal conversion
+            new TestParameter<>(1, Boolean.class, null), //
+            // null input
+            new TestParameter<>(null, Object.class, null) //
+    );
+
+    @SuppressWarnings("unused")
+    private static Stream<TestParameter<?>> valueAsTest() {
+        return TEST_PARAMETERS.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void valueAsTest(TestParameter<?> parameter) {
+        Object result = ConfigParser.valueAs(parameter.input, parameter.type);
+        Assertions.assertEquals(parameter.result, result, "Failed equals: " + parameter);
+    }
+
+    @Test
+    public void valueAsDefaultTest() {
+        Object result = ConfigParser.valueAs(null, String.class, "foo");
+        Assertions.assertEquals("foo", result);
+    }
+
+    private enum TestEnum {
+        ENUM1
+    }
+
+    private static class TestParameter<T> {
+        public final @Nullable Object input;
+        public final Class<T> type;
+        public final @Nullable T result;
+
+        public TestParameter(@Nullable Object input, Class<T> type, @Nullable T result) {
+            this.input = input;
+            this.type = type;
+            this.result = result;
+        }
+
+        @Override
+        public String toString() {
+            return "TestParameter{input=" + input + ", type=" + type + ", result=" + result + "}";
+        }
+    }
+}

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -32,26 +32,36 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ConfigParserTest {
 
     private static final List<TestParameter<?>> TEST_PARAMETERS = List.of( //
-            // int/Integer
-            new TestParameter<>("1", int.class, 1), //
-            new TestParameter<>("-1", Integer.class, -1), //
-            new TestParameter<>(-1, int.class, -1), //
-            new TestParameter<>(1, Integer.class, 1), //
-            // long/Long
-            new TestParameter<>("1", long.class, 1L), //
-            new TestParameter<>("-1", Long.class, -1L), //
-            new TestParameter<>(-1, long.class, -1L), //
-            new TestParameter<>(1, Long.class, 1L), //
-            // double/Double
-            new TestParameter<>("7.5", double.class, 7.5), //
-            new TestParameter<>("-7.5", Double.class, -7.5), //
-            new TestParameter<>(-7.5, double.class, -7.5), //
-            new TestParameter<>(7.5, Double.class, 7.5), //
             // float/Float
             new TestParameter<>("7.5", float.class, 7.5f), //
             new TestParameter<>("-7.5", Float.class, -7.5f), //
             new TestParameter<>(-7.5, float.class, -7.5f), //
             new TestParameter<>(7.5, Float.class, 7.5f), //
+            // double/Double
+            new TestParameter<>("7.5", double.class, 7.5), //
+            new TestParameter<>("-7.5", Double.class, -7.5), //
+            new TestParameter<>(-7.5, double.class, -7.5), //
+            new TestParameter<>(7.5, Double.class, 7.5), //
+            // long/Long
+            new TestParameter<>("1", long.class, 1L), //
+            new TestParameter<>("-1", Long.class, -1L), //
+            new TestParameter<>(-1, long.class, -1L), //
+            new TestParameter<>(1, Long.class, 1L), //
+            // int/Integer
+            new TestParameter<>("1", int.class, 1), //
+            new TestParameter<>("-1", Integer.class, -1), //
+            new TestParameter<>(-1, int.class, -1), //
+            new TestParameter<>(1, Integer.class, 1), //
+            // short/Short
+            new TestParameter<>("1", short.class, (short) 1), //
+            new TestParameter<>("-1", Short.class, (short) -1), //
+            new TestParameter<>(-1, short.class, (short) -1), //
+            new TestParameter<>(1, Short.class, (short) 1), //
+            // byte/Byte
+            new TestParameter<>("1", byte.class, (byte) 1), //
+            new TestParameter<>("-1", Byte.class, (byte) -1), //
+            new TestParameter<>(-1, byte.class, (byte) -1), //
+            new TestParameter<>(1, Byte.class, (byte) 1), //
             // boolean/Boolean
             new TestParameter<>("true", boolean.class, true), //
             new TestParameter<>("true", Boolean.class, true), //
@@ -60,6 +70,7 @@ public class ConfigParserTest {
             // BigDecimal
             new TestParameter<>("7.5", BigDecimal.class, BigDecimal.valueOf(7.5)), //
             new TestParameter<>(BigDecimal.valueOf(-7.5), BigDecimal.class, BigDecimal.valueOf(-7.5)), //
+            new TestParameter<>(1, BigDecimal.class, BigDecimal.valueOf(1)), //
             // String
             new TestParameter<>("foo", String.class, "foo"), //
             // Enum
@@ -87,7 +98,7 @@ public class ConfigParserTest {
 
     @Test
     public void valueAsDefaultTest() {
-        Object result = ConfigParser.valueAs(null, String.class, "foo");
+        Object result = ConfigParser.valueAsOrElse(null, String.class, "foo");
         Assertions.assertEquals("foo", result);
     }
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test;
  * @author Dennis Nobel - Initial contribution
  * @author Wouter Born - Migrate tests from Groovy to Java
  */
+@NonNullByDefault
 public class ConfigurationTest {
 
     public static class ConfigClass {
@@ -44,14 +47,15 @@ public class ConfigurationTest {
         public int intField;
         public boolean booleanField;
         public String stringField = "somedefault";
-        public List<String> listField;
+        public @NonNullByDefault({}) List<String> listField;
+        public @NonNullByDefault({}) Set<String> setField;
         @SuppressWarnings("unused")
         private static final String CONSTANT = "SOME_CONSTANT";
     }
 
     public static class ExtendedConfigClass extends ConfigClass {
         public int additionalIntField;
-        public String listField;
+        public @NonNullByDefault({}) String listField;
     }
 
     @Test
@@ -62,6 +66,7 @@ public class ConfigurationTest {
         configuration.put("stringField", "test");
         configuration.put("enumField", "ON");
         configuration.put("listField", List.of("one", "two", "three"));
+        configuration.put("setField", List.of("one", "two", "three"));
         configuration.put("notExisitingProperty", true);
 
         ConfigClass configClass = configuration.as(ConfigClass.class);
@@ -71,6 +76,7 @@ public class ConfigurationTest {
         assertThat(configClass.stringField, is("test"));
         assertThat(configClass.enumField, is(ConfigClass.MyEnum.ON));
         assertThat(configClass.listField, is(hasItems("one", "two", "three")));
+        assertThat(configClass.setField, is(hasItems("one", "two", "three")));
     }
 
     @Test
@@ -143,7 +149,7 @@ public class ConfigurationTest {
 
     @Test
     public void assertToStringHandlesNullValuesGracefully() {
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, @Nullable Object> properties = new HashMap<>();
         properties.put("stringField", null);
 
         Configuration configuration = new Configuration(properties);


### PR DESCRIPTION
Closes #2700 

Some points are still open:

- If a conversion is not possible (e.g. provided value is `"foo"` and desired type is `int`), shall we return `null` or throw an `IllegalArgumentException` (or better a newly defined checked `ConfigValueParserException`)?
- Currently `float`, `int`, `long` and `double` (and their wrapper classes) are supported. Shall we add code for `short`, `byte` and `char`?
- There is no support for arrays. Is that needed?
- All `Collections` are mapped to `List`. Shall we at least add `Set`?
- 