### PR TITLE
Script Engines now removed from manager when closed

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -198,7 +198,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
 
     @Override
     public void removeEngine(String engineIdentifier) {
-        ScriptEngineContainer container = loadedScriptEngineInstances.get(engineIdentifier);
+        ScriptEngineContainer container = loadedScriptEngineInstances.remove(engineIdentifier);
         if (container != null) {
             ScriptEngine scriptEngine = container.getScriptEngine();
             if (scriptEngine instanceof Invocable) {


### PR DESCRIPTION
Remove script engines from managed once they are closed. It looks like this is a longstanding bug that was only recently uncovered by https://github.com/openhab/openhab-core/pull/2681.

Signed-off-by: Jonathan Gilbert <jpg@trillica.com>