### PR TITLE
[config] Enable config validation for updates by handler

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -407,11 +407,8 @@ public abstract class BaseThingHandler implements ThingHandler {
             return;
         }
         synchronized (this) {
-            if (this.callback != null) {
-                this.thing = thing;
-                this.callback.thingUpdated(thing);
-            } else {
-            }
+            this.thing = thing;
+            callback.thingUpdated(thing);
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -404,6 +404,8 @@ public abstract class BaseThingHandler implements ThingHandler {
         }
         try {
             callback.validateConfigurationParameters(thing, thing.getConfiguration().getProperties());
+            thing.getChannels().forEach(channel -> callback.validateConfigurationParameters(channel,
+                    channel.getConfiguration().getProperties()));
         } catch (ConfigValidationException e) {
             logger.warn(
                     "Attempt to update thing '{}' with a thing containing invalid configuration '{}', blocked. This is most likely a bug.",

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -384,6 +384,10 @@ public abstract class BaseThingHandler implements ThingHandler {
      * Informs the framework, that a thing was updated. This method must be called after the configuration or channels
      * was changed.
      *
+     * Any method overriding this method has to make sure that only things with valid configurations are passed to the
+     * callback. This can be achieved by calling
+     * {@link ThingHandlerCallback#validateConfigurationParameters(Thing, Map)}.
+     * 
      * @param thing thing, that was updated and should be persisted
      */
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
@@ -426,6 +430,9 @@ public abstract class BaseThingHandler implements ThingHandler {
     /**
      * Updates the configuration of the thing and informs the framework about it.
      *
+     * Any method overriding this method has to make sure that only valid configurations are passed to the callback.
+     * This can be achieved by calling {@link ThingHandlerCallback#validateConfigurationParameters(Thing, Map)}.
+     *
      * @param configuration configuration, that was updated and should be persisted
      */
     protected void updateConfiguration(Configuration configuration) {
@@ -459,7 +466,7 @@ public abstract class BaseThingHandler implements ThingHandler {
 
     /**
      * Returns a copy of the properties map, that can be modified. The method {@link
-     * BaseThingHandler#updateProperties(Map<String, String> properties)} must be called to persist the properties.
+     * BaseThingHandler#updateProperties(Map)} must be called to persist the properties.
      *
      * @return copy of the thing properties (not null)
      */

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -25,6 +25,7 @@ import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigValidationException;
 import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -386,7 +387,9 @@ public abstract class BaseThingHandler implements ThingHandler {
      *
      * Any method overriding this method has to make sure that only things with valid configurations are passed to the
      * callback. This can be achieved by calling
-     * {@link ThingHandlerCallback#validateConfigurationParameters(Thing, Map)}.
+     * {@link ThingHandlerCallback#validateConfigurationParameters(Thing, Map)}. It is also necessary to ensure that all
+     * channel configurations are valid by calling
+     * {@link ThingHandlerCallback#validateConfigurationParameters(Channel, Map)}.
      * 
      * @param thing thing, that was updated and should be persisted
      */

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
@@ -83,12 +83,22 @@ public interface ThingHandlerCallback {
     /**
      * Validates the given configuration parameters against the configuration description.
      *
-     * @param thing thing with the updated configuration (must no be null)
+     * @param thing thing with the updated configuration (must not be null)
      * @param configurationParameters the configuration parameters to be validated
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
     void validateConfigurationParameters(Thing thing, Map<String, Object> configurationParameters);
+
+    /**
+     * Validates the given configuration parameters against the configuration description.
+     *
+     * @param channel channel with the updated configuration (must not be null)
+     * @param configurationParameters the configuration parameters to be validated
+     * @throws ConfigValidationException if one or more of the given configuration parameters do not match
+     *             their declarations in the configuration description
+     */
+    void validateConfigurationParameters(Channel channel, Map<String, Object> configurationParameters);
 
     /**
      * Informs about an updated configuration of a thing.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -292,6 +292,14 @@ public class ThingManagerImpl
         }
 
         @Override
+        public void validateConfigurationParameters(Channel channel, Map<String, Object> configurationParameters) {
+            ChannelType channelType = channelTypeRegistry.getChannelType(channel.getChannelTypeUID());
+            if (channelType != null && channelType.getConfigDescriptionURI() != null) {
+                configDescriptionValidator.validate(configurationParameters, channelType.getConfigDescriptionURI());
+            }
+        }
+
+        @Override
         public void configurationUpdated(Thing thing) {
             if (!ThingHandlerHelper.isHandlerInitialized(thing)) {
                 initializeHandler(thing);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -556,13 +556,7 @@ public class ThingManagerImpl
             // called from the thing handler itself, therefore
             // it exists, is initializing/initialized and
             // must not be informed (in order to prevent infinite loops)
-            if (isInitializable(thing, getThingType(thing))) {
-                replaceThing(getThing(thingUID), thing);
-            } else {
-                logger.warn(
-                        "Updating thing/configuration for thing '{}' denied, thing can't be initialized with the provided configuration.",
-                        thingUID);
-            }
+            replaceThing(getThing(thingUID), thing);
         } else {
             Lock lock1 = getLockForThing(thing.getUID());
             try {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -556,8 +556,13 @@ public class ThingManagerImpl
             // called from the thing handler itself, therefore
             // it exists, is initializing/initialized and
             // must not be informed (in order to prevent infinite loops)
-            // we assume the handler knows what he's doing and don't check config validity
-            replaceThing(getThing(thingUID), thing);
+            if (isInitializable(thing, getThingType(thing))) {
+                replaceThing(getThing(thingUID), thing);
+            } else {
+                logger.warn(
+                        "Updating thing/configuration for thing '{}' denied, thing can't be initialized with the provided configuration.",
+                        thingUID);
+            }
         } else {
             Lock lock1 = getLockForThing(thing.getUID());
             try {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -629,13 +629,17 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
 
         SimpleThingHandler handler = (SimpleThingHandler) thing.getHandler();
         assertNotNull(handler);
+        Object parameter = handler.getThing().getConfiguration().get("parameter");
+        assertNotNull(parameter);
+        assertEquals("someValue", parameter);
 
         handler.updateConfiguration(new Configuration(Map.of("parameter", "otherValue")));
-        Object parameter = handler.getThing().getConfiguration().get("parameter");
+        parameter = handler.getThing().getConfiguration().get("parameter");
         assertNotNull(parameter);
         assertEquals("otherValue", parameter);
 
         handler.updateConfiguration(new Configuration(Map.of()));
+        parameter = handler.getThing().getConfiguration().get("parameter");
         // configuration should not change
         assertNotNull(parameter);
         assertEquals("otherValue", parameter);


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/pull/2682#discussion_r795035470

It was assumed that thing handlers only update valid configuration. After merging #2682 it was discovered that this is not true. This PR enables the same validation for updates through the handler. If an invalid configuration or otherwise illegal (not-initializable) thing is detected, the changes are discarded and a warning logged.

Signed-off-by: Jan N. Klug <github@klug.nrw>