### PR TITLE
[javasound/dialogprocessor] Not share mic ref on javasound + close audio streams and use RecognitionStartEvent on dialogprocessor

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -16,7 +16,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.DataLine;
 import javax.sound.sampled.TargetDataLine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -32,6 +31,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kelly Davis - Initial contribution and API
  * @author Kai Kreuzer - Refactored and stabilized
+ * @author Miguel Álvarez - Don't share TargetDataLine
  *
  */
 @NonNullByDefault
@@ -50,11 +50,6 @@ public class JavaSoundAudioSource implements AudioSource {
     private final AudioFormat audioFormat = convertAudioFormat(format);
 
     /**
-     * TargetDataLine for the mic
-     */
-    private @Nullable TargetDataLine microphone;
-
-    /**
      * Constructs a JavaSoundAudioSource
      */
     public JavaSoundAudioSource() {
@@ -63,13 +58,7 @@ public class JavaSoundAudioSource implements AudioSource {
     private TargetDataLine initMicrophone(javax.sound.sampled.AudioFormat format) throws AudioException {
         try {
             TargetDataLine microphone = AudioSystem.getTargetDataLine(format);
-
-            DataLine.Info info = new DataLine.Info(TargetDataLine.class, format);
-            microphone = (TargetDataLine) AudioSystem.getLine(info);
-
             microphone.open(format);
-
-            this.microphone = microphone;
             return microphone;
         } catch (Exception e) {
             throw new AudioException("Error creating the audio input stream.", e);
@@ -81,10 +70,7 @@ public class JavaSoundAudioSource implements AudioSource {
         if (!expectedFormat.isCompatible(audioFormat)) {
             throw new AudioException("Cannot produce streams in format " + expectedFormat);
         }
-        TargetDataLine mic = this.microphone;
-        if (mic == null) {
-            mic = initMicrophone(format);
-        }
+        TargetDataLine mic = initMicrophone(format);
         return new JavaSoundInputStream(mic, audioFormat);
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -95,11 +95,11 @@ public class JavaSoundAudioSource implements AudioSource {
         TargetDataLine microphoneDataLine;
         synchronized (openStreamRefs) {
             microphoneDataLine = this.microphone;
-            openStreamRefs.add(ref);
             if (microphoneDataLine == null) {
                 microphoneDataLine = initMicrophone(format);
                 this.microphone = microphoneDataLine;
             }
+            openStreamRefs.add(ref);
         }
         return new JavaSoundInputStream(microphoneDataLine, audioFormat, () -> {
             synchronized (openStreamRefs) {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
@@ -35,6 +35,7 @@ public class JavaSoundInputStream extends AudioStream {
      */
     private final TargetDataLine input;
     private final AudioFormat format;
+    private final @Nullable JavaSoundInputStreamCloseHandler closeHandler;
 
     /**
      * Constructs a JavaSoundInputStream with the passed input
@@ -42,7 +43,18 @@ public class JavaSoundInputStream extends AudioStream {
      * @param input The mic which data is pulled from
      */
     public JavaSoundInputStream(TargetDataLine input, AudioFormat format) {
+        this(input, format, null);
+    }
+
+    /**
+     * Constructs a JavaSoundInputStream with the passed input and a close handler.
+     *
+     * @param input The mic which data is pulled from
+     */
+    public JavaSoundInputStream(TargetDataLine input, AudioFormat format,
+            @Nullable JavaSoundInputStreamCloseHandler closeHandler) {
         this.format = format;
+        this.closeHandler = closeHandler;
         this.input = input;
         this.input.start();
     }
@@ -74,11 +86,20 @@ public class JavaSoundInputStream extends AudioStream {
 
     @Override
     public void close() throws IOException {
-        input.close();
+        var closeHandler = this.closeHandler;
+        if (closeHandler != null) {
+            closeHandler.onStreamClosed();
+        } else {
+            input.close();
+        }
     }
 
     @Override
     public AudioFormat getFormat() {
         return format;
+    }
+
+    public interface JavaSoundInputStreamCloseHandler {
+        void onStreamClosed();
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -137,7 +137,7 @@ public class DialogProcessor implements KSListener, STTListener {
             streamKS = stream;
             ksServiceHandle = ks.spot(this, stream, locale, keyword);
         } catch (AudioException e) {
-            logger.warn("Error creating the audio stream: {}", e.getMessage());
+            logger.warn("Encountered audio error: {}", e.getMessage());
         } catch (KSException e) {
             logger.warn("Encountered error calling spot: {}", e.getMessage());
             closeStreamKS();
@@ -166,7 +166,7 @@ public class DialogProcessor implements KSListener, STTListener {
             try {
                 stream.close();
             } catch (IOException e) {
-                logger.warn("IOException closing ks audio stream: {}", e.getMessage(), e);
+                logger.debug("IOException closing ks audio stream: {}", e.getMessage(), e);
             }
             streamKS = null;
         }
@@ -187,7 +187,7 @@ public class DialogProcessor implements KSListener, STTListener {
             try {
                 stream.close();
             } catch (IOException e) {
-                logger.warn("IOException closing stt audio stream: {}", e.getMessage(), e);
+                logger.debug("IOException closing stt audio stream: {}", e.getMessage(), e);
             }
             streamSTT = null;
         }
@@ -221,10 +221,8 @@ public class DialogProcessor implements KSListener, STTListener {
                         sttServiceHandle = stt.recognize(this, stream, locale, new HashSet<>());
                     } catch (AudioException e) {
                         logger.warn("Error creating the audio stream: {}", e.getMessage());
-                        toggleProcessing(false);
                     } catch (STTException e) {
                         closeStreamSTT();
-                        toggleProcessing(false);
                         String msg = e.getMessage();
                         String text = i18nProvider.getText(bundle, "error.stt-exception", null, locale);
                         if (msg != null) {


### PR DESCRIPTION
This is a proposed solution for https://github.com/openhab/openhab-core/issues/2702 about the system audio (javasound) returning closed audio streams after the first audio stream is closed. 
Also includes the use of RecognitionStartEvent on the dialog processor to wait for the STT add-on to be ready for toggling the "listening" item, so everything is really ready for the user to start talking.
Hope everything is in place. I have tested this changes with the porcupineKS and googleSTT add-ons.