### PR TITLE
fix recursive membership throws StackOverflowException on REST API call

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.core.io.rest.core.item;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Predicate;
 
@@ -59,11 +61,19 @@ public class EnrichedItemDTOMapper {
     public static EnrichedItemDTO map(Item item, boolean drillDown, @Nullable Predicate<Item> itemFilter,
             @Nullable UriBuilder uriBuilder, @Nullable Locale locale) {
         ItemDTO itemDTO = ItemDTOMapper.map(item);
-        return map(item, itemDTO, uriBuilder, drillDown, itemFilter, locale);
+        return map(item, itemDTO, drillDown, itemFilter, uriBuilder, locale, new ArrayList<>());
     }
 
-    private static EnrichedItemDTO map(Item item, ItemDTO itemDTO, @Nullable UriBuilder uriBuilder, boolean drillDown,
-            @Nullable Predicate<Item> itemFilter, @Nullable Locale locale) {
+    private static EnrichedItemDTO map(Item item, boolean drillDown, @Nullable Predicate<Item> itemFilter,
+            @Nullable UriBuilder uriBuilder, @Nullable Locale locale, List<Item> parents) {
+        ItemDTO itemDTO = ItemDTOMapper.map(item);
+        return map(item, itemDTO, drillDown, itemFilter, uriBuilder, locale, parents);
+    }
+
+    private static EnrichedItemDTO map(Item item, ItemDTO itemDTO, boolean drillDown,
+            @Nullable Predicate<Item> itemFilter, @Nullable UriBuilder uriBuilder, @Nullable Locale locale,
+            List<Item> parents) {
+        parents.add(item);
         String state = item.getState().toFullString();
         String transformedState = considerTransformation(state, item, locale);
         if (transformedState != null && transformedState.equals(state)) {
@@ -86,8 +96,12 @@ public class EnrichedItemDTOMapper {
             if (drillDown) {
                 Collection<EnrichedItemDTO> members = new LinkedHashSet<>();
                 for (Item member : groupItem.getMembers()) {
-                    if (itemFilter == null || itemFilter.test(member)) {
-                        members.add(map(member, drillDown, itemFilter, uriBuilder, locale));
+                    if (parents.contains(member)) {
+                        LOGGER.error(
+                                "Recursive group membership found: {} is both, a direct or indirect parent and a child of {}.",
+                                member.getName(), groupItem.getName());
+                    } else if (itemFilter == null || itemFilter.test(member)) {
+                        members.add(map(member, drillDown, itemFilter, uriBuilder, locale, parents));
                     }
                 }
                 memberDTOs = members.toArray(new EnrichedItemDTO[members.size()]);

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.rest.core.item;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,5 +77,29 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
                 null, null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(1));
+    }
+
+    @Test
+    public void testDirectRecursiveMembershipDoesNotThrowStackOverflowException() {
+        GroupItem groupItem1 = new GroupItem("group1");
+        GroupItem groupItem2 = new GroupItem("group2");
+
+        groupItem1.addMember(groupItem2);
+        groupItem2.addMember(groupItem1);
+
+        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
+    }
+
+    @Test
+    public void testIndirectRecursiveMembershipDoesNotThrowStackOverflowException() {
+        GroupItem groupItem1 = new GroupItem("group1");
+        GroupItem groupItem2 = new GroupItem("group2");
+        GroupItem groupItem3 = new GroupItem("group3");
+
+        groupItem1.addMember(groupItem2);
+        groupItem2.addMember(groupItem3);
+        groupItem3.addMember(groupItem1);
+
+        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
     }
 }


### PR DESCRIPTION
Fixes #2734 

This adds a check if a child is already a parent of the currently processed item in recursive mapping. If a recursion is found an ERROR is logged and the child is not processed.

I chose ERROR because this may cause issues in several components and could potentially affect the system stability.

Signed-off-by: Jan N. Klug <github@klug.nrw>