### PR TITLE
Upgrade XStream to 1.4.19

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -257,7 +257,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.18</version>
+      <version>1.4.19</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -520,7 +520,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.18</version>
+      <version>1.4.19</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -35,7 +35,7 @@
 		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.1</bundle>
 
 		<!-- TODO: Unbundled libraries -->
-		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.18</bundle>
+		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.19</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.binding.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.binding.xml.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.core.binding.xml
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -57,4 +56,5 @@ Fragment-Host: org.openhab.core.binding.xml
 	org.openhab.core.config.core;version='[3.3.0,3.3.1)',\
 	org.openhab.core.config.xml;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -63,4 +62,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.config.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.xml.tests/itest.bndrun
@@ -26,7 +26,6 @@ Fragment-Host: org.openhab.core.config.xml
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -50,4 +49,5 @@ Fragment-Host: org.openhab.core.config.xml
 	org.openhab.core.config.xml;version='[3.3.0,3.3.1)',\
 	org.openhab.core.config.xml.tests;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -34,7 +34,6 @@ feature.openhab-config: \
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -59,4 +58,5 @@ feature.openhab-config: \
 	org.openhab.core.ephemeris;version='[3.3.0,3.3.1)',\
 	org.openhab.core.ephemeris.tests;version='[3.3.0,3.3.1)',\
 	org.openhab.core.test;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -107,5 +107,5 @@ Fragment-Host: org.openhab.core.model.core
 	org.openhab.core.voice;version='[3.3.0,3.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
 	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
-	org.openhab.core.model.persistence.runtime;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	org.openhab.core.model.rule.runtime;version='[3.3.0,3.3.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -105,5 +105,5 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.voice;version='[3.3.0,3.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
 	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
-	org.openhab.core.model.persistence.runtime;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	org.openhab.core.model.rule.runtime;version='[3.3.0,3.3.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -107,6 +107,5 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.voice;version='[3.3.0,3.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
 	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
-	org.openhab.core.model.persistence.runtime;version='[3.3.0,3.3.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -107,5 +107,5 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.voice;version='[3.3.0,3.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
 	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
-	org.openhab.core.model.persistence.runtime;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	org.openhab.core.model.rule.runtime;version='[3.3.0,3.3.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.client;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
@@ -118,5 +117,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.voice;version='[3.3.0,3.3.1)',\
 	org.apache.xbean.bundleutils;version='[4.20.0,4.20.1)',\
 	org.apache.xbean.finder;version='[4.20.0,4.20.1)',\
-	org.openhab.core.model.persistence.runtime;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	org.openhab.core.model.rule.runtime;version='[3.3.0,3.3.1)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -33,7 +33,6 @@ Fragment-Host: org.openhab.core.thing
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
 	org.apache.felix.configadmin;version='[1.9.22,1.9.23)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -65,4 +64,5 @@ Fragment-Host: org.openhab.core.thing
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.tests;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/itests/org.openhab.core.thing.xml.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.xml.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	xstream;version='[1.4.18,1.4.19)',\
 	org.eclipse.jetty.http;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.io;version='[9.4.43,9.4.44)',\
 	org.eclipse.jetty.security;version='[9.4.43,9.4.44)',\
@@ -56,4 +55,5 @@ Fragment-Host: org.openhab.core.thing.xml
 	org.openhab.core.thing;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.xml;version='[3.3.0,3.3.1)',\
 	org.openhab.core.thing.xml.tests;version='[3.3.0,3.3.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.0.14,2.0.15)',\
+	xstream;version='[1.4.19,1.4.20)'

--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.18</version>
+      <version>1.4.19</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
This addresses CVE-2021-43859, see:

https://x-stream.github.io/changes.html

---

Replaces #2721, #2722, #2737