### PR TITLE
[discovery] keep format of thing properties

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.config.discovery;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -51,7 +52,7 @@ public interface DiscoveryResult {
      *
      * @return the Thing ID
      */
-    public ThingUID getThingUID();
+    ThingUID getThingUID();
 
     /**
      * Returns the unique {@code Thing} type ID of this result object.
@@ -61,7 +62,7 @@ public interface DiscoveryResult {
      *
      * @return the unique Thing type
      */
-    public ThingTypeUID getThingTypeUID();
+    ThingTypeUID getThingTypeUID();
 
     /**
      * Returns the binding ID of this result object.
@@ -70,7 +71,7 @@ public interface DiscoveryResult {
      *
      * @return the binding ID
      */
-    public String getBindingId();
+    String getBindingId();
 
     /**
      * Returns the properties of this result object.<br>
@@ -80,7 +81,7 @@ public interface DiscoveryResult {
      *
      * @return the properties (could be empty)
      */
-    public Map<String, Object> getProperties();
+    Map<String, Object> getProperties();
 
     /**
      * Returns the representation property of this result object.
@@ -92,7 +93,8 @@ public interface DiscoveryResult {
      *
      * @return the representation property
      */
-    public @Nullable String getRepresentationProperty();
+    @Nullable
+    String getRepresentationProperty();
 
     /**
      * Returns the flag of this result object.<br>
@@ -103,33 +105,44 @@ public interface DiscoveryResult {
      *
      * @return the flag
      */
-    public DiscoveryResultFlag getFlag();
+    DiscoveryResultFlag getFlag();
 
     /**
      * Returns the human readable label for this result object.
      *
      * @return the human readable label (could be empty)
      */
-    public String getLabel();
+    String getLabel();
 
     /**
      * Returns the unique {@link Bridge} ID of this result object.
      *
      * @return the unique Bridge ID
      */
-    public @Nullable ThingUID getBridgeUID();
+    @Nullable
+    ThingUID getBridgeUID();
 
     /**
      * Returns the timestamp of this result object.
      *
      * @return timestamp as long
      */
-    public long getTimestamp();
+    long getTimestamp();
 
     /**
      * Returns the time to live in seconds for this entry.
      *
      * @return time to live in seconds
      */
-    public long getTimeToLive();
+    long getTimeToLive();
+
+    /**
+     * Normalizes non-configuration properties by converting them to a String.
+     * Properties in the list passed to this method remain unchanged.
+     *
+     * @param configurationParameters a {@link List} containing the names of configuration parameters
+     */
+    default void normalizePropertiesOnConfigDescription(List<String> configurationParameters) {
+        // do nothing - optional
+    }
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -14,7 +14,9 @@ package org.openhab.core.config.discovery.internal;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -160,6 +162,17 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         }
     }
 
+    @Override
+    public void normalizePropertiesOnConfigDescription(List<String> configurationParameters) {
+        properties = properties.entrySet().stream().map(e -> {
+            if (!configurationParameters.contains(e.getKey())) {
+                return Map.entry(e.getKey(), String.valueOf(e.getValue()));
+            } else {
+                return e;
+            }
+        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     /**
      * Sets the flag of this result object.<br>
      * The flag signals e.g. if the result is {@link DiscoveryResultFlag#NEW} or has been marked as
@@ -167,7 +180,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * case the result object should be regarded as known by the system so that
      * further processing should be skipped.
      * <p>
-     * If the specified flag is {@code null}, {@link DiscoveryResultFlag.NEW} is set by default.
+     * If the specified flag is {@code null}, {@link DiscoveryResultFlag#NEW} is set by default.
      *
      * @param flag the flag of this result object to be set
      */

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -18,8 +18,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.math.BigDecimal;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -103,43 +104,10 @@ public class PersistentInboxTest {
     }
 
     @Test
-    public void testConfigUpdateNormalizationGuessTypeManagedThing() {
-        Configuration config = new Configuration(Map.of("foo", 1));
-        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
-
-        when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);
-        when(thingProviderMock.get(eq(THING_UID))).thenReturn(thing);
-
-        assertTrue(thing.getConfiguration().get("foo") instanceof BigDecimal);
-
-        inbox.activate();
-        inbox.add(DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build());
-
-        assertTrue(thing.getConfiguration().get("foo") instanceof BigDecimal);
-        // thing updated if managed
-        assertEquals(new BigDecimal(3), thing.getConfiguration().get("foo"));
-    }
-
-    @Test
-    public void testConfigUpdateNormalizationGuessTypeUnmanagedThing() {
-        Configuration config = new Configuration(Map.of("foo", 1));
-        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
-
-        when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);
-
-        assertTrue(thing.getConfiguration().get("foo") instanceof BigDecimal);
-
-        inbox.activate();
-        inbox.add(DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build());
-
-        assertTrue(thing.getConfiguration().get("foo") instanceof BigDecimal);
-        // thing not updated if unmanaged
-        assertEquals(new BigDecimal(1), thing.getConfiguration().get("foo"));
-    }
-
-    @Test
-    public void testConfigUpdateNormalizationWithConfigDescriptionManagedThing() {
-        Configuration config = new Configuration(Map.of("foo", "1"));
+    public void testConfigUpdateNormalizationWithConfigDescription() throws URISyntaxException {
+        Map<String, Object> props = new HashMap<>();
+        props.put("foo", "1");
+        Configuration config = new Configuration(props);
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);


### PR DESCRIPTION
Fixes #1098 

This fixes the reported problem with thing properties having a wrong representation. When adding a thing to the `PersistentInbox` the config description is retrieved and all non-configuration properties are converted to `String`. Properties with the same name as a configuration parameter stay unchanged.

There is one thing to consider:

The implementation relies on a config description being available. This is currently not enforced as it breaks a lot of tests for the persistent inbox. IMO it would be ok to not accept discovery results if the thing-type is missing in the registry or the config-description is not available. 