### PR TITLE
Fix WatchQueueReader cancelling jobs too early

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
@@ -268,16 +268,16 @@ public class WatchQueueReader implements Runnable {
                         }
                         if (services != null) {
                             File f = resolvedPath.toFile();
-                            if (kind == ENTRY_MODIFY && f.isDirectory()) {
+                            if (ENTRY_MODIFY.equals(kind) && f.isDirectory()) {
                                 logger.trace("Skipping modification event for directory: {}", f);
                             } else {
-                                if (kind == ENTRY_MODIFY) {
+                                if (ENTRY_MODIFY.equals(kind)) {
                                     processModificationEvent(key, event, resolvedPath, services);
                                 } else {
                                     services.forEach(s -> s.processWatchEvent(event, kind, resolvedPath));
                                 }
                             }
-                            if (kind == ENTRY_CREATE && f.isDirectory()) {
+                            if (ENTRY_CREATE.equals(kind) && f.isDirectory()) {
                                 for (AbstractWatchService service : services) {
                                     if (service.watchSubDirectories()
                                             && service.getWatchEventKinds(resolvedPath) != null) {
@@ -285,7 +285,7 @@ public class WatchQueueReader implements Runnable {
                                                 resolvedPath);
                                     }
                                 }
-                            } else if (kind == ENTRY_DELETE) {
+                            } else if (ENTRY_DELETE.equals(kind)) {
                                 synchronized (this) {
                                     WatchKey toCancel = null;
                                     for (Map.Entry<WatchKey, Path> entry : registeredKeys.entrySet()) {
@@ -350,7 +350,7 @@ public class WatchQueueReader implements Runnable {
                 removeScheduledNotifications(key, service, resolvedPath, true);
                 ScheduledFuture<?> future = scheduler.schedule(() -> {
                     logger.trace("Executing job for {}", resolvedPath);
-                    if (!removeScheduledNotifications(key, service, resolvedPath, false)) {
+                    if (removeScheduledNotifications(key, service, resolvedPath, false)) {
                         logger.trace("Job removed itself for {}", resolvedPath);
                     } else {
                         logger.trace("Job couldn't find itself for {}", resolvedPath);
@@ -473,10 +473,12 @@ public class WatchQueueReader implements Runnable {
 
         @Override
         public boolean equals(@Nullable Object o) {
-            if (this == o)
+            if (this == o) {
                 return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (o == null || getClass() != o.getClass()) {
                 return false;
+            }
             Notification notification = (Notification) o;
             return key.equals(notification.key) && service.equals(notification.service)
                     && path.equals(notification.path) && future.equals(notification.future);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
@@ -252,7 +252,7 @@ public class WatchQueueReader implements Runnable {
                 }
                 for (WatchEvent<?> event : key.pollEvents()) {
                     Kind<?> kind = event.kind();
-                    if (kind == OVERFLOW) {
+                    if (OVERFLOW.equals(kind)) {
                         logger.warn(
                                 "Found an event of kind 'OVERFLOW': {}. File system changes might have been missed.",
                                 event);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/JavaTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/JavaTest.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * {@link JavaTest} is an abstract base class for tests which are not necessarily based on OSGi.
+ *
+ * @author Simon Kaufmann - Initial contribution
+ */
+@NonNullByDefault
+public class JavaTest {
+
+    protected static final int DFL_TIMEOUT = 10000;
+    protected static final int DFL_SLEEP_TIME = 50;
+
+    /**
+     * Wait until the condition is fulfilled or the timeout is reached.
+     *
+     * <p>
+     * This method uses the default timing parameters.
+     *
+     * @param condition the condition to check
+     * @return true on success, false on timeout
+     */
+    protected boolean waitFor(BooleanSupplier condition) {
+        return waitFor(condition, DFL_TIMEOUT, DFL_SLEEP_TIME);
+    }
+
+    /**
+     * Wait until the condition is fulfilled or the timeout is reached.
+     *
+     * @param condition the condition to check
+     * @param timeout timeout
+     * @param sleepTime interval for checking the condition
+     * @return true on success, false on timeout
+     */
+    protected boolean waitFor(BooleanSupplier condition, long timeout, long sleepTime) {
+        int waitingTime = 0;
+        boolean rv;
+        while (!(rv = condition.getAsBoolean()) && waitingTime < timeout) {
+            waitingTime += sleepTime;
+            internalSleep(sleepTime);
+        }
+        return rv;
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * <p>
+     * This method uses the default timing parameters.
+     *
+     * @param assertion closure that must not have an argument
+     */
+    protected void waitForAssert(Runnable assertion) {
+        waitForAssert(assertion, null, DFL_TIMEOUT, DFL_SLEEP_TIME);
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * @param assertion the logic to execute
+     * @param timeout timeout
+     * @param sleepTime interval for checking the condition
+     */
+    protected void waitForAssert(Runnable assertion, long timeout, long sleepTime) {
+        waitForAssert(assertion, null, timeout, sleepTime);
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * <p>
+     * This method uses the default timing parameters.
+     *
+     * @param assertion the logic to execute
+     * @return the return value of the supplied assertion object's function on success
+     */
+    protected <T> T waitForAssert(Supplier<T> assertion) {
+        return waitForAssert(assertion, null, DFL_TIMEOUT, DFL_SLEEP_TIME);
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * @param assertion the logic to execute
+     * @param timeout timeout
+     * @param sleepTime interval for checking the condition
+     * @return the return value of the supplied assertion object's function on success
+     */
+    protected <T> T waitForAssert(Supplier<T> assertion, long timeout, long sleepTime) {
+        return waitForAssert(assertion, null, timeout, sleepTime);
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * @param assertion the logic to execute
+     * @param beforeLastCall logic to execute in front of the last call to ${code assertion}
+     * @param sleepTime interval for checking the condition
+     */
+    protected void waitForAssert(Runnable assertion, @Nullable Runnable beforeLastCall, long timeout, long sleepTime) {
+        waitForAssert(assertion, beforeLastCall, null, timeout, sleepTime);
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * @param assertion the logic to execute
+     * @param beforeLastCall logic to execute in front of the last call to ${code assertion}
+     * @param afterLastCall logic to execute after the last call to ${code assertion}
+     * @param sleepTime interval for checking the condition
+     */
+    protected void waitForAssert(Runnable assertion, @Nullable Runnable beforeLastCall,
+            @Nullable Runnable afterLastCall, long timeout, long sleepTime) {
+        long waitingTime = 0;
+        while (waitingTime < timeout) {
+            try {
+                assertion.run();
+
+                if (afterLastCall != null) {
+                    afterLastCall.run();
+                }
+                return;
+            } catch (final Error error) {
+                waitingTime += sleepTime;
+                internalSleep(sleepTime);
+            }
+        }
+        if (beforeLastCall != null) {
+            beforeLastCall.run();
+        }
+
+        try {
+            assertion.run();
+        } finally {
+            if (afterLastCall != null) {
+                afterLastCall.run();
+            }
+        }
+    }
+
+    /**
+     * Useful for testing @NonNull annotated parameters
+     *
+     * <p>
+     * This method can be used if you want to check the behavior of a method if you supply null to a non-null marked
+     * argument.
+     * If you use null directly the compiler will raise an error. Using this method allows you to work around that
+     * compiler check by using a null value that is marked as non-null.
+     *
+     * @return null for testing purpose
+     */
+    protected static <T> T giveNull() {
+        return null;
+    }
+
+    /**
+     * Wait until the assertion is fulfilled or the timeout is reached.
+     *
+     * @param assertion the logic to execute
+     * @param beforeLastCall logic to execute in front of the last call to ${code assertion}
+     * @param sleepTime interval for checking the condition
+     * @return the return value of the supplied assertion object's function on success
+     */
+    @SuppressWarnings("PMD.AvoidCatchingNPE")
+    private <T> T waitForAssert(Supplier<T> assertion, @Nullable Runnable beforeLastCall, long timeout,
+            long sleepTime) {
+        final long timeoutNs = TimeUnit.MILLISECONDS.toNanos(timeout);
+        final long startingTime = System.nanoTime();
+        while (System.nanoTime() - startingTime < timeoutNs) {
+            try {
+                return assertion.get();
+            } catch (final Error | NullPointerException error) {
+                internalSleep(sleepTime);
+            }
+        }
+        if (beforeLastCall != null) {
+            beforeLastCall.run();
+        }
+        return assertion.get();
+    }
+
+    private void internalSleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("We shouldn't be interrupted while testing");
+        }
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/service/AbstractWatchServiceTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/service/AbstractWatchServiceTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package service;
+package org.openhab.core.service;
 
 import static java.nio.file.StandardWatchEventKinds.*;
 import static org.hamcrest.CoreMatchers.is;
@@ -32,8 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openhab.core.service.AbstractWatchService;
-import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.JavaTest;
 
 /**
  * Test for {@link AbstractWatchService}.
@@ -224,8 +223,8 @@ public class AbstractWatchServiceTest extends JavaTest {
     }
 
     private void fullEventAssertionsByKind(String fileName, Kind<?> kind, boolean osSpecific) throws Exception {
-        waitForAssert(() -> assertThat(!watchService.allFullEvents.isEmpty(), is(true)), DFL_TIMEOUT * 2,
-                DFL_SLEEP_TIME);
+        waitForAssert(() -> assertThat(!watchService.allFullEvents.isEmpty(), is(true)), JavaTest.DFL_TIMEOUT * 2,
+                JavaTest.DFL_SLEEP_TIME);
 
         if (osSpecific && ENTRY_DELETE.equals(kind)) {
             // There is possibility that one more modify event is triggered on some OS


### PR DESCRIPTION
Related to #2727 

While investigating the issue above I found that the new version of the `WatchQueueReader` erroneously cancelled the job when removing it from the stored jobs. 

This is done on two occasions: 
- If a jobs is stored and we try to replace it. In this case cancellation is correct.
- If the job executes. Cancelling the job here is wrong. It is not noticed by the tests because it interrupts the job, which is not checked for our short-running jobs. In the issue above the job is checking if the thread is interrupted and therefore fails.

@wborn I also moved the tests to the `org.openhab.core` package and added the `JavaTest` as you suggested.

Signed-off-by: Jan N. Klug <github@klug.nrw>