### PR TITLE
Support multi bundle bindings in i18n-maven-plugin

### DIFF
--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfo.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfo.java
@@ -33,11 +33,20 @@ import org.openhab.core.thing.xml.internal.ThingTypeXmlResult;
 @NonNullByDefault
 public class BundleInfo {
 
+    private String bindingId = "";
     private @Nullable BindingInfoXmlResult bindingInfoXml;
     private List<ConfigDescription> configDescriptions = new ArrayList<>(5);
     private List<ChannelGroupTypeXmlResult> channelGroupTypesXml = new ArrayList<>(5);
     private List<ChannelTypeXmlResult> channelTypesXml = new ArrayList<>(5);
     private List<ThingTypeXmlResult> thingTypesXml = new ArrayList<>(5);
+
+    public String getBindingId() {
+        return bindingId;
+    }
+
+    public void setBindingId(String bindingId) {
+        this.bindingId = bindingId;
+    }
 
     public @Nullable BindingInfoXmlResult getBindingInfoXml() {
         return bindingInfoXml;
@@ -77,11 +86,6 @@ public class BundleInfo {
 
     public void setThingTypesXml(List<ThingTypeXmlResult> thingTypesXml) {
         this.thingTypesXml = thingTypesXml;
-    }
-
-    public String getBindingId() {
-        BindingInfoXmlResult localBindingInfoXml = bindingInfoXml;
-        return localBindingInfoXml == null ? "" : localBindingInfoXml.getBindingInfo().getUID();
     }
 
     public Optional<ConfigDescription> getConfigDescription(@Nullable URI uri) {

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
@@ -117,6 +117,9 @@ public class BundleInfoReader {
                     } else if (type instanceof ChannelTypeXmlResult) {
                         ChannelTypeXmlResult result = (ChannelTypeXmlResult) type;
                         bundleInfo.getChannelTypesXml().add(result);
+                        if (bundleInfo.getBindingId().isBlank()) {
+                            bundleInfo.setBindingId(result.toChannelType().getUID().getBindingId());
+                        }
                     }
                 }
             } catch (ConversionException | MalformedURLException e) {

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
@@ -68,6 +68,7 @@ public class BundleInfoReader {
             try {
                 BindingInfoXmlResult bindingInfoXml = reader.readFromXML(path.toUri().toURL());
                 if (bindingInfoXml != null) {
+                    bundleInfo.setBindingId(bindingInfoXml.getBindingInfo().getUID());
                     bundleInfo.setBindingInfoXml(bindingInfoXml);
                 }
             } catch (ConversionException | MalformedURLException e) {
@@ -102,11 +103,20 @@ public class BundleInfoReader {
                 }
                 for (Object type : types) {
                     if (type instanceof ThingTypeXmlResult) {
-                        bundleInfo.getThingTypesXml().add((ThingTypeXmlResult) type);
+                        ThingTypeXmlResult result = (ThingTypeXmlResult) type;
+                        bundleInfo.getThingTypesXml().add(result);
+                        if (bundleInfo.getBindingId().isBlank()) {
+                            bundleInfo.setBindingId(result.getUID().getBindingId());
+                        }
                     } else if (type instanceof ChannelGroupTypeXmlResult) {
-                        bundleInfo.getChannelGroupTypesXml().add((ChannelGroupTypeXmlResult) type);
+                        ChannelGroupTypeXmlResult result = (ChannelGroupTypeXmlResult) type;
+                        bundleInfo.getChannelGroupTypesXml().add(result);
+                        if (bundleInfo.getBindingId().isBlank()) {
+                            bundleInfo.setBindingId(result.getUID().getBindingId());
+                        }
                     } else if (type instanceof ChannelTypeXmlResult) {
-                        bundleInfo.getChannelTypesXml().add((ChannelTypeXmlResult) type);
+                        ChannelTypeXmlResult result = (ChannelTypeXmlResult) type;
+                        bundleInfo.getChannelTypesXml().add(result);
                     }
                 }
             } catch (ConversionException | MalformedURLException e) {

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverter.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverter.java
@@ -51,8 +51,8 @@ import org.openhab.core.types.StateDescription;
 public class XmlToTranslationsConverter {
 
     public Translations convert(BundleInfo bundleInfo) {
-        BindingInfoXmlResult bindingInfoXml = bundleInfo.getBindingInfoXml();
-        return bindingInfoXml == null ? configTranslations(bundleInfo) : bindingTranslations(bundleInfo);
+        String bindingId = bundleInfo.getBindingId();
+        return bindingId.isBlank() ? configTranslations(bundleInfo) : bindingTranslations(bundleInfo);
     }
 
     private Translations bindingTranslations(BundleInfo bundleInfo) {


### PR DESCRIPTION
The plugin did not generate translations for bundles of bindings that do not have a binding.xml file.
With this change it should also be possible to generate the default translations of the modbus and mqtt bindings.

Related to openhab/openhab-addons#12220