### PR TITLE
Log a message if a model is parsed and no thing handler factory can be found

### DIFF
--- a/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
+++ b/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
@@ -120,7 +120,7 @@ public class GenericThingProviderMultipleBundlesTest {
 
     @Test
     public void testDifferentHandlerFactoriesForBridgeAndThing() {
-        thingProvider.onReadyMarkerAdded(new ReadyMarker("", BUNDLE_NAME));
+        thingProvider.onReadyMarkerAdded(new ReadyMarker("openhab.xmlThingTypes", BUNDLE_NAME));
         thingProvider.modelChanged(TEST_MODEL_THINGS, EventType.ADDED);
 
         verify(bridgeHandlerFactory).createThing(eq(BRIDGE_TYPE_UID), any(Configuration.class), eq(BRIDGE_UID),

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -576,7 +576,6 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
     override onReadyMarkerAdded(ReadyMarker readyMarker) {
         val type = readyMarker.type
         if (StartLevelService.STARTLEVEL_MARKER_TYPE.equals(type)) {
-            logger.error("StartLevel {}", readyMarker.identifier)
             modelLoaded = Integer.parseInt(readyMarker.identifier) >= StartLevelService.STARTLEVEL_MODEL;
         } else if (XML_THING_TYPE.equals(type)) {
             val bsn = readyMarker.identifier

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -30,6 +30,7 @@ import org.openhab.core.i18n.LocaleProvider
 import org.openhab.core.service.ReadyMarker
 import org.openhab.core.service.ReadyMarkerFilter
 import org.openhab.core.service.ReadyService
+import org.openhab.core.service.StartLevelService
 import org.openhab.core.thing.Channel
 import org.openhab.core.thing.ChannelUID
 import org.openhab.core.thing.Thing
@@ -100,6 +101,8 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
 
     private val Set<String> loadedXmlThingTypes = new CopyOnWriteArraySet
 
+    private var modelLoaded = false
+
     def void activate() {
         modelRepository.getAllModelNamesOfType("things").forEach [
             createThingsFromModel
@@ -132,11 +135,16 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
                     // ignore the Thing because its definition is broken
                     return null
                 }
-                return thingHandlerFactories.findFirst [
+                val factory = thingHandlerFactories.findFirst [
                     supportsThingType(thingTypeUID)
                 ]
+                if (factory == null && modelLoaded) {
+                    logger.info("No ThingHandlerFactory found for thing {} (thing-type is {}). Deferring initialization.",
+                        thingUID, thingTypeUID)
+                }
+                return factory
             ]?.filter [
-                // Drop it if there is no ThingHandlerFactory yet which can handle it 
+                // Drop it if there is no ThingHandlerFactory yet which can handle it
                 it !== null
             ]?.toSet?.forEach [
                 // Execute for each unique ThingHandlerFactory
@@ -558,7 +566,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
 
     @Reference
     def void setReadyService(ReadyService readyService) {
-        readyService.registerTracker(this, new ReadyMarkerFilter().withType(XML_THING_TYPE));
+        readyService.registerTracker(this);
     }
 
     def void unsetReadyService(ReadyService readyService) {
@@ -566,9 +574,15 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
     }
 
     override onReadyMarkerAdded(ReadyMarker readyMarker) {
-        val bsn = readyMarker.identifier
-        loadedXmlThingTypes.add(bsn)
-        bsn.handleXmlThingTypesLoaded
+        val type = readyMarker.type
+        if (StartLevelService.STARTLEVEL_MARKER_TYPE.equals(type)) {
+            logger.error("StartLevel {}", readyMarker.identifier)
+            modelLoaded = Integer.parseInt(readyMarker.identifier) >= StartLevelService.STARTLEVEL_MODEL;
+        } else if (XML_THING_TYPE.equals(type)) {
+            val bsn = readyMarker.identifier
+            loadedXmlThingTypes.add(bsn)
+            bsn.handleXmlThingTypesLoaded
+        }
     }
 
     def private getBundleName(ThingHandlerFactory thingHandlerFactory) {


### PR DESCRIPTION
Fixes #2218 

A message at INFO level is logged when a thing could not be added because there is no corresponding binding (which could indicate a typo in the binding name or thing-type). This is only relevant for textual configuration as the UI prevents typos.

The message is suppressed on initial loading to prevent flooding the log (the model most likely is parsed before all ThingHandlerFactories have been added).

Signed-off-by: Jan N. Klug <github@klug.nrw>