### PR TITLE
Fix missing STARTLEVEL_COMPLETE ReadyMarker

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
@@ -177,6 +177,8 @@ public class StartLevelService {
         startlevels = parseConfig(configuration);
         startlevels.keySet()
                 .forEach(sl -> slmarker.put(sl, new ReadyMarker(STARTLEVEL_MARKER_TYPE, Integer.toString(sl))));
+        slmarker.put(STARTLEVEL_COMPLETE,
+                new ReadyMarker(STARTLEVEL_MARKER_TYPE, Integer.toString(STARTLEVEL_COMPLETE)));
         startlevels.values().stream().forEach(ms -> ms.forEach(e -> registerTracker(e)));
     }
 


### PR DESCRIPTION
Since no requirements are defined for `STARTLEVEL_COMPLETE` no `ReadyMarker` was added to the map of `ReadyMarker`s.

Signed-off-by: Jan N. Klug <github@klug.nrw>