### PR TITLE
Add triggeringThing name to DSL rules

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -150,11 +150,13 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                         val channelRef = ruleModel.newTypeRef(String)
                         parameters += rule.toParameter(VAR_TRIGGERING_CHANNEL, channelRef)
                     }
-                    if (containsThingStateChangedEventTrigger(rule) && !containsParam(parameters, VAR_PREVIOUS_STATE)) {
-                        val stateTypeRef = ruleModel.newTypeRef(State)
-                        parameters += rule.toParameter(VAR_PREVIOUS_STATE, stateTypeRef)
+                    if (containsThingStateChangedEventTrigger(rule)) {
                         val thingRef = ruleModel.newTypeRef(String)
                         parameters += rule.toParameter(VAR_TRIGGERING_THING, thingRef)
+                        val oldStatusRef = ruleModel.newTypeRef(String)
+                        parameters += rule.toParameter(VAR_PREVIOUS_STATUS, oldStatusRef)
+                        val newStatusRef = ruleModel.newTypeRef(String)
+                        parameters += rule.toParameter(VAR_NEW_STATUS, newStatusRef)
                     }
                     if ((containsStateChangeTrigger(rule) || containsStateUpdateTrigger(rule)) && !containsParam(parameters, VAR_NEW_STATE)) {
                         val stateTypeRef = ruleModel.newTypeRef(State)

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -153,6 +153,8 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                     if (containsThingStateChangedEventTrigger(rule) && !containsParam(parameters, VAR_PREVIOUS_STATE)) {
                         val stateTypeRef = ruleModel.newTypeRef(State)
                         parameters += rule.toParameter(VAR_PREVIOUS_STATE, stateTypeRef)
+                        val thingRef = ruleModel.newTypeRef(String)
+                        parameters += rule.toParameter(VAR_TRIGGERING_THING, thingRef)
                     }
                     if ((containsStateChangeTrigger(rule) || containsStateUpdateTrigger(rule)) && !containsParam(parameters, VAR_NEW_STATE)) {
                         val stateTypeRef = ruleModel.newTypeRef(State)

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -178,6 +178,10 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
             ThingStatusInfoChangedEvent event = (ThingStatusInfoChangedEvent) value;
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_THING),
                     event.getThingUID().toString());
+            evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_PREVIOUS_STATUS),
+                    event.getOldStatusInfo().getStatus().toString());
+            evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_NEW_STATUS),
+                    event.getStatusInfo().getStatus().toString());
         }
 
         return evalContext;

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -38,6 +38,7 @@ import org.openhab.core.model.script.engine.ScriptParsingException;
 import org.openhab.core.model.script.jvmmodel.ScriptJvmModelInferrer;
 import org.openhab.core.model.script.runtime.DSLScriptContextProvider;
 import org.openhab.core.thing.events.ChannelTriggeredEvent;
+import org.openhab.core.thing.events.ThingStatusInfoChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +173,11 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
             ItemEvent event = (ItemEvent) value;
             evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM_NAME),
                     event.getItemName());
+        }
+        if (value instanceof ThingStatusInfoChangedEvent) {
+            ThingStatusInfoChangedEvent event = (ThingStatusInfoChangedEvent) value;
+            evalContext.newValue(QualifiedName.create(ScriptJvmModelInferrer.VAR_TRIGGERING_THING),
+                    event.getThingUID().toString());
         }
 
         return evalContext;

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -61,6 +61,9 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     /** Variable name for the triggering channel in a "trigger event" rule */
     public static final String VAR_TRIGGERING_CHANNEL = "triggeringChannel";
 
+    /** Variable name for the triggering thing in a "thing status trigger" rule */
+    public static final String VAR_TRIGGERING_THING = "triggeringThing";
+    
     /**
      * conveninence API to build and initialize JvmTypes and their members.
      */
@@ -124,6 +127,8 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
                 parameters += script.toParameter(VAR_RECEIVED_EVENT, eventTypeRef)
                 val channelRef = script.newTypeRef(String)
                 parameters += script.toParameter(VAR_TRIGGERING_CHANNEL, channelRef)
+                val thingRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_TRIGGERING_THING, thingRef)
                 val stateTypeRef2 = script.newTypeRef(State)
                 parameters += script.toParameter(VAR_NEW_STATE, stateTypeRef2)
                 body = script

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -64,6 +64,12 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     /** Variable name for the triggering thing in a "thing status trigger" rule */
     public static final String VAR_TRIGGERING_THING = "triggeringThing";
     
+    /** Variable name for the previous status of the triggering thing in a "thing status trigger" rule */
+    public static final String VAR_PREVIOUS_STATUS = "previousStatus";
+    
+    /** Variable name for the new status of the triggering thing in a "thing status trigger" rule */
+    public static final String VAR_NEW_STATUS = "newStatus";
+    
     /**
      * conveninence API to build and initialize JvmTypes and their members.
      */
@@ -129,6 +135,10 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
                 parameters += script.toParameter(VAR_TRIGGERING_CHANNEL, channelRef)
                 val thingRef = script.newTypeRef(String)
                 parameters += script.toParameter(VAR_TRIGGERING_THING, thingRef)
+                val oldThingStatusRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_PREVIOUS_STATUS, oldThingStatusRef)
+                val newThingStatusRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_NEW_STATUS, newThingStatusRef)
                 val stateTypeRef2 = script.newTypeRef(State)
                 parameters += script.toParameter(VAR_NEW_STATE, stateTypeRef2)
                 body = script


### PR DESCRIPTION
I wanted to be able to detect which thing had triggered a DSL rule in order to write rules which used a single set of functionality when detecting that one of many things had gone offline. Whilst I was at it I figured it might be useful to include the previous and new statuses and remove the reference to previousState which didn't seem to make sense. I've tried to follow the pattern in the code and this PR #2567 