### PR TITLE
Always run OSGi HTTP service on random port in itests

### DIFF
--- a/itests/itest-include.bndrun
+++ b/itests/itest-include.bndrun
@@ -20,6 +20,10 @@ Import-Package: org.osgi.framework.*;version="[1.8,2)",*
 -runfw: org.eclipse.osgi
 -runee: JavaSE-11
 
+# An unused random HTTP port is used during tests to prevent resource conflicts
+# This property is set by the build-helper-maven-plugin in the itests pom.xml
+-runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+
 # The integration test itself does not export anything.
 Export-Package:
 -exportcontents:

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -49,6 +49,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
+    <org.osgi.service.http.port>9090</org.osgi.service.http.port>
   </properties>
 
   <dependencies>
@@ -198,6 +199,24 @@
                 <bndrun>itest.bndrun</bndrun>
               </bndruns>
             </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>reserve-network-port</id>
+                <goals>
+                  <goal>reserve-network-port</goal>
+                </goals>
+                <phase>process-resources</phase>
+                <configuration>
+                  <portNames>
+                    <portName>org.osgi.service.http.port</portName>
+                  </portNames>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
It is probably always a good idea to run the OSGi HTTP service on a random available port in itests.
This fixes some stacktraces when running itests and it will also prevent future issues when tests using the HTTP service are written.

These stacktraces often show when running itests in parallel:

```
org.ops4j.pax.web.pax-web-runtime [org.ops4j.pax.web.service.internal.HttpServiceStarted] ERROR : Could not start the servlet context for context path []
java.io.IOException: Failed to bind to /0.0.0.0:8080
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:349)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:310)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl$1.start(JettyServerImpl.java:350)
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:255)
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:226)
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.registerServlet(HttpServiceStarted.java:210)
	at org.ops4j.pax.web.service.internal.HttpServiceProxy.registerServlet(HttpServiceProxy.java:69)
	at org.openhab.core.io.http.servlet.BaseOpenHABServlet.activate(BaseOpenHABServlet.java:56)
	at org.openhab.core.io.http.servlet.OpenHABServlet.activate(OpenHABServlet.java:40)
...
```

Similar to: openhab/openhab-addons#11523