### PR TITLE
Fix context being re-used for next execution

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -101,11 +101,11 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     }
 
     /**
-     * Adds the passed context variables of the rule engine to the context scope of the ScriptEngine, this should be
-     * updated each time the module is executed
+     * Adds the passed context variables of the rule engine to the context scope of the ScriptEngine
+     * this should be done each time the module is executed to prevent leaking context to later executions
      *
      * @param engine the script engine that is used
-     * @param context the variables and types to put into the execution context
+     * @param context the variables and types to remove from the execution context
      */
     protected void setExecutionContext(ScriptEngine engine, Map<String, ?> context) {
         ScriptContext executionContext = engine.getContext();
@@ -128,6 +128,28 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
                 key = key.substring(dotIndex + 1);
             }
             executionContext.setAttribute(key, value, ScriptContext.ENGINE_SCOPE);
+        }
+    }
+
+    /**
+     * Removes passed context variables of the rule engine from the context scope of the ScriptEngine, this should be
+     * updated each time the module is executed
+     *
+     * @param engine the script engine that is used
+     * @param context the variables and types to put into the execution context
+     */
+
+    protected void resetExecutionContext(ScriptEngine engine, Map<String, ?> context) {
+        ScriptContext executionContext = engine.getContext();
+
+        for (Entry<String, ?> entry : context.entrySet()) {
+            Object value = entry.getValue();
+            String key = entry.getKey();
+            int dotIndex = key.indexOf('.');
+            if (dotIndex != -1) {
+                key = key.substring(dotIndex + 1);
+            }
+            executionContext.removeAttribute(key, ScriptContext.ENGINE_SCOPE);
         }
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -65,6 +65,7 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
                 logger.error("Script execution of rule with UID '{}' failed: {}", ruleUID, e.getMessage(),
                         logger.isDebugEnabled() ? e : null);
             }
+            resetExecutionContext(scriptEngine, context);
         });
 
         return resultMap;


### PR DESCRIPTION
Fixes #2751 

Trigger information is inserted in the execution context. This information is changed to the new information each time the context is updated with the same keys. If the context of the next execution does not contain values for each key, the old key is re-used, leading e.g. to wrong event information in the context.

The solution is to remove the content of the triggering context after each execution.

Signed-off-by: Jan N. Klug <github@klug.nrw>