### PR TITLE
[DialogProcessor] processor aborting before response

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -244,7 +244,6 @@ public class DialogProcessor implements KSListener, STTListener {
     public synchronized void sttEventReceived(STTEvent sttEvent) {
         if (sttEvent instanceof SpeechRecognitionEvent) {
             if (!isSTTServerAborting) {
-                abortSTT();
                 SpeechRecognitionEvent sre = (SpeechRecognitionEvent) sttEvent;
                 String question = sre.getTranscript();
                 try {
@@ -259,6 +258,7 @@ public class DialogProcessor implements KSListener, STTListener {
                         say(msg);
                     }
                 }
+                abortSTT();
             }
         } else if (sttEvent instanceof RecognitionStartEvent) {
             toggleProcessing(true);


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

Hi, this small change fix the execution of the dialog processor.

It was aborting its own thread, because the event was produced by the stt service. So it causes an interruption execution during the tss execution after the hli.

I already tested this and change should not have other side effects as the whole method is synchronized.

Is this change ok @kaikreuzer, @lolodomo?