### PR TITLE
Fix dispose is called on handlers for disabled things

### DIFF
--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -89,6 +89,8 @@ public class ThingManagerImplTest {
     public void thingHandlerFactoryLifecycle() {
         ThingHandlerFactory mockFactory1 = mock(ThingHandlerFactory.class);
         ThingHandlerFactory mockFactory2 = mock(ThingHandlerFactory.class);
+        when(storageServiceMock.getStorage(any(), any())).thenReturn(storageMock);
+        when(storageMock.get(any())).thenReturn(null);
 
         ThingManagerImpl thingManager = createThingManager();
 


### PR DESCRIPTION
Fixes #1893 

The reason for the reported behavior is that a handler is registered on startup for disabled things. The thing is not initialized because the enabled-state is check while initializing the handler. 

Since we unregister the handler if the thing is disabled at runtime (and register a new one once the thing is enabled again), I believe we should not register a handler at this point.

Signed-off-by: Jan N. Klug <github@klug.nrw>