### PR TITLE
Improve log message for invalid configuration updates by handler

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -451,8 +451,9 @@ public abstract class BaseThingHandler implements ThingHandler {
         try {
             callback.validateConfigurationParameters(this.thing, configuration.getProperties());
         } catch (ConfigValidationException e) {
-            logger.warn("Attempt to apply invalid configuration '{}' on thing '{}' blocked. This is most likely a bug.",
-                    configuration, thing.getUID());
+            logger.warn(
+                    "Attempt to apply invalid configuration '{}' on thing '{}' blocked. This is most likely a bug: {}",
+                    configuration, thing.getUID(), e.getValidationMessages());
             return;
         }
         try {


### PR DESCRIPTION
Related to #2764 

The reason why the new configuration was rejected is now included in the log message.

Signed-off-by: Jan N. Klug <github@klug.nrw>