### PR TITLE
Move Java only tests from org.openhab.core.tests to org.openhab.core

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheAsyncTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheAsyncTest.java
@@ -21,7 +21,7 @@ import java.util.function.Supplier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
-import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.JavaTest;
 
 /**
  * Tests cases for {@link ExpiringAsyncCache}.

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/common/SafeCallerImplTest.java
@@ -46,8 +46,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.JavaTest;
 import org.openhab.core.common.QueueingThreadPoolExecutor;
-import org.openhab.core.test.java.JavaTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
These tests only require Java and not OSGi.