### PR TITLE
Add a profile for linking trigger channels to String items

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
@@ -66,14 +66,15 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             OFFSET_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
             RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE,
             RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
-            RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE, TIMESTAMP_CHANGE_TYPE,
-            TIMESTAMP_OFFSET_TYPE, TIMESTAMP_TRIGGER_TYPE, TIMESTAMP_UPDATE_TYPE);
+            RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE,
+            TRIGGER_EVENT_STRING_TYPE, TIMESTAMP_CHANGE_TYPE, TIMESTAMP_OFFSET_TYPE, TIMESTAMP_TRIGGER_TYPE,
+            TIMESTAMP_UPDATE_TYPE);
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(DEFAULT, FOLLOW, HYSTERESIS, OFFSET,
             RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
             RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE,
-            RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TIMESTAMP_CHANGE, TIMESTAMP_OFFSET,
-            TIMESTAMP_TRIGGER, TIMESTAMP_UPDATE);
+            RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TRIGGER_EVENT_STRING,
+            TIMESTAMP_CHANGE, TIMESTAMP_OFFSET, TIMESTAMP_TRIGGER, TIMESTAMP_UPDATE);
 
     private final Map<LocalizedKey, ProfileType> localizedProfileTypeCache = new ConcurrentHashMap<>();
 
@@ -124,6 +125,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new RawRockerStopMoveProfile(callback);
         } else if (RAWROCKER_UP_DOWN.equals(profileTypeUID)) {
             return new RawRockerUpDownProfile(callback);
+        } else if (TRIGGER_EVENT_STRING.equals(profileTypeUID)) {
+            return new TriggerEventStringProfile(callback);
         } else if (TIMESTAMP_CHANGE.equals(profileTypeUID)) {
             return new TimestampChangeProfile(callback);
         } else if (TIMESTAMP_OFFSET.equals(profileTypeUID)) {
@@ -165,6 +168,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
                     } else if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
                         return RAWROCKER_ON_OFF;
                     }
+                } else if (CoreItemFactory.STRING.equalsIgnoreCase(itemType)) {
+                    return TRIGGER_EVENT_STRING;
                 }
                 break;
             default:

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfile.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static org.openhab.core.thing.profiles.SystemProfiles.TRIGGER_EVENT_STRING;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.TriggerProfile;
+import org.openhab.core.types.State;
+
+/**
+ * The {@link TriggerEventStringProfile} transforms a trigger event to a String
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class TriggerEventStringProfile implements TriggerProfile {
+
+    private final ProfileCallback callback;
+
+    TriggerEventStringProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return TRIGGER_EVENT_STRING;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+
+    @Override
+    public void onTriggerFromHandler(String event) {
+        callback.sendCommand(new StringType(event));
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
@@ -26,116 +26,109 @@ import org.openhab.core.thing.DefaultSystemChannelTypeProvider;
 @NonNullByDefault
 public interface SystemProfiles {
 
-    public static final ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
-    public static final ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
-    public static final ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
-    public static final ProfileTypeUID HYSTERESIS = new ProfileTypeUID(SYSTEM_SCOPE, "hysteresis");
-    public static final ProfileTypeUID RANGE = new ProfileTypeUID(SYSTEM_SCOPE, "range");
-    public static final ProfileTypeUID RAWBUTTON_ON_OFF_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawbutton-on-off-switch");
-    public static final ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawbutton-toggle-player");
-    public static final ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawbutton-toggle-rollershutter");
-    public static final ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawbutton-toggle-switch");
-    public static final ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-dimmer");
-    public static final ProfileTypeUID RAWROCKER_NEXT_PREVIOUS = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawrocker-to-next-previous");
-    public static final ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-on-off");
-    public static final ProfileTypeUID RAWROCKER_PLAY_PAUSE = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawrocker-to-play-pause");
-    public static final ProfileTypeUID RAWROCKER_REWIND_FASTFORWARD = new ProfileTypeUID(SYSTEM_SCOPE,
-            "rawrocker-to-rewind-fastforward");
-    public static final ProfileTypeUID RAWROCKER_STOP_MOVE = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-stop-move");
-    public static final ProfileTypeUID RAWROCKER_UP_DOWN = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-up-down");
-    public static final ProfileTypeUID TIMESTAMP_CHANGE = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-change");
-    public static final ProfileTypeUID TIMESTAMP_OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-offset");
-    public static final ProfileTypeUID TIMESTAMP_TRIGGER = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-trigger");
-    public static final ProfileTypeUID TIMESTAMP_UPDATE = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-update");
+    ProfileTypeUID DEFAULT = new ProfileTypeUID(SYSTEM_SCOPE, "default");
+    ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
+    ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
+    ProfileTypeUID HYSTERESIS = new ProfileTypeUID(SYSTEM_SCOPE, "hysteresis");
+    ProfileTypeUID RANGE = new ProfileTypeUID(SYSTEM_SCOPE, "range");
+    ProfileTypeUID RAWBUTTON_ON_OFF_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-on-off-switch");
+    ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
+    ProfileTypeUID RAWBUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-rollershutter");
+    ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-switch");
+    ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-dimmer");
+    ProfileTypeUID RAWROCKER_NEXT_PREVIOUS = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-next-previous");
+    ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-on-off");
+    ProfileTypeUID RAWROCKER_PLAY_PAUSE = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-play-pause");
+    ProfileTypeUID RAWROCKER_REWIND_FASTFORWARD = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-rewind-fastforward");
+    ProfileTypeUID RAWROCKER_STOP_MOVE = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-stop-move");
+    ProfileTypeUID RAWROCKER_UP_DOWN = new ProfileTypeUID(SYSTEM_SCOPE, "rawrocker-to-up-down");
+    ProfileTypeUID TRIGGER_EVENT_STRING = new ProfileTypeUID(SYSTEM_SCOPE, "trigger-event-string");
+    ProfileTypeUID TIMESTAMP_CHANGE = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-change");
+    ProfileTypeUID TIMESTAMP_OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-offset");
+    ProfileTypeUID TIMESTAMP_TRIGGER = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-trigger");
+    ProfileTypeUID TIMESTAMP_UPDATE = new ProfileTypeUID(SYSTEM_SCOPE, "timestamp-update");
 
-    static final ProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
+    ProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
-    static final ProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
+    ProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
-    static final ProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
+    ProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
             .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
             .build();
 
-    static final ProfileType HYSTERESIS_TYPE = ProfileTypeBuilder.newState(HYSTERESIS, "Hysteresis") //
+    ProfileType HYSTERESIS_TYPE = ProfileTypeBuilder.newState(HYSTERESIS, "Hysteresis") //
             .withSupportedItemTypesOfChannel(CoreItemFactory.DIMMER, CoreItemFactory.NUMBER) //
             .withSupportedItemTypes(CoreItemFactory.SWITCH) //
             .build();
 
-    static final ProfileType RANGE_TYPE = ProfileTypeBuilder.newState(RANGE, "Range") //
+    ProfileType RANGE_TYPE = ProfileTypeBuilder.newState(RANGE, "Range") //
             .withSupportedItemTypesOfChannel(CoreItemFactory.DIMMER, CoreItemFactory.NUMBER) //
             .withSupportedItemTypes(CoreItemFactory.SWITCH) //
             .build();
 
-    static final ProfileType RAWBUTTON_ON_OFF_SWITCH_TYPE = ProfileTypeBuilder
+    ProfileType RAWBUTTON_ON_OFF_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_ON_OFF_SWITCH, "Raw Button To On Off")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON).build();
 
-    static final ProfileType RAWBUTTON_TOGGLE_PLAYER_TYPE = ProfileTypeBuilder
+    ProfileType RAWBUTTON_TOGGLE_PLAYER_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_PLAYER, "Raw Button Toggle Player")
             .withSupportedItemTypes(CoreItemFactory.PLAYER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON).build();
 
-    static final ProfileType RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE = ProfileTypeBuilder
+    ProfileType RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_ROLLERSHUTTER, "Raw Button Toggle Rollershutter")
             .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON).build();
 
-    static final ProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
+    ProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle Switch")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWBUTTON).build();
 
-    static final ProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
+    ProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer").withSupportedItemTypes(CoreItemFactory.DIMMER)
+    ProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer")
+            .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_NEXT_PREVIOUS_TYPE = ProfileTypeBuilder
+    ProfileType RAWROCKER_NEXT_PREVIOUS_TYPE = ProfileTypeBuilder
             .newTrigger(RAWROCKER_NEXT_PREVIOUS, "Raw Rocker To Next/Previous")
             .withSupportedItemTypes(CoreItemFactory.PLAYER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_PLAY_PAUSE_TYPE = ProfileTypeBuilder
+    ProfileType RAWROCKER_PLAY_PAUSE_TYPE = ProfileTypeBuilder
             .newTrigger(RAWROCKER_PLAY_PAUSE, "Raw Rocker To Play/Pause").withSupportedItemTypes(CoreItemFactory.PLAYER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_REWIND_FASTFORWARD_TYPE = ProfileTypeBuilder
+    ProfileType RAWROCKER_REWIND_FASTFORWARD_TYPE = ProfileTypeBuilder
             .newTrigger(RAWROCKER_REWIND_FASTFORWARD, "Raw Rocker To Rewind/Fastforward")
             .withSupportedItemTypes(CoreItemFactory.PLAYER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_STOP_MOVE_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_STOP_MOVE, "Raw Rocker To Stop/Move")
+    ProfileType RAWROCKER_STOP_MOVE_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_STOP_MOVE, "Raw Rocker To Stop/Move")
             .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType RAWROCKER_UP_DOWN_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_UP_DOWN, "Raw Rocker To Up/Down")
+    ProfileType RAWROCKER_UP_DOWN_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_UP_DOWN, "Raw Rocker To Up/Down")
             .withSupportedItemTypes(CoreItemFactory.ROLLERSHUTTER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_CHANNEL_TYPE_UID_RAWROCKER).build();
 
-    static final ProfileType TIMESTAMP_CHANGE_TYPE = ProfileTypeBuilder
-            .newState(TIMESTAMP_CHANGE, "Timestamp on change").withSupportedItemTypes(CoreItemFactory.DATETIME).build();
+    ProfileType TRIGGER_EVENT_STRING_TYPE = ProfileTypeBuilder.newTrigger(TRIGGER_EVENT_STRING, "Trigger Event String")
+            .withSupportedItemTypes(CoreItemFactory.STRING).build();
 
-    static final ProfileType TIMESTAMP_OFFSET_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_OFFSET, "Timestamp Offset")
+    ProfileType TIMESTAMP_CHANGE_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_CHANGE, "Timestamp on change")
+            .withSupportedItemTypes(CoreItemFactory.DATETIME).build();
+
+    ProfileType TIMESTAMP_OFFSET_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_OFFSET, "Timestamp Offset")
             .withSupportedItemTypes(CoreItemFactory.DATETIME).withSupportedItemTypesOfChannel(CoreItemFactory.DATETIME)
             .build();
 
-    static final ProfileType TIMESTAMP_TRIGGER_TYPE = ProfileTypeBuilder
-            .newTrigger(TIMESTAMP_TRIGGER, "Timestamp on Trigger").withSupportedItemTypes(CoreItemFactory.DATETIME)
-            .build();
+    ProfileType TIMESTAMP_TRIGGER_TYPE = ProfileTypeBuilder.newTrigger(TIMESTAMP_TRIGGER, "Timestamp on Trigger")
+            .withSupportedItemTypes(CoreItemFactory.DATETIME).build();
 
-    static final ProfileType TIMESTAMP_UPDATE_TYPE = ProfileTypeBuilder
-            .newState(TIMESTAMP_UPDATE, "Timestamp on update").withSupportedItemTypes(CoreItemFactory.DATETIME).build();
+    ProfileType TIMESTAMP_UPDATE_TYPE = ProfileTypeBuilder.newState(TIMESTAMP_UPDATE, "Timestamp on update")
+            .withSupportedItemTypes(CoreItemFactory.DATETIME).build();
 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfileTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.thing.CommonTriggerEvents;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.TriggerProfile;
+
+/**
+ * Tests for the system:trigger-event-string profile
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class TriggerEventStringProfileTest {
+
+    private @Mock @NonNullByDefault({}) ProfileCallback callbackMock;
+
+    @Test
+    public void testEventStringItem() {
+        TriggerProfile profile = new TriggerEventStringProfile((callbackMock));
+        profile.onTriggerFromHandler(CommonTriggerEvents.PRESSED);
+        verify(callbackMock, times(1)).sendCommand(eq(new StringType(CommonTriggerEvents.PRESSED)));
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -73,7 +73,7 @@ public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
     @Test
     public void systemProfileTypesAndUidsShouldBeAvailable() {
         Collection<ProfileTypeUID> systemProfileTypeUIDs = profileFactory.getSupportedProfileTypeUIDs();
-        assertThat(systemProfileTypeUIDs, hasSize(20));
+        assertThat(systemProfileTypeUIDs, hasSize(21));
 
         Collection<ProfileType> systemProfileTypes = profileFactory.getProfileTypes(null);
         assertThat(systemProfileTypes, hasSize(systemProfileTypeUIDs.size()));


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-webui/issues/886

This was suggested by @kaikreuzer because there is no profile available to link non-system-channeltype trigger channels to an item. 

Signed-off-by: Jan N. Klug <github@klug.nrw>