### PR TITLE
Avoid `URISyntaxException` in tests

### DIFF
--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -18,7 +18,6 @@ import static org.openhab.core.config.core.ConfigDescriptionParameter.Type.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -174,11 +173,11 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void firstDesciptionWinsForNormalization() throws URISyntaxException {
-        ConfigDescription configDescriptionInteger = ConfigDescriptionBuilder.create(new URI("thing:fooThing"))
+    public void firstDesciptionWinsForNormalization() {
+        ConfigDescription configDescriptionInteger = ConfigDescriptionBuilder.create(URI.create("thing:fooThing"))
                 .withParameter(ConfigDescriptionParameterBuilder.create("foo", INTEGER).build()).build();
 
-        ConfigDescription configDescriptionString = ConfigDescriptionBuilder.create(new URI("thingType:fooThing"))
+        ConfigDescription configDescriptionString = ConfigDescriptionBuilder.create(URI.create("thingType:fooThing"))
                 .withParameter(ConfigDescriptionParameterBuilder.create("foo", TEXT).build()).build();
 
         assertThat(ConfigUtil.normalizeTypes(Map.of("foo", "1"), List.of(configDescriptionInteger)).get("foo"),

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -61,8 +60,8 @@ class ConfigDescriptionDTOTest {
     private static final String PARAMETER_GROUP_LABEL = "label";
 
     @Test
-    public void testConfigDescriptionDTOMappingContainsDecodedURIString() throws URISyntaxException {
-        final URI systemI18nURI = new URI(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
+    public void testConfigDescriptionDTOMappingContainsDecodedURIString() {
+        final URI systemI18nURI = URI.create(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
         ConfigDescription subject = ConfigDescriptionBuilder.create(systemI18nURI).build();
 
         ConfigDescriptionDTO result = ConfigDescriptionDTOMapper.map(subject);

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,15 +143,7 @@ public class ConfigDescriptionValidatorTest {
     private static final ConfigDescriptionParameter DECIMAL_MAX_PARAM = ConfigDescriptionParameterBuilder
             .create(DECIMAL_MAX_PARAM_NAME, ConfigDescriptionParameter.Type.DECIMAL).withMaximum(DECIMAL_MAX).build();
 
-    private static final URI CONFIG_DESCRIPTION_URI = createURI("config:dummy");
-
-    private static final URI createURI(String s) {
-        try {
-            return new URI(s);
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Failed to create URI: " + e.getMessage(), e);
-        }
-    }
+    private static final URI CONFIG_DESCRIPTION_URI = URI.create("config:dummy");
 
     private static final ConfigDescription CONFIG_DESCRIPTION = ConfigDescriptionBuilder.create(CONFIG_DESCRIPTION_URI)
             .withParameters(List.of(BOOL_PARAM, BOOL_REQUIRED_PARAM, TXT_PARAM, TXT_REQUIRED_PARAM, TXT_MIN_PARAM,

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -20,8 +20,6 @@ import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -107,9 +105,7 @@ public class PersistentInboxTest {
 
     @Test
     public void testConfigUpdateNormalizationGuessType() {
-        Map<String, Object> props = new HashMap<>();
-        props.put("foo", 1);
-        Configuration config = new Configuration(props);
+        Configuration config = new Configuration(Map.of("foo", 1));
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
 
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);
@@ -124,10 +120,8 @@ public class PersistentInboxTest {
     }
 
     @Test
-    public void testConfigUpdateNormalizationWithConfigDescription() throws URISyntaxException {
-        Map<String, Object> props = new HashMap<>();
-        props.put("foo", "1");
-        Configuration config = new Configuration(props);
+    public void testConfigUpdateNormalizationWithConfigDescription() {
+        Configuration config = new Configuration(Map.of("foo", "1"));
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withConfiguration(config).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(thing);
@@ -142,7 +136,7 @@ public class PersistentInboxTest {
     }
 
     @Test
-    public void testApproveNormalization() throws URISyntaxException {
+    public void testApproveNormalization() {
         DiscoveryResult result = DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);
         when(storageMock.getValues()).thenReturn(List.of(result));
@@ -156,7 +150,7 @@ public class PersistentInboxTest {
     }
 
     @Test
-    public void testApproveWithThingId() throws URISyntaxException {
+    public void testApproveWithThingId() {
         DiscoveryResult result = DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);
         when(storageMock.getValues()).thenReturn(List.of(result));
@@ -170,7 +164,7 @@ public class PersistentInboxTest {
     }
 
     @Test
-    public void testApproveWithInvalidThingId() throws URISyntaxException {
+    public void testApproveWithInvalidThingId() {
         DiscoveryResult result = DiscoveryResultBuilder.create(THING_UID).withProperty("foo", 3).build();
         configureConfigDescriptionRegistryMock("foo", Type.TEXT);
         when(storageMock.getValues()).thenReturn(List.of(result));
@@ -235,8 +229,8 @@ public class PersistentInboxTest {
         assertThat(eventCaptor.getValue().getDiscoveryResult().properties, hasEntry("foo", "bar"));
     }
 
-    private void configureConfigDescriptionRegistryMock(String paramName, Type type) throws URISyntaxException {
-        URI configDescriptionURI = new URI("thing-type:test:test");
+    private void configureConfigDescriptionRegistryMock(String paramName, Type type) {
+        URI configDescriptionURI = URI.create("thing-type:test:test");
         ThingType thingType = ThingTypeBuilder.instance(THING_TYPE_UID, "Test")
                 .withConfigDescriptionURI(configDescriptionURI).build();
         ConfigDescription configDesc = ConfigDescriptionBuilder.create(configDescriptionURI)

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -61,13 +60,13 @@ public class ConfigDescriptionResourceTest {
     private @Mock @NonNullByDefault({}) LocaleService localeServiceMock;
 
     @BeforeEach
-    public void beforeEach() throws URISyntaxException {
-        final URI systemI18nURI = new URI(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
+    public void beforeEach() {
+        final URI systemI18nURI = URI.create(CONFIG_DESCRIPTION_SYSTEM_I18N_URI);
         final ConfigDescription systemI18n = ConfigDescriptionBuilder.create(systemI18nURI)
                 .withParameter(ConfigDescriptionParameterBuilder.create(PARAM_NAME, Type.TEXT)
                         .withDefault(PARAMETER_NAME_DEFAULT_VALUE).build())
                 .build();
-        final ConfigDescription systemEphemeris = ConfigDescriptionBuilder.create(new URI("system:ephemeris"))
+        final ConfigDescription systemEphemeris = ConfigDescriptionBuilder.create(URI.create("system:ephemeris"))
                 .withParameter(ConfigDescriptionParameterBuilder.create(PARAM_COUNTRY, Type.TEXT).build()).build();
         when(configDescriptionRegistryMock.getConfigDescriptions(any()))
                 .thenReturn(List.of(systemI18n, systemEphemeris));

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.*;
 import static org.openhab.core.io.rest.internal.filter.ProxyFilter.*;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -159,14 +158,10 @@ public class ProxyFilterTest {
     }
 
     private void setupContextURIs(String baseURI, String requestURI) {
-        try {
-            when(uriInfoMock.getBaseUri()).thenReturn(new URI(baseURI));
-            when(uriInfoMock.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(baseURI));
-            when(uriInfoMock.getRequestUri()).thenReturn(new URI(requestURI));
-            when(uriInfoMock.getRequestUriBuilder()).thenReturn(UriBuilder.fromUri(requestURI));
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Error while setting up context mock", e);
-        }
+        when(uriInfoMock.getBaseUri()).thenReturn(URI.create(baseURI));
+        when(uriInfoMock.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri(baseURI));
+        when(uriInfoMock.getRequestUri()).thenReturn(URI.create(requestURI));
+        when(uriInfoMock.getRequestUriBuilder()).thenReturn(UriBuilder.fromUri(requestURI));
     }
 
     private void setupContextHeaders(@Nullable String protoHeader, @Nullable String hostHeader) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -15,7 +15,6 @@ package org.openhab.core.thing.internal.firmware;
 import static org.openhab.core.thing.firmware.FirmwareStatusInfo.*;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -79,7 +78,7 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
     protected static final String PERIOD_CONFIG_KEY = "period";
     protected static final String DELAY_CONFIG_KEY = "delay";
     protected static final String TIME_UNIT_CONFIG_KEY = "timeUnit";
-    private static final String CONFIG_DESC_URI_KEY = "system:firmware-status-info-job";
+    private static final URI CONFIG_DESC_URI = URI.create("system:firmware-status-info-job");
 
     private final Logger logger = LoggerFactory.getLogger(FirmwareUpdateServiceImpl.class);
 
@@ -433,8 +432,8 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
         }
 
         try {
-            configDescriptionValidator.validate(config, new URI(CONFIG_DESC_URI_KEY));
-        } catch (URISyntaxException | ConfigValidationException e) {
+            configDescriptionValidator.validate(config, CONFIG_DESC_URI);
+        } catch (ConfigValidationException e) {
             logger.debug("Validation of new configuration values failed. Will keep current configuration.", e);
             return false;
         }

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
@@ -17,7 +17,6 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Base64;
 
 import javax.servlet.http.HttpServletRequest;
@@ -108,27 +107,27 @@ public class ProxyServletServiceTest {
     }
 
     @Test
-    public void testMaybeAppendAuthHeaderWithFullCredentials() throws URISyntaxException {
+    public void testMaybeAppendAuthHeaderWithFullCredentials() {
         Request request = mock(Request.class);
-        URI uri = new URI("http://testuser:testpassword@127.0.0.1:8080/content");
+        URI uri = URI.create("http://testuser:testpassword@127.0.0.1:8080/content");
         service.maybeAppendAuthHeader(uri, request);
         verify(request).header(HttpHeader.AUTHORIZATION,
                 "Basic " + Base64.getEncoder().encodeToString("testuser:testpassword".getBytes()));
     }
 
     @Test
-    public void testMaybeAppendAuthHeaderWithoutPassword() throws URISyntaxException {
+    public void testMaybeAppendAuthHeaderWithoutPassword() {
         Request request = mock(Request.class);
-        URI uri = new URI("http://testuser@127.0.0.1:8080/content");
+        URI uri = URI.create("http://testuser@127.0.0.1:8080/content");
         service.maybeAppendAuthHeader(uri, request);
         verify(request).header(HttpHeader.AUTHORIZATION,
                 "Basic " + Base64.getEncoder().encodeToString("testuser:".getBytes()));
     }
 
     @Test
-    public void testMaybeAppendAuthHeaderWithoutCredentials() throws URISyntaxException {
+    public void testMaybeAppendAuthHeaderWithoutCredentials() {
         Request request = mock(Request.class);
-        URI uri = new URI("http://127.0.0.1:8080/content");
+        URI uri = URI.create("http://127.0.0.1:8080/content");
         service.maybeAppendAuthHeader(uri, request);
         verify(request, never()).header(any(HttpHeader.class), anyString());
     }

--- a/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/ConfigOptionRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/ConfigOptionRegistryOSGiTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +49,7 @@ public class ConfigOptionRegistryOSGiTest extends JavaOSGiTest {
     private @Mock @NonNullByDefault({}) ConfigOptionProvider configOptionsProviderMock;
 
     @BeforeEach
-    public void setUp() throws URISyntaxException {
+    public void setUp() {
         // Register config registry
         configDescriptionRegistry = getService(ConfigDescriptionRegistry.class);
         ConfigDescriptionParameter param1 = ConfigDescriptionParameterBuilder

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -20,7 +20,6 @@ import static org.openhab.core.config.discovery.inbox.InboxPredicates.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -130,7 +129,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
             .withBridge(OTHER_BRIDGE_THING_UID).withProperty("Thing4", "12345").withRepresentationProperty("Thing4")
             .withLabel("thing4").withTTL(DEFAULT_TTL).build();
 
-    private final URI testURI = createURI("http:dummy");
+    private final URI testURI = URI.create("http:dummy");
     private final String testThingLabel = "dummy_thing";
     private final ThingUID testUID = new ThingUID("binding:type:id");
     private final ThingTypeUID testTypeUID = new ThingTypeUID("binding:type");
@@ -202,14 +201,6 @@ public class InboxOSGiTest extends JavaOSGiTest {
         inboxListeners.clear();
         registry.remove(BRIDGE_THING_UID);
         managedThingProvider.getAll().forEach(thing -> managedThingProvider.remove(thing.getUID()));
-    }
-
-    private static URI createURI(String s) {
-        try {
-            return new URI(s);
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Failed to create URI for: " + s, e);
-        }
     }
 
     private boolean addDiscoveryResult(DiscoveryResult discoveryResult) {

--- a/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionI18nTest.java
+++ b/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionI18nTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Objects;
@@ -105,11 +104,7 @@ public class ConfigDescriptionI18nTest extends JavaOSGiTest {
     }
 
     private static @Nullable ConfigDescription findDescription(Collection<ConfigDescription> descriptions, String uri) {
-        try {
-            return findDescription(descriptions, new URI(uri));
-        } catch (URISyntaxException e) {
-            return null;
-        }
+        return findDescription(descriptions, URI.create(uri));
     }
 
     private static ConfigDescription findDescription(Collection<ConfigDescription> descriptions, URI uri) {

--- a/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.config.xml.tests/src/main/java/org/openhab/core/config/xml/test/ConfigDescriptionsTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -261,11 +260,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
     }
 
     private static @Nullable ConfigDescription findDescription(Collection<ConfigDescription> descriptions, String uri) {
-        try {
-            return findDescription(descriptions, new URI(uri));
-        } catch (URISyntaxException e) {
-            return null;
-        }
+        return findDescription(descriptions, URI.create(uri));
     }
 
     private static ConfigDescription findDescription(Collection<ConfigDescription> descriptions, URI uri) {

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
@@ -12,14 +12,10 @@
  */
 package org.openhab.core.model.thing.testsupport.hue;
 
-import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
-
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
-import java.util.stream.Stream;
 
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionBuilder;
@@ -39,27 +35,18 @@ public class TestHueConfigDescriptionProvider implements ConfigDescriptionProvid
 
     @Override
     public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
-        return emptyList();
+        return List.of();
     }
 
     @Override
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
-        if (uri.equals(createURI("hue:LCT001:color"))) {
+        if (uri.equals(URI.create("hue:LCT001:color"))) {
             ConfigDescriptionParameter paramDefault = ConfigDescriptionParameterBuilder
                     .create("defaultConfig", Type.TEXT).withDefault("defaultValue").build();
             ConfigDescriptionParameter paramCustom = ConfigDescriptionParameterBuilder.create("customConfig", Type.TEXT)
                     .withDefault("none").build();
-            return ConfigDescriptionBuilder.create(uri)
-                    .withParameters(Stream.of(paramDefault, paramCustom).collect(toList())).build();
+            return ConfigDescriptionBuilder.create(uri).withParameters(List.of(paramDefault, paramCustom)).build();
         }
         return null;
-    }
-
-    private URI createURI(String s) {
-        try {
-            return new URI(s);
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Failed to create URI: " + s, e);
-        }
     }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -97,6 +96,7 @@ import org.osgi.service.component.ComponentContext;
 @NonNullByDefault
 public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
 
+    private static final URI BINDING_CONFIG_URI = URI.create("test:test");
     private static final String BINDING_ID = "testBinding";
     private static final String THING_TYPE_ID = "testThingType";
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID);
@@ -741,18 +741,10 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         return null;
     }
 
-    private URI configDescriptionUri() {
-        try {
-            return new URI("test:test");
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Error creating config description URI");
-        }
-    }
-
     private void registerThingTypeAndConfigDescription() {
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID(BINDING_ID, THING_TYPE_ID), "label")
-                .withConfigDescriptionURI(configDescriptionUri()).build();
-        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+                .withConfigDescriptionURI(BINDING_CONFIG_URI).build();
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(BINDING_CONFIG_URI)
                 .withParameter(ConfigDescriptionParameterBuilder
                         .create("parameter", ConfigDescriptionParameter.Type.TEXT).withRequired(true).build())
                 .build();
@@ -774,7 +766,7 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
 
     private void registerThingTypeProvider() {
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID(BINDING_ID, THING_TYPE_ID), "label")
-                .withConfigDescriptionURI(configDescriptionUri()).build();
+                .withConfigDescriptionURI(BINDING_CONFIG_URI).build();
 
         ThingTypeProvider thingTypeProvider = mock(ThingTypeProvider.class);
         when(thingTypeProvider.getThingType(ArgumentMatchers.any(ThingTypeUID.class),
@@ -787,7 +779,7 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
     }
 
     private void registerConfigDescriptionProvider(boolean withRequiredParameter) {
-        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(BINDING_CONFIG_URI)
                 .withParameter(
                         ConfigDescriptionParameterBuilder.create("parameter", ConfigDescriptionParameter.Type.TEXT)
                                 .withRequired(withRequiredParameter).build())

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
@@ -116,6 +115,7 @@ import org.osgi.service.component.ComponentContext;
 @NonNullByDefault
 public class ThingManagerOSGiTest extends JavaOSGiTest {
 
+    private static final URI THING_CONFIG_URI = URI.create("test:test");
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
     private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
@@ -2051,17 +2051,9 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         });
     }
 
-    private URI configDescriptionUri() {
-        try {
-            return new URI("test:test");
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Error creating config description URI");
-        }
-    }
-
     private void registerThingTypeProvider() {
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID("binding", "type"), "label")
-                .withConfigDescriptionURI(configDescriptionUri()).build();
+                .withConfigDescriptionURI(THING_CONFIG_URI).build();
 
         ThingTypeProvider thingTypeProvider = mock(ThingTypeProvider.class);
         when(thingTypeProvider.getThingType(any(ThingTypeUID.class), nullable(Locale.class))).thenReturn(thingType);
@@ -2073,7 +2065,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
     }
 
     private void registerConfigDescriptionProvider(boolean withRequiredParameter) {
-        ConfigDescription configDescription = ConfigDescriptionBuilder.create(configDescriptionUri())
+        ConfigDescription configDescription = ConfigDescriptionBuilder.create(THING_CONFIG_URI)
                 .withParameter(
                         ConfigDescriptionParameterBuilder.create("parameter", ConfigDescriptionParameter.Type.TEXT)
                                 .withRequired(withRequiredParameter).build())

--- a/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.thing.xml.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
@@ -57,7 +57,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
     @Test
     public void configDescriptionsShouldLoadProperly() throws Exception {
         try (final AutoCloseable unused = loadedTestBundle()) {
-            URI bridgeURI = new URI("thing-type:hue:bridge");
+            URI bridgeURI = URI.create("thing-type:hue:bridge");
             ConfigDescription bridgeConfigDescription = configDescriptionRegistry.getConfigDescriptions().stream()
                     .filter(it -> it.getUID().equals(bridgeURI)).findFirst().get();
 
@@ -87,7 +87,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
             assertThat(userNameParameter.getDescription(),
                     is("Name of a registered hue bridge user, that allows to access the API."));
 
-            URI colorURI = new URI("channel-type:hue:color");
+            URI colorURI = URI.create("channel-type:hue:color");
             ConfigDescription colorConfigDescription = configDescriptionRegistry.getConfigDescriptions().stream()
                     .filter(it -> it.getUID().equals(colorURI)).findFirst().get();
 
@@ -116,7 +116,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
     @Test
     public void parametersWithOptionsAndFiltersShouldLoadProperly() throws Exception {
         try (final AutoCloseable unused = loadedTestBundle()) {
-            URI dummyURI = new URI("thing-type:hue:dummy");
+            URI dummyURI = URI.create("thing-type:hue:dummy");
             ConfigDescription bridgeConfigDescription = configDescriptionRegistry.getConfigDescriptions().stream()
                     .filter(it -> it.getUID().equals(dummyURI)).findFirst().get();
             assertThat(bridgeConfigDescription, is(notNullValue()));

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -18,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -48,6 +47,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 @NonNullByDefault
 public class VoiceManagerImplTest extends JavaOSGiTest {
+    private static final URI VOICE_CONFIG_URI = URI.create("system:voice");
     private static final String CONFIG_DEFAULT_SINK = "defaultSink";
     private static final String CONFIG_DEFAULT_SOURCE = "defaultSource";
     private static final String CONFIG_DEFAULT_HLI = "defaultHLI";
@@ -418,14 +418,14 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void getParameterOptionsForTheDefaultHli() throws URISyntaxException {
+    public void getParameterOptionsForTheDefaultHli() {
         hliStub = new HumanLanguageInterpreterStub();
         registerService(hliStub);
 
         boolean isHliStubInTheOptions = false;
 
-        Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultHLI",
-                null, null);
+        Collection<ParameterOption> options = voiceManager.getParameterOptions(VOICE_CONFIG_URI, "defaultHLI", null,
+                null);
 
         assertNotNull(options);
 
@@ -443,14 +443,14 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void getParameterOptionsForTheDefaultKs() throws URISyntaxException {
+    public void getParameterOptionsForTheDefaultKs() {
         ksService = new KSServiceStub();
         registerService(ksService);
 
         boolean isKSStubInTheOptions = false;
 
-        Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultKS",
-                null, null);
+        Collection<ParameterOption> options = voiceManager.getParameterOptions(VOICE_CONFIG_URI, "defaultKS", null,
+                null);
 
         assertNotNull(options);
 
@@ -468,14 +468,14 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void getParameterOptionsForTheDefaultSTT() throws URISyntaxException {
+    public void getParameterOptionsForTheDefaultSTT() {
         sttService = new STTServiceStub();
         registerService(sttService);
 
         boolean isSTTStubInTheOptions = false;
 
-        Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultSTT",
-                null, null);
+        Collection<ParameterOption> options = voiceManager.getParameterOptions(VOICE_CONFIG_URI, "defaultSTT", null,
+                null);
         assertNotNull(options);
 
         for (ParameterOption option : options) {
@@ -492,14 +492,14 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void getParameterOptionsForTheDefaultTts() throws URISyntaxException {
+    public void getParameterOptionsForTheDefaultTts() {
         ttsService = new TTSServiceStub();
         registerService(ttsService);
 
         boolean isTTSStubInTheOptions = false;
 
-        Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultTTS",
-                null, null);
+        Collection<ParameterOption> options = voiceManager.getParameterOptions(VOICE_CONFIG_URI, "defaultTTS", null,
+                null);
 
         assertNotNull(options);
 
@@ -517,7 +517,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void getParameterOptionsForTheDefaultVoice() throws URISyntaxException {
+    public void getParameterOptionsForTheDefaultVoice() {
         BundleContext context = bundleContext;
         ttsService = new TTSServiceStub(context);
         registerService(ttsService);
@@ -525,8 +525,8 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         boolean isVoiceStubInTheOptions = false;
 
-        Collection<ParameterOption> options = voiceManager.getParameterOptions(new URI("system:voice"), "defaultVoice",
-                null, null);
+        Collection<ParameterOption> options = voiceManager.getParameterOptions(VOICE_CONFIG_URI, "defaultVoice", null,
+                null);
 
         assertNotNull(options);
 


### PR DESCRIPTION
- Avoid `URISyntaxException` in tests by using`URI.create()` method

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>