### PR TITLE
[rest] Add ability to change loggers and expose package names of addons

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -162,6 +162,7 @@ public class JsonAddonService extends AbstractRemoteAddonService {
                 .withDetailedDescription(addonEntry.description).withContentType(addonEntry.contentType)
                 .withAuthor(addonEntry.author).withVersion(addonEntry.version).withLabel(addonEntry.title)
                 .withMaturity(addonEntry.maturity).withProperties(properties).withLink(addonEntry.link)
-                .withImageLink(addonEntry.imageUrl).withConfigDescriptionURI(addonEntry.configDescriptionURI).build();
+                .withImageLink(addonEntry.imageUrl).withConfigDescriptionURI(addonEntry.configDescriptionURI)
+                .withLoggerPackages(addonEntry.loggerPackages).build();
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.addon.marketplace.internal.json.model;
 
+import java.util.List;
+
 import com.google.gson.annotations.SerializedName;
 
 /**
@@ -34,4 +36,6 @@ public class AddonEntryDTO {
     @SerializedName("image_url")
     public String imageUrl;
     public String url = "";
+    @SerializedName("logger_packages")
+    public List<String> loggerPackages = List.of();
 }

--- a/bundles/org.openhab.core.karaf/pom.xml
+++ b/bundles/org.openhab.core.karaf/pom.xml
@@ -38,6 +38,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.karaf.log</groupId>
+      <artifactId>org.apache.karaf.log.core</artifactId>
+      <version>${karaf.compile.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.karaf.wrapper</groupId>
       <artifactId>org.apache.karaf.wrapper.core</artifactId>
       <version>${karaf.compile.version}</version>
@@ -48,6 +54,12 @@
       <artifactId>org.apache.karaf.jaas.modules</artifactId>
       <version>${karaf.compile.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.rest</artifactId>
+      <version>3.3.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 import org.apache.karaf.features.Feature;
 import org.apache.karaf.features.FeaturesService;
@@ -146,9 +147,18 @@ public class KarafAddonService implements AddonService {
                 break;
         }
 
+        // for openHAB add-on bundles the package is the same as the bundle name
+        List<String> packages = feature.getBundles().stream().filter(bundle -> !bundle.isDependency()).map(bundle -> {
+            String location = bundle.getLocation();
+            location = location.substring(0, location.lastIndexOf("/")); // strip version
+            location = location.substring(location.lastIndexOf("/") + 1); // strip groupId and protocol
+            return location;
+        }).collect(Collectors.toList());
+
         return Addon.create(type + "-" + name).withType(type).withLabel(feature.getDescription())
                 .withVersion(feature.getVersion()).withContentType(ADDONS_CONTENTTYPE).withLink(link)
-                .withAuthor(ADDONS_AUTHOR, true).withInstalled(featuresService.isInstalled(feature)).build();
+                .withLoggerPackages(packages).withAuthor(ADDONS_AUTHOR, true)
+                .withInstalled(featuresService.isInstalled(feature)).build();
     }
 
     @Override

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerBean.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerBean.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.karaf.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This is a java bean that is used to define logger settings for the REST interface.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class LoggerBean {
+
+    public final List<LoggerInfo> loggers;
+
+    public static class LoggerInfo {
+        public final String loggerName;
+        public final String level;
+
+        public LoggerInfo(String loggerName, String level) {
+            this.loggerName = loggerName;
+            this.level = level;
+        }
+    }
+
+    public LoggerBean(Map<String, String> logLevels) {
+        loggers = logLevels.entrySet().stream().map(l -> new LoggerInfo(l.getKey(), l.getValue()))
+                .collect(Collectors.toList());
+    }
+}

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.karaf.internal;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.karaf.log.core.Level;
+import org.apache.karaf.log.core.LogService;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.auth.Role;
+import org.openhab.core.io.rest.RESTConstants;
+import org.openhab.core.io.rest.RESTResource;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * This class acts as a REST resource for changing logging configuration.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@Component
+@JaxrsResource
+@JaxrsName(LoggerResource.PATH_LOGGING)
+@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JSONRequired
+@Path(LoggerResource.PATH_LOGGING)
+@RolesAllowed({ Role.ADMIN })
+@SecurityRequirement(name = "oauth2", scopes = { "admin" })
+@Tag(name = LoggerResource.PATH_LOGGING)
+@NonNullByDefault
+public class LoggerResource implements RESTResource {
+    public static final String PATH_LOGGING = "logging";
+
+    private static final Set<String> LOG_LEVELS = Set.of(Level.strings());
+    private static final Pattern BUNDLE_REGEX = Pattern.compile("[\\w.]+");
+
+    private final LogService logService;
+
+    @Activate
+    public LoggerResource(@Reference LogService logService) {
+        this.logService = logService;
+    }
+
+    @GET
+    @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "getLogger", summary = "Get all loggers", responses = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoggerBean.class))) })
+    public Response getLoggers(@Context UriInfo uriInfo) {
+        final LoggerBean bean = new LoggerBean(logService.getLevel("ALL"));
+        return Response.ok(bean).build();
+    }
+
+    @PUT
+    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "putLogger", summary = "Modify or add logger", responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Payload is invalid.") })
+    public Response putLoggers(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+            @Parameter(description = "logger", required = true) LoggerBean.@Nullable LoggerInfo logger,
+            @Context UriInfo uriInfo) {
+        if (logger == null || !BUNDLE_REGEX.matcher(logger.loggerName).matches() || !LOG_LEVELS.contains(logger.level)
+                || !logger.loggerName.equals(loggerName)) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+        logService.setLevel(logger.loggerName, logger.level);
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
+    }
+
+    @GET
+    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "getLogger", summary = "Get a single logger.", responses = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoggerBean.LoggerInfo.class))) })
+    public Response getLogger(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+            @Context UriInfo uriInfo) {
+        final LoggerBean bean = new LoggerBean(logService.getLevel(loggerName));
+        return Response.ok(bean).build();
+    }
+
+    @DELETE
+    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Operation(operationId = "removeLogger", summary = "Remove a single logger.", responses = {
+            @ApiResponse(responseCode = "200", description = "OK") })
+    public Response removeLogger(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+            @Context UriInfo uriInfo) {
+        logService.setLevel(loggerName, "DEFAULT");
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
@@ -74,13 +74,14 @@ public class Addon {
      * @param backgroundColor for displaying the add-on (may be null)
      * @param imageLink the link to an image (png/svg) (may be null)
      * @param properties a {@link Map} containing addition information
+     * @param loggerPackages a {@link List} containing the package names belonging to this add-on
      */
     private Addon(String id, String type, String label, String version, @Nullable String maturity, String contentType,
             @Nullable String link, String author, boolean verifiedAuthor, boolean installed,
             @Nullable String description, @Nullable String detailedDescription, String configDescriptionURI,
             String keywords, String countries, @Nullable String license, String connection,
             @Nullable String backgroundColor, @Nullable String imageLink, @Nullable Map<String, Object> properties,
-            List<String> loggerBundles) {
+            List<String> loggerPackages) {
         this.id = id;
         this.label = label;
         this.version = version;
@@ -101,7 +102,7 @@ public class Addon {
         this.installed = installed;
         this.type = type;
         this.properties = properties == null ? Map.of() : properties;
-        this.loggerPackages = loggerBundles;
+        this.loggerPackages = loggerPackages;
     }
 
     /**
@@ -252,7 +253,7 @@ public class Addon {
     }
 
     /**
-     * The package names that are associated with this addon
+     * The package names that are associated with this add-on
      */
     public List<String> getLoggerPackages() {
         return loggerPackages;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
@@ -13,6 +13,7 @@
 package org.openhab.core.addon;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +35,7 @@ public class Addon {
     private final String contentType;
     private final @Nullable String link;
     private final String author;
-    private boolean verifiedAuthor;
+    private final boolean verifiedAuthor;
     private boolean installed;
     private final String type;
     private final @Nullable String description;
@@ -47,6 +48,7 @@ public class Addon {
     private final @Nullable String backgroundColor;
     private final @Nullable String imageLink;
     private final Map<String, Object> properties;
+    private final List<String> loggerPackages;
 
     /**
      * Creates a new Addon instance
@@ -77,7 +79,8 @@ public class Addon {
             @Nullable String link, String author, boolean verifiedAuthor, boolean installed,
             @Nullable String description, @Nullable String detailedDescription, String configDescriptionURI,
             String keywords, String countries, @Nullable String license, String connection,
-            @Nullable String backgroundColor, @Nullable String imageLink, @Nullable Map<String, Object> properties) {
+            @Nullable String backgroundColor, @Nullable String imageLink, @Nullable Map<String, Object> properties,
+            List<String> loggerBundles) {
         this.id = id;
         this.label = label;
         this.version = version;
@@ -98,6 +101,7 @@ public class Addon {
         this.installed = installed;
         this.type = type;
         this.properties = properties == null ? Map.of() : properties;
+        this.loggerPackages = loggerBundles;
     }
 
     /**
@@ -247,6 +251,13 @@ public class Addon {
         return imageLink;
     }
 
+    /**
+     * The package names that are associated with this addon
+     */
+    public List<String> getLoggerPackages() {
+        return loggerPackages;
+    }
+
     public static Builder create(String id) {
         return new Builder(id);
     }
@@ -272,6 +283,7 @@ public class Addon {
         private @Nullable String backgroundColor;
         private @Nullable String imageLink;
         private Map<String, Object> properties = new HashMap<>();
+        private List<String> loggerPackages = List.of();
 
         private Builder(String id) {
             this.id = id;
@@ -378,10 +390,15 @@ public class Addon {
             return this;
         }
 
+        public Builder withLoggerPackages(List<String> loggerPackages) {
+            this.loggerPackages = loggerPackages;
+            return this;
+        }
+
         public Addon build() {
             return new Addon(id, type, label, version, maturity, contentType, link, author, verifiedAuthor, installed,
                     description, detailedDescription, configDescriptionURI, keywords, countries, license, connection,
-                    backgroundColor, imageLink, properties.isEmpty() ? null : properties);
+                    backgroundColor, imageLink, properties.isEmpty() ? null : properties, loggerPackages);
         }
     }
 }


### PR DESCRIPTION
Related to #299

This adds the necessary parts in core for solving the mentioned issue. With these extensions it is possible 

- to add/modify/delete log settings via REST API
- get the Java package names that belong to an add-on

A future UI component can then retrieve the package names for an add-on and modify the log-levels of these packages. This could e.g. be integrated in the add-on page (next to the "remove" button). 

This is much more user-friendly than directing user to use the karaf console. On openHABian the log is displayed in frontail, so no console interaction is needed at all to get DEBUG logs.