### PR TITLE
Make ConfigDescription for thing and channels available to ThingHandler

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -205,7 +205,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     /**
      * Get the {@link ConfigDescription} of the thing
      *
-     * @return the config description (or null if not found or handler dispsed)
+     * @return the config description (or null if not found or handler disposed)
      */
     protected @Nullable ConfigDescription getConfigDescription() {
         ThingHandlerCallback callback = this.callback;
@@ -221,7 +221,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     /**
      * Get the {@link ConfigDescription} for a {@link ChannelTypeUID}
      *
-     * @return the config description (or null if not found or handler dispsed)
+     * @return the config description (or null if not found or handler disposed)
      */
     protected @Nullable ConfigDescription getConfigDescription(ChannelTypeUID channelTypeUID) {
         ThingHandlerCallback callback = this.callback;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigValidationException;
 import org.openhab.core.thing.Bridge;
@@ -35,6 +36,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.thing.util.ThingHandlerHelper;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -191,12 +193,46 @@ public abstract class BaseThingHandler implements ThingHandler {
      *             their declarations in the configuration description
      */
     protected void validateConfigurationParameters(Map<String, Object> configurationParameters) {
-        if (this.callback != null) {
-            this.callback.validateConfigurationParameters(this.getThing(), configurationParameters);
+        ThingHandlerCallback callback = this.callback;
+        if (callback != null) {
+            callback.validateConfigurationParameters(this.getThing(), configurationParameters);
         } else {
             logger.warn("Handler {} tried validating its configuration although the handler was already disposed.",
                     this.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * Get the {@link ConfigDescription} of the thing
+     *
+     * @return the config description (or null if not found or handler dispsed)
+     */
+    protected @Nullable ConfigDescription getConfigDescription() {
+        ThingHandlerCallback callback = this.callback;
+        if (callback != null) {
+            return callback.getConfigDescription(this.thing.getThingTypeUID());
+        } else {
+            logger.warn("Handler {} tried retrieving its config description although the handler was already disposed.",
+                    this.getClass().getSimpleName());
+        }
+        return null;
+    }
+
+    /**
+     * Get the {@link ConfigDescription} for a {@link ChannelTypeUID}
+     *
+     * @return the config description (or null if not found or handler dispsed)
+     */
+    protected @Nullable ConfigDescription getConfigDescription(ChannelTypeUID channelTypeUID) {
+        ThingHandlerCallback callback = this.callback;
+        if (callback != null) {
+            return callback.getConfigDescription(channelTypeUID);
+        } else {
+            logger.warn(
+                    "Handler {} tried retrieving a channel config description although the handler was already disposed.",
+                    this.getClass().getSimpleName());
+        }
+        return null;
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigValidationException;
 import org.openhab.core.thing.Bridge;
@@ -99,6 +100,24 @@ public interface ThingHandlerCallback {
      *             their declarations in the configuration description
      */
     void validateConfigurationParameters(Channel channel, Map<String, Object> configurationParameters);
+
+    /**
+     * Get the {@link ConfigDescription} for a {@link ChannelTypeUID}
+     *
+     * @param channelTypeUID the channel type UID
+     * @return the corresponding configuration description (or null if not found)
+     */
+    @Nullable
+    ConfigDescription getConfigDescription(ChannelTypeUID channelTypeUID);
+
+    /**
+     * Get the {@link ConfigDescription} for a {@link ThingTypeUID}
+     *
+     * @param thingTypeUID the thing type UID
+     * @return the corresponding configuration description (or null if not found)
+     */
+    @Nullable
+    ConfigDescription getConfigDescription(ThingTypeUID thingTypeUID);
 
     /**
      * Informs about an updated configuration of a thing.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -41,6 +41,7 @@ import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.common.registry.Identifiable;
 import org.openhab.core.common.registry.ManagedProvider;
 import org.openhab.core.common.registry.Provider;
+import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigDescriptionValidator;
@@ -303,6 +304,30 @@ public class ThingManagerImpl
                     configDescriptionValidator.validate(configurationParameters, configDescriptionURI);
                 }
             }
+        }
+
+        @Override
+        public @Nullable ConfigDescription getConfigDescription(ChannelTypeUID channelTypeUID) {
+            ChannelType channelType = channelTypeRegistry.getChannelType(channelTypeUID);
+            if (channelType != null) {
+                URI configDescriptionUri = channelType.getConfigDescriptionURI();
+                if (configDescriptionUri != null) {
+                    return configDescriptionRegistry.getConfigDescription(configDescriptionUri);
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public @Nullable ConfigDescription getConfigDescription(ThingTypeUID thingTypeUID) {
+            ThingType thingType = thingTypeRegistry.getThingType(thingTypeUID);
+            if (thingType != null) {
+                URI configDescriptionUri = thingType.getConfigDescriptionURI();
+                if (configDescriptionUri != null) {
+                    return configDescriptionRegistry.getConfigDescription(configDescriptionUri);
+                }
+            }
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Closes #2719 

This enables a thing handler to check the configuration of the thing and it's channels prior to changing them. 

Signed-off-by: Jan N. Klug <github@klug.nrw>