### PR TITLE
[config] Fixed config validation message for parameter options

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
@@ -35,7 +35,7 @@ final class OptionsValidator implements ConfigDescriptionParameterValidator {
         if (param.getOptions().stream().map(o -> o.getValue()).noneMatch(v -> v.equals(value.toString()))) {
             MessageKey messageKey = MessageKey.OPTIONS_VIOLATED;
             return new ConfigValidationMessage(param.getName(), messageKey.defaultMessage, messageKey.key,
-                    param.getOptions());
+                    String.valueOf(value), param.getOptions());
         }
         return null;
     }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -424,10 +424,11 @@ public class ConfigDescriptionValidatorTest {
 
     @Test
     public void assertValidationThrowsExceptionForNotAllowedLimitedParameterOption() {
+        String parameterValue = "ftp";
         List<ConfigValidationMessage> expected = List.of(new ConfigValidationMessage(
                 TXT_PARAM_WITH_LIMITED_OPTIONS_NAME, MessageKey.OPTIONS_VIOLATED.defaultMessage,
-                MessageKey.OPTIONS_VIOLATED.key, PARAMETER_OPTIONS));
-        params.put(TXT_PARAM_WITH_LIMITED_OPTIONS_NAME, "ftp");
+                MessageKey.OPTIONS_VIOLATED.key, parameterValue, PARAMETER_OPTIONS));
+        params.put(TXT_PARAM_WITH_LIMITED_OPTIONS_NAME, parameterValue);
         ConfigValidationException exception = Assertions.assertThrows(ConfigValidationException.class,
                 () -> configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI));
         assertThat(getConfigValidationMessages(exception), is(expected));


### PR DESCRIPTION
- Fixed config validation message for parameter options

The message has two placeholder ans we should pass the current value and the possible options to it. 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>