### PR TITLE
[DialogProcessor] change non null check for non empty check

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -249,10 +249,7 @@ public class DialogProcessor implements KSListener, STTListener {
                 String question = sre.getTranscript();
                 try {
                     toggleProcessing(false);
-                    String answer = hli.interpret(locale, question);
-                    if (answer != null) {
-                        say(answer);
-                    }
+                    say(hli.interpret(locale, question));
                 } catch (InterpretationException e) {
                     String msg = e.getMessage();
                     if (msg != null) {
@@ -280,7 +277,11 @@ public class DialogProcessor implements KSListener, STTListener {
      *
      * @param text The text to say
      */
-    protected void say(String text) {
+    protected void say(@Nullable String text) {
+        if (text == null || text.isEmpty()) {
+            logger.debug("Empty value, nothing to say");
+            return;
+        }
         try {
             Voice voice = null;
             for (Voice currentVoice : tts.getAvailableVoices()) {


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

After recent changes to null checks, seems like this need to be changed as the way of return no response from an hli has changed to return an empty string.
@lolodomo, @wborn WDYT?