### PR TITLE
[rest] Allow editing transformation files

### DIFF
--- a/bundles/org.openhab.core.io.rest.transform/pom.xml
+++ b/bundles/org.openhab.core.io.rest.transform/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.io.rest.transform</artifactId>
+
+  <name>openHAB Core :: Bundles :: Transformation REST Interface</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.io.rest</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.transform</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/TransformationResource.java
+++ b/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/TransformationResource.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.transform;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.OpenHAB;
+import org.openhab.core.auth.Role;
+import org.openhab.core.io.rest.RESTConstants;
+import org.openhab.core.io.rest.RESTResource;
+import org.openhab.core.io.rest.Stream2JSONInputStream;
+import org.openhab.core.transform.ManagedTransformationService;
+import org.openhab.core.transform.TransformationService;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
+import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * The {@link TransformationResource} is a
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@Component(immediate = true)
+@JaxrsResource
+@JaxrsName(TransformationResource.PATH_TRANSFORM)
+@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JSONRequired
+@Path(TransformationResource.PATH_TRANSFORM)
+@RolesAllowed({ Role.ADMIN })
+@SecurityRequirement(name = "oauth2", scopes = { "admin" })
+@Tag(name = TransformationResource.PATH_TRANSFORM)
+@NonNullByDefault
+public class TransformationResource implements RESTResource {
+    public static final String PATH_TRANSFORM = "transform";
+
+    private static final java.nio.file.Path TRANSFORM_FOLDER = java.nio.file.Path.of(OpenHAB.getConfigFolder(),
+            TransformationService.TRANSFORM_FOLDER_NAME);
+
+    private final Logger logger = LoggerFactory.getLogger(TransformationResource.class);
+    private @Context @NonNullByDefault({}) UriInfo uriInfo;
+
+    private final List<ManagedTransformationService> transformationServices = new CopyOnWriteArrayList<>();
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addTransformationService(ManagedTransformationService transformationService) {
+        transformationServices.add(transformationService);
+    }
+
+    protected void removeTransformationService(ManagedTransformationService transformationService) {
+        transformationServices.remove(transformationService);
+    }
+
+    @GET
+    @Path("files")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "getTransformationFiles", summary = "Get a list of all transformation files", responses = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
+            @ApiResponse(responseCode = "500", description = "Could not list files") })
+    public Response getTransformationFiles() {
+        logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
+
+        try (Stream<java.nio.file.Path> files = Files.walk(TRANSFORM_FOLDER)) {
+            List<String> fileList = files.filter(this::fileFilter).map(p -> TRANSFORM_FOLDER.relativize(p).toString())
+                    .collect(Collectors.toList());
+            return Response.ok(new Stream2JSONInputStream(fileList.stream())).build();
+        } catch (IOException ignored) {
+        }
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+
+    @GET
+    @Path("files/{fileName: .+}")
+    @Produces(MediaType.TEXT_PLAIN)
+    @Operation(operationId = "getTransformationFile", summary = "Get the content of a transformation file", responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "403", description = "Path is forbidden"),
+            @ApiResponse(responseCode = "404", description = "File not found"),
+            @ApiResponse(responseCode = "500", description = "Could not read file or invalid path") })
+    public Response getTransformationFile(
+            @PathParam("fileName") @Parameter(description = "file name") String fileName) {
+        logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
+
+        try {
+            java.nio.file.Path filePath = TRANSFORM_FOLDER.resolve(fileName).normalize();
+            if (!filePath.startsWith(TRANSFORM_FOLDER)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
+            if (!Files.exists(filePath)) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
+
+            String content = Files.readString(filePath, StandardCharsets.UTF_8);
+            return Response.ok(content, MediaType.TEXT_PLAIN).build();
+        } catch (InvalidPathException | IOException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PUT
+    @Path("files/{fileName: .+}")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Operation(operationId = "putTransformationFile", summary = "Add or modify a transformation file", responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Invalid extension of content invalid"),
+            @ApiResponse(responseCode = "403", description = "Path is forbidden"),
+            @ApiResponse(responseCode = "500", description = "Could not write file or invalid path") })
+    public Response putTransformationFile(@PathParam("fileName") @Parameter(description = "file name") String fileName,
+            @Parameter(description = "file content", required = true) @Nullable String content) {
+        logger.debug("Received HTTP PUT request at '{}'", uriInfo.getPath());
+
+        try {
+            java.nio.file.Path filePath = TRANSFORM_FOLDER.resolve(fileName).normalize();
+            if (!filePath.startsWith(TRANSFORM_FOLDER)) {
+                return Response.status(Response.Status.FORBIDDEN).build();
+            }
+
+            ManagedTransformationService transformationService = transformationServices.stream()
+                    .filter(t -> t.supportedFileExtensions().stream().anyMatch(fileName::endsWith)).findAny()
+                    .orElse(null);
+
+            if (transformationService != null && transformationService.configurationIsValid(content)) {
+                Files.writeString(filePath, Objects.requireNonNullElse(content, ""), StandardCharsets.UTF_8,
+                        StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+
+                return Response.ok().build();
+            } else {
+                return Response.status(Response.Status.BAD_REQUEST).build();
+            }
+
+        } catch (InvalidPathException | IOException e) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * Check if file is a regular file, is not hidden and has an extension that belongs to one of the registered
+     * services
+     * 
+     * @param path {@link java.nio.file.Path} to a single directory entry
+     * @return true if all conditions are fulfilled, false otherwise
+     */
+    private boolean fileFilter(java.nio.file.Path path) {
+        try {
+            return Files.isRegularFile(path) && !Files.isHidden(path) && hasValidExtension(path);
+        } catch (IOException ignored) {
+        }
+        return false;
+    }
+
+    private boolean hasValidExtension(java.nio.file.Path path) {
+        String pathStr = path.toString();
+        return transformationServices.stream().map(ManagedTransformationService::supportedFileExtensions)
+                .flatMap(List::stream).anyMatch(pathStr::endsWith);
+    }
+}

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationService.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.transform;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ManagedTransformationService} can be implemented by transformations to make their configuration managable
+ * over the REST UI
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public interface ManagedTransformationService {
+
+    default boolean configurationIsValid(@Nullable String configuration) {
+        return true;
+    };
+
+    List<String> supportedFileExtensions();
+}

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationService.java
@@ -26,9 +26,22 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface ManagedTransformationService {
 
+    /**
+     * Check if the provided configuration is valid
+     *
+     * Services that don't provide validation can rely on the default implementation which returns true
+     *
+     * @param configuration the configuration to check
+     * @return true if configuration is valid or service does not implement validation
+     */
     default boolean configurationIsValid(@Nullable String configuration) {
         return true;
     };
 
+    /**
+     * Get a list of all file extensions supported by this service
+     * 
+     * @return A list of file extensions
+     */
     List<String> supportedFileExtensions();
 }

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -67,6 +67,7 @@
     <module>org.openhab.core.io.rest.sitemap</module>
     <module>org.openhab.core.io.rest.sse</module>
     <module>org.openhab.core.io.rest.swagger</module>
+    <module>org.openhab.core.io.rest.transform</module>
     <module>org.openhab.core.io.rest.ui</module>
     <module>org.openhab.core.io.rest.voice</module>
     <module>org.openhab.core.io.transport.mdns</module>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -152,6 +152,11 @@
 		<feature dependency="true">openhab.tp-swagger-jaxrs</feature>
 	</feature>
 
+	<feature name="openhab-core-io-rest-transform" version="${project.version}">
+		<feature>openhab-core-base</feature>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.transform/${project.version}</bundle>
+	</feature>
+
 	<feature name="openhab-core-io-rest-audio" version="${project.version}">
 		<feature>openhab-core-base</feature>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest.audio/${project.version}</bundle>
@@ -382,6 +387,7 @@
 		<feature>openhab-core-io-rest-auth</feature>
 		<feature>openhab-core-io-rest-sitemap</feature>
 		<feature>openhab-core-io-rest-audio</feature>
+		<feature>openhab-core-io-rest-transform</feature>
 		<feature>openhab-core-io-rest-voice</feature>
 		<feature>openhab-core-io-rest-swagger</feature>
 		<feature>openhab-core-io-rest-mdns</feature>


### PR DESCRIPTION
This solves the necessary core-part of #2068.

The implementation makes sure that only files with registered extensions are processed and that breaking out of the configured transformation directory is not possible. The new `ManagedTransformationService` could easily be integrated into `TransformationService`, however since it provides a file extension and `TransformationService` is agnostic of the way the configuration is provided I decided against it.

@ghys Do you think this will be sufficient for the UI to support editing these files?

Signed-off-by: Jan N. Klug <github@klug.nrw>