### PR TITLE
Allow type migrations in JSONStorage

### DIFF
--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/RenamingTypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/RenamingTypeMigrator.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.storage.json.internal.migration;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link RenamingTypeMigrator} is an {@link TypeMigrator} for renaming types
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class RenamingTypeMigrator implements TypeMigrator {
+
+    private final String oldType;
+    private final String newType;
+
+    public RenamingTypeMigrator(String oldType, String newType) {
+        this.oldType = oldType;
+        this.newType = newType;
+    }
+
+    @Override
+    public String getOldType() {
+        return oldType;
+    }
+
+    @Override
+    public String getNewType() {
+        return newType;
+    }
+}

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrationException.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrationException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.storage.json.internal.migration;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link TypeMigrationException} is thrown if a migration fails
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class TypeMigrationException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public TypeMigrationException(String message) {
+        super(message);
+    }
+}

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrator.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.storage.json.internal.migration;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import com.google.gson.JsonElement;
+
+/**
+ * The {@link TypeMigrator} interface allows the implementation of JSON storage type migrations
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public interface TypeMigrator {
+
+    /**
+     * Get the name of the old (stored) type
+     *
+     * @return Full class name
+     */
+    String getOldType();
+
+    /**
+     * Get the name of the new type
+     *
+     * @return Full class name
+     */
+    String getNewType();
+
+    /**
+     * Migrate the old type to the new type
+     *
+     * The default implementation can be used if type is renamed only.
+     *
+     * @param oldValue The {@link JsonElement} representation of the old type
+     * @return The corresponding {@link JsonElement} representation of the new type
+     * @throws TypeMigrationException if an error occurs
+     */
+    default JsonElement migrate(JsonElement oldValue) throws TypeMigrationException {
+        return oldValue;
+    }
+}

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
@@ -55,13 +55,13 @@ public class JsonStorageTest extends JavaTest {
     public void setUp() throws IOException {
         tmpFile = File.createTempFile("storage-debug", ".json");
         tmpFile.deleteOnExit();
-        objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0);
+        objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0, List.of());
     }
 
     private void persistAndReadAgain() {
         objectStorage.flush();
         waitForAssert(() -> {
-            objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0);
+            objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0, List.of());
             DummyObject dummy = objectStorage.get("DummyObject");
             assertNotNull(dummy);
             assertNotNull(dummy.configuration);
@@ -137,7 +137,7 @@ public class JsonStorageTest extends JavaTest {
         persistAndReadAgain();
         String storageString1 = Files.readString(tmpFile.toPath());
 
-        objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0);
+        objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0, List.of());
         objectStorage.flush();
         String storageString2 = Files.readString(tmpFile.toPath());
 
@@ -166,7 +166,7 @@ public class JsonStorageTest extends JavaTest {
         assertEquals(storageStringAB, storageStringBA);
 
         {
-            objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0);
+            objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0, List.of());
             objectStorage.flush();
         }
         String storageStringReserialized = Files.readString(tmpFile.toPath());

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/MigrationTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/MigrationTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.storage.json.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.storage.json.internal.migration.RenamingTypeMigrator;
+import org.openhab.core.storage.json.internal.migration.TypeMigrationException;
+import org.openhab.core.storage.json.internal.migration.TypeMigrator;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+/**
+ * The {@link MigrationTest} is a
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class MigrationTest {
+    private static final String OBJECT_KEY = "foo";
+    private static final String OBJECT_VALUE = "bar";
+
+    private @NonNullByDefault({}) File tmpFile;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        tmpFile = File.createTempFile("storage-debug", ".json");
+        tmpFile.deleteOnExit();
+
+        // store old class
+        OldNameClass oldNameInstance = new OldNameClass(OBJECT_VALUE);
+        JsonStorage<OldNameClass> storage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0,
+                List.of());
+        storage.put(OBJECT_KEY, oldNameInstance);
+        storage.flush();
+    }
+
+    @Test
+    public void testRenameClassMigration() {
+        // read new class
+        JsonStorage<NewNameClass> storage1 = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0,
+                List.of(new RenamingTypeMigrator(OldNameClass.class.getName(), NewNameClass.class.getName())));
+        NewNameClass newNameInstance = storage1.get(OBJECT_KEY);
+        assertNotNull(newNameInstance);
+
+        Objects.requireNonNull(newNameInstance);
+        assertEquals(OBJECT_VALUE, newNameInstance.value);
+    }
+
+    @Test
+    public void testRenameFieldMigration() {
+        // read new class
+        JsonStorage<NewFieldClass> storage1 = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0,
+                List.of(new OldToNewFieldMigrator()));
+        NewFieldClass newNameInstance = storage1.get(OBJECT_KEY);
+        assertNotNull(newNameInstance);
+
+        Objects.requireNonNull(newNameInstance);
+        assertEquals(OBJECT_VALUE, newNameInstance.val);
+    }
+
+    @SuppressWarnings("unused")
+    private static class OldNameClass {
+        public String value;
+
+        public OldNameClass(String value) {
+            this.value = value;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class NewNameClass {
+        public String value;
+
+        public NewNameClass(String value) {
+            this.value = value;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class NewFieldClass {
+        public String val;
+
+        public NewFieldClass(String value) {
+            this.val = value;
+        }
+    }
+
+    private static class OldToNewFieldMigrator implements TypeMigrator {
+
+        @Override
+        public String getOldType() {
+            return OldNameClass.class.getName();
+        }
+
+        @Override
+        public String getNewType() {
+            return NewFieldClass.class.getName();
+        }
+
+        @Override
+        public JsonElement migrate(JsonElement oldValue) throws TypeMigrationException {
+            JsonObject newElement = oldValue.getAsJsonObject();
+            JsonElement element = newElement.remove("value");
+            newElement.add("val", element);
+            return newElement;
+        }
+    }
+}


### PR DESCRIPTION
This is a pre-requisite to solving #1301. It allows maintaining backward compatibility when types are renamed or changed.

Inspired by https://github.com/maggu2810/openhab-core/commit/b5c224e

Signed-off-by: Jan N. Klug <github@klug.nrw>