### PR TITLE
Fix test failures when building with Java 17

### DIFF
--- a/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptScopeOSGiTest.java
+++ b/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptScopeOSGiTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script.internal.defaultscope;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -29,12 +30,14 @@ import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.openhab.core.test.java.JavaOSGiTest;
 
 /**
- * This tests the script modules
+ * This tests the script modules if the Nashorn JavaScript engine is available.
  *
  * @author Kai Kreuzer - Initial contribution
  */
 @NonNullByDefault
 public class ScriptScopeOSGiTest extends JavaOSGiTest {
+
+    private static final boolean NASHORN_AVAILABLE = isNashornAvailable();
 
     private @NonNullByDefault({}) ScriptEngine engine;
 
@@ -42,8 +45,25 @@ public class ScriptScopeOSGiTest extends JavaOSGiTest {
     private final String workingFile = "scopeWorking.js";
     private final String failureFile = "scopeFailure.js";
 
+    /**
+     * Returns if the Nashorn JavaScript engine is available based on the Java specification version property.
+     * Nashorn has been removed from JDK 15 and onwards.
+     *
+     * @return {@code true} if Nashorn is available, {@code false} otherwise
+     */
+    private static boolean isNashornAvailable() {
+        try {
+            String javaVersion = System.getProperty("java.specification.version");
+            return javaVersion == null ? false : Long.parseLong(javaVersion) < 15;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
     @BeforeEach
     public void init() {
+        assumeTrue(NASHORN_AVAILABLE);
+
         ScriptEngineManager scriptManager = getService(ScriptEngineManager.class);
         ScriptEngineContainer container = scriptManager.createScriptEngine("js", "myJSEngine");
         engine = container.getScriptEngine();

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,10 @@ Import-Package: \\
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
+            <argLine>
+              --add-opens java.base/java.net=ALL-UNNAMED
+              --add-opens java.base/java.util=ALL-UNNAMED
+            </argLine>
             <systemPropertyVariables>
               <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>
             </systemPropertyVariables>


### PR DESCRIPTION
* Adds some --add-opens to maven-surefire-plugin for:
  * modbus transport tests (java.net)
  * tests using Gson/XStream (java.util)
* Only run ScriptScopeOSGiTest when Nashorn is available as it has been removed since JDK 15