### PR TITLE
[Voice] get compatible audio format refactor

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -225,19 +225,19 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 throw new TTSException(
                         "Unable to find a voice for language " + localeProvider.getLocale().getLanguage());
             }
-            Set<AudioFormat> audioFormats = tts.getSupportedFormats();
+            Set<AudioFormat> sttAudioFormats = tts.getSupportedFormats();
             AudioSink sink = audioManager.getSink(sinkId);
             if (sink == null) {
                 throw new TTSException("Unable to find the audio sink " + sinkId);
             }
 
-            AudioFormat audioFormat = getBestMatch(audioFormats, sink.getSupportedFormats());
-            if (audioFormat == null) {
+            AudioFormat sttAudioFormat = AudioFormat.getBestMatch(sink.getSupportedFormats(), sttAudioFormats);
+            if (sttAudioFormat == null) {
                 throw new TTSException("No compatible audio format found for TTS '" + tts.getId() + "' and sink '"
                         + sink.getId() + "'");
             }
 
-            AudioStream audioStream = tts.synthesize(text, voice, audioFormat);
+            AudioStream audioStream = tts.synthesize(text, voice, sttAudioFormat);
             if (!sink.getSupportedStreams().stream().anyMatch(clazz -> clazz.isInstance(audioStream))) {
                 throw new TTSException(
                         "Failed playing audio stream '" + audioStream + "' as audio sink doesn't support it");
@@ -423,22 +423,6 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         }
 
         // Return null indicating failure
-        return null;
-    }
-
-    public static @Nullable AudioFormat getBestMatch(Set<AudioFormat> inputs, Set<AudioFormat> outputs) {
-        AudioFormat preferredFormat = getPreferredFormat(inputs);
-        for (AudioFormat output : outputs) {
-            if (output.isCompatible(preferredFormat)) {
-                return preferredFormat;
-            } else {
-                for (AudioFormat input : inputs) {
-                    if (output.isCompatible(input)) {
-                        return input;
-                    }
-                }
-            }
-        }
         return null;
     }
 


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>
This is a proposed solution for https://github.com/openhab/openhab-core/issues/2794.

Includes:

* use specific format for ks, stt and tts on the dialog processor.
* <s>refactor of static method getBestMatch in AudioFormat.</s>
* remove duplicated method getBestMatch in VoiceManagerImpl and use the one from AudioFormat.