### PR TITLE
Rename Thing status variables to be more explicit

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -65,10 +65,10 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     public static final String VAR_TRIGGERING_THING = "triggeringThing";
     
     /** Variable name for the previous status of the triggering thing in a "thing status trigger" rule */
-    public static final String VAR_PREVIOUS_STATUS = "previousStatus";
+    public static final String VAR_PREVIOUS_STATUS = "previousThingStatus";
     
     /** Variable name for the new status of the triggering thing in a "thing status trigger" rule */
-    public static final String VAR_NEW_STATUS = "newStatus";
+    public static final String VAR_NEW_STATUS = "newThingStatus";
     
     /**
      * conveninence API to build and initialize JvmTypes and their members.


### PR DESCRIPTION
Follow up to #2756

Suggestion from [rossko57](https://community.openhab.org/t/oh3-getting-triggeringitemname-and-previousstate-of-thing-changed/128794/9) that we make the variable names more explicit to avoid confusion of `previousStatus` with `previousState`.

I'll log a docs PR assuming this is accepted.