### PR TITLE
Fix proxy can't handle requests with forwarded host list

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
@@ -59,7 +59,7 @@ public class ProxyFilter implements ContainerRequestFilter {
         String host = getValue(ctx.getHeaders(), HOST_PROXY_HEADER);
         String scheme = getValue(ctx.getHeaders(), PROTO_PROXY_HEADER);
 
-        // if our request does not have neither headers end right here
+        // if our request does not have scheme or headers end right here
         if (scheme == null && host == null) {
             return;
         }
@@ -84,9 +84,15 @@ public class ProxyFilter implements ContainerRequestFilter {
             }
         }
 
+        // host may contain a list of hosts, cf. https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#x-headers
+        // we only take the first hostname
+        if (host.indexOf(",") > 0) {
+            host = host.substring(0, host.indexOf(","));
+        }
+
         // create a new URI from the current scheme + host in order to validate
         // it
-        String uriString = scheme + "://" + host;
+        String uriString = scheme + "://" + host.trim();
 
         URI newBaseUri = null;
         try {

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
@@ -87,6 +87,21 @@ public class ProxyFilterTest {
     }
 
     @Test
+    public void hostListTest() throws Exception {
+        String baseURI = "http://localhost:8080/rest";
+        String requestURI = "http://localhost:8080/rest/test";
+        setupContextURIs(baseURI, requestURI);
+
+        setupContextHeaders("https", "eclipse.org, foo.bar");
+
+        filter.filter(contextMock);
+
+        URI newBaseURI = new URI("https://eclipse.org/rest");
+        URI newRequestURI = new URI("https://eclipse.org/rest/test");
+        verify(contextMock).setRequestUri(eq(newBaseURI), eq(newRequestURI));
+    }
+
+    @Test
     public void noHeaderTest() throws Exception {
         String baseURI = "http://localhost:8080/rest";
         String requestURI = "http://localhost:8080/rest/test";


### PR DESCRIPTION
Fixes #2684 

This seems to be safe, because a comma is not an allowed character in a host-name.

Signed-off-by: Jan N. Klug <github@klug.nrw>