### PR TITLE
[Voice] restore getBestMatch method

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -119,9 +119,9 @@ public class DialogProcessor implements KSListener, STTListener {
         this.eventPublisher = eventPublisher;
         this.i18nProvider = i18nProvider;
         this.bundle = bundle;
-        this.ksFormat = AudioFormat.getBestMatch(source.getSupportedFormats(), ks.getSupportedFormats());
-        this.sttFormat = AudioFormat.getBestMatch(source.getSupportedFormats(), stt.getSupportedFormats());
-        this.ttsFormat = AudioFormat.getBestMatch(sink.getSupportedFormats(), tts.getSupportedFormats());
+        this.ksFormat = VoiceManagerImpl.getBestMatch(source.getSupportedFormats(), ks.getSupportedFormats());
+        this.sttFormat = VoiceManagerImpl.getBestMatch(source.getSupportedFormats(), stt.getSupportedFormats());
+        this.ttsFormat = VoiceManagerImpl.getBestMatch(sink.getSupportedFormats(), tts.getSupportedFormats());
     }
 
     public void start() {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -231,7 +231,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 throw new TTSException("Unable to find the audio sink " + sinkId);
             }
 
-            AudioFormat sttAudioFormat = AudioFormat.getBestMatch(sink.getSupportedFormats(), sttAudioFormats);
+            AudioFormat sttAudioFormat = getBestMatch(sink.getSupportedFormats(), sttAudioFormats);
             if (sttAudioFormat == null) {
                 throw new TTSException("No compatible audio format found for TTS '" + tts.getId() + "' and sink '"
                         + sink.getId() + "'");
@@ -423,6 +423,22 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         }
 
         // Return null indicating failure
+        return null;
+    }
+
+    public static @Nullable AudioFormat getBestMatch(Set<AudioFormat> inputs, Set<AudioFormat> outputs) {
+        AudioFormat preferredFormat = getPreferredFormat(inputs);
+        for (AudioFormat output : outputs) {
+            if (output.isCompatible(preferredFormat)) {
+                return preferredFormat;
+            } else {
+                for (AudioFormat input : inputs) {
+                    if (output.isCompatible(input)) {
+                        return input;
+                    }
+                }
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

Partially revert https://github.com/openhab/openhab-core/pull/2795
The getBestMatch implementation from AudioFormat behaves different. 
This restores the previous one.
Described here https://github.com/openhab/openhab-core/issues/2801 
