### PR TITLE
Re-introduce removed DecimalType ctors to maintain compatibility

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -49,8 +49,8 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         this(bigDecimal(value));
     }
 
-    // TODO: Remove this constructors. They are still in place to maintain binary compatibility and will be removed once
-    // another change breaking binary compatibility is merged
+    // TODO: Remove these constructors. They are still in place to maintain binary compatibility and will be removed
+    // once another change breaking binary compatibility is merged
     public DecimalType(BigDecimal value) {
         this.value = value;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -49,6 +49,21 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         this(bigDecimal(value));
     }
 
+    @Deprecated
+    public DecimalType(BigDecimal value) {
+        this.value = value;
+    }
+
+    @Deprecated
+    public DecimalType(long value) {
+        this(bigDecimal(value));
+    }
+
+    @Deprecated
+    public DecimalType(double value) {
+        this(bigDecimal(value));
+    }
+
     private static BigDecimal bigDecimal(Number value) {
         if (value instanceof QuantityType) {
             return ((QuantityType<?>) value).toBigDecimal();
@@ -59,10 +74,6 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         }
 
         return new BigDecimal(value.toString());
-    }
-
-    public DecimalType(BigDecimal value) {
-        this.value = value;
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -49,17 +49,16 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         this(bigDecimal(value));
     }
 
-    @Deprecated
+    // TODO: Remove this constructors. They are still in place to maintain binary compatibility and will be removed once
+    // another change breaking binary compatibility is merged
     public DecimalType(BigDecimal value) {
         this.value = value;
     }
 
-    @Deprecated
     public DecimalType(long value) {
         this(bigDecimal(value));
     }
 
-    @Deprecated
     public DecimalType(double value) {
         this(bigDecimal(value));
     }


### PR DESCRIPTION
This re-introduces the constructors removed in #2596. This should restore binary compatibility with 3.2.

Signed-off-by: Jan N. Klug <github@klug.nrw>