### PR TITLE
Remove unused local variable

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -142,7 +142,6 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         ScriptContext executionContext = engine.getContext();
 
         for (Entry<String, ?> entry : context.entrySet()) {
-            Object value = entry.getValue();
             String key = entry.getKey();
             int dotIndex = key.indexOf('.');
             if (dotIndex != -1) {


### PR DESCRIPTION
It's unused so it can be safely removed.