### PR TITLE
[Voice] fix "best match" format resolution and language check for services involved in dialog

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -212,9 +212,6 @@ public class DialogProcessor implements KSListener, STTListener {
             if (ksEvent instanceof KSpottedEvent) {
                 abortSTT();
                 closeStreamSTT();
-                // stop ks while stt is running
-                abortKS();
-                closeStreamKS();
                 isSTTServerAborting = false;
                 AudioFormat fmt = sttFormat;
                 if (fmt != null) {
@@ -224,8 +221,6 @@ public class DialogProcessor implements KSListener, STTListener {
                         sttServiceHandle = stt.recognize(this, stream, locale, new HashSet<>());
                     } catch (AudioException e) {
                         logger.warn("Error creating the audio stream: {}", e.getMessage());
-                        // start ks
-                        start();
                     } catch (STTException e) {
                         closeStreamSTT();
                         String msg = e.getMessage();
@@ -235,8 +230,6 @@ public class DialogProcessor implements KSListener, STTListener {
                         } else if (text != null) {
                             say(text.replace("{0}", ""));
                         }
-                        // start ks
-                        start();
                     }
                 } else {
                     logger.warn("No compatible audio format found for stt '{}' and source '{}'", stt.getId(),
@@ -266,8 +259,6 @@ public class DialogProcessor implements KSListener, STTListener {
                     }
                 }
                 abortSTT();
-                // start ks
-                start();
             }
         } else if (sttEvent instanceof RecognitionStartEvent) {
             toggleProcessing(true);
@@ -280,8 +271,6 @@ public class DialogProcessor implements KSListener, STTListener {
                 SpeechRecognitionErrorEvent sre = (SpeechRecognitionErrorEvent) sttEvent;
                 String text = i18nProvider.getText(bundle, "error.stt-error", null, locale);
                 say(text == null ? sre.getMessage() : text.replace("{0}", sre.getMessage()));
-                // start ks
-                start();
             }
         }
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -225,13 +225,13 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 throw new TTSException(
                         "Unable to find a voice for language " + localeProvider.getLocale().getLanguage());
             }
-            Set<AudioFormat> sttAudioFormats = tts.getSupportedFormats();
+            Set<AudioFormat> ttsAudioFormats = tts.getSupportedFormats();
             AudioSink sink = audioManager.getSink(sinkId);
             if (sink == null) {
                 throw new TTSException("Unable to find the audio sink " + sinkId);
             }
 
-            AudioFormat sttAudioFormat = getBestMatch(sttAudioFormats, sink.getSupportedFormats());
+            AudioFormat sttAudioFormat = getBestMatch(ttsAudioFormats, sink.getSupportedFormats());
             if (sttAudioFormat == null) {
                 throw new TTSException("No compatible audio format found for TTS '" + tts.getId() + "' and sink '"
                         + sink.getId() + "'");

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -225,19 +225,19 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 throw new TTSException(
                         "Unable to find a voice for language " + localeProvider.getLocale().getLanguage());
             }
-            Set<AudioFormat> ttsAudioFormats = tts.getSupportedFormats();
+            Set<AudioFormat> ttsSupportedFormats = tts.getSupportedFormats();
             AudioSink sink = audioManager.getSink(sinkId);
             if (sink == null) {
                 throw new TTSException("Unable to find the audio sink " + sinkId);
             }
 
-            AudioFormat sttAudioFormat = getBestMatch(ttsAudioFormats, sink.getSupportedFormats());
-            if (sttAudioFormat == null) {
+            AudioFormat ttsAudioFormat = getBestMatch(ttsSupportedFormats, sink.getSupportedFormats());
+            if (ttsAudioFormat == null) {
                 throw new TTSException("No compatible audio format found for TTS '" + tts.getId() + "' and sink '"
                         + sink.getId() + "'");
             }
 
-            AudioStream audioStream = tts.synthesize(text, voice, sttAudioFormat);
+            AudioStream audioStream = tts.synthesize(text, voice, ttsAudioFormat);
             if (!sink.getSupportedStreams().stream().anyMatch(clazz -> clazz.isInstance(audioStream))) {
                 throw new TTSException(
                         "Failed playing audio stream '" + audioStream + "' as audio sink doesn't support it");

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -231,7 +231,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 throw new TTSException("Unable to find the audio sink " + sinkId);
             }
 
-            AudioFormat sttAudioFormat = getBestMatch(sink.getSupportedFormats(), sttAudioFormats);
+            AudioFormat sttAudioFormat = getBestMatch(sttAudioFormats, sink.getSupportedFormats());
             if (sttAudioFormat == null) {
                 throw new TTSException("No compatible audio format found for TTS '" + tts.getId() + "' and sink '"
                         + sink.getId() + "'");
@@ -503,8 +503,9 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         if (ksService == null || sttService == null || ttsService == null || interpreter == null || audioSource == null
                 || audioSink == null || b == null) {
             throw new IllegalStateException("Cannot start dialog as services are missing.");
-        } else if (!ksService.getSupportedLocales().contains(loc) || !sttService.getSupportedLocales().contains(loc)
-                || !interpreter.getSupportedLocales().contains(loc)) {
+        } else if (!checkLocales(ksService.getSupportedLocales(), loc)
+                || !checkLocales(sttService.getSupportedLocales(), loc)
+                || !checkLocales(interpreter.getSupportedLocales(), loc)) {
             throw new IllegalStateException("Cannot start dialog as provided locale is not supported by all services.");
         } else {
             DialogProcessor processor = dialogProcessors.get(audioSource.getId());
@@ -546,6 +547,18 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
             processor.stop();
         });
         dialogProcessors.clear();
+    }
+
+    private boolean checkLocales(@Nullable Set<Locale> supportedLocales, Locale locale) {
+        if (supportedLocales == null) {
+            // rule interpreter returns null so allowing it
+            return true;
+        }
+        return supportedLocales.stream().anyMatch(sLocale -> {
+            var country = sLocale.getCountry();
+            return Objects.equals(sLocale.getLanguage(), locale.getLanguage())
+                    && (country == null || country.isBlank() || country.equals(locale.getCountry()));
+        });
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

This pr contains:

* <s>stop ks while stt in dialog processor (we were already ignoring ks events)</s>
* fix language check for services involved in dialog
* fix the "best match" format resolution broken by me in a previous pr.

I'm able to use the audio capabilities again after this changes.