### PR TITLE
[Voice] fix checklocale with RuleHumanLanguageInterpreter

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -549,9 +549,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         dialogProcessors.clear();
     }
 
-    private boolean checkLocales(@Nullable Set<Locale> supportedLocales, Locale locale) {
-        if (supportedLocales == null) {
-            // rule interpreter returns null so allowing it
+    private boolean checkLocales(Set<Locale> supportedLocales, Locale locale) {
+        if (supportedLocales.isEmpty()) {
             return true;
         }
         return supportedLocales.stream().anyMatch(sLocale -> {


### PR DESCRIPTION
Check for null and emptyness, as, for example, RuleHumanLanguageInterpreter returns an empty set to tell it has no locale preference.
Found by testing the new voice system (ks, stt)

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>