### PR TITLE
Add accepted types to ProfileContext

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
@@ -38,9 +38,7 @@ public class ProfileContextImpl implements ProfileContext {
     private final List<Class<? extends Command>> acceptedCommandTypes;
 
     public ProfileContextImpl(Configuration configuration) {
-        this.configuration = configuration;
-        this.acceptedDataTypes = List.of();
-        this.acceptedCommandTypes = List.of();
+        this(configuration, List.of(), List.of());
     }
 
     public ProfileContextImpl(Configuration configuration, List<Class<? extends State>> acceptedDataTypes,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
@@ -12,17 +12,21 @@
  */
 package org.openhab.core.thing.internal;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 
 /**
  * {@link ProfileContext} implementation.
  *
  * @author Simon Kaufmann - Initial contribution
+ * @author Jan N. Klug - Add accepted type methods
  */
 @NonNullByDefault
 public class ProfileContextImpl implements ProfileContext {
@@ -30,8 +34,20 @@ public class ProfileContextImpl implements ProfileContext {
     private static final String THREAD_POOL_NAME = "profiles";
     private final Configuration configuration;
 
+    private final List<Class<? extends State>> acceptedDataTypes;
+    private final List<Class<? extends Command>> acceptedCommandTypes;
+
     public ProfileContextImpl(Configuration configuration) {
         this.configuration = configuration;
+        this.acceptedDataTypes = List.of();
+        this.acceptedCommandTypes = List.of();
+    }
+
+    public ProfileContextImpl(Configuration configuration, List<Class<? extends State>> acceptedDataTypes,
+            List<Class<? extends Command>> acceptedCommandTypes) {
+        this.configuration = configuration;
+        this.acceptedDataTypes = acceptedDataTypes;
+        this.acceptedCommandTypes = acceptedCommandTypes;
     }
 
     @Override
@@ -42,5 +58,15 @@ public class ProfileContextImpl implements ProfileContext {
     @Override
     public ScheduledExecutorService getExecutorService() {
         return ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME);
+    }
+
+    @Override
+    public List<Class<? extends State>> getAcceptedDataTypes() {
+        return acceptedDataTypes;
+    }
+
+    @Override
+    public List<Class<? extends Command>> getAcceptedCommandTypes() {
+        return acceptedCommandTypes;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
@@ -12,10 +12,13 @@
  */
 package org.openhab.core.thing.profiles;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 
 /**
  * The profile's context
@@ -23,6 +26,7 @@ import org.openhab.core.config.core.Configuration;
  * It gives access to related information like the profile's configuration or a scheduler.
  *
  * @author Simon Kaufmann - Initial contribution
+ * @author Jan N. Klug - Add accepted type methods
  */
 @NonNullByDefault
 public interface ProfileContext {
@@ -40,4 +44,26 @@ public interface ProfileContext {
      * @return the scheduler
      */
     ScheduledExecutorService getExecutorService();
+
+    /**
+     * Get the list of accepted data types for state updates to the linked item
+     *
+     * This is an optional method and will return an empty list if not implemented.
+     *
+     * @return A list of all accepted data types
+     */
+    default List<Class<? extends State>> getAcceptedDataTypes() {
+        return List.of();
+    }
+
+    /**
+     * Get the list of accepted command types for commands send to the linked item
+     *
+     * This is an optional method and will return an empty list if not implemented.
+     *
+     * @return A list of all accepted command types
+     */
+    default List<Class<? extends Command>> getAcceptedCommandTypes() {
+        return List.of();
+    }
 }


### PR DESCRIPTION
I'm working on a very generic script profile which can be used with every item type. E.g. a script could half all commands from the handler to the item. Since a `Dimmer` channel accepts different item types, I need to know which types are accepted by the receiving item. This could e.g. also be used to link a `String` channel (containing a JSON array as result of an HTTP request) to an `Number` item (for element count in the array).

Even tough I doubt that there are other implementations of `ProfileContext` out there, I decided to keep it backward compatible and make the implementation of the newly introduced methods optional. If you don't mind the breaking change, I can easily remove them.

Signed-off-by: Jan N. Klug <github@klug.nrw>