### PR TITLE
Add Java 17 to GHA CI build matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,8 +16,9 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        java: [ '11' ]
+        java: [ '11', '17' ]
         maven: [ '3.8.4']
         os: [ 'ubuntu-20.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
@@ -55,6 +56,7 @@ jobs:
           maven-version: ${{ matrix.maven }}
 
       - name: Register Problem Matchers
+        if: ${{ matrix.java == '11' }}
         id: problem_matchers
         run: |
           echo "::add-matcher::.github/openhab-compile-problems.json"
@@ -70,7 +72,7 @@ jobs:
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
       - name: Upload Build Log
-        if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
+        if: ${{ matrix.java == '11' && always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
         uses: actions/upload-artifact@v2
         with:
           name: build-log-java-${{ matrix.java }}-${{ matrix.os }}

--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@ Import-Package: \\
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[11.0,12.0)</version>
+                  <version>[11.0,18.0)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
This adds Java 17 to the GitHub Actions CI build matrix so we can make sure the build keeps working with both Java 11 and Java 17. It also updates the required Java version range used by the enforcer plugin so it is also possible to build with the supported Java versions. Furthermore it prevents duplicate error annotations being added by only adding these in the Java 11 matrix build.