### PR TITLE
Remove temporary OSGi framework inclusion

### DIFF
--- a/itests/itest-include.bndrun
+++ b/itests/itest-include.bndrun
@@ -11,9 +11,6 @@
 # Run all integration tests which are named xyzTest
 Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 
-# A temporary inclusion until an R7 framework is available
-Import-Package: org.osgi.framework.*;version="[1.8,2)",*
-
 # Used by Objenesis/Mockito and not actually optional
 -runsystempackages: sun.reflect
 


### PR DESCRIPTION
The itests are run using an R7 framework so the inclusion no longer seems required.
This also allows for easily customizing Import-Package headers in itest bundles.

Sometimes it useful to be able to customize this header when including libraries without OSGi bundle headers like in https://github.com/openhab/openhab-addons/pull/12431/.