### PR TITLE
[standardinterpreter] spanish: fix text tokenization and on/off rule

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
@@ -261,7 +261,7 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
 
                 /* OnOffType */
 
-                itemRule(seq(encenderApagar, articulo), /* item */ onOff),
+                itemRule(seq(encenderApagar, articulo)/* item */),
 
                 /* IncreaseDecreaseType */
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -599,6 +599,8 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         if (Locale.FRENCH.getLanguage().equalsIgnoreCase(locale.getLanguage())) {
             split = text.toLowerCase(locale).replaceAll("[\\']", " ").replaceAll("[^\\w\\sàâäçéèêëîïôùûü]", " ")
                     .split("\\s");
+        } else if ("es".equalsIgnoreCase(locale.getLanguage())) {
+            split = text.toLowerCase(locale).replaceAll("[\\']", " ").replaceAll("[^\\w\\sáéíóúü]", " ").split("\\s");
         } else {
             split = text.toLowerCase(locale).replaceAll("[\\']", "").replaceAll("[^\\w\\s]", " ").split("\\s");
         }


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

This just apply to 'es' locale. Fixes tokenization and onOff rule.