### PR TITLE
Run org.openhab.core tests in forks to reduce build time

### DIFF
--- a/bundles/org.openhab.core/pom.xml
+++ b/bundles/org.openhab.core/pom.xml
@@ -14,4 +14,20 @@
 
   <name>openHAB Core :: Bundles :: Core</name>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <!-- This bundle has many tests so run them in forks to reduce the build time -->
+            <forkCount>4</forkCount>
+            <reuseForks>false</reuseForks>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>


### PR DESCRIPTION
This saves about 1 minute when building this bundle.
Most bundles depend on org.openhab.core so cores would stay idle until this bundle is build in a parallel build.