### PR TITLE
Fix CertificateGenerator package

### DIFF
--- a/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
+++ b/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.io.jetty.certificate.internal;
+package org.openhab.core.io.jetty.certificate.internal;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;


### PR DESCRIPTION
The class is in a package that does not match the bundle name.