### PR TITLE
Fix KAR installation check

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -218,14 +218,17 @@ public class FeatureInstaller implements ConfigurationListener {
     private boolean allKarsInstalled() {
         try {
             List<String> karRepos = karService.list();
-            Dictionary<String, Object> felixProperties = configurationAdmin
-                    .getConfiguration("org.apache.felix.fileinstall~deploy").getProperties();
-            String addonsDirectory = (String) felixProperties.get("felix.fileinstall.dir");
-            if (addonsDirectory != null) {
-                return Files.list(Path.of(addonsDirectory)).map(Path::getFileName).map(Path::toString)
-                        .filter(file -> file.endsWith(".kar"))
-                        .map(karFileName -> karFileName.substring(0, karFileName.lastIndexOf(".")))
-                        .allMatch(karRepos::contains);
+            Configuration[] configurations = configurationAdmin
+                    .listConfigurations("(service.factoryPid=org.apache.felix.fileinstall)");
+            if (configurations.length > 0) {
+                Dictionary<String, Object> felixProperties = configurations[0].getProperties();
+                String addonsDirectory = (String) felixProperties.get("felix.fileinstall.dir");
+                if (addonsDirectory != null) {
+                    return Files.list(Path.of(addonsDirectory)).map(Path::getFileName).map(Path::toString)
+                            .filter(file -> file.endsWith(".kar"))
+                            .map(karFileName -> karFileName.substring(0, karFileName.lastIndexOf(".")))
+                            .allMatch(karRepos::contains);
+                }
             }
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
Follow-Up To #2753

It was reported on the forum that under some circumstances the service PID of the fileinstall service is not `org.apache.felix.fileinstall~deploy` but something like `org.apache.felix.fileinstall.a702e1ba-1635-4154-906d-a9646a043a56`. As a result the check if all KARs are installed failed because the addons directory could not be determined.

This PR requests all configurations for the factoryPID `org.apache.felix.fileinstall` and then takes the first to determine the addons directory. I believe this is fine because the service should not exist multiple times.

Signed-off-by: Jan N. Klug <github@klug.nrw>