### PR TITLE
Upgrade Eclipse OSGi system bundle to 3.17.200 in runtime BOM

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.eclipse.platform</groupId>
       <artifactId>org.eclipse.osgi</artifactId>
-      <version>3.16.300</version>
+      <version>3.17.200</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
This prevents deprecation warnings when running the itests with Java 17:

```
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.eclipse.osgi.internal.framework.SystemBundleActivator (file:org.openhab.core.tests/target/test/tmp/testing/itest/cnf/cache/6.2.0/org.openhab.core.bom.runtime-index/org.eclipse.osgi-3.16.300.v20210525-1715.jar)
WARNING: Please consider reporting this to the maintainers of org.eclipse.osgi.internal.framework.SystemBundleActivator
WARNING: System::setSecurityManager will be removed in a future release
```

See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=574729