### PR TITLE
Extend ProfileContext to allow data type changing profiles

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -306,7 +306,6 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
         if (context == null) {
             logger.debug("Could not create full channel context, item or channel missing in registry.");
             return null;
-            // context = new ProfileContextImpl(link.getConfiguration());
         }
 
         if (supportsProfileTypeUID(defaultProfileFactory, profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -41,6 +41,7 @@ import org.openhab.core.items.ItemFactory;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ItemStateConverter;
 import org.openhab.core.items.ItemUtil;
+import org.openhab.core.items.events.AbstractItemRegistryEvent;
 import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemStateEvent;
 import org.openhab.core.library.items.NumberItem;
@@ -51,6 +52,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.events.AbstractThingRegistryEvent;
 import org.openhab.core.thing.events.ChannelTriggeredEvent;
 import org.openhab.core.thing.events.ThingEventFactory;
 import org.openhab.core.thing.internal.link.ItemChannelLinkConfigDescriptionProvider;
@@ -61,6 +63,7 @@ import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.thing.profiles.Profile;
 import org.openhab.core.thing.profiles.ProfileAdvisor;
 import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
 import org.openhab.core.thing.profiles.ProfileFactory;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.openhab.core.thing.profiles.StateProfile;
@@ -188,6 +191,18 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             receiveCommand((ItemCommandEvent) event);
         } else if (event instanceof ChannelTriggeredEvent) {
             receiveTrigger((ChannelTriggeredEvent) event);
+        } else if (event instanceof AbstractItemRegistryEvent) {
+            String itemName = ((AbstractItemRegistryEvent) event).getItem().name;
+            profiles.entrySet().removeIf(entry -> {
+                ItemChannelLink link = itemChannelLinkRegistry.get(entry.getKey());
+                return link != null && itemName.equals(link.getItemName());
+            });
+        } else if (event instanceof AbstractThingRegistryEvent) {
+            ThingUID thingUid = new ThingUID(((AbstractThingRegistryEvent) event).getThing().UID);
+            profiles.entrySet().removeIf(entry -> {
+                ItemChannelLink link = itemChannelLinkRegistry.get(entry.getKey());
+                return link != null && thingUid.equals(link.getLinkedUID().getThingUID());
+            });
         }
     }
 
@@ -275,7 +290,24 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     private @Nullable Profile getProfileFromFactories(ProfileTypeUID profileTypeUID, ItemChannelLink link,
             ProfileCallback callback) {
-        ProfileContextImpl context = new ProfileContextImpl(link.getConfiguration());
+        ProfileContext context = null;
+
+        Item item = getItem(link.getItemName());
+        Thing thing = getThing(link.getLinkedUID().getThingUID());
+        if (item != null && thing != null) {
+            Channel channel = thing.getChannel(link.getLinkedUID());
+            if (channel != null) {
+                context = new ProfileContextImpl(link.getConfiguration(), item.getAcceptedDataTypes(),
+                        item.getAcceptedCommandTypes(),
+                        acceptedCommandTypeMap.getOrDefault(channel.getAcceptedItemType(), List.of()));
+            }
+        }
+
+        if (context == null) {
+            logger.debug("Could not create channel context, item or channel missing in registry.");
+            return null;
+        }
+
         if (supportsProfileTypeUID(defaultProfileFactory, profileTypeUID)) {
             logger.trace("Using the default ProfileFactory to create profile '{}' for link '{}'", profileTypeUID, link);
             return defaultProfileFactory.createProfile(profileTypeUID, callback, context);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -298,14 +298,15 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             Channel channel = thing.getChannel(link.getLinkedUID());
             if (channel != null) {
                 context = new ProfileContextImpl(link.getConfiguration(), item.getAcceptedDataTypes(),
-                        item.getAcceptedCommandTypes(),
-                        acceptedCommandTypeMap.getOrDefault(channel.getAcceptedItemType(), List.of()));
+                        item.getAcceptedCommandTypes(), acceptedCommandTypeMap.getOrDefault(
+                                Objects.requireNonNullElse(channel.getAcceptedItemType(), ""), List.of()));
             }
         }
 
         if (context == null) {
-            logger.debug("Could not create channel context, item or channel missing in registry.");
+            logger.debug("Could not create full channel context, item or channel missing in registry.");
             return null;
+            // context = new ProfileContextImpl(link.getConfiguration());
         }
 
         if (supportsProfileTypeUID(defaultProfileFactory, profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
@@ -36,16 +36,19 @@ public class ProfileContextImpl implements ProfileContext {
 
     private final List<Class<? extends State>> acceptedDataTypes;
     private final List<Class<? extends Command>> acceptedCommandTypes;
+    private final List<Class<? extends Command>> handlerAcceptedCommandTypes;
 
     public ProfileContextImpl(Configuration configuration) {
-        this(configuration, List.of(), List.of());
+        this(configuration, List.of(), List.of(), List.of());
     }
 
     public ProfileContextImpl(Configuration configuration, List<Class<? extends State>> acceptedDataTypes,
-            List<Class<? extends Command>> acceptedCommandTypes) {
+            List<Class<? extends Command>> acceptedCommandTypes,
+            List<Class<? extends Command>> handlerAcceptedCommandTypes) {
         this.configuration = configuration;
         this.acceptedDataTypes = acceptedDataTypes;
         this.acceptedCommandTypes = acceptedCommandTypes;
+        this.handlerAcceptedCommandTypes = handlerAcceptedCommandTypes;
     }
 
     @Override
@@ -66,5 +69,10 @@ public class ProfileContextImpl implements ProfileContext {
     @Override
     public List<Class<? extends Command>> getAcceptedCommandTypes() {
         return acceptedCommandTypes;
+    }
+
+    @Override
+    public List<Class<? extends Command>> getHandlerAcceptedCommandTypes() {
+        return handlerAcceptedCommandTypes;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
@@ -66,4 +66,15 @@ public interface ProfileContext {
     default List<Class<? extends Command>> getAcceptedCommandTypes() {
         return List.of();
     }
+
+    /**
+     * Get the list of accepted command types for commands send to the handler
+     *
+     * This is an optional method and will return an empty list if not implemented.
+     *
+     * @return A list of all accepted command types
+     */
+    default List<Class<? extends Command>> getHandlerAcceptedCommandTypes() {
+        return List.of();
+    }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
@@ -68,7 +68,7 @@ public interface ProfileContext {
     }
 
     /**
-     * Get the list of accepted command types for commands send to the handler
+     * Get the list of accepted command types for commands sent to the handler
      *
      * This is an optional method and will return an empty list if not implemented.
      *


### PR DESCRIPTION
This is a follow-up to #2814.

It makes use of the methods added in #2814 and also adds a new method to access the command types accepted by the handler. Additionally it adds support for thing/item change detection. In case an update/creation/removal event is received, all corresponding profiles are removed from the cache. This ensures that the accepted data types and command types are always up-to-date with the current link configuration. If the item or channel cannot be found in the registry/thing, no profile is created. While this seems like a breaking change at first glance it is not, because the link would not work anyway if either item or thing(-channel) are not available.