### PR TITLE
Improve PeridodicSchedulerImplTest

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -47,7 +47,7 @@ public class PeriodicSchedulerImplTest {
         final long now = System.currentTimeMillis();
 
         ScheduledCompletableFuture<Object> future = periodicScheduler.schedule(() -> {
-            times.add((System.currentTimeMillis() - now) / 100);
+            times.add(System.currentTimeMillis() - now);
             semaphore.release();
         }, delays);
         semaphore.acquire(6);
@@ -55,9 +55,10 @@ public class PeriodicSchedulerImplTest {
         // Because starting scheduler takes some time and we don't know how long
         // the first time set is the offset on which we check the next values.
         long offset = times.poll();
-        long[] expectedResults = { 2, 5, 8, 11, 14 };
+        long[] expectedResults = { 200, 500, 800, 1100, 1400 };
         for (long expectedResult : expectedResults) {
-            assertEquals(offset + expectedResult, times.poll().longValue(), "Expected periodic time");
+            assertEquals((offset + expectedResult) / 100.0, times.poll().longValue() / 100.0, 0.1,
+                    "Expected periodic time");
         }
         assertFalse(semaphore.tryAcquire(1, TimeUnit.SECONDS), "No more jobs should have been scheduled");
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -55,10 +55,12 @@ public class PeriodicSchedulerImplTest {
         // Because starting scheduler takes some time and we don't know how long
         // the first time set is the offset on which we check the next values.
         long offset = times.poll();
-        long[] expectedResults = { 200, 500, 800, 1100, 1400 };
+        long[] expectedResults = { 200, 300, 300, 300, 300 };
         for (long expectedResult : expectedResults) {
-            assertEquals((offset + expectedResult) / 100.0, times.poll().longValue() / 100.0, 0.3,
-                    "Expected periodic time");
+            long actualValue = times.poll().longValue();
+            assertEquals((offset + expectedResult) / 100.0, actualValue / 100.0, 0.3,
+                    "Expected periodic time, total: " + actualValue);
+            offset = actualValue;
         }
         assertFalse(semaphore.tryAcquire(1, TimeUnit.SECONDS), "No more jobs should have been scheduled");
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -57,7 +57,7 @@ public class PeriodicSchedulerImplTest {
         long offset = times.poll();
         long[] expectedResults = { 200, 500, 800, 1100, 1400 };
         for (long expectedResult : expectedResults) {
-            assertEquals((offset + expectedResult) / 100.0, times.poll().longValue() / 100.0, 0.1,
+            assertEquals((offset + expectedResult) / 100.0, times.poll().longValue() / 100.0, 0.3,
                     "Expected periodic time");
         }
         assertFalse(semaphore.tryAcquire(1, TimeUnit.SECONDS), "No more jobs should have been scheduled");


### PR DESCRIPTION
Fixes #2848 

The old implementation truncated timestamps to 1/10 s. Under some circumstances this could result in a failed tests:

offset = 201 -> truncatedOffset = 2
200ms delay expected, adjustment calculation results in an actual delay of 198ms
time = 399 -> truncatedTime = 3

expected: truncatedOffset + expected => 2 + 2 = 4
actual: truncatedTime = 3

The new implementation allows for an error of +/- 30ms which is far more than needed (and better than the +99/-1 ms we had before). Also the periodic time is always calculated from the last value, not from the original start, preventing failures from small deviations summing up. 

Signed-off-by: Jan N. Klug <github@klug.nrw>