### PR TITLE
Improve ScriptFileWatcherTest

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
@@ -107,7 +107,7 @@ class ScriptFileWatcherTest {
 
         scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
 
-        verify(scriptEngineManager).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(1000)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -236,7 +236,7 @@ class ScriptFileWatcherTest {
         scheduledTask.getValue().run();
 
         // verify script has now been processed
-        verify(scriptEngineManager, times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -281,7 +281,7 @@ class ScriptFileWatcherTest {
 
         scriptFileWatcher.onDependencyChange(p.toFile().toURI().toString());
 
-        verify(scriptEngineManager, times(2)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(1000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -344,6 +344,6 @@ class ScriptFileWatcherTest {
         scriptFileWatcher.processWatchEvent(null, ENTRY_MODIFY, p);
 
         verify(scriptEngineManager).removeEngine(p.toFile().toURI().toString());
-        verify(scriptEngineManager, times(2)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(1000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 }


### PR DESCRIPTION
Fixes #2854 

Most of the tests add a timeout of 1s to account for small delays in async processing in the AbstractWatchService. This adds some more timeouts for tests which were missing those.

Signed-off-by: Jan N. Klug <github@klug.nrw>