### PR TITLE
Improve ThingManagerOSGiTest

### DIFF
--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -1806,9 +1806,9 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         doAnswer(new Answer<Void>() {
             @Override
             public @Nullable Void answer(InvocationOnMock invocation) throws Throwable {
-                bridgeState.childHandlerInitializedCalled = true;
                 bridgeState.initializedHandler = (ThingHandler) invocation.getArgument(0);
                 bridgeState.initializedThing = (Thing) invocation.getArgument(1);
+                bridgeState.childHandlerInitializedCalled = true;
                 return null;
             }
         }).when(bridgeHandler).childHandlerInitialized(any(ThingHandler.class), any(Thing.class));
@@ -1816,9 +1816,9 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         doAnswer(new Answer<Void>() {
             @Override
             public @Nullable Void answer(InvocationOnMock invocation) throws Throwable {
-                bridgeState.childHandlerDisposedCalled = true;
                 bridgeState.disposedHandler = (ThingHandler) invocation.getArgument(0);
                 bridgeState.disposedThing = (Thing) invocation.getArgument(1);
+                bridgeState.childHandlerDisposedCalled = true;
                 return null;
             }
         }).when(bridgeHandler).childHandlerDisposed(any(ThingHandler.class), any(Thing.class));


### PR DESCRIPTION
Fixes #2539 

This change ensures that the storage of bridge and thing are done before the initialization is reported.

Signed-off-by: Jan N. Klug <github@klug.nrw>