### PR TITLE
Fix enabling/disabling CommunityMarketplace

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -83,7 +83,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
     static final String CONFIG_URI = "system:marketplace";
     static final String CONFIG_API_KEY = "apiKey";
     static final String CONFIG_SHOW_UNPUBLISHED_ENTRIES_KEY = "showUnpublished";
-    static final String CONFIG_ENABLED_KEY = "enabled";
+    static final String CONFIG_ENABLED_KEY = "enable";
 
     private static final String COMMUNITY_BASE_URL = "https://community.openhab.org";
     private static final String COMMUNITY_MARKETPLACE_URL = COMMUNITY_BASE_URL + "/c/marketplace/69/l/latest";


### PR DESCRIPTION
For some reason if I disable "Enable Community Marketplace" it still keeps showing marketplace add-ons.

_Originally posted by @wborn in https://github.com/openhab/openhab-core/issues/2811#issuecomment-1073362324_

Simple typo when I refactored the config key to a static constant. In the `marketplace.xml` the configuration option is named `enable` not `enabled`.

Signed-off-by: Jan N. Klug <github@klug.nrw>