### PR TITLE
Add missing default translations for add-ons/marketplace configuration options

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/resources/OH-INF/i18n/marketplace.properties
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/resources/OH-INF/i18n/marketplace.properties
@@ -4,6 +4,8 @@ system.config.jsonaddonservice.urls.label = Add-on Service URLs
 system.config.jsonaddonservice.urls.description = Pipe (|) separated list of URLS that provide 3rd party add-on services via Json files. Warning: Bundles distributed over 3rd party add-on services may lack proper review and can potentially contain malicious code and thus harm your system.
 system.config.marketplace.apiKey.label = API Key for community.openhab.org
 system.config.marketplace.apiKey.description = Specify the API key to use on the community forum (for staff and curators - this allows for instance to see content which is not yet reviewed or otherwise hidden from the general public). Leave blank if you don't have one.
+system.config.marketplace.enable.label = Enable Community Marketplace
+system.config.marketplace.enable.description = If set to false no add-ons from the community marketplace will be shown. Already installed add-ons will still be available.
 system.config.marketplace.showUnpublished.label = Show Unpublished Entries
 system.config.marketplace.showUnpublished.description = Include entries which have not been tagged as published. Warning: this may include entries that are not ready and might not work or harm your installation. Enable at your own risk, for testing purposes only.
 

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/addons.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/addons.properties
@@ -1,3 +1,5 @@
+system.config.addons.includeIncompatible.label = Include (Potentially) Incompatible Add-ons
+system.config.addons.includeIncompatible.description = Some add-on services may provide add-ons where compatibility with the currently running system is not expected. Enabling this option will include these entries in the list of available add-ons.
 system.config.addons.remote.label = Access Remote Repository
 system.config.addons.remote.description = Defines whether openHAB should access the remote repository for add-on installation.
 


### PR DESCRIPTION
This makes it possible to use Crowdin for translating the new configuration options introduced in #2811.