### PR TITLE
Introduce a generic scripting profile

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/pom.xml
+++ b/bundles/org.openhab.core.automation.module.script/pom.xml
@@ -25,6 +25,12 @@
       <artifactId>org.openhab.core.transform</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -46,7 +46,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jan N. Klug - Initial contribution
  */
-@Component(service = TransformationService.class, property = { "openhab.transform=SCRIPT" })
+@Component(service = { TransformationService.class, ScriptTransformationService.class }, property = {
+        "openhab.transform=SCRIPT" })
 @NonNullByDefault
 public class ScriptTransformationService
         implements TransformationService, RegistryChangeListener<TransformationConfiguration> {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.ScriptEngineFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.script.ScriptEngine;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The {@link ScriptEngineFactoryHelper} contains helper methods for handling script engines
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class ScriptEngineFactoryHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScriptEngineFactoryHelper.class);
+
+    private ScriptEngineFactoryHelper() {
+        // prevent instantiation of static utility class
+    }
+
+    public static Map.@Nullable Entry<String, String> getParameterOption(ScriptEngineFactory engineFactory) {
+        List<String> scriptTypes = engineFactory.getScriptTypes();
+        if (!scriptTypes.isEmpty()) {
+            ScriptEngine scriptEngine = engineFactory.createScriptEngine(scriptTypes.get(0));
+            if (scriptEngine != null) {
+                Map.Entry<String, String> parameterOption = Map.entry(getPreferredMimeType(engineFactory), getLanguageName(scriptEngine.getFactory()));
+                LOGGER.trace("ParameterOptions: {}", parameterOption);
+            } else {
+                LOGGER.trace("setScriptEngineFactory: engine was null");
+            }
+        } else {
+            LOGGER.trace("addScriptEngineFactory: scriptTypes was empty");
+        }
+
+        return null;
+    }
+
+    public static String getPreferredMimeType(ScriptEngineFactory factory) {
+        List<String> mimeTypes = new ArrayList<>(factory.getScriptTypes());
+        mimeTypes.removeIf(mimeType -> !mimeType.contains("application") || "application/python".equals(mimeType));
+        return mimeTypes.isEmpty() ? factory.getScriptTypes().get(0) : mimeTypes.get(0);
+    }
+
+    public static String getLanguageName(javax.script.ScriptEngineFactory factory) {
+        return String.format("%s (%s)",
+                factory.getLanguageName().substring(0, 1).toUpperCase() + factory.getLanguageName().substring(1),
+                factory.getLanguageVersion());
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
@@ -12,16 +12,17 @@
  */
 package org.openhab.core.automation.module.script.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.script.ScriptEngine;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.ScriptEngineFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.script.ScriptEngine;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * The {@link ScriptEngineFactoryHelper} contains helper methods for handling script engines
@@ -41,8 +42,10 @@ public class ScriptEngineFactoryHelper {
         if (!scriptTypes.isEmpty()) {
             ScriptEngine scriptEngine = engineFactory.createScriptEngine(scriptTypes.get(0));
             if (scriptEngine != null) {
-                Map.Entry<String, String> parameterOption = Map.entry(getPreferredMimeType(engineFactory), getLanguageName(scriptEngine.getFactory()));
+                Map.Entry<String, String> parameterOption = Map.entry(getPreferredMimeType(engineFactory),
+                        getLanguageName(scriptEngine.getFactory()));
                 LOGGER.trace("ParameterOptions: {}", parameterOption);
+                return parameterOption;
             } else {
                 LOGGER.trace("setScriptEngineFactory: engine was null");
             }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.module.script.profile;
 
 import java.util.List;
 
+import javax.script.ScriptException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigParser;
@@ -38,9 +40,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class ScriptProfile implements StateProfile {
-    protected static final String CONFIG_TO_ITEM_SCRIPT = "toItemScript";
-    protected static final String CONFIG_TO_HANDLER_SCRIPT = "toHandlerScript";
-    protected static final String CONFIG_SCRIPT_TYPE = "scriptType";
+    public static final String CONFIG_TO_ITEM_SCRIPT = "toItemScript";
+    public static final String CONFIG_TO_HANDLER_SCRIPT = "toHandlerScript";
 
     private final Logger logger = LoggerFactory.getLogger(ScriptProfile.class);
 
@@ -139,7 +140,11 @@ public class ScriptProfile implements StateProfile {
             try {
                 return transformationService.transform(script, input.toFullString());
             } catch (TransformationException e) {
-                logger.warn("Failed to process script '{}': {}", script, e.getMessage());
+                if (e.getCause() instanceof ScriptException) {
+                    logger.warn("Failed to process script '{}': {}", script, e.getCause().getMessage());
+                } else {
+                    logger.warn("Failed to process script '{}': {}", script, e.getMessage());
+                }
             }
         }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -12,8 +12,13 @@
  */
 package org.openhab.core.automation.module.script.profile;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import javax.script.Compilable;
+import javax.script.CompiledScript;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
@@ -42,8 +47,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class ScriptProfile implements StateProfile {
-    protected static final String CONFIG_INBOUND_SCRIPT = "inboundScript";
-    protected static final String CONFIG_OUTBOUND_SCRIPT = "outboundScript";
+    protected static final String CONFIG_TO_ITEM_SCRIPT = "toItemScript";
+    protected static final String CONFIG_TO_HANDLER_SCRIPT = "toHandlerScript";
     protected static final String CONFIG_SCRIPT_TYPE = "scriptType";
 
     private final Logger logger = LoggerFactory.getLogger(ScriptProfile.class);
@@ -53,8 +58,13 @@ public class ScriptProfile implements StateProfile {
     private final ProfileCallback callback;
     private final ScriptEngineManager scriptEngineManager;
 
-    private final String inboundScript;
-    private final String outboundScript;
+    private final List<Class<? extends State>> acceptedDataTypes;
+    private final List<Class<? extends Command>> acceptedCommandTypes;
+    private final List<Class<? extends Command>> handlerAcceptedCommandTypes;
+
+    private final Map<Direction, String> scripts = new HashMap<>();
+    private final Map<Direction, CompiledScript> compiledScripts = new HashMap<>();
+
     private final String scriptType;
 
     private final boolean isConfigured;
@@ -66,20 +76,25 @@ public class ScriptProfile implements StateProfile {
         this.callback = callback;
         this.scriptEngineManager = scriptEngineManager;
 
-        this.inboundScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_INBOUND_SCRIPT),
-                String.class, "");
-        this.outboundScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_OUTBOUND_SCRIPT),
-                String.class, "");
+        this.acceptedCommandTypes = profileContext.getAcceptedCommandTypes();
+        this.acceptedDataTypes = profileContext.getAcceptedDataTypes();
+        this.handlerAcceptedCommandTypes = profileContext.getHandlerAcceptedCommandTypes();
+
+        this.scripts.put(Direction.TO_ITEM, ConfigParser
+                .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_ITEM_SCRIPT), String.class, ""));
+        this.scripts.put(Direction.TO_HANDLER, ConfigParser
+                .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_HANDLER_SCRIPT), String.class, ""));
         this.scriptType = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_SCRIPT_TYPE),
                 String.class, "");
 
-        if (this.inboundScript.isBlank() && this.outboundScript.isBlank()) {
-            logger.error("Neither inbound nor outbound script defined. Profile will discard states and commands.");
+        if (this.scripts.values().stream().allMatch(String::isBlank)) {
+            logger.error(
+                    "Neither 'toItem' nor 'toHandler' script defined. Profile will discard all states and commands.");
             isConfigured = false;
             return;
         }
         if (this.scriptType.isBlank()) {
-            logger.error("Parameter 'scriptType' must not be empty. Profile will discard states and commands.");
+            logger.error("Parameter 'scriptType' must not be empty. Profile will discard all states and commands.");
             isConfigured = false;
             return;
         }
@@ -98,13 +113,17 @@ public class ScriptProfile implements StateProfile {
 
     @Override
     public void onCommandFromItem(Command command) {
-        if (isConfigured && !outboundScript.isBlank()) {
-            Object returnValue = executeScript(outboundScript, command);
-            if (returnValue != null) {
-                Command newCommand = TypeParser.parseCommand(callback.getHandlerAcceptedCommandTypes(),
-                        returnValue.toString());
+        if (isConfigured) {
+            Object returnValue = executeScript(Direction.TO_HANDLER, command);
+            if (returnValue instanceof String) {
+                // try to parse the value
+                Command newCommand = TypeParser.parseCommand(handlerAcceptedCommandTypes, (String) returnValue);
                 if (newCommand != null) {
                     callback.handleCommand(newCommand);
+                }
+            } else if (returnValue instanceof Command) {
+                if (handlerAcceptedCommandTypes.contains(returnValue.getClass())) {
+                    callback.handleCommand((Command) returnValue);
                 }
             }
         }
@@ -112,13 +131,16 @@ public class ScriptProfile implements StateProfile {
 
     @Override
     public void onCommandFromHandler(Command command) {
-        if (isConfigured && !inboundScript.isBlank()) {
-            Object returnValue = executeScript(inboundScript, command);
-            if (returnValue != null) {
-                Command newCommand = TypeParser.parseCommand(callback.getAcceptedCommandTypes(),
-                        returnValue.toString());
+        if (isConfigured) {
+            Object returnValue = executeScript(Direction.TO_ITEM, command);
+            if (returnValue instanceof String) {
+                Command newCommand = TypeParser.parseCommand(acceptedCommandTypes, (String) returnValue);
                 if (newCommand != null) {
                     callback.sendCommand(newCommand);
+                }
+            } else if (returnValue instanceof Command) {
+                if (acceptedCommandTypes.contains(returnValue.getClass())) {
+                    callback.sendCommand((Command) returnValue);
                 }
             }
         }
@@ -126,45 +148,77 @@ public class ScriptProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromHandler(State state) {
-        if (isConfigured && !inboundScript.isBlank()) {
-            Object returnValue = executeScript(inboundScript, state);
-            if ("UNDEF".equals(returnValue) || UnDefType.UNDEF.equals(returnValue)) {
-                callback.sendUpdate(UnDefType.UNDEF);
-            } else if ("NULL".equals(returnValue) || UnDefType.NULL.equals(returnValue)) {
-                callback.sendUpdate(UnDefType.NULL);
-            } else if (returnValue != null) {
-                State newState = TypeParser.parseState(callback.getAcceptedDataTypes(), returnValue.toString());
-                if (newState != null) {
-                    callback.sendUpdate(newState);
+        if (isConfigured) {
+            Object returnValue = executeScript(Direction.TO_ITEM, state);
+            if (returnValue instanceof String) {
+                // special handling for UnDefType, it's not available in the TypeParser
+                if ("UNDEF".equals(returnValue)) {
+                    callback.sendUpdate(UnDefType.UNDEF);
+                } else if ("NULL".equals(returnValue)) {
+                    callback.sendUpdate(UnDefType.NULL);
+                } else {
+                    State newState = TypeParser.parseState(acceptedDataTypes, (String) returnValue);
+                    if (newState != null) {
+                        callback.sendUpdate(newState);
+                    }
+                }
+            } else if (returnValue instanceof State) {
+                if (acceptedDataTypes.contains(returnValue.getClass())) {
+                    callback.sendUpdate((State) returnValue);
                 }
             }
         }
     }
 
-    private synchronized @Nullable Object executeScript(String script, Type input) {
-        if (!scriptEngineManager.isSupported(scriptType)) {
-            if (scriptEngineContainer != null) {
-                scriptEngineContainer = null;
-                scriptEngineManager.removeEngine(profileUuid);
-            }
+    private synchronized @Nullable Object executeScript(Direction direction, Type input) {
+        String script = this.scripts.get(direction);
+
+        if (script.isBlank()) {
             return null;
         }
 
-        if (scriptEngineContainer == null) {
+        if (!scriptEngineManager.isSupported(scriptType)) {
+            // language has been removed, clear container and compiled scripts if found
+            if (this.scriptEngineContainer != null) {
+                this.scriptEngineContainer = null;
+                scriptEngineManager.removeEngine(profileUuid);
+            }
+            compiledScripts.clear();
+            return null;
+        } else if (this.scriptEngineContainer == null) {
+            // try to create a ScriptEngine
             this.scriptEngineContainer = scriptEngineManager.createScriptEngine(scriptType, profileUuid);
         }
 
-        ScriptEngineContainer localContainer = this.scriptEngineContainer;
-        if (localContainer != null) {
+        ScriptEngineContainer scriptEngineContainer = this.scriptEngineContainer;
+
+        if (scriptEngineContainer != null) {
             try {
-                ScriptEngine engine = localContainer.getScriptEngine();
+                CompiledScript compiledScript = this.compiledScripts.get(direction);
+
+                if (compiledScript == null && scriptEngineContainer.getScriptEngine() instanceof Compilable) {
+                    // no compiled script available but compiling is supported
+                    compiledScript = ((Compilable) scriptEngineContainer.getScriptEngine()).compile(script);
+                    this.compiledScripts.put(direction, compiledScript);
+                }
+
+                ScriptEngine engine = compiledScript != null ? compiledScript.getEngine()
+                        : scriptEngineContainer.getScriptEngine();
                 ScriptContext executionContext = engine.getContext();
-                executionContext.setAttribute("input", input.toFullString(), ScriptContext.ENGINE_SCOPE);
-                return engine.eval(script);
+                executionContext.setAttribute("input", input, ScriptContext.ENGINE_SCOPE);
+                executionContext.setAttribute("inputString", input.toFullString(), ScriptContext.ENGINE_SCOPE);
+
+                return compiledScript != null ? compiledScript.eval() : engine.eval(script);
             } catch (ScriptException e) {
                 logger.warn("Failed to execute script: {}", e.getMessage());
             }
         }
+
         return null;
+    }
+
+    private enum Direction {
+        TO_ITEM,
+        TO_HANDLER;
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -69,15 +69,15 @@ public class ScriptProfile implements StateProfile {
         this.acceptedDataTypes = profileContext.getAcceptedDataTypes();
         this.handlerAcceptedCommandTypes = profileContext.getHandlerAcceptedCommandTypes();
 
-        this.scriptLanguage = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_SCRIPT_LANGUAGE), String.class, "");
+        this.scriptLanguage = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_SCRIPT_LANGUAGE),
+                String.class, "");
         this.toItemScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_ITEM_SCRIPT),
                 String.class, "");
         this.toHandlerScript = ConfigParser
                 .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_HANDLER_SCRIPT), String.class, "");
 
         if (scriptLanguage.isBlank()) {
-            logger.error(
-                    "Script language is not defined. Profile will discard all states and commands.");
+            logger.error("Script language is not defined. Profile will discard all states and commands.");
             isConfigured = false;
             return;
         }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.profile;
+
+import java.util.UUID;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.config.core.ConfigParser;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.openhab.core.types.TypeParser;
+import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ScriptProfile} is generic profile for managing values with scripts
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class ScriptProfile implements StateProfile {
+    protected static final String CONFIG_INBOUND_SCRIPT = "inboundScript";
+    protected static final String CONFIG_OUTBOUND_SCRIPT = "outboundScript";
+    protected static final String CONFIG_SCRIPT_TYPE = "scriptType";
+
+    private final Logger logger = LoggerFactory.getLogger(ScriptProfile.class);
+
+    private final String profileUuid = ScriptProfileFactory.SCRIPT_PROFILE_UID + ":" + UUID.randomUUID();
+
+    private final ProfileCallback callback;
+    private final ScriptEngineManager scriptEngineManager;
+
+    private final String inboundScript;
+    private final String outboundScript;
+    private final String scriptType;
+
+    private final boolean isConfigured;
+
+    private @Nullable ScriptEngineContainer scriptEngineContainer;
+
+    public ScriptProfile(ProfileCallback callback, ProfileContext profileContext,
+            ScriptEngineManager scriptEngineManager) {
+        this.callback = callback;
+        this.scriptEngineManager = scriptEngineManager;
+
+        this.inboundScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_INBOUND_SCRIPT),
+                String.class, "");
+        this.outboundScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_OUTBOUND_SCRIPT),
+                String.class, "");
+        this.scriptType = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_SCRIPT_TYPE),
+                String.class, "");
+
+        if (this.inboundScript.isBlank() && this.outboundScript.isBlank()) {
+            logger.error("Neither inbound nor outbound script defined. Profile will discard states and commands.");
+            isConfigured = false;
+            return;
+        }
+        if (this.scriptType.isBlank()) {
+            logger.error("Parameter 'scriptType' must not be empty. Profile will discard states and commands.");
+            isConfigured = false;
+            return;
+        }
+
+        isConfigured = true;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return ScriptProfileFactory.SCRIPT_PROFILE_UID;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        if (isConfigured && !outboundScript.isBlank()) {
+            Object returnValue = executeScript(outboundScript, command);
+            if (returnValue != null) {
+                Command newCommand = TypeParser.parseCommand(callback.getHandlerAcceptedCommandTypes(),
+                        returnValue.toString());
+                if (newCommand != null) {
+                    callback.handleCommand(newCommand);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        if (isConfigured && !inboundScript.isBlank()) {
+            Object returnValue = executeScript(inboundScript, command);
+            if (returnValue != null) {
+                Command newCommand = TypeParser.parseCommand(callback.getAcceptedCommandTypes(),
+                        returnValue.toString());
+                if (newCommand != null) {
+                    callback.sendCommand(newCommand);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        if (isConfigured && !inboundScript.isBlank()) {
+            Object returnValue = executeScript(inboundScript, state);
+            if ("UNDEF".equals(returnValue) || UnDefType.UNDEF.equals(returnValue)) {
+                callback.sendUpdate(UnDefType.UNDEF);
+            } else if ("NULL".equals(returnValue) || UnDefType.NULL.equals(returnValue)) {
+                callback.sendUpdate(UnDefType.NULL);
+            } else if (returnValue != null) {
+                State newState = TypeParser.parseState(callback.getAcceptedDataTypes(), returnValue.toString());
+                if (newState != null) {
+                    callback.sendUpdate(newState);
+                }
+            }
+        }
+    }
+
+    private synchronized @Nullable Object executeScript(String script, Type input) {
+        if (!scriptEngineManager.isSupported(scriptType)) {
+            if (scriptEngineContainer != null) {
+                scriptEngineContainer = null;
+                scriptEngineManager.removeEngine(profileUuid);
+            }
+            return null;
+        }
+
+        if (scriptEngineContainer == null) {
+            this.scriptEngineContainer = scriptEngineManager.createScriptEngine(scriptType, profileUuid);
+        }
+
+        ScriptEngineContainer localContainer = this.scriptEngineContainer;
+        if (localContainer != null) {
+            try {
+                ScriptEngine engine = localContainer.getScriptEngine();
+                ScriptContext executionContext = engine.getContext();
+                executionContext.setAttribute("input", input.toFullString(), ScriptContext.ENGINE_SCOPE);
+                return engine.eval(script);
+            } catch (ScriptException e) {
+                logger.warn("Failed to execute script: {}", e.getMessage());
+            }
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -39,6 +39,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = { ScriptProfileFactory.class, ProfileFactory.class, ProfileTypeProvider.class })
 @NonNullByDefault
 public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
+
     public static final ProfileTypeUID SCRIPT_PROFILE_UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "script");
 
     private static final ProfileType PROFILE_TYPE_SCRIPT = ProfileTypeBuilder.newState(SCRIPT_PROFILE_UID, "Script")

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -27,6 +27,7 @@ import org.openhab.core.thing.profiles.ProfileType;
 import org.openhab.core.thing.profiles.ProfileTypeBuilder;
 import org.openhab.core.thing.profiles.ProfileTypeProvider;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,7 +41,8 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
 
-    public static final ProfileTypeUID SCRIPT_PROFILE_UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "script");
+    public static final ProfileTypeUID SCRIPT_PROFILE_UID = new ProfileTypeUID(
+            TransformationService.TRANSFORM_PROFILE_SCOPE, "SCRIPT");
 
     private static final ProfileType PROFILE_TYPE_SCRIPT = ProfileTypeBuilder.newState(SCRIPT_PROFILE_UID, "Script")
             .build();

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -18,7 +18,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.automation.module.script.ScriptTransformationService;
 import org.openhab.core.thing.profiles.Profile;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
@@ -44,18 +44,18 @@ public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider
     private static final ProfileType PROFILE_TYPE_SCRIPT = ProfileTypeBuilder.newState(SCRIPT_PROFILE_UID, "Script")
             .build();
 
-    private final ScriptEngineManager scriptEngineManager;
+    private final ScriptTransformationService transformationService;
 
     @Activate
-    public ScriptProfileFactory(final @Reference ScriptEngineManager scriptEngineManager) {
-        this.scriptEngineManager = scriptEngineManager;
+    public ScriptProfileFactory(final @Reference ScriptTransformationService transformationService) {
+        this.transformationService = transformationService;
     }
 
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
         if (SCRIPT_PROFILE_UID.equals(profileTypeUID)) {
-            return new ScriptProfile(callback, profileContext, scriptEngineManager);
+            return new ScriptProfile(callback, profileContext, transformationService);
         }
         return null;
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.profile;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.thing.profiles.Profile;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileFactory;
+import org.openhab.core.thing.profiles.ProfileType;
+import org.openhab.core.thing.profiles.ProfileTypeBuilder;
+import org.openhab.core.thing.profiles.ProfileTypeProvider;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link ScriptProfileFactory} creates {@link ScriptProfile} instances
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@Component(service = { ScriptProfileFactory.class, ProfileFactory.class, ProfileTypeProvider.class })
+@NonNullByDefault
+public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
+    public static final ProfileTypeUID SCRIPT_PROFILE_UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "script");
+
+    private static final ProfileType PROFILE_TYPE_SCRIPT = ProfileTypeBuilder.newState(SCRIPT_PROFILE_UID, "Script")
+            .build();
+
+    private final ScriptEngineManager scriptEngineManager;
+
+    @Activate
+    public ScriptProfileFactory(final @Reference ScriptEngineManager scriptEngineManager) {
+        this.scriptEngineManager = scriptEngineManager;
+    }
+
+    @Override
+    public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
+            ProfileContext profileContext) {
+        if (SCRIPT_PROFILE_UID.equals(profileTypeUID)) {
+            return new ScriptProfile(callback, profileContext, scriptEngineManager);
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
+        return Set.of(SCRIPT_PROFILE_UID);
+    }
+
+    @Override
+    public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
+        return Set.of(PROFILE_TYPE_SCRIPT);
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -7,7 +7,7 @@
 	<config-description uri="profile:system:script">
 		<parameter name="toItemScript" type="text">
 			<label>To Item Script</label>
-			<description>she Script for transforming states and commands from handler to item.</description>
+			<description>The Script for transforming states and commands from handler to item.</description>
 		</parameter>
 		<parameter name="toHandlerScript" type="text">
 			<label>To Handler Script</label>
@@ -15,7 +15,6 @@
 		</parameter>
 		<parameter name="scriptType" type="text" required="true">
 			<label>ScriptType</label>
-			<description>Script type</description>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -7,7 +7,7 @@
 	<config-description uri="profile:transform:SCRIPT">
 		<parameter name="scriptLanguage" type="text" required="true">
 			<label>Script Language</label>
-			<description>MIME-type ("application/vnd.openhab.dsl.rule") or file extension ("js") of a scripting language</description>
+			<description>MIME-type ("application/vnd.openhab.dsl.rule") of the scripting language</description>
 		</parameter>
 		<parameter name="toItemScript" type="text">
 			<label>To Item Script</label>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -13,9 +13,6 @@
 			<label>To Handler Script</label>
 			<description>The Script for transforming states and commands from item to handler.</description>
 		</parameter>
-		<parameter name="scriptType" type="text" required="true">
-			<label>ScriptType</label>
-		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -4,7 +4,7 @@
 	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="profile:system:script">
+	<config-description uri="profile:transform:SCRIPT">
 		<parameter name="scriptLanguage" type="text" required="true">
 			<label>Script Language</label>
 			<description>MIME-type ("application/vnd.openhab.dsl.rule") or file extension ("js") of a scripting language</description>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -5,11 +5,11 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="profile:system:script">
-		<parameter name="toItem" type="text">
+		<parameter name="toItemScript" type="text">
 			<label>To Item Script</label>
 			<description>she Script for transforming states and commands from handler to item.</description>
 		</parameter>
-		<parameter name="toHandler" type="text">
+		<parameter name="toHandlerScript" type="text">
 			<label>To Handler Script</label>
 			<description>The Script for transforming states and commands from item to handler.</description>
 		</parameter>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -5,6 +5,10 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="profile:system:script">
+		<parameter name="scriptLanguage" type="text" required="true">
+			<label>Script Language</label>
+			<description>MIME-type ("application/vnd.openhab.dsl.rule") or file extension ("js") of a scripting language</description>
+		</parameter>
 		<parameter name="toItemScript" type="text">
 			<label>To Item Script</label>
 			<description>The Script for transforming states and commands from handler to item.</description>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -5,12 +5,12 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="profile:system:script">
-		<parameter name="inboundScript" type="text">
-			<label>Inbound Script</label>
+		<parameter name="toItem" type="text">
+			<label>To Item Script</label>
 			<description>she Script for transforming states and commands from handler to item.</description>
 		</parameter>
-		<parameter name="outboundScript" type="text">
-			<label>Outbound Script</label>
+		<parameter name="toHandler" type="text">
+			<label>To Handler Script</label>
 			<description>The Script for transforming states and commands from item to handler.</description>
 		</parameter>
 		<parameter name="scriptType" type="text" required="true">

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:system:script">
+		<parameter name="inboundScript" type="text">
+			<label>Inbound Script</label>
+			<description>she Script for transforming states and commands from handler to item.</description>
+		</parameter>
+		<parameter name="outboundScript" type="text">
+			<label>Outbound Script</label>
+			<description>The Script for transforming states and commands from item to handler.</description>
+		</parameter>
+		<parameter name="scriptType" type="text" required="true">
+			<label>ScriptType</label>
+			<description>Script type</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,0 +1,5 @@
+profile.system.script.toItemScript.label = To Item Script
+profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
+profile.system.script.toHandlerScript.label = To Handler Script
+profile.system.script.toHandlerScript.description = The Script for transforming states and commands from item to handler.
+profile.system.script.scriptType = Script Type

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,5 +1,5 @@
 profile.system.script.scriptLanguage.label = Script Language
-profile.system.script.scriptLanguage.description = MIME-type ("application/vnd.openhab.dsl.rule") or file extension ("js") of a scripting language
+profile.system.script.scriptLanguage.description = MIME-type ("application/vnd.openhab.dsl.rule") of the scripting language
 profile.system.script.toItemScript.label = To Item Script
 profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
 profile.system.script.toHandlerScript.label = To Handler Script

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -2,4 +2,3 @@ profile.system.script.toItemScript.label = To Item Script
 profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
 profile.system.script.toHandlerScript.label = To Handler Script
 profile.system.script.toHandlerScript.description = The Script for transforming states and commands from item to handler.
-profile.system.script.scriptType = Script Type

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,3 +1,5 @@
+profile.system.script.scriptLanguage.label = Script Language
+profile.system.script.scriptLanguage.description = MIME-type ("application/vnd.openhab.dsl.rule") or file extension ("js") of a scripting language
 profile.system.script.toItemScript.label = To Item Script
 profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
 profile.system.script.toHandlerScript.label = To Handler Script

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_SCRIPT_TYPE;
 import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_HANDLER_SCRIPT;
 import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_ITEM_SCRIPT;
 
@@ -25,10 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
-
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,8 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import org.openhab.core.automation.module.script.ScriptEngineContainer;
-import org.openhab.core.automation.module.script.ScriptEngineManager;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -47,6 +40,8 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.transform.TransformationException;
+import org.openhab.core.transform.TransformationService;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -59,201 +54,147 @@ import org.openhab.core.types.State;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @NonNullByDefault
 public class ScriptProfileTest {
-    private static final String SUPPORTED_SCRIPT_TYPE = "supportedScriptType";
-    private static final String UNSUPPORTED_SCRIPT_TYPE = "unsupportedScriptType";
-
-    private @Mock @NonNullByDefault({}) ScriptEngineManager scriptEngineManager;
-    private @Mock @NonNullByDefault({}) ScriptEngineContainer scriptEngineContainer;
-
-    private @Mock @NonNullByDefault({}) ScriptEngine scriptEngine;
-    private @Mock @NonNullByDefault({}) ScriptContext scriptContext;
-
     private @Mock @NonNullByDefault({}) ProfileCallback profileCallback;
 
+    private @Mock @NonNullByDefault({}) TransformationService transformationServiceMock;
+
     @BeforeEach
-    public void setUp() {
-        when(scriptEngineManager.isSupported(SUPPORTED_SCRIPT_TYPE)).thenReturn(true);
-        when(scriptEngineManager.isSupported(UNSUPPORTED_SCRIPT_TYPE)).thenReturn(false);
-
-        when(scriptEngineManager.createScriptEngine(any(), any())).thenReturn(scriptEngineContainer);
-
-        when(scriptEngineContainer.getScriptEngine()).thenReturn(scriptEngine);
-        when(scriptEngine.getContext()).thenReturn(scriptContext);
+    public void setUp() throws TransformationException {
+        when(transformationServiceMock.transform(any(), any())).thenReturn("");
     }
 
     @Test
-    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfScriptTypeMissing() {
+    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfNoScriptDefined() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().build();
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(transformationServiceMock, never()).transform(any(), any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void scriptExecutionErrorForwardsNoValueToCallback() throws TransformationException {
         ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
                 .withToHandlerScript("outScript").build();
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        when(transformationServiceMock.transform(any(), any()))
+                .thenThrow(new TransformationException("intentional failure"));
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(OnOffType.ON);
         scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
         scriptProfile.onCommandFromItem(OnOffType.ON);
 
-        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
+        verify(transformationServiceMock, times(3)).transform(any(), any());
         verify(profileCallback, never()).handleCommand(any());
         verify(profileCallback, never()).sendUpdate(any());
         verify(profileCallback, never()).sendCommand(any());
     }
 
     @Test
-    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfNoScriptDefined() {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE).build();
+    public void scriptExecutionResultNullForwardsNoValueToCallback() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
+                .withToHandlerScript("outScript").build();
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        when(transformationServiceMock.transform(any(), any())).thenReturn(null);
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(OnOffType.ON);
         scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
         scriptProfile.onCommandFromItem(OnOffType.ON);
 
-        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
+        verify(transformationServiceMock, times(3)).transform(any(), any());
         verify(profileCallback, never()).handleCommand(any());
         verify(profileCallback, never()).sendUpdate(any());
         verify(profileCallback, never()).sendCommand(any());
     }
 
     @Test
-    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfUnsupportedScriptTypeDefined() {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(UNSUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withToHandlerScript("outScript").build();
-
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
-
-        scriptProfile.onCommandFromHandler(OnOffType.ON);
-        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
-        scriptProfile.onCommandFromItem(OnOffType.ON);
-
-        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
-        verify(profileCallback, never()).handleCommand(any());
-        verify(profileCallback, never()).sendUpdate(any());
-        verify(profileCallback, never()).sendCommand(any());
-    }
-
-    @Test
-    public void scriptExecutionErrorForwardsNoValueToCallback() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withToHandlerScript("outScript").build();
-
-        when(scriptEngine.eval((String) any())).thenThrow(new ScriptException("intentional failure"));
-
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
-
-        scriptProfile.onCommandFromHandler(OnOffType.ON);
-        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
-        scriptProfile.onCommandFromItem(OnOffType.ON);
-
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(3)).eval((String) any());
-        verify(profileCallback, never()).handleCommand(any());
-        verify(profileCallback, never()).sendUpdate(any());
-        verify(profileCallback, never()).sendCommand(any());
-    }
-
-    @Test
-    public void scriptExecutionResultNullForwardsNoValueToCallback() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withToHandlerScript("outScript").build();
-
-        when(scriptEngine.eval((String) any())).thenReturn(null);
-
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
-
-        scriptProfile.onCommandFromHandler(OnOffType.ON);
-        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
-        scriptProfile.onCommandFromItem(OnOffType.ON);
-
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(3)).eval((String) any());
-        verify(profileCallback, never()).handleCommand(any());
-        verify(profileCallback, never()).sendUpdate(any());
-        verify(profileCallback, never()).sendCommand(any());
-    }
-
-    @Test
-    public void scriptExecutionResultForwardsTransformedValueToCallback() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withToHandlerScript("outScript")
-                .withAcceptedCommandTypes(List.of(OnOffType.class)).withAcceptedDataTypes(List.of(OnOffType.class))
+    public void scriptExecutionResultForwardsTransformedValueToCallback() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
+                .withToHandlerScript("outScript").withAcceptedCommandTypes(List.of(OnOffType.class))
+                .withAcceptedDataTypes(List.of(OnOffType.class))
                 .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
 
-        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+        when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
         scriptProfile.onCommandFromItem(DecimalType.ZERO);
 
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(3)).eval((String) any());
+        verify(transformationServiceMock, times(3)).transform(any(), any());
         verify(profileCallback).handleCommand(OnOffType.OFF);
         verify(profileCallback).sendUpdate(OnOffType.OFF);
         verify(profileCallback).sendCommand(OnOffType.OFF);
     }
 
     @Test
-    public void onlyToItemScriptDoesNotForwardOutboundCommands() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withAcceptedCommandTypes(List.of(OnOffType.class))
-                .withAcceptedDataTypes(List.of(OnOffType.class))
+    public void onlyToItemScriptDoesNotForwardOutboundCommands() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
+                .withAcceptedCommandTypes(List.of(OnOffType.class)).withAcceptedDataTypes(List.of(OnOffType.class))
                 .withHandlerAcceptedCommandTypes(List.of(DecimalType.class)).build();
 
-        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+        when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
         scriptProfile.onCommandFromItem(DecimalType.ZERO);
 
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(2)).eval((String) any());
+        verify(transformationServiceMock, times(2)).transform(any(), any());
         verify(profileCallback, never()).handleCommand(any());
         verify(profileCallback).sendUpdate(OnOffType.OFF);
         verify(profileCallback).sendCommand(OnOffType.OFF);
     }
 
     @Test
-    public void onlyToHandlerScriptDoesNotForwardInboundCommands() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToHandlerScript("outScript").withAcceptedCommandTypes(List.of(DecimalType.class))
-                .withAcceptedDataTypes(List.of(DecimalType.class))
+    public void onlyToHandlerScriptDoesNotForwardInboundCommands() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToHandlerScript("outScript")
+                .withAcceptedCommandTypes(List.of(DecimalType.class)).withAcceptedDataTypes(List.of(DecimalType.class))
                 .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
 
-        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+        when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
         scriptProfile.onCommandFromItem(DecimalType.ZERO);
 
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(1)).eval((String) any());
+        verify(transformationServiceMock).transform(any(), any());
         verify(profileCallback).handleCommand(OnOffType.OFF);
         verify(profileCallback, never()).sendUpdate(any());
         verify(profileCallback, never()).sendCommand(any());
     }
 
     @Test
-    public void incompatibleStateOrCommandNotForwardedToCallback() throws ScriptException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
-                .withToItemScript("inScript").withToHandlerScript("outScript")
-                .withAcceptedCommandTypes(List.of(DecimalType.class)).withAcceptedDataTypes(List.of(PercentType.class))
+    public void incompatibleStateOrCommandNotForwardedToCallback() throws TransformationException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
+                .withToHandlerScript("outScript").withAcceptedCommandTypes(List.of(DecimalType.class))
+                .withAcceptedDataTypes(List.of(PercentType.class))
                 .withHandlerAcceptedCommandTypes(List.of(HSBType.class)).build();
 
-        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+        when(transformationServiceMock.transform(any(), any())).thenReturn(OnOffType.OFF.toString());
 
-        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, transformationServiceMock);
 
         scriptProfile.onCommandFromHandler(DecimalType.ZERO);
         scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
         scriptProfile.onCommandFromItem(DecimalType.ZERO);
 
-        verify(scriptEngineManager).createScriptEngine(any(), any());
-        verify(scriptEngine, times(3)).eval((String) any());
+        verify(transformationServiceMock, times(3)).transform(any(), any());
         verify(profileCallback, never()).handleCommand(any());
         verify(profileCallback, never()).sendUpdate(any());
         verify(profileCallback, never()).sendCommand(any());
@@ -276,11 +217,6 @@ public class ScriptProfileTest {
 
         public ProfileContextBuilder withToHandlerScript(String toHandlerScript) {
             configuration.put(CONFIG_TO_HANDLER_SCRIPT, toHandlerScript);
-            return this;
-        }
-
-        public ProfileContextBuilder withScriptType(String scriptType) {
-            configuration.put(CONFIG_SCRIPT_TYPE, scriptType);
             return this;
         }
 

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.profile;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_INBOUND_SCRIPT;
+import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_OUTBOUND_SCRIPT;
+import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_SCRIPT_TYPE;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.automation.module.script.ScriptEngineContainer;
+import org.openhab.core.automation.module.script.ScriptEngineManager;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+
+/**
+ * The {@link ScriptProfileTest} contains tests for the {@link ScriptProfile}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+public class ScriptProfileTest {
+    private static final String SUPPORTED_SCRIPT_TYPE = "supportedScriptType";
+    private static final String UNSUPPORTED_SCRIPT_TYPE = "unsupportedScriptType";
+
+    private @Mock @NonNullByDefault({}) ScriptEngineManager scriptEngineManager;
+    private @Mock @NonNullByDefault({}) ScriptEngineContainer scriptEngineContainer;
+
+    private @Mock @NonNullByDefault({}) ScriptEngine scriptEngine;
+    private @Mock @NonNullByDefault({}) ScriptContext scriptContext;
+
+    private @Mock @NonNullByDefault({}) ProfileCallback profileCallback;
+
+    @BeforeEach
+    public void setUp() {
+        when(scriptEngineManager.isSupported(SUPPORTED_SCRIPT_TYPE)).thenReturn(true);
+        when(scriptEngineManager.isSupported(UNSUPPORTED_SCRIPT_TYPE)).thenReturn(false);
+
+        when(scriptEngineManager.createScriptEngine(any(), any())).thenReturn(scriptEngineContainer);
+
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(scriptEngine);
+        when(scriptEngine.getContext()).thenReturn(scriptContext);
+    }
+
+    @Test
+    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfScriptTypeMissing() {
+        ProfileContext profileContext = ProfileContextBuilder.create().withInboundScript("inScript")
+                .withOutboundScript("outScript").build();
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfNoScriptDefined() {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE).build();
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void testScriptNotExecutedAndNoValueForwardedToCallbackIfUnsupportedScriptTypeDefined() {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(UNSUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").withOutboundScript("outScript").build();
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(scriptEngineManager, never()).createScriptEngine(any(), any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void scriptExecutionErrorForwardsNoValueToCallback() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").withOutboundScript("outScript").build();
+
+        when(scriptEngine.eval((String) any())).thenThrow(new ScriptException("intentional failure"));
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(3)).eval((String) any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void scriptExecutionResultNullForwardsNoValueToCallback() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").withOutboundScript("outScript").build();
+
+        when(scriptEngine.eval((String) any())).thenReturn(null);
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(OnOffType.ON);
+        scriptProfile.onStateUpdateFromHandler(OnOffType.ON);
+        scriptProfile.onCommandFromItem(OnOffType.ON);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(3)).eval((String) any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void scriptExecutionResultForwardsTransformedValueToCallback() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").withOutboundScript("outScript").build();
+
+        when(profileCallback.getAcceptedCommandTypes()).thenReturn(List.of(OnOffType.class));
+        when(profileCallback.getAcceptedDataTypes()).thenReturn(List.of(OnOffType.class));
+        when(profileCallback.getHandlerAcceptedCommandTypes()).thenReturn(List.of(OnOffType.class));
+
+        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(DecimalType.ZERO);
+        scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
+        scriptProfile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(3)).eval((String) any());
+        verify(profileCallback).handleCommand(OnOffType.OFF);
+        verify(profileCallback).sendUpdate(OnOffType.OFF);
+        verify(profileCallback).sendCommand(OnOffType.OFF);
+    }
+
+    @Test
+    public void onlyInboundScriptDoesNotForwardOutboundCommands() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").build();
+
+        when(profileCallback.getAcceptedCommandTypes()).thenReturn(List.of(OnOffType.class));
+        when(profileCallback.getAcceptedDataTypes()).thenReturn(List.of(OnOffType.class));
+        when(profileCallback.getHandlerAcceptedCommandTypes()).thenReturn(List.of(DecimalType.class));
+
+        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(DecimalType.ZERO);
+        scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
+        scriptProfile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(2)).eval((String) any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback).sendUpdate(OnOffType.OFF);
+        verify(profileCallback).sendCommand(OnOffType.OFF);
+    }
+
+    @Test
+    public void onlyOutboundScriptDoesNotForwardInboundCommands() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withOutboundScript("outScript").build();
+
+        when(profileCallback.getAcceptedCommandTypes()).thenReturn(List.of(DecimalType.class));
+        when(profileCallback.getAcceptedDataTypes()).thenReturn(List.of(DecimalType.class));
+        when(profileCallback.getHandlerAcceptedCommandTypes()).thenReturn(List.of(OnOffType.class));
+
+        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(DecimalType.ZERO);
+        scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
+        scriptProfile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(1)).eval((String) any());
+        verify(profileCallback).handleCommand(OnOffType.OFF);
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    @Test
+    public void incompatibleStateOrCommandNotForwardedToCallback() throws ScriptException {
+        ProfileContext profileContext = ProfileContextBuilder.create().withScriptType(SUPPORTED_SCRIPT_TYPE)
+                .withInboundScript("inScript").withOutboundScript("outScript").build();
+
+        when(profileCallback.getAcceptedCommandTypes()).thenReturn(List.of(DecimalType.class));
+        when(profileCallback.getAcceptedDataTypes()).thenReturn(List.of(PercentType.class));
+        when(profileCallback.getHandlerAcceptedCommandTypes()).thenReturn(List.of(HSBType.class));
+
+        when(scriptEngine.eval((String) any())).thenReturn(OnOffType.OFF.toString());
+
+        ScriptProfile scriptProfile = new ScriptProfile(profileCallback, profileContext, scriptEngineManager);
+
+        scriptProfile.onCommandFromHandler(DecimalType.ZERO);
+        scriptProfile.onStateUpdateFromHandler(DecimalType.ZERO);
+        scriptProfile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(scriptEngineManager).createScriptEngine(any(), any());
+        verify(scriptEngine, times(3)).eval((String) any());
+        verify(profileCallback, never()).handleCommand(any());
+        verify(profileCallback, never()).sendUpdate(any());
+        verify(profileCallback, never()).sendCommand(any());
+    }
+
+    private static class ProfileContextBuilder {
+        private final Map<String, Object> configuration = new HashMap<>();
+
+        public static ProfileContextBuilder create() {
+            return new ProfileContextBuilder();
+        }
+
+        public ProfileContextBuilder withInboundScript(String inboundScript) {
+            configuration.put(CONFIG_INBOUND_SCRIPT, inboundScript);
+            return this;
+        }
+
+        public ProfileContextBuilder withOutboundScript(String outboundScript) {
+            configuration.put(CONFIG_OUTBOUND_SCRIPT, outboundScript);
+            return this;
+        }
+
+        public ProfileContextBuilder withScriptType(String scriptType) {
+            configuration.put(CONFIG_SCRIPT_TYPE, scriptType);
+            return this;
+        }
+
+        public ProfileContext build() {
+            return new ProfileContext() {
+                @Override
+                public Configuration getConfiguration() {
+                    return new Configuration(configuration);
+                }
+
+                @Override
+                public ScheduledExecutorService getExecutorService() {
+                    throw new IllegalStateException();
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Closes #2201
Depends on #2852 

This introduces a profile that can be used on all channel types and all item types with all available script languages. Input/Output values can either be `State`, `Command` or `String`. In the latter case the profile tries to convert the `String` to an acceptable `State`/`Command` for channel/item.