### PR TITLE
Improve test stability and OS compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-.java text=auto
-.xml text=auto
+*.java text=auto
+*.xml text=auto
+*.xml_gen text=auto

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
@@ -69,7 +69,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
         }
     };
 
-    private final int testTimeout = 1;
+    private final int testTimeout = 5;
 
     @BeforeEach
     public void setUp() throws IOException {
@@ -100,7 +100,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
     public void audioConsolePlaysFile() throws AudioException, IOException {
         AudioStream audioStream = new FileAudioStream(new File(fileHandler.wavFilePath()));
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_PLAY, fileHandler.wavFileName() };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_PLAY, fileHandler.wavFileName() };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         assertThat(audioSink.audioFormat.isCompatible(audioStream.getFormat()), is(true));
@@ -111,8 +111,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
     public void audioConsolePlaysFileForASpecifiedSink() throws AudioException, IOException {
         AudioStream audioStream = new FileAudioStream(new File(fileHandler.wavFilePath()));
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(),
-                fileHandler.wavFileName() };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(), fileHandler.wavFileName() };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         assertThat(audioSink.audioFormat.isCompatible(audioStream.getFormat()), is(true));
@@ -123,8 +122,8 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
     public void audioConsolePlaysFileForASpecifiedSinkWithASpecifiedVolume() throws AudioException, IOException {
         AudioStream audioStream = new FileAudioStream(new File(fileHandler.wavFilePath()));
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(),
-                fileHandler.wavFileName(), "25" };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(), fileHandler.wavFileName(),
+                "25" };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         assertThat(audioSink.audioFormat.isCompatible(audioStream.getFormat()), is(true));
@@ -133,8 +132,8 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
 
     @Test
     public void audioConsolePlaysFileForASpecifiedSinkWithAnInvalidVolume() {
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(),
-                fileHandler.wavFileName(), "invalid" };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_PLAY, audioSink.getId(), fileHandler.wavFileName(),
+                "invalid" };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         waitForAssert(() -> assertThat("The given volume was invalid", consoleOutput,
@@ -148,7 +147,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
 
         String url = serveStream(audioStream, testTimeout);
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_STREAM, url };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_STREAM, url };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         assertThat("The streamed URL was not as expected", ((URLAudioStream) audioSink.audioStream).getURL(), is(url));
@@ -161,7 +160,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
 
         String url = serveStream(audioStream, testTimeout);
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_STREAM, audioSink.getId(), url };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_STREAM, audioSink.getId(), url };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         assertThat("The streamed URL was not as expected", ((URLAudioStream) audioSink.audioStream).getURL(), is(url));
@@ -169,7 +168,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
 
     @Test
     public void audioConsoleListsSinks() {
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_SINKS };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_SINKS };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         waitForAssert(() -> assertThat("The listed sink was not as expected", consoleOutput,
@@ -182,7 +181,7 @@ public class AudioConsoleTest extends AbstractAudioServletTest {
         when(audioSource.getId()).thenReturn("sourceId");
         audioManager.addAudioSource(audioSource);
 
-        String[] args = new String[] { AudioConsoleCommandExtension.SUBCMD_SOURCES };
+        String[] args = { AudioConsoleCommandExtension.SUBCMD_SOURCES };
         audioConsoleCommandExtension.execute(args, consoleMock);
 
         waitForAssert(() -> assertThat("The listed source was not as expected", consoleOutput,

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -111,7 +111,7 @@ public class AudioServletTest extends AbstractAudioServletTest {
 
     @Test
     public void requestToMultitimeStreamCannotBeDoneAfterTheTimeoutOfTheStreamHasExipred() throws Exception {
-        final int streamTimeout = 1;
+        final int streamTimeout = 3;
 
         AudioStream audioStream = getByteArrayAudioStream(testByteArray, AudioFormat.CONTAINER_NONE,
                 AudioFormat.CODEC_MP3);

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
@@ -107,7 +107,7 @@ class ScriptFileWatcherTest {
 
         scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p);
 
-        verify(scriptEngineManager, timeout(1000)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -125,7 +125,7 @@ class ScriptFileWatcherTest {
 
         // verify is called when the start level increases
         updateStartLevel(100);
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -145,7 +145,7 @@ class ScriptFileWatcherTest {
 
         // verify is called when the start level increases
         updateStartLevel(100);
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -170,12 +170,12 @@ class ScriptFileWatcherTest {
 
         updateStartLevel(60);
 
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
         verify(scriptEngineManager, never()).createScriptEngine(anyString(), eq(p1.toFile().toURI().toString()));
 
         updateStartLevel(80);
 
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
     }
 
     @Test
@@ -200,12 +200,12 @@ class ScriptFileWatcherTest {
 
         updateStartLevel(60);
 
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p2.toFile().toURI().toString());
         verify(scriptEngineManager, never()).createScriptEngine(anyString(), eq(p1.toFile().toURI().toString()));
 
         updateStartLevel(80);
 
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p1.toFile().toURI().toString());
     }
 
     @Test
@@ -236,7 +236,7 @@ class ScriptFileWatcherTest {
         scheduledTask.getValue().run();
 
         // verify script has now been processed
-        verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -258,11 +258,11 @@ class ScriptFileWatcherTest {
 
         InOrder inOrder = inOrder(scriptEngineManager);
 
-        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
                 p64.toFile().toURI().toString());
-        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
                 p65.toFile().toURI().toString());
-        inOrder.verify(scriptEngineManager, timeout(1000).times(1)).createScriptEngine("js",
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
                 p66.toFile().toURI().toString());
     }
 
@@ -281,7 +281,7 @@ class ScriptFileWatcherTest {
 
         scriptFileWatcher.onDependencyChange(p.toFile().toURI().toString());
 
-        verify(scriptEngineManager, timeout(1000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 
     @Test
@@ -344,6 +344,6 @@ class ScriptFileWatcherTest {
         scriptFileWatcher.processWatchEvent(null, ENTRY_MODIFY, p);
 
         verify(scriptEngineManager).removeEngine(p.toFile().toURI().toString());
-        verify(scriptEngineManager, timeout(1000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
+        verify(scriptEngineManager, timeout(10000).times(2)).createScriptEngine("js", p.toFile().toURI().toString());
     }
 }

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 @NonNullByDefault
 public class ExecUtilTest {
 
+    private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
     @Test
     public void testBasicExecuteCommandLine() {
         if (isWindowsSystem()) {
@@ -40,9 +42,9 @@ public class ExecUtilTest {
     public void testBasicExecuteCommandLineAndWaitResponse() {
         final String result;
         if (isWindowsSystem()) {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "cmd", "/c", "dir");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "cmd", "/c", "dir");
         } else {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "ls");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "ls");
         }
         assertNotNull(result);
         assertNotEquals("", result);
@@ -52,9 +54,9 @@ public class ExecUtilTest {
     public void testExecuteCommandLineAndWaitResponseWithArguments() {
         final String result;
         if (isWindowsSystem()) {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "cmd", "/c", "echo", "test");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "cmd", "/c", "echo", "test");
         } else {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "echo", "'test'");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "echo", "'test'");
         }
         assertNotNull(result);
         assertNotEquals("test", result);
@@ -69,10 +71,9 @@ public class ExecUtilTest {
     public void testExecuteCommandLineAndWaitStdErrRedirection() {
         final String result;
         if (isWindowsSystem()) {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "cmd", "/c", "dir", "xxx.xxx",
-                    "1>", "nul");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "cmd", "/c", "dir", "xxx.xxx", "1>", "nul");
         } else {
-            result = ExecUtil.executeCommandLineAndWaitResponse(Duration.ofSeconds(1), "ls", "xxx.xxx");
+            result = ExecUtil.executeCommandLineAndWaitResponse(TIMEOUT, "ls", "xxx.xxx");
         }
         assertNotNull(result);
         assertNotEquals("", result);

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/internal/actions/TimerImplTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/internal/actions/TimerImplTest.java
@@ -71,7 +71,7 @@ public class TimerImplTest {
         assertThat(subject.hasTerminated(), is(false));
         assertThat(subject.isCancelled(), is(false));
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 3));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
         assertThat(subject.isCancelled(), is(false));
@@ -79,17 +79,17 @@ public class TimerImplTest {
 
     @Test
     public void testTimerHasTerminatedAndReschedule() throws InterruptedException {
-        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 3));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
         assertThat(subject.isCancelled(), is(false));
-     
+
         subject.reschedule(ZonedDateTime.now().plusSeconds(DEFAULT_TIMEOUT_SECONDS));
         assertThat(subject.isActive(), is(true));
         assertThat(subject.hasTerminated(), is(false));
         assertThat(subject.isCancelled(), is(false));
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 1));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_TIMEOUT_SECONDS + DEFAULT_RUNTIME_SECONDS + 3));
         assertThat(subject.isActive(), is(false));
         assertThat(subject.hasTerminated(), is(true));
         assertThat(subject.isCancelled(), is(false));
@@ -106,7 +106,7 @@ public class TimerImplTest {
         assertThat(subject.hasTerminated(), is(false));
         assertThat(subject.isCancelled(), is(false));
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_RUNTIME_SECONDS + 1));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(DEFAULT_RUNTIME_SECONDS + 3));
         assertThat(subject.isRunning(), is(false));
         assertThat(subject.hasTerminated(), is(true));
         assertThat(subject.isCancelled(), is(false));

--- a/bundles/org.openhab.core/pom.xml
+++ b/bundles/org.openhab.core/pom.xml
@@ -22,12 +22,30 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <!-- This bundle has many tests so run them in forks to reduce the build time -->
-            <forkCount>4</forkCount>
+            <forkCount>${cpu.count}</forkCount>
             <reuseForks>false</reuseForks>
           </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-cpu-count</id>
+            <goals>
+              <goal>cpu-count</goal>
+            </goals>
+            <configuration>
+              <cpuCount>cpu.count</cpuCount>
+              <factor>0.5</factor>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -144,7 +144,7 @@ class ExpireManagerTest {
         expireManager.receive(event);
         Thread.sleep(1500L);
         verify(eventPublisherMock, never()).post(any());
-        Thread.sleep(2000L);
+        Thread.sleep(2500L);
         verify(eventPublisherMock, times(1)).post(any());
     }
 
@@ -162,7 +162,7 @@ class ExpireManagerTest {
         expireManager.receive(event);
         Thread.sleep(1500L);
         verify(eventPublisherMock, never()).post(any());
-        Thread.sleep(2000L);
+        Thread.sleep(2500L);
         verify(eventPublisherMock, times(1)).post(any());
     }
 
@@ -178,7 +178,7 @@ class ExpireManagerTest {
         Thread.sleep(1500L);
         event = ItemEventFactory.createStateEvent(ITEMNAME, new DecimalType(1));
         expireManager.receive(event);
-        Thread.sleep(1500L);
+        Thread.sleep(2500L);
         verify(eventPublisherMock, times(1)).post(any());
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -39,11 +39,11 @@ public class PeriodicSchedulerImplTest {
     private final PeriodicSchedulerImpl periodicScheduler = new PeriodicSchedulerImpl(new SchedulerImpl());
 
     @Test
-    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
     public void testSchedule() throws InterruptedException, IOException {
         Queue<Long> times = new ArrayDeque<>();
         Semaphore semaphore = new Semaphore(0);
-        Duration[] delays = { Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(300) };
+        Duration[] delays = { Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(400) };
         final long now = System.currentTimeMillis();
 
         ScheduledCompletableFuture<Object> future = periodicScheduler.schedule(() -> {
@@ -54,11 +54,11 @@ public class PeriodicSchedulerImplTest {
         future.cancel(true);
         // Because starting scheduler takes some time and we don't know how long
         // the first time set is the offset on which we check the next values.
-        long offset = times.poll();
-        long[] expectedResults = { 200, 300, 300, 300, 300 };
+        long offset = times.poll().longValue();
+        long[] expectedResults = { 200, 400, 400, 400, 400 };
         for (long expectedResult : expectedResults) {
             long actualValue = times.poll().longValue();
-            assertEquals((offset + expectedResult) / 100.0, actualValue / 100.0, 0.9,
+            assertEquals((offset + expectedResult) / 100.0, actualValue / 100.0, 1.5,
                     "Expected periodic time, total: " + actualValue);
             offset = actualValue;
         }

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
@@ -72,7 +72,6 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
         assertNotNull(itemRegistry);
 
         itemProvider = new ItemProvider() {
-
             @Override
             public void addProviderChangeListener(ProviderChangeListener<Item> listener) {
             }
@@ -89,6 +88,8 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
         };
 
         registerService(itemProvider);
+
+        waitForAssert(() -> assertThat(itemRegistry.getAll().size(), is(itemProvider.getAll().size())));
 
         ScriptServiceUtil scriptServiceUtil = getService(ScriptServiceUtil.class);
         assertNotNull(scriptServiceUtil);

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.test.java.JavaOSGiTest;
@@ -85,27 +84,25 @@ public class GenericItemChannelLinkProviderTest extends JavaOSGiTest {
                 "}";
 
         modelRepository.addOrRefreshModel(THINGS_TESTMODEL_NAME, new ByteArrayInputStream(thingsModel.getBytes()));
-        Collection<Thing> actualThings = thingRegistry.getAll();
 
-        assertThat(actualThings.size(), is(3));
-
-        Collection<Item> items = itemRegistry.getItems();
-        assertThat(items.size(), is(0));
-
-        Collection<ItemChannelLink> itemChannelLinks = itemChannelLinkRegistry.getAll();
-        assertThat(itemChannelLinks.size(), is(0));
+        waitForAssert(() -> {
+            assertThat(thingRegistry.getAll().size(), is(3));
+            assertThat(itemRegistry.getItems().size(), is(0));
+            assertThat(itemChannelLinkRegistry.getAll().size(), is(0));
+        });
 
         String itemsModel = "Color Light3Color \"Light3 Color\" { channel=\"hue:LCT001:huebridge:bulb3:color\" }";
 
         modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.getBytes()));
-        Collection<Item> actualItems = itemRegistry.getItems();
 
-        assertThat(actualItems.size(), is(1));
+        waitForAssert(() -> {
+            assertThat(itemRegistry.getItems().size(), is(1));
 
-        List<ItemChannelLink> actualItemChannelLinks = new ArrayList<>(itemChannelLinkRegistry.getAll());
-        assertThat(actualItemChannelLinks.size(), is(1));
-        assertThat(actualItemChannelLinks.get(0).toString(),
-                is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color")));
+            List<ItemChannelLink> actualItemChannelLinks = new ArrayList<>(itemChannelLinkRegistry.getAll());
+            assertThat(actualItemChannelLinks.size(), is(1));
+            assertThat(actualItemChannelLinks.get(0).toString(),
+                    is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color")));
+        });
     }
 
     @Test
@@ -120,28 +117,26 @@ public class GenericItemChannelLinkProviderTest extends JavaOSGiTest {
                 "}";
 
         modelRepository.addOrRefreshModel(THINGS_TESTMODEL_NAME, new ByteArrayInputStream(thingsModel.getBytes()));
-        Collection<Thing> actualThings = thingRegistry.getAll();
 
-        assertThat(actualThings.size(), is(3));
-
-        Collection<Item> items = itemRegistry.getItems();
-        assertThat(items.size(), is(0));
-
-        Collection<ItemChannelLink> itemChannelLinks = itemChannelLinkRegistry.getAll();
-        assertThat(itemChannelLinks.size(), is(0));
+        waitForAssert(() -> {
+            assertThat(thingRegistry.getAll().size(), is(3));
+            assertThat(itemRegistry.getItems().size(), is(0));
+            assertThat(itemChannelLinkRegistry.getAll().size(), is(0));
+        });
 
         String itemsModel = "Color Light3Color \"Light3 Color\" { channel=\"hue:LCT001:huebridge:bulb3:color, hue:LCT001:huebridge:bulb4:color\" }";
 
         modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.getBytes()));
-        Collection<Item> actualItems = itemRegistry.getItems();
 
-        assertThat(actualItems.size(), is(1));
+        waitForAssert(() -> {
+            assertThat(itemRegistry.getItems().size(), is(1));
 
-        List<ItemChannelLink> actualItemChannelLinks = new ArrayList<>(itemChannelLinkRegistry.getAll());
-        assertThat(actualItemChannelLinks.size(), is(2));
-        assertThat(actualItemChannelLinks.get(0).toString(),
-                is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color")));
-        assertThat(actualItemChannelLinks.get(1).toString(),
-                is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb4:color")));
+            List<ItemChannelLink> actualItemChannelLinks = new ArrayList<>(itemChannelLinkRegistry.getAll());
+            assertThat(actualItemChannelLinks.size(), is(2));
+            assertThat(actualItemChannelLinks.get(0).toString(),
+                    is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color")));
+            assertThat(actualItemChannelLinks.get(1).toString(),
+                    is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb4:color")));
+        });
     }
 }

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
@@ -495,7 +495,11 @@ public class GenericThingProviderTest extends JavaOSGiTest {
 
             @Override
             public void receive(Event event) {
-                receivedEvents.add((AbstractThingRegistryEvent) event);
+                AbstractThingRegistryEvent registryEvent = (AbstractThingRegistryEvent) event;
+                if (List.of("hue:bridge:my1234Bridge", "hue:LCT001:my1234Bridge:myKitchenBulb1")
+                        .contains(registryEvent.getThing().UID)) {
+                    receivedEvents.add(registryEvent);
+                }
             }
         };
 
@@ -503,8 +507,8 @@ public class GenericThingProviderTest extends JavaOSGiTest {
 
         assertThat(thingRegistry.getAll().size(), is(0));
 
-        String model = "Bridge hue:bridge:myBridge [ ip = \"1.2.3.4\", username = \"123\" ] {" + //
-                "    LCT001 bulb1 [ lightId = \"1\" ] { Switch : notification }" + //
+        String model = "Bridge hue:bridge:my1234Bridge [ ip = \"1.2.3.4\", username = \"123\" ] {" + //
+                "    LCT001 myKitchenBulb1 [ lightId = \"1\" ] { Switch : notification }" + //
                 "}";
 
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
@@ -515,8 +519,8 @@ public class GenericThingProviderTest extends JavaOSGiTest {
         });
         receivedEvents.clear();
 
-        String newModel = "Bridge hue:bridge:myBridge [ ip = \"1.2.3.4\", username = \"123\" ]  {" + //
-                "    LCT001 bulb1 [ lightId = \"2\" ] { Switch : notification }" + //
+        String newModel = "Bridge hue:bridge:my1234Bridge [ ip = \"1.2.3.4\", username = \"123\" ]  {" + //
+                "    LCT001 myKitchenBulb1 [ lightId = \"2\" ] { Switch : notification }" + //
                 "}";
 
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(newModel.getBytes()));
@@ -527,7 +531,7 @@ public class GenericThingProviderTest extends JavaOSGiTest {
             Event event = receivedEvents.get(0);
             assertEquals(ThingUpdatedEvent.class, event.getClass());
             ThingUpdatedEvent thingUpdatedEvent = (ThingUpdatedEvent) event;
-            assertEquals("hue:LCT001:myBridge:bulb1", thingUpdatedEvent.getThing().UID.toString());
+            assertEquals("hue:LCT001:my1234Bridge:myKitchenBulb1", thingUpdatedEvent.getThing().UID);
         });
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -208,13 +209,8 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
 
         registerService(new TestDynamicCommandDescriptionProvider(), DynamicCommandDescriptionProvider.class.getName());
 
-        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
-                null, "test thing", new Configuration());
-
-        assertNotNull(thing);
-        if (thing == null) {
-            throw new IllegalStateException("thing is null");
-        }
+        Thing thing = Objects.requireNonNull(thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"),
+                new ThingUID("hue:lamp:lamp1"), null, "test thing", new Configuration()));
 
         managedThingProvider.add(thing);
         ItemChannelLink link = new ItemChannelLink("TestItem1", getChannel(thing, "1").getUID());
@@ -230,9 +226,10 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         Item item = itemRegistry.getItem("TestItem1");
         assertEquals(CoreItemFactory.NUMBER, item.getType());
 
-        CommandDescription command = item.getCommandDescription();
-        assertNotNull(command);
+        final Item finalItem = item;
+        waitForAssert(() -> assertNotNull(finalItem.getCommandDescription()));
 
+        CommandDescription command = Objects.requireNonNull(item.getCommandDescription());
         List<CommandOption> opts = command.getCommandOptions();
         assertNotNull(opts);
         assertEquals(1, opts.size());
@@ -280,12 +277,8 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
                 DynamicCommandDescriptionProvider.class.getName());
         registerService(new TestDynamicCommandDescriptionProvider(), DynamicCommandDescriptionProvider.class.getName());
 
-        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
-                null, "test thing", new Configuration());
-        assertNotNull(thing);
-        if (thing == null) {
-            throw new IllegalStateException("thing is null");
-        }
+        Thing thing = Objects.requireNonNull(thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"),
+                new ThingUID("hue:lamp:lamp1"), null, "test thing", new Configuration()));
 
         managedThingProvider.add(thing);
         ItemChannelLink link = new ItemChannelLink("TestItem7_2", getChannel(thing, "7_2").getUID());
@@ -294,11 +287,10 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         final Collection<Item> items = itemRegistry.getItems();
         assertFalse(items.isEmpty());
 
-        Item item = itemRegistry.getItem("TestItem7_2");
+        final Item item = itemRegistry.getItem("TestItem7_2");
+        waitForAssert(() -> assertNotNull(item.getCommandDescription()));
 
-        CommandDescription command = item.getCommandDescription();
-        assertNotNull(command);
-
+        CommandDescription command = Objects.requireNonNull(item.getCommandDescription());
         List<CommandOption> opts = command.getCommandOptions();
         assertNotNull(opts);
         assertEquals(1, opts.size());
@@ -310,7 +302,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
     /*
      * Helper
      */
-    class TestDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+    static class TestDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
         final CommandDescription newCommand = CommandDescriptionBuilder.create()
                 .withCommandOption(new CommandOption("NEW COMMAND", "My new command.")).build();
 
@@ -326,7 +318,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class MalfunctioningDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
+    static class MalfunctioningDynamicCommandDescriptionProvider extends BaseDynamicCommandDescriptionProvider {
         @Override
         public @Nullable CommandDescription getCommandDescription(Channel channel,
                 @Nullable CommandDescription originalCommandDescription, @Nullable Locale locale) {
@@ -362,7 +354,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class TestItemProvider implements ItemProvider {
+    static class TestItemProvider implements ItemProvider {
         private final Collection<Item> items;
 
         TestItemProvider(Collection<Item> items) {
@@ -383,7 +375,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    private abstract class AbstractThingHandler extends BaseThingHandler {
+    private abstract static class AbstractThingHandler extends BaseThingHandler {
         public AbstractThingHandler(Thing thing) {
             super(thing);
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -237,13 +238,8 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
 
         registerService(new TestDynamicStateDescriptionProvider(), DynamicStateDescriptionProvider.class.getName());
 
-        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
-                null, "test thing", new Configuration());
-
-        assertNotNull(thing);
-        if (thing == null) {
-            throw new IllegalStateException("thing is null");
-        }
+        Thing thing = Objects.requireNonNull(thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"),
+                new ThingUID("hue:lamp:lamp1"), null, "test thing", new Configuration()));
 
         managedThingProvider.add(thing);
         ItemChannelLink link = new ItemChannelLink("TestItem", getChannel(thing, "1").getUID());
@@ -269,9 +265,10 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         Item item = itemRegistry.getItem("TestItem");
         assertEquals(CoreItemFactory.NUMBER, item.getType());
 
-        StateDescription state = item.getStateDescription();
-        assertNotNull(state);
+        final Item finalItem = item;
+        waitForAssert(() -> assertNotNull(finalItem.getStateDescription()));
 
+        StateDescription state = Objects.requireNonNull(item.getStateDescription());
         assertEquals(BigDecimal.ZERO, state.getMinimum());
         assertEquals(BigDecimal.valueOf(100), state.getMaximum());
         assertEquals(BigDecimal.TEN, state.getStep());
@@ -384,13 +381,8 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
                 DynamicStateDescriptionProvider.class.getName());
         registerService(new TestDynamicStateDescriptionProvider(), DynamicStateDescriptionProvider.class.getName());
 
-        Thing thing = thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"), new ThingUID("hue:lamp:lamp1"),
-                null, "test thing", new Configuration());
-
-        assertNotNull(thing);
-        if (thing == null) {
-            throw new IllegalStateException("thing is null");
-        }
+        Thing thing = Objects.requireNonNull(thingRegistry.createThingOfType(new ThingTypeUID("hue:lamp"),
+                new ThingUID("hue:lamp:lamp1"), null, "test thing", new Configuration()));
 
         managedThingProvider.add(thing);
         ItemChannelLink link = new ItemChannelLink("TestItem7_2", getChannel(thing, "7_2").getUID());
@@ -401,9 +393,10 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
 
         Item item = itemRegistry.getItem("TestItem7_2");
 
-        StateDescription state = item.getStateDescription();
-        assertNotNull(state);
+        final Item finalItem = item;
+        waitForAssert(() -> assertNotNull(finalItem.getStateDescription()));
 
+        StateDescription state = Objects.requireNonNull(item.getStateDescription());
         assertEquals(BigDecimal.valueOf(1), state.getMinimum());
         assertEquals(BigDecimal.valueOf(101), state.getMaximum());
         assertEquals(BigDecimal.valueOf(20), state.getStep());
@@ -421,7 +414,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
     /*
      * Helper
      */
-    class TestDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+    static class TestDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
         final @Nullable StateDescription newState = StateDescriptionFragmentBuilder.create()
                 .withMinimum(BigDecimal.valueOf(10)).withMaximum(BigDecimal.valueOf(100))
                 .withStep(BigDecimal.valueOf(5)).withPattern("VALUE %d").withReadOnly(false)
@@ -450,7 +443,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class TestMalfunctioningDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
+    static class TestMalfunctioningDynamicStateDescriptionProvider extends BaseDynamicStateDescriptionProvider {
         @Override
         public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
                 @Nullable Locale locale) {
@@ -486,7 +479,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class TestItemProvider implements ItemProvider {
+    static class TestItemProvider implements ItemProvider {
         private final Collection<Item> items;
 
         TestItemProvider(Collection<Item> items) {
@@ -507,7 +500,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    private abstract class AbstractThingHandler extends BaseThingHandler {
+    private abstract static class AbstractThingHandler extends BaseThingHandler {
         public AbstractThingHandler(Thing thing) {
             super(thing);
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -804,6 +804,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         String itemName = "name";
         managedThingProvider.add(thing);
         managedItemChannelLinkProvider.add(new ItemChannelLink(itemName, CHANNEL_UID));
+        waitForAssert(() -> assertThat(itemChannelLinkRegistry.getLinks(itemName).size(), is(1)));
 
         registerService(thingHandlerFactory);
         Item item = new StringItem(itemName);
@@ -870,12 +871,12 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         managedThingProvider.add(thing);
         managedItemChannelLinkProvider.add(new ItemChannelLink(itemName, CHANNEL_UID));
+        waitForAssert(() -> assertThat(itemChannelLinkRegistry.getLinks(itemName).size(), is(1)));
 
         state.callback.statusUpdated(thing, ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build());
 
         final List<Event> receivedEvents = new ArrayList<>();
 
-        @NonNullByDefault
         EventSubscriber itemUpdateEventSubscriber = new EventSubscriber() {
             @Override
             public void receive(Event event) {
@@ -990,7 +991,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void thingManagerIgnoresRestoringOfThingStatusFromRemoving() {
+    public void thingManagerIgnoresRestoringOfThingStatusFromRemoving() throws Exception {
         class ThingHandlerState {
             @Nullable
             ThingHandlerCallback callback;
@@ -1028,7 +1029,8 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         assertThat(thing.getStatusInfo(), is(removingNone));
 
-        // handleRemoval is called when thing is fully initialized and shall be removed
+        // handleRemoval is called asynchronously when thing is fully initialized and shall be removed
+        Thread.sleep(500);
         verify(thingHandler).handleRemoval();
     }
 
@@ -1125,6 +1127,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         managedThingProvider.add(thing);
         managedItemChannelLinkProvider.add(new ItemChannelLink(itemName, CHANNEL_UID));
+        waitForAssert(() -> assertThat(itemChannelLinkRegistry.getLinks(itemName).size(), is(1)));
 
         class ThingHandlerState {
             @Nullable
@@ -1218,7 +1221,6 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         final List<Event> receivedEvents = new ArrayList<>();
 
-        @NonNullByDefault
         EventSubscriber thingStatusEventSubscriber = new EventSubscriber() {
             @Override
             public Set<String> getSubscribedEventTypes() {
@@ -1315,7 +1317,6 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         final List<ThingStatusInfoChangedEvent> infoChangedEvents = new ArrayList<>();
 
-        @NonNullByDefault
         EventSubscriber thingStatusEventSubscriber = new EventSubscriber() {
             @Override
             public Set<String> getSubscribedEventTypes() {
@@ -1398,7 +1399,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         thingStatusInfoI18nLocalizationService.setBundleResolver(bundleResolver);
 
         final List<ThingStatusInfoEvent> infoEvents = new ArrayList<>();
-        @NonNullByDefault
+
         EventSubscriber thingStatusInfoEventSubscriber = new EventSubscriber() {
             @Override
             public Set<String> getSubscribedEventTypes() {
@@ -1418,7 +1419,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         registerService(thingStatusInfoEventSubscriber);
 
         final List<ThingStatusInfoChangedEvent> infoChangedEvents = new ArrayList<>();
-        @NonNullByDefault
+
         EventSubscriber thingStatusInfoChangedEventSubscriber = new EventSubscriber() {
             @Override
             public Set<String> getSubscribedEventTypes() {

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -159,8 +159,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void interpretSomethingWhenTheDefaultHliIsSetAndItIsARegisteredService()
-            throws IOException, InterpretationException {
+    public void interpretSomethingWhenTheDefaultHliIsSetAndItIsARegisteredService() throws Exception {
         hliStub = new HumanLanguageInterpreterStub();
         registerService(hliStub);
 
@@ -171,10 +170,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         configuration.update(voiceConfig);
 
         // Wait some time to be sure that the configuration will be updated
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-        }
+        Thread.sleep(2000);
 
         String result = voiceManager.interpret("something", null);
         assertThat(result, is("Interpreted text"));
@@ -368,7 +364,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
     }
 
     @Test
-    public void startDialogWithoutPassingAnyParameters() throws IOException, InterruptedException {
+    public void startDialogWithoutPassingAnyParameters() throws Exception {
         sttService = new STTServiceStub();
         ksService = new KSServiceStub();
         hliStub = new HumanLanguageInterpreterStub();
@@ -390,10 +386,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         configuration.update(config);
 
         // Wait some time to be sure that the configuration will be updated
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-        }
+        Thread.sleep(2000);
 
         voiceManager.startDialog();
 

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
@@ -63,18 +63,20 @@ public class BundleInfoReader {
 
     private void readBindingInfo(Path ohinfPath, BundleInfo bundleInfo) throws IOException {
         BindingInfoReader reader = new BindingInfoReader();
-        xmlPathStream(ohinfPath, "binding").forEach(path -> {
-            log.info("Reading: " + path);
-            try {
-                BindingInfoXmlResult bindingInfoXml = reader.readFromXML(path.toUri().toURL());
-                if (bindingInfoXml != null) {
-                    bundleInfo.setBindingId(bindingInfoXml.getBindingInfo().getUID());
-                    bundleInfo.setBindingInfoXml(bindingInfoXml);
+        try (Stream<Path> xmlPathStream = xmlPathStream(ohinfPath, "binding")) {
+            xmlPathStream.forEach(path -> {
+                log.info("Reading: " + path);
+                try {
+                    BindingInfoXmlResult bindingInfoXml = reader.readFromXML(path.toUri().toURL());
+                    if (bindingInfoXml != null) {
+                        bundleInfo.setBindingId(bindingInfoXml.getBindingInfo().getUID());
+                        bundleInfo.setBindingInfoXml(bindingInfoXml);
+                    }
+                } catch (ConversionException | MalformedURLException e) {
+                    log.warn("Exception while reading binding info from: " + path, e);
                 }
-            } catch (ConversionException | MalformedURLException e) {
-                log.warn("Exception while reading binding info from: " + path, e);
-            }
-        });
+            });
+        }
     }
 
     private void readConfigInfo(Path ohinfPath, BundleInfo bundleInfo) throws IOException {

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
@@ -17,19 +17,22 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openhab.core.tools.i18n.plugin.DefaultTranslationsGenerationMode.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests {@link GenerateDefaultTranslationsMojo}.
@@ -39,7 +42,6 @@ import org.junit.jupiter.api.io.TempDir;
 @NonNullByDefault
 public class GenerateDefaultTranslationsMojoTest {
 
-    @TempDir
     public @NonNullByDefault({}) Path tempPath;
     public @NonNullByDefault({}) Path tempI18nPath;
 
@@ -92,7 +94,8 @@ public class GenerateDefaultTranslationsMojoTest {
     }
 
     @BeforeEach
-    public void before() {
+    public void before() throws IOException {
+        tempPath = Files.createTempDirectory("i18n-");
         tempI18nPath = tempPath.resolve("OH-INF/i18n");
 
         mojo = new GenerateDefaultTranslationsMojo();
@@ -101,9 +104,21 @@ public class GenerateDefaultTranslationsMojoTest {
         mojo.setTargetDirectory(tempI18nPath.toFile());
     }
 
+    @AfterEach
+    public void afterEach() {
+        try {
+            Files.walk(tempPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        } catch (IOException e) {
+            // XStream does not close the HierarchicalStreamReader created in XStream.fromXML(URL)
+            // which causes issues when deleting the temporary path on Windows.
+            // See: https://github.com/x-stream/xstream/pull/287
+            tempPath.toFile().deleteOnExit();
+        }
+    }
+
     private void assertSameProperties(Path expectedPath, Path actualPath) throws IOException {
-        String expected = Files.readString(expectedPath);
-        String actual = Files.readString(actualPath);
+        String expected = Files.readAllLines(expectedPath).stream().collect(Collectors.joining(System.lineSeparator()));
+        String actual = Files.readAllLines(actualPath).stream().collect(Collectors.joining(System.lineSeparator()));
         assertThat(expected, equalTo(actual));
     }
 


### PR DESCRIPTION
This fixes the build being broken when building on Windows.
It also contains many fixes for timing issues which seem to impact macOS and Windows more than Linux.

* Fix .gitattributes and add *.xml_gen to fix line ending issues on Windows
* Derive fork count from CPU details in org.openhab.core tests for more stable tests on machines with fewer cores
* Adjust SafeCallerImplTest timings
* Increase ExecUtilTest timeout
* Increase SchedulerImplTest timeouts
* Increase AudioConsoleTest serveStream timeout
* Increase AudioServletTest serveStream timeout
* Increase SchedulerImplTest test timeouts
* Increase ExpireManagerTest timeout used for checking published events
* Increase PeriodicSchedulerImplTest max allowed delta
* Increase SchedulerImplTest timeouts
* Fix BundleInfoReader file stream not closed causing temp dir deletion issues on Windows
* Fix GenerateDefaultTranslationsMojoTest Windows line endings issues
* Fix GenerateDefaultTranslationsMojoTest Windows temp dir deletion problem
* Fix GenericItemProviderTest tearDown sometimes fails because of queued events
* Fix ChannelLinkNotifierOSGiTest wait for channel link events
* Fix ChannelCommandDescriptionProviderOSGiTest fails if provider not immediately registered
* Fix ChannelStateDescriptionProviderOSGiTest fails if provider not immediately registered
* Fix GenericItemChannelLinkProviderTest not waiting for async updated state to become true
* Fix GenericThingProviderTest failing due to events of previous test
* Fix InboxOSGiTest sometimes fails because of queued events
* Fix ScriptEngineOSGiTest failing because items are not yet added to registry
* Fix ThingManagerOSGiTest failing due to async handleRemoval call

Fixes #1640
Fixes #2862