### PR TITLE
Fix i18n-maven-plugin project name

### DIFF
--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -14,7 +14,7 @@
 
   <packaging>maven-plugin</packaging>
 
-  <name>Internationalization Maven Plugin</name>
+  <name>openHAB Core :: Tools :: Internationalization Maven Plugin</name>
   <description>Generates translations files</description>
 
   <properties>


### PR DESCRIPTION
This makes it follow the naming scheme as used with the other projects:

```
...
[INFO] openHAB Core :: Tools :: Archetypes                                [pom]
[INFO] openHAB Core :: Tools :: Archetypes :: Binding         [maven-archetype]
[INFO] openHAB Core :: Tools :: Internationalization Maven Plugin [maven-plugin]
[INFO] openHAB Core :: Integration Tests                                  [pom]
[INFO] openHAB Core :: Integration Tests :: Tests                         [jar]
[INFO] openHAB Core :: Integration Tests :: OAuth2Client Tests            [jar]
...
```