### PR TITLE
Update semantic metadata of group members when groups are added/removed

### DIFF
--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -82,10 +82,10 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     @Activate
     protected void activate() {
         initRelations();
-        itemRegistry.addRegistryChangeListener(this);
         for (Item item : itemRegistry.getAll()) {
             processItem(item);
         }
+        itemRegistry.addRegistryChangeListener(this);
     }
 
     @Deactivate

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -82,10 +82,10 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
     @Activate
     protected void activate() {
         initRelations();
+        itemRegistry.addRegistryChangeListener(this);
         for (Item item : itemRegistry.getAll()) {
             processItem(item);
         }
-        itemRegistry.addRegistryChangeListener(this);
     }
 
     @Deactivate
@@ -122,6 +122,12 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
             Metadata removedMd = semantics.remove(item.getName());
             if (removedMd != null) {
                 notifyListenersAboutRemovedElement(removedMd);
+            }
+        }
+
+        if (item instanceof GroupItem) {
+            for (Item memberItem : ((GroupItem) item).getMembers()) {
+                processItem(memberItem);
             }
         }
     }
@@ -251,6 +257,12 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
         Metadata removedMd = semantics.remove(item.getName());
         if (removedMd != null) {
             notifyListenersAboutRemovedElement(removedMd);
+
+            if (item instanceof GroupItem) {
+                for (Item memberItem : ((GroupItem) item).getMembers()) {
+                    processItem(memberItem);
+                }
+            }
         }
     }
 

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
@@ -16,8 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import java.util.Collection;
-import java.util.Optional;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -32,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.items.GenericItem;
+import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.Metadata;
@@ -47,6 +47,8 @@ public class SemanticsMetadataProviderTest {
 
     private static final String ITEM_NAME = "switchItem";
 
+    private static final String GROUP_ITEM_NAME = "groupItem";
+
     private @NonNullByDefault({}) @Mock ItemRegistry itemRegistry;
     private @NonNullByDefault({}) @Mock ProviderChangeListener<@NonNull Metadata> changeListener;
 
@@ -59,6 +61,8 @@ public class SemanticsMetadataProviderTest {
                 addProviderChangeListener(changeListener);
             }
         };
+
+        semanticsMetadataProvider.activate();
     }
 
     private void assertCorrectAddedEvents(Metadata expected) {
@@ -92,12 +96,10 @@ public class SemanticsMetadataProviderTest {
         item.addTag("Door");
         semanticsMetadataProvider.added(item);
 
-        Metadata metadata = getMetadata(item);
-        assertNotNull(metadata);
-        if (metadata != null) {
-            assertEquals("Equipment_Door", metadata.getValue());
-            assertCorrectAddedEvents(metadata);
-        }
+        Metadata metadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", metadata.getValue());
+
+        assertCorrectAddedEvents(metadata);
     }
 
     @Test
@@ -106,19 +108,16 @@ public class SemanticsMetadataProviderTest {
         oldItem.addTag("Door");
         semanticsMetadataProvider.added(oldItem);
 
-        Metadata oldMetadata = getMetadata(oldItem);
-        assertNotNull(oldMetadata);
+        Metadata oldMetadata = Objects.requireNonNull(getMetadata(oldItem));
 
         GenericItem newItem = new SwitchItem(ITEM_NAME);
         newItem.addTag("Indoor");
         semanticsMetadataProvider.updated(oldItem, newItem);
 
-        Metadata metadata = getMetadata(newItem);
-        assertNotNull(metadata);
-        if (oldMetadata != null && metadata != null) {
-            assertEquals("Location_Indoor", metadata.getValue());
-            assertCorrectUpdatedEvents(oldMetadata, metadata);
-        }
+        Metadata metadata = Objects.requireNonNull(getMetadata(newItem));
+        assertEquals("Location_Indoor", metadata.getValue());
+
+        assertCorrectUpdatedEvents(oldMetadata, metadata);
     }
 
     @Test
@@ -127,17 +126,15 @@ public class SemanticsMetadataProviderTest {
         oldItem.addTag("Door");
         semanticsMetadataProvider.added(oldItem);
 
-        Metadata oldMetadata = getMetadata(oldItem);
-        assertNotNull(oldMetadata);
+        Metadata oldMetadata = Objects.requireNonNull(getMetadata(oldItem));
 
         GenericItem newItem = new SwitchItem(ITEM_NAME);
         semanticsMetadataProvider.updated(oldItem, newItem);
 
         Metadata metadata = getMetadata(newItem);
         assertNull(metadata);
-        if (oldMetadata != null) {
-            assertCorrectRemoveEvents(oldMetadata);
-        }
+
+        assertCorrectRemoveEvents(oldMetadata);
     }
 
     @Test
@@ -146,26 +143,93 @@ public class SemanticsMetadataProviderTest {
         item.addTag("Door");
         semanticsMetadataProvider.added(item);
 
-        Metadata oldMetadata = getMetadata(item);
-        assertNotNull(oldMetadata);
+        Metadata oldMetadata = Objects.requireNonNull(getMetadata(item));
 
         semanticsMetadataProvider.removed(item);
 
         Metadata metadata = getMetadata(item);
         assertNull(metadata);
-        if (oldMetadata != null) {
-            assertCorrectRemoveEvents(oldMetadata);
-        }
+
+        assertCorrectRemoveEvents(oldMetadata);
+    }
+
+    @Test
+    public void testGroupItemAddedBeforeMemberItemAdded() {
+        GenericItem item = new SwitchItem(ITEM_NAME);
+        item.addTag("Door");
+        item.addGroupName(GROUP_ITEM_NAME);
+
+        GroupItem groupItem = new GroupItem(GROUP_ITEM_NAME);
+        groupItem.addMember(item);
+        groupItem.addTag("LivingRoom");
+
+        when(itemRegistry.get(GROUP_ITEM_NAME)).thenReturn(groupItem);
+
+        semanticsMetadataProvider.added(groupItem);
+        semanticsMetadataProvider.added(item);
+
+        Metadata metadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", metadata.getValue());
+        assertEquals(metadata.getConfiguration().get("hasLocation"), GROUP_ITEM_NAME);
+    }
+
+    @Test
+    public void testGroupItemAddedAfterMemberItemAdded() {
+        GenericItem item = new SwitchItem(ITEM_NAME);
+        item.addTag("Door");
+        item.addGroupName(GROUP_ITEM_NAME);
+
+        GroupItem groupItem = new GroupItem(GROUP_ITEM_NAME);
+        groupItem.addMember(item);
+        groupItem.addTag("LivingRoom");
+
+        semanticsMetadataProvider.added(item);
+
+        Metadata oldMetadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", oldMetadata.getValue());
+        assertNull(oldMetadata.getConfiguration().get("hasLocation"));
+
+        when(itemRegistry.get(GROUP_ITEM_NAME)).thenReturn(groupItem);
+
+        semanticsMetadataProvider.added(groupItem);
+
+        Metadata metadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", oldMetadata.getValue());
+        assertEquals(metadata.getConfiguration().get("hasLocation"), GROUP_ITEM_NAME);
+    }
+
+    @Test
+    public void testGroupItemRemovedAfterMemberItemAdded() {
+        GenericItem item = new SwitchItem(ITEM_NAME);
+        item.addTag("Door");
+        item.addGroupName(GROUP_ITEM_NAME);
+
+        GroupItem groupItem = new GroupItem(GROUP_ITEM_NAME);
+        groupItem.addMember(item);
+        groupItem.addTag("LivingRoom");
+
+        when(itemRegistry.get(GROUP_ITEM_NAME)).thenReturn(groupItem);
+
+        semanticsMetadataProvider.added(groupItem);
+        semanticsMetadataProvider.added(item);
+
+        Metadata oldMetadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", oldMetadata.getValue());
+        assertEquals(oldMetadata.getConfiguration().get("hasLocation"), GROUP_ITEM_NAME);
+
+        when(itemRegistry.get(GROUP_ITEM_NAME)).thenReturn(null);
+
+        semanticsMetadataProvider.removed(groupItem);
+
+        Metadata metadata = Objects.requireNonNull(getMetadata(item));
+        assertEquals("Equipment_Door", metadata.getValue());
+        assertNull(metadata.getConfiguration().get("hasLocation"));
     }
 
     private @Nullable Metadata getMetadata(Item item) {
-        Collection<Metadata> metadataCollection = semanticsMetadataProvider.getAll();
-        Optional<Metadata> foundMetadata = metadataCollection.stream()
-                .filter(metadata -> metadata.getUID().getItemName().equals(item.getName())).findFirst();
-        if (foundMetadata.isPresent()) {
-            return foundMetadata.get();
-        } else {
-            return null;
-        }
+        return semanticsMetadataProvider.getAll().stream() //
+                .filter(metadata -> metadata.getUID().getItemName().equals(item.getName())) //
+                .findFirst() //
+                .orElse(null);
     }
 }


### PR DESCRIPTION
This fixes the issue that the semantic metadata is incorrect when defining group member items in files and their groups in the UI.

Fixes #2106
Fixes #2117