### PR TITLE
Add an access-tracking cache to be used in rules

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -55,9 +56,9 @@ public class CacheScriptExtension implements ScriptExtensionProvider {
 
     private final Lock cacheLock = new ReentrantLock();
     private final Map<String, Object> sharedCache = new HashMap<>();
-    private final Map<String, Set<String>> sharedCacheKeyAccessors = new HashMap<>();
+    private final Map<String, Set<String>> sharedCacheKeyAccessors = new ConcurrentHashMap<>();
 
-    private final Map<String, ValueCacheImpl> privateCaches = new HashMap<>();
+    private final Map<String, ValueCacheImpl> privateCaches = new ConcurrentHashMap<>();
 
     public CacheScriptExtension() {
     }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
@@ -21,7 +21,6 @@ import org.eclipse.jdt.annotation.Nullable;
  * The {@link ValueCache} can be used by scripts to share information between subsequent runs of the same script or
  * between scripts (depending on implementation).
  *
- *
  * @author Jan N. Klug - Initial contribution
  */
 @NonNullByDefault

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared;
+
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ValueCache} can be used by scripts to share information between subsequent runs of the same script or
+ * between scripts (depending on implementation).
+ *
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public interface ValueCache {
+
+    /**
+     * Add a new key-value-pair to the cache. If the key is already present, the old value is replaces by the new value.
+     *
+     * @param key a string used as key
+     * @param value an {@code Object} to store with the key
+     * @return the old value associated with this key or {@code null} if key didn't exist
+     */
+    @Nullable
+    Object put(String key, Object value);
+
+    /**
+     * Remove a key (and its associated value) from the cache
+     *
+     * @param key the key to remove
+     * @return the previously associated value to this key or {@code null} if key not present
+     */
+    @Nullable
+    Object remove(String key);
+
+    /**
+     * Get a value from the cache
+     *
+     * @param key the key of the requested value
+     * @return the value associated with the key or {@code null} if key not present
+     */
+    @Nullable
+    Object get(String key);
+
+    /**
+     * Get a value from the cache or create a new key-value-pair from the given supplier
+     *
+     * @param key the key of the requested value
+     * @param supplier a supplier that returns a non-null value to be used if the key was not present
+     * @return the value associated with the key
+     */
+    Object get(String key, Supplier<Object> supplier);
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -177,8 +178,8 @@ public class CacheScriptExtensionTest {
         cache.put(KEY1, timerMock);
         cache.put(KEY2, futureMock);
         se.unload(SCRIPT1);
-        verify(timerMock).cancel();
-        verify(futureMock).cancel(true);
+        verify(timerMock, timeout(1000)).cancel();
+        verify(futureMock, timeout(1000)).cancel(true);
     }
 
     public void testCacheBasicFunctions(ValueCache cache) {

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.internal;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache;
+
+/**
+ * The {@link CacheScriptExtensionTest} contains tests for {@link CacheScriptExtension}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class CacheScriptExtensionTest {
+    private static final String SCRIPT1 = "script1";
+    private static final String SCRIPT2 = "script2";
+
+    private static final String KEY1 = "key1";
+    private static final String KEY2 = "key2";
+
+    private static final String VALUE1 = "value1";
+    private static final String VALUE2 = "value2";
+
+    @Test
+    public void sharedCacheBasicFunction() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache = getCache(se, SCRIPT1, CacheScriptExtension.SHARED_CACHE_NAME);
+
+        testCacheBasicFunctions(cache);
+    }
+
+    @Test
+    public void privateCacheBasicFunction() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache = getCache(se, SCRIPT1, CacheScriptExtension.PRIVATE_CACHE_NAME);
+
+        testCacheBasicFunctions(cache);
+    }
+
+    @Test
+    public void sharedCacheIsSharedBetweenTwoRuns() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.SHARED_CACHE_NAME);
+        Objects.requireNonNull(cache1);
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+
+        ValueCache cache2 = getCache(se, SCRIPT1, CacheScriptExtension.SHARED_CACHE_NAME);
+        assertThat(cache2, not(sameInstance(cache1)));
+
+        assertThat(cache2.get(KEY1), is(VALUE1));
+    }
+
+    @Test
+    public void sharedCacheIsClearedIfScriptUnloaded() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.SHARED_CACHE_NAME);
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+
+        se.unload(SCRIPT1);
+
+        ValueCache cache1new = getCache(se, SCRIPT2, CacheScriptExtension.SHARED_CACHE_NAME);
+        assertThat(cache1new.get(KEY1), nullValue());
+    }
+
+    @Test
+    public void sharedCachesIsSharedBetweenTwoScripts() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.SHARED_CACHE_NAME);
+        ValueCache cache2 = getCache(se, SCRIPT2, CacheScriptExtension.SHARED_CACHE_NAME);
+
+        assertThat(cache1, not(is(cache2)));
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+        assertThat(cache2.get(KEY1), is(VALUE1));
+
+        cache2.remove(KEY1);
+        assertThat(cache2.get(KEY1), nullValue());
+        assertThat(cache1.get(KEY1), nullValue());
+    }
+
+    @Test
+    public void privateCacheIsSharedBetweenTwoRuns() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.PRIVATE_CACHE_NAME);
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+
+        ValueCache cache2 = getCache(se, SCRIPT1, CacheScriptExtension.PRIVATE_CACHE_NAME);
+        assertThat(cache2, sameInstance(cache1));
+
+        assertThat(cache2.get(KEY1), is(VALUE1));
+    }
+
+    @Test
+    public void privateCacheIsClearedIfScriptUnloaded() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.PRIVATE_CACHE_NAME);
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+
+        se.unload(SCRIPT1);
+
+        ValueCache cache1new = getCache(se, SCRIPT2, CacheScriptExtension.PRIVATE_CACHE_NAME);
+        assertThat(cache1new, not(sameInstance(cache1)));
+        assertThat(cache1new.get(KEY1), nullValue());
+    }
+
+    @Test
+    public void privateCachesIsNotSharedBetweenTwoScripts() {
+        CacheScriptExtension se = new CacheScriptExtension();
+        ValueCache cache1 = getCache(se, SCRIPT1, CacheScriptExtension.PRIVATE_CACHE_NAME);
+        ValueCache cache2 = getCache(se, SCRIPT2, CacheScriptExtension.PRIVATE_CACHE_NAME);
+
+        assertThat(cache1, not(is(cache2)));
+
+        cache1.put(KEY1, VALUE1);
+        assertThat(cache1.get(KEY1), is(VALUE1));
+        assertThat(cache2.get(KEY1), nullValue());
+    }
+
+    public void testCacheBasicFunctions(ValueCache cache) {
+        // cache is initially empty
+        assertThat(cache.get(KEY1), nullValue());
+
+        // return value is null if no value before and new value can be retrieved
+        assertThat(cache.put(KEY1, VALUE1), nullValue());
+        assertThat(cache.get(KEY1), is(VALUE1));
+
+        // value returns old value on update and updated value can be retrieved
+        assertThat(cache.put(KEY1, VALUE2), is(VALUE1));
+        assertThat(cache.get(KEY1), is(VALUE2));
+
+        // old value is returned on removal and cache empty afterwards
+        assertThat(cache.remove(KEY1), is(VALUE2));
+        assertThat(cache.get(KEY1), nullValue());
+
+        // new value is inserted from supplier
+        assertThat(cache.get(KEY1, () -> VALUE1), is(VALUE1));
+        assertThat(cache.get(KEY1), is(VALUE1));
+
+        // different keys return different values
+        cache.put(KEY2, VALUE2);
+        assertThat(cache.get(KEY1), is(VALUE1));
+        assertThat(cache.get(KEY2), is(VALUE2));
+    }
+
+    private ValueCache getCache(CacheScriptExtension se, String scriptIdentifier, String type) {
+        ValueCache cache = (ValueCache) se.get(scriptIdentifier, type);
+        Objects.requireNonNull(cache);
+
+        return cache;
+    }
+}


### PR DESCRIPTION
Closes #2084
Closes #2881 
Closes #2943 
Depends on #2886

This implements option 1 that was discussed in #2084 (which seems to be what most comments prefer). It is remotely based on the code here: https://github.com/openhab/openhab-addons/blob/4f4dfcca20f39c2d8ed059b67e1dba09c9c83957/bundles/org.openhab.automation.jsscripting/src/main/java/org/openhab/automation/jsscripting/internal/scope/SharedCache.java.

Two separate key-value-caches are implemented:

1. `privateCache`: It is created per `scriptIdentifier` and can only be accessed from the same script. It is not cleared between two subsequent runs of a rule but removed when the script is unloaded. This can be used e.g. to store timers. 

2. `sharedCache`: It is shared between all scripts. Every access to a certain key in the cache is tracked. The key is removed from the map if all scripts that ever accessed (`put` or `get`) that key have been unloaded.

Since script unloading is tracked by the framework nothing special needs to be done in the script itself. That makes it usable also in UI rules, where `scriptUnloaded` is not available.

~~I am currently investigating if I can auto-cancel `ScheduledFutures` and `Timer` when a key is removed (i.e. the last script that used the key was unloaded).~~ `ScheduledFuture<?>` and `Timer` objects are cancelled when the script is unloaded in a private cache or if the last accessor was removed in the shared cache. They are not cancelled on `remove` because I might be that the script wants to use it or take special actions before cancellation.

@jpg0: do you think the preset name `cache` should be changed, so that we do not run into conflicts? I changed the case of the `sharedcache` to be more consistent with the camel-case we use in general. As an alternative, I could implement `sharedcache` as an alias to `sharedCache` and log a warning if that is used instead of the new name. The old name could then be removed in a later version.

Signed-off-by: Jan N. Klug <github@klug.nrw>