### PR TITLE
[AbstractRuleBasedInterpreter] Fix spanish tokenization

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -600,7 +600,8 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             split = text.toLowerCase(locale).replaceAll("[\\']", " ").replaceAll("[^\\w\\sàâäçéèêëîïôùûü]", " ")
                     .split("\\s");
         } else if ("es".equalsIgnoreCase(locale.getLanguage())) {
-            split = text.toLowerCase(locale).replaceAll("[\\']", " ").replaceAll("[^\\w\\sáéíóúü]", " ").split("\\s");
+            split = text.toLowerCase(locale).replaceAll("[\\']", " ").replaceAll("[^\\w\\sáéíóúïüñç]", " ")
+                    .split("\\s");
         } else {
             split = text.toLowerCase(locale).replaceAll("[\\']", "").replaceAll("[^\\w\\s]", " ").split("\\s");
         }


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

Fix Spanish tokenization. I realize last time I tried to do it I forgot the 'ñ' character.
This time it should be right as I have followed this reference https://www1.icsi.berkeley.edu/~chema/espanol/caracteres_hispanos.html

Regards