### PR TITLE
[Javasound] Fix microphone data line sharing on Windows OS

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -78,7 +78,7 @@ public class JavaSoundAudioSource implements AudioSource {
     private final ConcurrentLinkedQueue<PipedOutputStream> openStreamRefs = new ConcurrentLinkedQueue<>();
 
     /**
-     * Task for writing microphone data to the each of the open sources on Windows OS
+     * Task for writing microphone data to each of the open sources on Windows OS
      */
     private @Nullable Future<?> pipeWriteTask;
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -146,7 +146,6 @@ public class JavaSoundAudioSource implements AudioSource {
             this.pipeWriteTask = executor.submit(() -> {
                 int lengthRead;
                 byte[] buffer = new byte[1024];
-                int readRetries = 3;
                 while (!openStreamRefs.isEmpty()) {
                     TargetDataLine stream = this.microphone;
                     if (stream != null) {
@@ -188,6 +187,7 @@ public class JavaSoundAudioSource implements AudioSource {
             } catch (InterruptedException ignored) {
             }
             if (openStreamRefs.isEmpty()) {
+                Future<?> pipeWriteTask = this.pipeWriteTask;
                 if (pipeWriteTask != null) {
                     pipeWriteTask.cancel(true);
                     this.pipeWriteTask = null;

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
@@ -13,8 +13,7 @@
 package org.openhab.core.audio.internal.javasound;
 
 import java.io.IOException;
-
-import javax.sound.sampled.TargetDataLine;
+import java.io.InputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -31,32 +30,19 @@ import org.openhab.core.audio.AudioStream;
 public class JavaSoundInputStream extends AudioStream {
 
     /**
-     * TargetDataLine for the input
+     * InputStream for the input
      */
-    private final TargetDataLine input;
+    private final InputStream input;
     private final AudioFormat format;
-    private final @Nullable JavaSoundInputStreamCloseHandler closeHandler;
-
-    /**
-     * Constructs a JavaSoundInputStream with the passed input
-     *
-     * @param input The mic which data is pulled from
-     */
-    public JavaSoundInputStream(TargetDataLine input, AudioFormat format) {
-        this(input, format, null);
-    }
 
     /**
      * Constructs a JavaSoundInputStream with the passed input and a close handler.
      *
      * @param input The mic which data is pulled from
      */
-    public JavaSoundInputStream(TargetDataLine input, AudioFormat format,
-            @Nullable JavaSoundInputStreamCloseHandler closeHandler) {
+    public JavaSoundInputStream(InputStream input, AudioFormat format) {
         this.format = format;
-        this.closeHandler = closeHandler;
         this.input = input;
-        this.input.start();
     }
 
     @Override
@@ -86,20 +72,11 @@ public class JavaSoundInputStream extends AudioStream {
 
     @Override
     public void close() throws IOException {
-        var closeHandler = this.closeHandler;
-        if (closeHandler != null) {
-            closeHandler.onStreamClosed();
-        } else {
-            input.close();
-        }
+        input.close();
     }
 
     @Override
     public AudioFormat getFormat() {
         return format;
-    }
-
-    public interface JavaSoundInputStreamCloseHandler {
-        void onStreamClosed();
     }
 }


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez Díez <miguelwork92@gmail.com>

This is a proposed solution to address the microphone stream sharing on Windows.

The problem was fixed before for other OSs in this PR https://github.com/openhab/openhab-core/pull/2732 by opening separate microphone instances as it's supported on those platform. In that pr there is a workaround for windows to avoid  closing the shared mic input stream until all consumer have closed their streams, but still do not ensure that all the microphone data reach all the consumers.

I used the same solution here https://github.com/openhab/openhab-addons/blob/main/bundles/org.openhab.binding.pulseaudio/src/main/java/org/openhab/binding/pulseaudio/internal/PulseAudioAudioSource.java as the problem was the same (there is just one input source that can be consumed from multiple AudioStream instances).

Let me know about any improvements that can be done.