### PR TITLE
Allow changing watched directory of a WatchService

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractWatchService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractWatchService.java
@@ -52,7 +52,7 @@ public abstract class AbstractWatchService {
      * @param pathToWatch the new path
      */
     protected void changeWatchDirectory(String pathToWatch) {
-        watchQueueReader.stopWatchService(this);
+        deactivate();
         this.pathToWatch = pathToWatch;
         activate();
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractWatchService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractWatchService.java
@@ -37,14 +37,25 @@ import org.eclipse.jdt.annotation.Nullable;
 public abstract class AbstractWatchService {
     protected @Nullable String pathToWatch;
 
+    /**
+     * The queue reader
+     */
+    protected WatchQueueReader watchQueueReader = WatchQueueReader.getInstance();
+
     protected AbstractWatchService(String pathToWatch) {
         this.pathToWatch = pathToWatch;
     }
 
     /**
-     * The queue reader
+     * Change the watch directory for this WatchService
+     *
+     * @param pathToWatch the new path
      */
-    protected WatchQueueReader watchQueueReader = WatchQueueReader.getInstance();
+    protected void changeWatchDirectory(String pathToWatch) {
+        watchQueueReader.stopWatchService(this);
+        this.pathToWatch = pathToWatch;
+        activate();
+    }
 
     /**
      * Method to call on service activation
@@ -61,7 +72,6 @@ public abstract class AbstractWatchService {
      */
     @SuppressWarnings("unused")
     public void deactivate() {
-        WatchQueueReader watchQueueReader = this.watchQueueReader;
         watchQueueReader.stopWatchService(this);
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/service/AbstractWatchServiceTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/service/AbstractWatchServiceTest.java
@@ -15,6 +15,8 @@ package org.openhab.core.service;
 import static java.nio.file.StandardWatchEventKinds.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -175,6 +177,18 @@ public class AbstractWatchServiceTest extends JavaTest {
         assertNoEventsAreProcessed();
     }
 
+    @Test
+    public void testChangeDirectory() {
+        WatchQueueReader watchQueueReaderMock = mock(WatchQueueReader.class);
+        watchService = new RelativeWatchService("foo", false);
+        watchService.setWatchQueueReader(watchQueueReaderMock);
+        watchService.activate();
+        verify(watchQueueReaderMock).customizeWatchQueueReader(watchService, Path.of("foo"), false);
+        watchService.changeWatchDirectory("bar");
+        verify(watchQueueReaderMock).stopWatchService(watchService);
+        verify(watchQueueReaderMock).customizeWatchQueueReader(watchService, Path.of("bar"), false);
+    }
+
     private void assertNoEventsAreProcessed() throws Exception {
         // Wait for a possible event for the maximum timeout
         Thread.sleep(noEventTimeoutInSeconds * 1000);
@@ -279,6 +293,15 @@ public class AbstractWatchServiceTest extends JavaTest {
         RelativeWatchService(String rootPath, boolean watchSubDirectories) {
             super(rootPath);
             watchSubDirs = watchSubDirectories;
+        }
+
+        /**
+         * Inject a mocked WatchQueueReader
+         *
+         * @param watchQueueReader the mock
+         */
+        public void setWatchQueueReader(WatchQueueReader watchQueueReader) {
+            this.watchQueueReader = watchQueueReader;
         }
 
         @Override


### PR DESCRIPTION
The current implementation of the `AbstractWatchService` requires the directory to be known on instantiation. It is not possible to retrieve it from anywhere because the parent's constructor must be called first. The `WatchQueueReader` is customized (subscribed by WatchService instance) in `activate` and unsubscribed in `deactivate`. This PR adds a new method that allows changing the directory. If called, the old subscription is removed, the directory changed and the service activated again.

Signed-off-by: Jan N. Klug <github@klug.nrw>