### PR TITLE
Fix memory leak in ScriptedRuleProvider

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
@@ -60,7 +60,7 @@ public class ScriptedRuleProvider implements RuleProvider {
     }
 
     public void removeRule(String ruleUID) {
-        Rule rule = rules.get(ruleUID);
+        Rule rule = rules.remove(ruleUID);
         if (rule != null) {
             removeRule(rule);
         }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
@@ -67,6 +67,7 @@ public class ScriptedRuleProvider implements RuleProvider {
     }
 
     public void removeRule(Rule rule) {
+        rules.remove(rule.getUID());
         for (ProviderChangeListener<Rule> providerChangeListener : listeners) {
             providerChangeListener.removed(this, rule);
         }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
@@ -60,7 +60,7 @@ public class ScriptedRuleProvider implements RuleProvider {
     }
 
     public void removeRule(String ruleUID) {
-        Rule rule = rules.remove(ruleUID);
+        Rule rule = rules.get(ruleUID);
         if (rule != null) {
             removeRule(rule);
         }


### PR DESCRIPTION
The Rule was never removed from the internal tracking map and therefore allocated resources were never freed.

Signed-off-by: Jan N. Klug <github@klug.nrw>