### PR TITLE
Upgrade nrjavaserial to fix file descriptor leak

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -512,7 +512,7 @@
     <dependency>
       <groupId>com.neuronrobotics</groupId>
       <artifactId>nrjavaserial</artifactId>
-      <version>5.2.1</version>
+      <version>5.2.1.OH1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -211,7 +211,7 @@
 
 	<feature name="openhab.tp-serial-rxtx" version="${project.version}">
 		<capability>openhab.tp;feature=serial;impl=rxtx</capability>
-		<bundle>mvn:com.neuronrobotics/nrjavaserial/5.2.1</bundle>
+		<bundle>mvn:com.neuronrobotics/nrjavaserial/5.2.1.OH1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">


### PR DESCRIPTION
Uses an openHAB 5.2.1.OH1 build based on the latest changes in the nrjavaserial master branch ([7aa21d1](https://github.com/NeuronRobotics/nrjavaserial/tree/7aa21d1dc8cecdc8daad3ebc40273cfb8179e9d2)).
When there is an official release containing those changes we can upgrade to that.

Most importantly this fixes a file descriptor leak when checking lock dir permissions.
It also adds FreeBSD aarch64 (ARM64) support.

Fixes #1842

---

Can you add the JAR/POM in https://github.com/wborn/nrjavaserial/releases/tag/5.2.1.OH1 to the openHAB Maven repository @kaikreuzer?