### PR TITLE
Add ability to name timers / scheduled jobs

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -14,6 +14,7 @@ package org.openhab.core.model.script.actions;
 
 import java.time.ZonedDateTime;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
@@ -76,11 +77,25 @@ public class ScriptExecution {
      * @throws ScriptExecutionException if an error occurs during the execution
      */
     public static Timer createTimer(ZonedDateTime instant, Procedure0 closure) {
+        return createTimer(null, instant, closure);
+    }
+
+    /**
+     * Schedules a block of code for later execution.
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param closure the code block to execute
+     *
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     * @throws ScriptExecutionException if an error occurs during the execution
+     */
+    public static Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Procedure0 closure) {
         Scheduler scheduler = ScriptServiceUtil.getScheduler();
 
         return new TimerImpl(scheduler, instant, () -> {
             closure.apply();
-        });
+        }, identifier);
     }
 
     /**
@@ -94,11 +109,25 @@ public class ScriptExecution {
      * @throws ScriptExecutionException if an error occurs during the execution
      */
     public static Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Procedure1<Object> closure) {
+        return createTimerWithArgument(null, instant, arg1, closure);
+    }
+
+    /**
+     * Schedules a block of code (with argument) for later execution
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param arg1 the argument to pass to the code block
+     * @param closure the code block to execute
+     *
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     * @throws ScriptExecutionException if an error occurs during the execution
+     */
+    public static Timer createTimerWithArgument(@Nullable String identifier,  ZonedDateTime instant, Object arg1, Procedure1<Object> closure) {
         Scheduler scheduler = ScriptServiceUtil.getScheduler();
 
         return new TimerImpl(scheduler, instant, () -> {
             closure.apply(arg1);
-        });
+        }, identifier);
     }
-
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/actions/TimerImpl.java
@@ -33,14 +33,20 @@ public class TimerImpl implements Timer {
     private final Scheduler scheduler;
     private final ZonedDateTime startTime;
     private final SchedulerRunnable runnable;
+    private final @Nullable String identifier;
     private ScheduledCompletableFuture<?> future;
 
     public TimerImpl(Scheduler scheduler, ZonedDateTime startTime, SchedulerRunnable runnable) {
+        this(scheduler, startTime, runnable, null);
+    }
+
+    public TimerImpl(Scheduler scheduler, ZonedDateTime startTime, SchedulerRunnable runnable, @Nullable String identifier) {
         this.scheduler = scheduler;
         this.startTime = startTime;
         this.runnable = runnable;
+        this.identifier = identifier;
 
-        future = scheduler.schedule(runnable, startTime.toInstant());
+        future = scheduler.schedule(runnable, identifier, startTime.toInstant());
     }
 
     @Override

--- a/bundles/org.openhab.core/pom.xml
+++ b/bundles/org.openhab.core/pom.xml
@@ -14,6 +14,15 @@
 
   <name>openHAB Core :: Bundles :: Core</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/DelegatedSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/DelegatedSchedulerImpl.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
 import org.openhab.core.scheduler.SchedulerRunnable;
@@ -94,6 +95,12 @@ public class DelegatedSchedulerImpl implements Scheduler {
     @Override
     public <T> ScheduledCompletableFuture<T> schedule(SchedulerRunnable runnable, TemporalAdjuster temporalAdjuster) {
         return add(delegate.schedule(runnable, temporalAdjuster));
+    }
+
+    @Override
+    public <T> ScheduledCompletableFuture<T> schedule(SchedulerRunnable runnable, @Nullable String identifier,
+            TemporalAdjuster temporalAdjuster) {
+        return add(delegate.schedule(runnable, identifier, temporalAdjuster));
     }
 
     private <T> ScheduledCompletableFuture<T> add(ScheduledCompletableFuture<T> t) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/Scheduler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/Scheduler.java
@@ -114,4 +114,17 @@ public interface Scheduler {
      * @return A {@link ScheduledCompletableFuture}
      */
     <T> ScheduledCompletableFuture<T> schedule(SchedulerRunnable callable, TemporalAdjuster temporalAdjuster);
+
+    /**
+     * Schedules the callable once or repeating using the temporalAdjuster to determine the
+     * time the callable should run. Runs until the job is cancelled or if the temporalAdjuster
+     * method {@link SchedulerTemporalAdjuster#isDone()) returns true.
+     *
+     * @param callable Provides the result
+     * @param an optional identifier for this job
+     * @param temporalAdjuster the temperalAdjuster to return the time the callable should run
+     * @return A {@link ScheduledCompletableFuture}
+     */
+    <T> ScheduledCompletableFuture<T> schedule(SchedulerRunnable callable, @Nullable String identifier,
+            TemporalAdjuster temporalAdjuster);
 }


### PR DESCRIPTION
Closes #1255
Closes #2750 

Potentially API breaking, although I think that alternative scheduler implementations are unlikely. I could add a default for the new method that just throws away the identifier.

Signed-off-by: Jan N. Klug <github@klug.nrw>