### PR TITLE
Add .gradle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/
 .DS_Store
 *.iml
 .idea/
+.gradle/
 **/.settings/org.eclipse.*
 
 dependency-reduced-pom.xml


### PR DESCRIPTION
While openHAB uses Maven, under some circumstances IntelliJ creates files in the .gradle/ directory.

Signed-off-by: Jan N. Klug <github@klug.nrw>