### PR TITLE
Fix "recursive membership detected" for plain items

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/pom.xml
+++ b/bundles/org.openhab.core.io.rest.core/pom.xml
@@ -41,6 +41,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Fixes #2916 

Plain items can't have Childs and therefore should not be considered when calculating parents/childs of a group.

Signed-off-by: Jan N. Klug <github@klug.nrw>