### PR TITLE
Improve SchedulerImplTest

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/SchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/SchedulerImplTest.java
@@ -212,6 +212,7 @@ public class SchedulerImplTest extends JavaTest {
         TestSchedulerWithCounter temporalAdjuster = new TestSchedulerWithCounter();
         ScheduledCompletableFuture<Void> schedule = scheduler.schedule(s::release, temporalAdjuster);
         s.acquire(1);
+        Thread.sleep(50);
         schedule.cancel(true);
         waitForAssert(() -> assertEquals(1, temporalAdjuster.getCount(), "Scheduler should have run 1 time"));
         Thread.sleep(1000); // wait a little longer to see if not more are scheduled.


### PR DESCRIPTION
Fixes #2915 
Related to #2878 

This re-adds the delay before the job is cancelled.

Signed-off-by: Jan N. Klug <github@klug.nrw>