### PR TITLE
Fix Metadata can't be deserialized

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -84,7 +84,7 @@ public abstract class AbstractUID {
     /**
      * Specifies how many segments the UID has to have at least.
      *
-     * @return
+     * @return the number of segments
      */
     protected abstract int getMinimalNumberOfSegments();
 
@@ -140,9 +140,6 @@ public abstract class AbstractUID {
             return false;
         }
         AbstractUID other = (AbstractUID) obj;
-        if (!segments.equals(other.segments)) {
-            return false;
-        }
-        return true;
+        return segments.equals(other.segments);
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
@@ -40,7 +40,7 @@ public final class Metadata implements Identifiable<MetadataKey> {
      * !!! DO NOT REMOVE - Gson needs it !!!
      */
     Metadata() {
-        key = new MetadataKey("", "");
+        key = new MetadataKey();
         value = "";
         configuration = Collections.emptyMap();
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataKey.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataKey.java
@@ -29,14 +29,14 @@ public final class MetadataKey extends AbstractUID {
      * !!! DO NOT REMOVE - Gson needs it !!!
      */
     MetadataKey() {
-        super("", "");
+        super();
     }
 
     /**
      * Creates a new instance.
      *
-     * @param namespace
-     * @param itemName
+     * @param namespace the namespace of this metadata key
+     * @param itemName the item name that is associated with this metadata key
      */
     public MetadataKey(String namespace, String itemName) {
         super(namespace, itemName);


### PR DESCRIPTION
Fixes #2917
Fixes #2920 

This fixes a side-effect of #2901. The no-args constructor of `MetadataKey` and `Metadata` tried to invoke `ÀbstractUID(String segments...)` with empty strings. Due to the added check this failed. Since the no-args constructors are only used during deserialization we can call the no-args constructor of `AbstractUID` instead and don't care about the required number of segments.

Signed-off-by: Jan N. Klug <github@klug.nrw>