### PR TITLE
[Semantics] Return parent Location and Equipment

### DIFF
--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.script.actions;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
@@ -104,7 +105,8 @@ public class SemanticsTest {
 
     @Test
     public void testGetLocation() {
-        assertNull(Semantics.getLocation(indoorLocationItem));
+        assertThat(Semantics.getLocation(indoorLocationItem), is(nullValue()));
+
         assertThat(Semantics.getLocation(bathroomLocationItem), is(indoorLocationItem));
 
         assertThat(Semantics.getLocation(equipmentItem), is(bathroomLocationItem));
@@ -117,6 +119,7 @@ public class SemanticsTest {
     @Test
     public void testGetLocationType() {
         assertThat(Semantics.getLocationType(indoorLocationItem), is(Indoor.class));
+
         assertThat(Semantics.getLocationType(bathroomLocationItem), is(Bathroom.class));
 
         assertNull(Semantics.getLocationType(humidityPointItem));
@@ -124,7 +127,8 @@ public class SemanticsTest {
 
     @Test
     public void testGetEquipment() {
-        assertNull(Semantics.getEquipment(equipmentItem));
+        assertThat(Semantics.getEquipment(equipmentItem), is(nullValue()));
+
         assertThat(Semantics.getEquipment(subEquipmentItem), is(equipmentItem));
 
         assertThat(Semantics.getEquipment(temperaturePointItem), is(equipmentItem));

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Semantics.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Semantics.java
@@ -74,24 +74,18 @@ public class Semantics {
      */
     @ActionDoc(text = "gets the Location Item of the Item")
     public static @Nullable Item getLocation(Item item) {
-        if (isLocation(item)) {
-            // if item is a location, return itself
-            return item;
-        } else {
-            // if item is not a location, iterate its groups and try to determine a location from them
-            return SemanticsActionService.getLocationItemFromGroupNames(item.getGroupNames());
-        }
+        return SemanticsActionService.getLocationItemFromGroupNames(item.getGroupNames());
     }
 
     /**
      * Gets the related {@link Location} type of an {@link Item}.
-     *
+     * 
      * @param item the Item to determine the Location for
      * @return the related Location type of the Item or null
      */
     @ActionDoc(text = "gets the Location type of the Item")
     public static @Nullable Class<? extends Location> getLocationType(Item item) {
-        Item locationItem = getLocation(item);
+        Item locationItem = isLocation(item) ? item : getLocation(item);
         return locationItem != null ? SemanticTags.getLocation(locationItem) : null;
     }
 
@@ -103,13 +97,7 @@ public class Semantics {
      */
     @ActionDoc(text = "gets the Equipment Item an Item belongs to")
     public static @Nullable Item getEquipment(Item item) {
-        if (isEquipment(item)) {
-            // if item is an equipment return its semantics equipment class
-            return item;
-        } else {
-            // if item is not an equipment, iterate its groups and try to determine a equipment there
-            return SemanticsActionService.getEquipmentItemFromGroupNames(item.getGroupNames());
-        }
+        return SemanticsActionService.getEquipmentItemFromGroupNames(item.getGroupNames());
     }
 
     /**
@@ -120,7 +108,7 @@ public class Semantics {
      */
     @ActionDoc(text = "gets the Equipment type an Item belongs to")
     public static @Nullable Class<? extends Equipment> getEquipmentType(Item item) {
-        Item equipmentItem = getEquipment(item);
+        Item equipmentItem = isEquipment(item) ? item : getEquipment(item);
         return equipmentItem != null ? SemanticTags.getEquipment(equipmentItem) : null;
 
     }


### PR DESCRIPTION
Resolve #2924 

Instead of returning the given item, getEquipment() and getLocation() return the item's parent Equipment / Location. This allows the caller to navigate the hierarchy, e.g. get the parent location of the given location.