### PR TITLE
Bump jackson to 2.12.6(.1)

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -17,7 +17,8 @@
 
   <properties>
     <cxf.version>3.4.5</cxf.version>
-    <jackson.version>2.12.5</jackson.version>
+    <!-- revert version of jackson-databind to ${jackson.version} when versions are in-line again -->
+    <jackson.version>2.12.6</jackson.version>
     <jetty.version>9.4.43.v20210629</jetty.version>
     <pax.logging.version>2.0.14</pax.logging.version>
     <pax.web.version>7.3.23</pax.web.version>
@@ -954,7 +955,8 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <!-- revert to ${jackson.version} when versions are in-line again -->
+      <version>2.12.6.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -82,17 +82,17 @@
 	</feature>
 
 	<feature name="openhab.tp-jackson" description="FasterXML Jackson bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jackson;version=2.12.5</capability>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.12.5</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.12.5</bundle>
+		<capability>openhab.tp;feature=jackson;version=2.12.6</capability>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.12.6.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.12.6</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.12.6</bundle>
 		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.27</bundle>
 	</feature>
 


### PR DESCRIPTION
The `jackson-databind` bundle contains a vulnerability that is fixed in version 2.12.6.1. This version is only available for that bundle, all other bundles are still available as 2.12.6. This requires a manual revert for the `jackson-databind` bundle. I have added a note as comment. 

See #2882

Signed-off-by: Jan N. Klug <github@klug.nrw>