### PR TITLE
Add spaces to Magic service labels

### DIFF
--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 @Component(immediate = true, service = MagicMultiActionMarker.class, //
         property = Constants.SERVICE_PID + "=org.openhab.MagicMultiAction")
-@ConfigurableService(category = "RuleActions", label = "MagicMultiActionsService", description_uri = "automationAction:magicMultiAction", factory = true)
+@ConfigurableService(category = "RuleActions", label = "Magic Multi Actions Service", description_uri = "automationAction:magicMultiAction", factory = true)
 public class MagicMultiActionMarker {
 
 }

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
 @NonNullByDefault
 @Component(immediate = true, service = MagicMultiInstanceServiceMarker.class, //
         property = Constants.SERVICE_PID + "=org.openhab.magicMultiInstance")
-@ConfigurableService(category = "test", label = "MagicMultiInstanceService", description_uri = "test:multipleMagic", factory = true)
+@ConfigurableService(category = "test", label = "Magic Multi Instance Service", description_uri = "test:multipleMagic", factory = true)
 public class MagicMultiInstanceServiceMarker {
     // this is a marker service and represents a service factory so multiple configuration instances of type
     // "org.openhab.core.magicMultiInstance" can be created.


### PR DESCRIPTION
This adds some spaces to the Magic service labels so they look nicer in UIs:

![Screenshot from 2022-04-27 21-08-53](https://user-images.githubusercontent.com/12213581/165604788-69ce559e-29a6-4ec4-a35f-cf040ba82d5b.png)

