### PR TITLE
Fix item name checking in ItemUtil

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
@@ -54,7 +54,7 @@ public class ItemUtil {
      * @return true if the specified name is a valid item name, otherwise false
      */
     public static boolean isValidItemName(final @Nullable String itemName) {
-        return itemName != null && !itemName.isEmpty() && itemName.matches("[a-zA-Z0-9_]*");
+        return itemName != null && !itemName.isEmpty() && itemName.matches("[a-zA-Z][a-zA-Z0-9_]*");
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
@@ -54,7 +54,7 @@ public class ItemUtil {
      * @return true if the specified name is a valid item name, otherwise false
      */
     public static boolean isValidItemName(final @Nullable String itemName) {
-        return itemName != null && !itemName.isEmpty() && itemName.matches("[a-zA-Z][a-zA-Z0-9_]*");
+        return itemName != null && !itemName.isEmpty() && itemName.matches("[a-zA-Z_][a-zA-Z0-9_]*");
     }
 
     /**


### PR DESCRIPTION
Fixes #2243 

Since numbers as first character of the item name cause issues and the documentation already states that they are not allowed, the validity check is adjusted to reflect the correct policy.

Signed-off-by: Jan N. Klug <github@klug.nrw>