### PR TITLE
Fix EphemerisManager crashing on invalid configuration

### DIFF
--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -68,6 +68,21 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     }
 
     @Test
+    public void testEphemerisManagerFixesIllegalCharacters() {
+        ephemerisManager.modified(Map.ofEntries(entry(CONFIG_DAYSET_PREFIX + CONFIG_DAYSET_WEEKEND, "\"( \"MONDAY\"")));
+
+        assertTrue(ephemerisManager.daysets.containsKey(CONFIG_DAYSET_WEEKEND));
+    }
+
+    @Test
+    public void testEphemerisManagerDoesNotCrashOnIllegalName() {
+        ephemerisManager.modified(Map.ofEntries(entry(CONFIG_DAYSET_PREFIX + CONFIG_DAYSET_WEEKEND, "Mondax")));
+
+        // assertion only to check if no exception occurs
+        assertFalse(ephemerisManager.daysets.isEmpty());
+    }
+
+    @Test
     public void testEphemerisManagerLoadedProperly() {
         assertTrue(ephemerisManager.daysets.containsKey(CONFIG_DAYSET_WEEKEND));
         assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY), ephemerisManager.daysets.get(CONFIG_DAYSET_WEEKEND));
@@ -77,20 +92,14 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testConfigurtationDaysetWeekendFailed() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ephemerisManager.modified(Map.of(CONFIG_DAYSET_PREFIX + CONFIG_DAYSET_WEEKEND, "Foo,Bar")));
-    }
-
-    @Test
-    public void testConfigurtationDaysetWeekendIterable() {
+    public void testConfigurationDaysetWeekendIterable() {
         ephemerisManager.modified(Map.of(CONFIG_DAYSET_PREFIX + CONFIG_DAYSET_WEEKEND, List.of("Saturday", "Sunday")));
         assertTrue(ephemerisManager.daysets.containsKey(CONFIG_DAYSET_WEEKEND));
         assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY), ephemerisManager.daysets.get(CONFIG_DAYSET_WEEKEND));
     }
 
     @Test
-    public void testConfigurtationDaysetWeekendListAsString() {
+    public void testConfigurationDaysetWeekendListAsString() {
         ephemerisManager.modified(Map.of(CONFIG_DAYSET_PREFIX + CONFIG_DAYSET_WEEKEND, List.of("Saturday", "Sunday")));
         assertTrue(ephemerisManager.daysets.containsKey(CONFIG_DAYSET_WEEKEND));
         assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY), ephemerisManager.daysets.get(CONFIG_DAYSET_WEEKEND));


### PR DESCRIPTION
It has been reported in the past (and in the forum) that the EphemerisManagerImpl can't handle illegal configurations. Due to dependencies in other bundles this results in the whole automation component to be unavailable.

This PR adds code to strip illegal characters (which will solve most reported issues with additional double quotes) and just skips a days configuration with unknown day names (instead of failing to activate/modify the service in total).

Signed-off-by: Jan N. Klug <github@klug.nrw>