### PR TITLE
Normalize Metadata configuration from managed provider

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
@@ -102,9 +102,15 @@ public class ManagedMetadataProviderImpl extends AbstractManagedProvider<Metadat
     }
 
     private Map.Entry<String, Object> normalizeConfigEntry(Map.Entry<String, Object> entry) {
-        if (entry.getValue() instanceof Number) {
-            return Map.entry(entry.getKey(), new BigDecimal(entry.getValue().toString()));
+        Object value = entry.getValue();
+        if (value instanceof Integer) {
+            BigDecimal newValue = new BigDecimal(value.toString());
+            newValue.setScale(0);
+            return Map.entry(entry.getKey(), newValue);
+        } else if (value instanceof Number) {
+            return Map.entry(entry.getKey(), new BigDecimal(value.toString()));
         }
+
         return entry;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
@@ -12,6 +12,11 @@
  */
 package org.openhab.core.internal.items;
 
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.AbstractManagedProvider;
@@ -75,5 +80,31 @@ public class ManagedMetadataProviderImpl extends AbstractManagedProvider<Metadat
     public void removeItemMetadata(String name) {
         logger.debug("Removing all metadata for item {}", name);
         getAll().stream().filter(MetadataPredicates.ofItem(name)).map(Metadata::getUID).forEach(this::remove);
+    }
+
+    @Override
+    public Collection<Metadata> getAll() {
+        return super.getAll().stream().map(this::normalizeMetadata).collect(Collectors.toUnmodifiableList());
+    }
+
+    @Override
+    public @Nullable Metadata get(MetadataKey key) {
+        Metadata metadata = super.get(key);
+        if (metadata != null) {
+            return normalizeMetadata(metadata);
+        }
+        return null;
+    }
+
+    private Metadata normalizeMetadata(Metadata metadata) {
+        return new Metadata(metadata.getUID(), metadata.getValue(), metadata.getConfiguration().entrySet().stream()
+                .map(this::normalizeConfigEntry).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private Map.Entry<String, Object> normalizeConfigEntry(Map.Entry<String, Object> entry) {
+        if (entry.getValue() instanceof Number) {
+            return Map.entry(entry.getKey(), new BigDecimal(entry.getValue().toString()));
+        }
+        return entry;
     }
 }


### PR DESCRIPTION
Fixes #1904 

The reason is that GSON de-serializes numeric metadata configuration values from JSON storage to `Double`, while textual defined values are `BigDecimal`. This PR adds normalization of the entries provided by the managed provider.

Signed-off-by: Jan N. Klug <github@klug.nrw>