### PR TITLE
Fix resource leaks in AudioServlet

### DIFF
--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -14,9 +14,14 @@ package org.openhab.core.audio.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -25,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.FileAudioStream;
+import org.openhab.core.audio.FixedLengthAudioStream;
 import org.openhab.core.audio.internal.utils.BundledSoundFileHandler;
 
 /**
@@ -149,5 +155,65 @@ public class AudioServletTest extends AbstractAudioServletTest {
 
         response = getHttpRequest(url).send();
         assertThat("The response status was not as expected", response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+
+    @Test
+    public void oneTimeStreamIsClosedAndRemovedAfterServed() throws Exception {
+        AudioStream audioStream = mock(AudioStream.class);
+        AudioFormat audioFormat = mock(AudioFormat.class);
+        when(audioStream.getFormat()).thenReturn(audioFormat);
+        when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
+
+        String url = serveStream(audioStream);
+
+        getHttpRequest(url).send();
+
+        verify(audioStream).close();
+        assertThat(audioServlet.getOneTimeStreams().values(), not(contains(audioStream)));
+    }
+
+    @Test
+    public void multiTimeStreamIsClosedAfterExpired() throws Exception {
+        AtomicInteger cloneCounter = new AtomicInteger();
+        FixedLengthAudioStream audioStream = mock(FixedLengthAudioStream.class);
+        AudioStream clonedStream = mock(AudioStream.class);
+        AudioFormat audioFormat = mock(AudioFormat.class);
+        when(audioStream.getFormat()).thenReturn(audioFormat);
+        when(audioStream.getClonedStream()).thenAnswer(answer -> {
+            cloneCounter.getAndIncrement();
+            return clonedStream;
+        });
+        when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
+
+        String url = serveStream(audioStream, 2);
+
+        waitForAssert(() -> {
+            try {
+                ContentResponse resp = getHttpRequest(url).send();
+                assertThat(resp.getStatus(), is(404));
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+
+        });
+
+        verify(audioStream).close();
+        assertThat(audioServlet.getMultiTimeStreams().values(), not(contains(audioStream)));
+
+        verify(clonedStream, times(cloneCounter.get())).close();
+    }
+
+    @Test
+    public void streamsAreClosedOnDeactivate() throws Exception {
+        AudioStream oneTimeStream = mock(AudioStream.class);
+        FixedLengthAudioStream multiTimeStream = mock(FixedLengthAudioStream.class);
+
+        serveStream(oneTimeStream);
+        serveStream(multiTimeStream, 10);
+
+        audioServlet.deactivate();
+
+        verify(oneTimeStream).close();
+        verify(multiTimeStream).close();
     }
 }


### PR DESCRIPTION
Fixes #532

Add closing of streams on deactivation and add tests to ensure that all streams are closed after they are expired or retrieved.

There might be still one possible resource leak: a one-time stream that is served but never retrieved will stay in the map forever. But since that is exactly the wanted behavior for streams without timeout, there is nothing we can do about it. Those streams are only closed if the servlet is deactivated.

Signed-off-by: Jan N. Klug <github@klug.nrw>