### PR TITLE
Fix console extension output to wrong console

### DIFF
--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -68,7 +68,7 @@ public class CommandWrapper implements Command, Action {
     public Object execute(Session session, List<Object> argList) throws Exception {
         String[] args = argList.stream().map(a -> a.toString()).collect(Collectors.toList()).toArray(new String[0]);
 
-        final Console console = new OSGiConsole(getScope());
+        final Console console = new OSGiConsole(getScope(), session.getConsole());
 
         if (args.length == 1 && "--help".equals(args[0])) {
             for (final String usage : command.getUsages()) {

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/OSGiConsole.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/OSGiConsole.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.console.karaf.internal;
 
+import java.io.PrintStream;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.console.Console;
 
@@ -23,28 +25,30 @@ import org.openhab.core.io.console.Console;
 public class OSGiConsole implements Console {
 
     private final String scope;
+    private final PrintStream out;
 
-    public OSGiConsole(final String scope) {
+    public OSGiConsole(final String scope, PrintStream out) {
         this.scope = scope;
+        this.out = out;
     }
 
     @Override
     public void printf(String format, Object... args) {
-        System.out.printf(format, args);
+        out.printf(format, args);
     }
 
     @Override
     public void print(final String s) {
-        System.out.print(s);
+        out.print(s);
     }
 
     @Override
     public void println(final String s) {
-        System.out.println(s);
+        out.println(s);
     }
 
     @Override
     public void printUsage(final String s) {
-        System.out.println(String.format("Usage: %s:%s", scope, s));
+        out.println(String.format("Usage: %s:%s", scope, s));
     }
 }


### PR DESCRIPTION
Fixes #1545

The `PrintStream` used for printing should not be `System.out` but the `PrintStream` associated with the `Session` of the karaf shell.

Signed-off-by: Jan N. Klug <github@klug.nrw>