### PR TITLE
Add DateTimeTrigger to DSL rule model

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -55,6 +55,7 @@ import org.openhab.core.model.rule.rules.SystemStartlevelTrigger;
 import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger;
 import org.openhab.core.model.rule.rules.ThingStateUpdateEventTrigger;
 import org.openhab.core.model.rule.rules.TimerTrigger;
+import org.openhab.core.model.rule.rules.DateTimeTrigger;
 import org.openhab.core.model.rule.rules.UpdateEventTrigger;
 import org.openhab.core.model.script.runtime.DSLScriptContextProvider;
 import org.openhab.core.service.ReadyMarker;
@@ -383,6 +384,12 @@ public class DSLRuleProvider
                 }
             }
             return TriggerBuilder.create().withId(Integer.toString(triggerId++)).withTypeUID("timer.GenericCronTrigger")
+                    .withConfiguration(cfg).build();
+        } else if (t instanceof DateTimeTrigger) {
+            DateTimeTrigger tt = (DateTimeTrigger) t;
+            Configuration cfg = new Configuration();
+            cfg.put("itemName", tt.getItem());
+            return TriggerBuilder.create().withId(Integer.toString((triggerId++))).withTypeUID("timer.DateTimeTrigger")
                     .withConfiguration(cfg).build();
         } else if (t instanceof EventEmittedTrigger) {
             EventEmittedTrigger eeTrigger = (EventEmittedTrigger) t;

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -35,6 +35,7 @@ EventTrigger:
 	GroupMemberChangedEventTrigger |
 	EventEmittedTrigger |
 	TimerTrigger |
+	DateTimeTrigger |
 	SystemTrigger |
 	ThingStateUpdateEventTrigger |
 	ThingStateChangedEventTrigger
@@ -72,6 +73,10 @@ EventEmittedTrigger:
 TimerTrigger:
 	'Time' 'cron' cron=STRING |
 	'Time' 'is' time=('midnight' | 'noon')
+;
+
+DateTimeTrigger:
+    'Time' 'equals' item=ItemName
 ;
 
 SystemTrigger:


### PR DESCRIPTION
Follow-Up to #2726 

The new trigger can't be used in DSL rules. This adds the missing parts in the model:

```
rule "foo"
when
    Time equals MyDateTimeItem
then
    ...
end
```

Signed-off-by: Jan N. Klug <github@klug.nrw>