### PR TITLE
Upgrade directory-maven-plugin from 0.3.1 to 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@ Import-Package: \\
                   <pluginExecutionFilter>
                     <groupId>org.commonjava.maven.plugins</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
-                    <versionRange>[0.3.1,)</versionRange>
+                    <versionRange>[1.0,)</versionRange>
                     <goals>
                       <goal>highest-basedir</goal>
                     </goals>
@@ -689,7 +689,7 @@ Import-Package: \\
       <plugin>
         <groupId>org.commonjava.maven.plugins</groupId>
         <artifactId>directory-maven-plugin</artifactId>
-        <version>0.3.1</version>
+        <version>1.0</version>
         <executions>
           <execution>
             <id>directories</id>


### PR DESCRIPTION
Windows build was failing with:

```
[ERROR] Failed to execute goal org.commonjava.maven.plugins:directory-maven-plugin:0.3.1:highest-basedir (directories) on project org.openhab.core.reactor: Cannot find a single highest directory for this project set. First two candidates directories don't share a common root. -> [Help 1]
```

when started from directory: "C:\Users\Jacob Laursen\Development\jlaur\openhab-core"

Maven version: 3.8.5

The issue might have been fixed by jdcasey/directory-maven-plugin#17, but I'm not sure.  At least the build works after upgrading to 1.0.

I don't know if the upgrade can have any undesired side-effects, so PR is to be considered a proposal and I'm hoping maintainers can assess this.

See also releases here: https://mvnrepository.com/artifact/org.commonjava.maven.plugins/directory-maven-plugin