### PR TITLE
Enable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Number of days of inactivity before an issue becomes stale (two month)
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed (another six month)
+daysUntilClose: 180
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - "PR pending"
+# Only issues with all of these labels are checked if stale.
+onlyLabels:
+  - "awaiting feedback"
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+# Limit to only `issues``
+only: issues


### PR DESCRIPTION
Issues will be marked as stale after 60 days of inactivity when the "awaiting feedback" label is set. 180 days later the issue will be automatically closed. stale bot is limited to issues, not PR and will not consider issues that are marked with either "security", "pinned" or "PR pending" label.

Signed-off-by: Jan N. Klug <github@klug.nrw>