### PR TITLE
Assume installed addons are compatible

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -116,7 +116,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
 
         // remove incompatible add-ons if not enabled
         boolean showIncompatible = includeIncompatible();
-        addons.removeIf(addon -> !addon.getCompatible() && !showIncompatible);
+        addons.removeIf(addon -> !addon.isInstalled() && !addon.getCompatible() && !showIncompatible);
 
         cachedAddons = addons;
         this.installedAddons = installedAddons;

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.openhab.core.addon.marketplace.AbstractRemoteAddonService.CONFIG_REMOTE_ENABLED;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.ALL_ADDON_COUNT;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.COMPATIBLE_ADDON_COUNT;
+import static org.openhab.core.addon.marketplace.test.TestAddonService.INCOMPATIBLE_VERSION;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.INSTALL_EXCEPTION_ADDON;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.SERVICE_PID;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.TEST_ADDON;
@@ -147,6 +148,12 @@ public class AbstractRemoteAddonServiceTest {
     @Test
     public void testIncompatibleAddonsNotIncludedByDefault() {
         assertThat(addonService.getAddons(null), hasSize(COMPATIBLE_ADDON_COUNT));
+    }
+
+    @Test
+    public void testIncompatibleAddonsAlwaysIncludedIfInstalled() {
+        addonService.setInstalled(INCOMPATIBLE_VERSION);
+        assertThat(addonService.getAddons(null), hasSize(COMPATIBLE_ADDON_COUNT + 1));
     }
 
     @Test


### PR DESCRIPTION
It was reported that after an upgrade from aprevious version installed addons from marketplaces are not shown in the add-ons pages. This is a result of the new compatibility check which excludes incompatible add-ons by default. Already installed add-ons must be excluded from this check otherwise they can't be uninstalled.

Signed-off-by: Jan N. Klug <github@klug.nrw>