### PR TITLE
Wait for thing-type available in PersistentInbox

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
@@ -13,6 +13,7 @@
 package org.openhab.core.config.discovery.inbox;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -57,7 +58,7 @@ public interface Inbox {
      * @param result the discovery result to be added to this inbox (could be null)
      * @return true if the specified discovery result could be added or updated, otherwise false
      */
-    boolean add(@Nullable DiscoveryResult result);
+    CompletableFuture<Boolean> add(@Nullable DiscoveryResult result);
 
     /**
      * Removes the {@link DiscoveryResult} associated with the specified {@code Thing} ID from

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -84,9 +84,12 @@ public class PersistentInboxTest {
     private @Mock @NonNullByDefault({}) ThingTypeRegistry thingTypeRegistryMock;
     private @Mock @NonNullByDefault({}) ConfigDescriptionRegistry configDescriptionRegistryMock;
     private @Mock @NonNullByDefault({}) ThingHandlerFactory thingHandlerFactoryMock;
+    private @Mock @NonNullByDefault({}) ThingType thingTypeMock;
 
     @BeforeEach
     public void setup() {
+        when(thingTypeMock.getConfigDescriptionURI()).thenReturn(null);
+        when(thingTypeRegistryMock.getThingType(any())).thenReturn(thingTypeMock);
         when(storageServiceMock.getStorage(any(String.class), any(ClassLoader.class))).thenReturn(storageMock);
         doAnswer(invocation -> lastAddedThing = (Thing) invocation.getArguments()[0]).when(thingRegistryMock)
                 .add(any(Thing.class));

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -29,10 +29,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.config.discovery.inbox.Inbox;
+import org.openhab.core.config.discovery.test.DummyThingTypeProvider;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.ThingTypeBuilder;
 import org.osgi.framework.ServiceRegistration;
 
 /**
@@ -56,12 +58,18 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
     private static final String ANY_BINDING_ID_1 = "any2BindingId1";
     private static final String ANY_THING_TYPE_1 = "any2ThingType1";
+    private static final ThingTypeUID ANY_BINDING_ID_1_ANY_THING_TYPE_1_UID = new ThingTypeUID(ANY_BINDING_ID_1,
+            ANY_THING_TYPE_1);
 
     private static final String ANY_BINDING_ID_2 = "any2BindingId2";
     private static final String ANY_THING_TYPE_2 = "any2ThingType2";
+    private static final ThingTypeUID ANY_BINDING_ID_2_ANY_THING_TYPE_2_UID = new ThingTypeUID(ANY_BINDING_ID_2,
+            ANY_THING_TYPE_2);
 
     private static final String ANY_BINDING_ID_3 = "any2BindingId3";
     private static final String ANY_THING_TYPE_3 = "any2ThingType3";
+    private static final ThingTypeUID ANY_BINDING_ID_3_ANY_THING_TYPE_3_UID = new ThingTypeUID(ANY_BINDING_ID_3,
+            ANY_THING_TYPE_3);
 
     private static final ThingUID BRIDGE_UID_1 = new ThingUID(ANY_BINDING_ID_3, "bridge", "1");
     private static final ThingUID BRIDGE_UID_2 = new ThingUID(ANY_BINDING_ID_3, "bridge", "2");
@@ -88,9 +96,21 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
     private @Mock @NonNullByDefault({}) DiscoveryListener discoveryListenerMock;
 
+    private @NonNullByDefault({}) DummyThingTypeProvider dummyThingTypeProvider;
+
     @BeforeEach
     public void beforeEach() {
         registerVolatileStorageService();
+
+        dummyThingTypeProvider = new DummyThingTypeProvider();
+        registerService(dummyThingTypeProvider);
+
+        dummyThingTypeProvider.add(ANY_BINDING_ID_1_ANY_THING_TYPE_1_UID,
+                ThingTypeBuilder.instance(ANY_BINDING_ID_1_ANY_THING_TYPE_1_UID, "label1").build());
+        dummyThingTypeProvider.add(ANY_BINDING_ID_2_ANY_THING_TYPE_2_UID,
+                ThingTypeBuilder.instance(ANY_BINDING_ID_2_ANY_THING_TYPE_2_UID, "label2").build());
+        dummyThingTypeProvider.add(ANY_BINDING_ID_3_ANY_THING_TYPE_3_UID,
+                ThingTypeBuilder.instance(ANY_BINDING_ID_3_ANY_THING_TYPE_3_UID, "label3").build());
 
         thingRegistry = getService(ThingRegistry.class);
         assertNotNull(thingRegistry);
@@ -98,10 +118,8 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
         inbox = getService(Inbox.class);
         assertNotNull(inbox);
 
-        discoveryServiceMockForBinding1 = new DiscoveryServiceMock(new ThingTypeUID(ANY_BINDING_ID_1, ANY_THING_TYPE_1),
-                1);
-        discoveryServiceMockForBinding2 = new DiscoveryServiceMock(new ThingTypeUID(ANY_BINDING_ID_2, ANY_THING_TYPE_2),
-                3);
+        discoveryServiceMockForBinding1 = new DiscoveryServiceMock(ANY_BINDING_ID_1_ANY_THING_TYPE_1_UID, 1);
+        discoveryServiceMockForBinding2 = new DiscoveryServiceMock(ANY_BINDING_ID_2_ANY_THING_TYPE_2_UID, 3);
 
         discoveryServiceMockForBinding3Bridge1 = new DiscoveryServiceMockOfBridge(
                 new ThingTypeUID(ANY_BINDING_ID_3, ANY_THING_TYPE_3), 1, BRIDGE_UID_1);
@@ -270,7 +288,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
         ScanListener mockScanListener1 = mock(ScanListener.class);
 
         discoveryServiceRegistry.addDiscoveryListener(discoveryListenerMock);
-        discoveryServiceRegistry.startScan(new ThingTypeUID(ANY_BINDING_ID_3, ANY_THING_TYPE_3), mockScanListener1);
+        discoveryServiceRegistry.startScan(ANY_BINDING_ID_3_ANY_THING_TYPE_3_UID, mockScanListener1);
 
         waitForAssert(() -> verify(mockScanListener1, times(1)).onFinished());
         verify(discoveryListenerMock, times(2)).thingDiscovered(any(), any());

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/test/DummyThingTypeProvider.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/test/DummyThingTypeProvider.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.discovery.test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.ThingTypeProvider;
+import org.openhab.core.thing.type.ThingType;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * The {@link DummyThingTypeProvider} is used in tests to provide thing types
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true)
+public class DummyThingTypeProvider implements ThingTypeProvider {
+
+    private final Map<ThingTypeUID, ThingType> thingTypeMap = new HashMap<>();
+
+    @Override
+    public Collection<ThingType> getThingTypes(@Nullable Locale locale) {
+        return thingTypeMap.values();
+    }
+
+    @Override
+    public @Nullable ThingType getThingType(ThingTypeUID thingTypeUID, @Nullable Locale locale) {
+        return thingTypeMap.get(thingTypeUID);
+    }
+
+    public void add(ThingTypeUID thingTypeUID, ThingType thingType) {
+        thingTypeMap.put(thingTypeUID, thingType);
+    }
+}


### PR DESCRIPTION
Fixes #1393

An alternative implementation would not break API (the return type of the `add` method would still be `boolean`), but this would move the retry-logic to the discovery service. IMO it is cleaner to have it in the `PersistentInbox` as it is specific to this implementation. It would also be difficult if the discovery result is rejected because the thing is already present.

The benefit of waiting on the thing type is that the normalization of the configuration values will always be possible.

Signed-off-by: Jan N. Klug <github@klug.nrw>