### PR TITLE
Allow bulk deletion of metadata

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -591,20 +591,24 @@ public class ItemResource implements RESTResource {
                     @ApiResponse(responseCode = "404", description = "Item not found."),
                     @ApiResponse(responseCode = "405", description = "Meta data not editable.") })
     public Response removeMetadata(@PathParam("itemname") @Parameter(description = "item name") String itemname,
-            @PathParam("namespace") @Parameter(description = "namespace") String namespace) {
+            @Nullable @PathParam("namespace") @Parameter(description = "namespace") String namespace) {
         Item item = getItem(itemname);
 
         if (item == null) {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        MetadataKey key = new MetadataKey(namespace, itemname);
-        if (metadataRegistry.get(key) != null) {
-            if (metadataRegistry.remove(key) == null) {
-                return Response.status(Status.CONFLICT).build();
-            }
+        if (namespace == null) {
+            metadataRegistry.removeItemMetadata(itemname);
         } else {
-            return Response.status(Status.NOT_FOUND).build();
+            MetadataKey key = new MetadataKey(namespace, itemname);
+            if (metadataRegistry.get(key) != null) {
+                if (metadataRegistry.remove(key) == null) {
+                    return Response.status(Status.CONFLICT).build();
+                }
+            } else {
+                return Response.status(Status.NOT_FOUND).build();
+            }
         }
 
         return Response.ok(null, MediaType.TEXT_PLAIN).build();


### PR DESCRIPTION
This adds similar functionality that is available for links with #2970. Also support for cleaning the metadata registry is added. Regarding exposing the compression functionality the general question in #2970 should be answered.

Signed-off-by: Jan N. Klug <github@klug.nrw>