### PR TITLE
[rest] add semantics query endpoint  to item resource

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/pom.xml
+++ b/bundles/org.openhab.core.io.rest.core/pom.xml
@@ -37,14 +37,13 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.test</artifactId>
+      <artifactId>org.openhab.core.semantics</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.test</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -792,12 +792,12 @@ public class ItemResource implements RESTResource {
 
         Class<? extends org.openhab.core.semantics.Tag> semanticClass = SemanticTags.getById(semanticClassName);
         if (semanticClass == null) {
-            return Response.status(Status.NOT_FOUND.getStatusCode()).build();
+            return Response.status(Status.NOT_FOUND).build();
         }
 
         Item foundItem = findParentByTag(getItem(itemName), SemanticsPredicates.isA(semanticClass));
         if (foundItem == null) {
-            return Response.status(Status.NOT_FOUND.getStatusCode()).build();
+            return Response.status(Status.NOT_FOUND).build();
         }
 
         EnrichedItemDTO dto = EnrichedItemDTOMapper.map(foundItem, false, null, uriBuilder(uriInfo, httpHeaders),

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -98,4 +98,7 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.persistence;version='[3.4.0,3.4.1)',\
 	org.openhab.core.test;version='[3.4.0,3.4.1)',\
 	org.openhab.core.thing;version='[3.4.0,3.4.1)',\
-	org.openhab.core.transform;version='[3.4.0,3.4.1)'
+	org.openhab.core.transform;version='[3.4.0,3.4.1)',\
+	junit-jupiter-params;version='[5.8.1,5.8.2)',\
+	org.openhab.core.semantics;version='[3.4.0,3.4.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'


### PR DESCRIPTION
Closes #2977

The approach here is a little bit broader than what was originally requested. The new endpoint delivers the item matching the provided semantic tag for a given item. To get the physical location, `Location` has to be used. 

Signed-off-by: Jan N. Klug <github@klug.nrw>