### PR TITLE
Fix SSE topic filters

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
@@ -85,7 +85,7 @@ public class SseUtil {
         } else {
             StringTokenizer tokenizer = new StringTokenizer(topicFilter, ",");
             while (tokenizer.hasMoreElements()) {
-                String regex = tokenizer.nextToken().trim().replace("*", ".*") + ".*";
+                String regex = tokenizer.nextToken().trim().replace("*", ".*") + "$";
                 filters.add(regex);
             }
         }

--- a/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/util/SseUtilTest.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/util/SseUtilTest.java
@@ -60,7 +60,7 @@ public class SseUtilTest {
     @Test
     public void testFilterMatchers() {
         List<String> regexes = SseUtil
-                .convertToRegex("openhab/*/test/test/test/test,    openhab/test/*/test/test/test, openhab,qivicon");
+                .convertToRegex("openhab/*/test/test/test/test,    openhab/test/*/test/test/test, openhab/*,qivicon/*");
 
         assertThat("openhab/test/test/test/test/test".matches(regexes.get(0)), is(true));
         assertThat("openhab/asdf/test/test/test/test".matches(regexes.get(0)), is(true));
@@ -81,7 +81,7 @@ public class SseUtilTest {
 
     @Test
     public void testMoreFilterMatchers() {
-        List<String> regexes = SseUtil.convertToRegex(",    *, openhab/items/*/added, openhab/items");
+        List<String> regexes = SseUtil.convertToRegex(",    *, openhab/items/*/added, openhab/items/*/*");
 
         assertThat("openhab/test/test/test/test/test".matches(regexes.get(0)), is(true));
         assertThat("openhab/asdf/test/test/test/test".matches(regexes.get(0)), is(true));
@@ -112,5 +112,9 @@ public class SseUtilTest {
         regexes = SseUtil.convertToRegex("*added");
         assertThat("openhab/items/anyitem/added".matches(regexes.get(0)), is(true));
         assertThat("openhab/items/anyitem/removed".matches(regexes.get(0)), is(false));
+
+        regexes = SseUtil.convertToRegex("openhab/items/*/state");
+        assertThat("openhab/items/anyitem/state".matches(regexes.get(0)), is(true));
+        assertThat("openhab/items/anyitem/statechanged".matches(regexes.get(0)), is(false));
     }
 }


### PR DESCRIPTION
Fixes #2473 

According to the [documentation](https://www.openhab.org/docs/developer/utils/events.html), topic filters are regular expressions. The SSE topic filters are converted to regular expressions, therefore `openhab/items/*/state` should result in `openhab/items/.*/state`. The code however adds a `.*` at the end `openhab/items/.*/state.*`. This makes it impossible to filter for `/state` but exclude `/statechanged`, which is IMO expected. 

Signed-off-by: Jan N. Klug <github@klug.nrw>