### PR TITLE
[javasound] Fix invalid cast on non windows OSs

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -109,7 +109,22 @@ public class JavaSoundAudioSource implements AudioSource {
         // on OSs other than windows we can open multiple lines for the microphone
         if (!windowsOS) {
             TargetDataLine microphone = initMicrophone(format);
-            var inputStream = new JavaSoundInputStream((InputStream) microphone, audioFormat);
+            var inputStream = new JavaSoundInputStream(new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    return microphone.available();
+                }
+
+                @Override
+                public int read(byte @Nullable [] b, int off, int len) throws IOException {
+                    return microphone.read(b, off, len);
+                }
+
+                @Override
+                public void close() throws IOException {
+                    microphone.close();
+                }
+            }, audioFormat);
             microphone.start();
             return inputStream;
         }


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>

Testing a new add-on I just discovered I broke the java sound for non windows OSs on my last change to it.

Fixed error:
```
java.lang.ClassCastException: class com.sun.media.sound.DirectAudioDevice$DirectTDL cannot be cast to class java.io.InputStream (com.sun.media.sound.DirectAudioDevice$DirectTDL is in module java.desktop of loader 'bootstrap'; java.io.InputStream is in module java.base of loader 'bootstrap')
```

Tested and working again on macOS, sorry for the problems.