### PR TITLE
Allow DSL scripts for script transformation

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 public class ScriptTransformationService
         implements TransformationService, RegistryChangeListener<TransformationConfiguration> {
     public static final String OPENHAB_TRANSFORMATION_SCRIPT = "openhab-transformation-script-";
+    public static final String SUPPORTED_CONFIGURATION_TYPE = "script";
 
     private static final Pattern SCRIPT_CONFIG_PATTERN = Pattern
             .compile("(?<scriptType>.*?):(?<scriptUid>.*?)(\\?(?<params>.*?))?");
@@ -99,7 +100,11 @@ public class ScriptTransformationService
         if (script == null) {
             TransformationConfiguration transformationConfiguration = transformationConfigurationRegistry
                     .get(scriptUid);
-            if (transformationConfiguration != null && "script".equals(transformationConfiguration.getType())) {
+            if (transformationConfiguration != null) {
+                if (!SUPPORTED_CONFIGURATION_TYPE.equals(transformationConfiguration.getType())) {
+                    throw new TransformationException("Configuration does not have correct type 'script' but '"
+                            + transformationConfiguration.getType() + "'.");
+                }
                 script = transformationConfiguration.getContent();
             }
             if (script == null) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -99,13 +99,12 @@ public class ScriptTransformationService
         if (script == null) {
             TransformationConfiguration transformationConfiguration = transformationConfigurationRegistry
                     .get(scriptUid);
-            if (transformationConfiguration != null) {
+            if (transformationConfiguration != null && "script".equals(transformationConfiguration.getType())) {
                 script = transformationConfiguration.getContent();
             }
             if (script == null) {
                 throw new TransformationException("Could not get script for UID '" + scriptUid + "'.");
             }
-
             scriptCache.put(scriptUid, script);
         }
 
@@ -137,7 +136,7 @@ public class ScriptTransformationService
             ScriptEngine engine = compiledScript != null ? compiledScript.getEngine()
                     : scriptEngineContainer.getScriptEngine();
             ScriptContext executionContext = engine.getContext();
-            executionContext.setAttribute("inputString", source, ScriptContext.ENGINE_SCOPE);
+            executionContext.setAttribute("input", source, ScriptContext.ENGINE_SCOPE);
 
             String params = configMatcher.group("params");
             if (params != null) {

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -46,7 +46,7 @@ import org.openhab.core.transform.TransformationException;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ScriptTransformationServiceTest {
-    private static final String SCRIPT_LANGUAGE = "script";
+    private static final String SCRIPT_LANGUAGE = "customDsl";
     private static final String SCRIPT_UID = "scriptUid";
     private static final String INVALID_SCRIPT_UID = "invalidScriptUid";
 
@@ -72,7 +72,7 @@ public class ScriptTransformationServiceTest {
 
         when(scriptEngineManager.createScriptEngine(eq(SCRIPT_LANGUAGE), any())).thenReturn(scriptEngineContainer);
         when(scriptEngineManager.isSupported(anyString()))
-                .thenAnswer(scriptType -> SCRIPT_LANGUAGE.equals(scriptType.getArgument(0)));
+                .thenAnswer(arguments -> SCRIPT_LANGUAGE.equals(arguments.getArgument(0)));
         when(scriptEngineContainer.getScriptEngine()).thenReturn(scriptEngine);
         when(scriptEngine.eval(SCRIPT)).thenReturn("output");
         when(scriptEngine.getContext()).thenReturn(scriptContext);

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -62,7 +62,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
     private static final Map<String, String> IMPLICIT_VARS = Map.of("command",
             ScriptJvmModelInferrer.VAR_RECEIVED_COMMAND, "state", ScriptJvmModelInferrer.VAR_NEW_STATE, "newState",
             ScriptJvmModelInferrer.VAR_NEW_STATE, "oldState", ScriptJvmModelInferrer.VAR_PREVIOUS_STATE,
-            "triggeringItem", ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM);
+            "triggeringItem", ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM, "inputString", ScriptJvmModelInferrer.VAR_INPUT_STRING);
 
     private final Logger logger = LoggerFactory.getLogger(DSLScriptEngine.class);
 

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -62,7 +62,7 @@ public class DSLScriptEngine implements javax.script.ScriptEngine {
     private static final Map<String, String> IMPLICIT_VARS = Map.of("command",
             ScriptJvmModelInferrer.VAR_RECEIVED_COMMAND, "state", ScriptJvmModelInferrer.VAR_NEW_STATE, "newState",
             ScriptJvmModelInferrer.VAR_NEW_STATE, "oldState", ScriptJvmModelInferrer.VAR_PREVIOUS_STATE,
-            "triggeringItem", ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM, "inputString", ScriptJvmModelInferrer.VAR_INPUT_STRING);
+            "triggeringItem", ScriptJvmModelInferrer.VAR_TRIGGERING_ITEM, "input", ScriptJvmModelInferrer.VAR_INPUT);
 
     private final Logger logger = LoggerFactory.getLogger(DSLScriptEngine.class);
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -40,6 +40,9 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
     static private final Logger logger = LoggerFactory.getLogger(ScriptJvmModelInferrer)
 
+    /** Variable name for the input string in a "script transformation" or "script profile" */
+    public static final String VAR_INPUT_STRING = "inputString";
+
     /** Variable name for the item in a "state triggered" or "command triggered" rule */
     public static final String VAR_TRIGGERING_ITEM = "triggeringItem";
 
@@ -121,6 +124,8 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
             members += script.toMethod("_script", null) [
                 static = true
+                val inputStringTypeRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_INPUT_STRING, inputStringTypeRef)
                 val itemTypeRef = script.newTypeRef(Item)
                 parameters += script.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
                 val itemNameRef = script.newTypeRef(String)

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -41,7 +41,7 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     static private final Logger logger = LoggerFactory.getLogger(ScriptJvmModelInferrer)
 
     /** Variable name for the input string in a "script transformation" or "script profile" */
-    public static final String VAR_INPUT_STRING = "input";
+    public static final String VAR_INPUT = "input";
 
     /** Variable name for the item in a "state triggered" or "command triggered" rule */
     public static final String VAR_TRIGGERING_ITEM = "triggeringItem";

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -41,7 +41,7 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     static private final Logger logger = LoggerFactory.getLogger(ScriptJvmModelInferrer)
 
     /** Variable name for the input string in a "script transformation" or "script profile" */
-    public static final String VAR_INPUT_STRING = "inputString";
+    public static final String VAR_INPUT_STRING = "input";
 
     /** Variable name for the item in a "state triggered" or "command triggered" rule */
     public static final String VAR_TRIGGERING_ITEM = "triggeringItem";
@@ -124,8 +124,8 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
             members += script.toMethod("_script", null) [
                 static = true
-                val inputStringTypeRef = script.newTypeRef(String)
-                parameters += script.toParameter(VAR_INPUT_STRING, inputStringTypeRef)
+                val inputTypeRef = script.newTypeRef(String)
+                parameters += script.toParameter(VAR_INPUT, inputTypeRef)
                 val itemTypeRef = script.newTypeRef(Item)
                 parameters += script.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
                 val itemNameRef = script.newTypeRef(String)


### PR DESCRIPTION
This extends the DSL scriptengine to accept `inputString` as implicit variable in the engine context. By that DSL scripts can be used for the script transformation. 

Signed-off-by: Jan N. Klug <github@klug.nrw>