### PR TITLE
Bump maven-shade-plugin to 3.3.0

### DIFF
--- a/bundles/org.openhab.core.io.jetty.certificate/pom.xml
+++ b/bundles/org.openhab.core.io.jetty.certificate/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
This is necessary for Java 17 source level.

Signed-off-by: Jan N. Klug <github@klug.nrw>