### PR TITLE
Bump maven-plugin-plugin to 3.6.4

### DIFF
--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -21,7 +21,7 @@
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
-    <maven.plugin.plugin.version>3.6.0</maven.plugin.plugin.version>
+    <maven.plugin.plugin.version>3.6.4</maven.plugin.plugin.version>
     <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
   </properties>
 
@@ -35,17 +35,13 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.plugin.api.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven.plugin.annotations.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-plugin-plugin</artifactId>
-      <version>${maven.plugin.plugin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt</groupId>


### PR DESCRIPTION
Needed for Java 17 source level. This also removes build errors with wrong scope and an unused dependency.

Signed-off-by: Jan N. Klug <github@klug.nrw>