### PR TITLE
Fix DateTime trigger syntax to not break the equals function in the execution script

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -76,7 +76,7 @@ TimerTrigger:
 ;
 
 DateTimeTrigger:
-    'Time' 'equals' item=ItemName
+    'Time' 'is' item=ItemName
 ;
 
 SystemTrigger:


### PR DESCRIPTION
This fixes a critical regression caused by #2963, which made the `equals` method disfunctional within rules.

This resulted in log messages like:
```
2022-06-06 11:30:46.587 [WARN ] [el.core.internal.ModelRepositoryImpl] - Configuration model 'test.rules' has errors, therefore ignoring it: [91,83]: no viable alternative at input 'equals'
```

It seems that Xtext is able to parse everything, if we use the same vocabulary as for the TimerTrigger, i.e. "is". The only drawback might be that the DateTime trigger cannot be used with items of name `midnight` or `noon`, but I think this is acceptable.


Signed-off-by: Kai Kreuzer <kai@openhab.org>