### PR TITLE
Exclude org.osgi.service.prefs to fix build

### DIFF
--- a/bom/compile-model/pom.xml
+++ b/bom/compile-model/pom.xml
@@ -38,6 +38,11 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.osgi</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- See: https://github.com/eclipse-equinox/equinox.bundles/issues/54 -->
+          <groupId>org.osgi.service</groupId>
+          <artifactId>org.osgi.service.prefs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -71,12 +76,24 @@
           <groupId>org.eclipse.platform</groupId>
           <artifactId>org.eclipse.osgi</artifactId>
         </exclusion>
+        <exclusion>
+          <!-- See: https://github.com/eclipse-equinox/equinox.bundles/issues/54 -->
+          <groupId>org.osgi.service</groupId>
+          <artifactId>org.osgi.service.prefs</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse.emf</groupId>
       <artifactId>org.eclipse.emf.codegen.ecore</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <!-- See: https://github.com/eclipse-equinox/equinox.bundles/issues/54 -->
+          <groupId>org.osgi.service</groupId>
+          <artifactId>org.osgi.service.prefs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- EMF MWE2 -->


### PR DESCRIPTION
Someone added a dependency on a non-existing artifact in the new Equinox release and now many builds are broken because Xtext defines a version range for Equinox :disappointed:, see:

* https://github.com/eclipse-equinox/equinox.bundles/issues/54
* https://github.com/eclipse/xtext/issues/2077