### PR TITLE
Fix config validation for integer values

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -39,11 +39,12 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
             return null;
         }
 
-        Object normalizedValue = ConfigUtil.normalizeType(value, parameter).toString();
+        String normalizedValueString = ConfigUtil.normalizeType(value, parameter).toString();
 
         // Allow specified options to be outside the min/max value
         // Option values are a string, so we can do a simple compare
-        if (parameter.getOptions().stream().map(ParameterOption::getValue).anyMatch(v -> v.equals(normalizedValue))) {
+        if (parameter.getOptions().stream().map(ParameterOption::getValue)
+                .anyMatch(v -> v.equals(normalizedValueString))) {
             return null;
         }
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.config.core.internal.validation.TypeIntrospections.TypeIntrospection;
 import org.openhab.core.config.core.validation.ConfigValidationMessage;
@@ -38,12 +39,11 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
             return null;
         }
 
-        String valString = (parameter.getType() == Type.INTEGER && value instanceof BigDecimal)
-                ? ((BigDecimal) value).setScale(0).toString()
-                : value.toString();
+        Object normalizedValue = ConfigUtil.normalizeType(value, parameter).toString();
+
         // Allow specified options to be outside the min/max value
         // Option values are a string, so we can do a simple compare
-        if (parameter.getOptions().stream().map(ParameterOption::getValue).anyMatch(v -> v.equals(valString))) {
+        if (parameter.getOptions().stream().map(ParameterOption::getValue).anyMatch(v -> v.equals(normalizedValue))) {
             return null;
         }
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
+import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.config.core.internal.validation.TypeIntrospections.TypeIntrospection;
 import org.openhab.core.config.core.validation.ConfigValidationMessage;
 
@@ -26,7 +27,7 @@ import org.openhab.core.config.core.validation.ConfigValidationMessage;
  * {@link ConfigDescriptionParameter}.
  *
  * @author Thomas Höfer - Initial contribution
- * @authod Chris Jackson - Allow options to be outside of min/max value
+ * @author Chris Jackson - Allow options to be outside of min/max value
  */
 @NonNullByDefault
 final class MinMaxValidator implements ConfigDescriptionParameterValidator {
@@ -37,9 +38,12 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
             return null;
         }
 
-        // Allow specified options to be outside of the min/max value
+        String valString = (parameter.getType() == Type.INTEGER && value instanceof BigDecimal)
+                ? ((BigDecimal) value).setScale(0).toString()
+                : value.toString();
+        // Allow specified options to be outside the min/max value
         // Option values are a string, so we can do a simple compare
-        if (parameter.getOptions().stream().map(o -> o.getValue()).anyMatch(v -> v.equals(value.toString()))) {
+        if (parameter.getOptions().stream().map(ParameterOption::getValue).anyMatch(v -> v.equals(valString))) {
             return null;
         }
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -87,6 +87,7 @@ public class ConfigDescriptionValidatorTest {
     private static final String INT_REQUIRED_PARAM_NAME = "int-required-param";
     private static final String INT_MIN_PARAM_NAME = "int-min-name";
     private static final String INT_MAX_PARAM_NAME = "int-max-name";
+    private static final String INT_OPTION_PARAM_NAME = "int-option-param-name";
 
     private static final String DECIMAL_PARAM_NAME = "decimal-param";
     private static final String DECIMAL_REQUIRED_PARAM_NAME = "decimal-required-param";
@@ -139,6 +140,9 @@ public class ConfigDescriptionValidatorTest {
             .create(INT_MIN_PARAM_NAME, ConfigDescriptionParameter.Type.INTEGER).withMinimum(MIN).build();
     private static final ConfigDescriptionParameter INT_MAX_PARAM = ConfigDescriptionParameterBuilder
             .create(INT_MAX_PARAM_NAME, ConfigDescriptionParameter.Type.INTEGER).withMaximum(MAX).build();
+    private static final ConfigDescriptionParameter INT_OPTION_PARAM = ConfigDescriptionParameterBuilder
+            .create(INT_OPTION_PARAM_NAME, Type.INTEGER).withMinimum(MIN).withMaximum(MAX)
+            .withOptions(List.of(new ParameterOption("10", "10"))).build();
 
     private static final ConfigDescriptionParameter DECIMAL_PARAM = ConfigDescriptionParameterBuilder
             .create(DECIMAL_PARAM_NAME, ConfigDescriptionParameter.Type.DECIMAL).build();
@@ -157,7 +161,7 @@ public class ConfigDescriptionValidatorTest {
             .withParameters(List.of(BOOL_PARAM, BOOL_REQUIRED_PARAM, TXT_PARAM, TXT_REQUIRED_PARAM, TXT_MIN_PARAM,
                     TXT_MAX_PARAM, TXT_PATTERN_PARAM, TXT_MAX_PATTERN_PARAM, TXT_PARAM_WITH_LIMITED_OPTIONS,
                     TXT_PARAM_WITH_UNLIMITED_OPTIONS, TXT_MULTIPLE_LIMIT_PARAM, INT_PARAM, INT_REQUIRED_PARAM,
-                    INT_MIN_PARAM, INT_MAX_PARAM, DECIMAL_PARAM, DECIMAL_REQUIRED_PARAM,
+                    INT_MIN_PARAM, INT_MAX_PARAM, DECIMAL_PARAM, DECIMAL_REQUIRED_PARAM, INT_OPTION_PARAM,
                     DECIMAL_WITH_LIMITED_OPTIONS_PARAM_OPTIONS, DECIMAL_MIN_PARAM, DECIMAL_MAX_PARAM))
             .build();
 
@@ -194,6 +198,7 @@ public class ConfigDescriptionValidatorTest {
         params.put(INT_REQUIRED_PARAM_NAME, 0);
         params.put(INT_MIN_PARAM_NAME, MIN);
         params.put(INT_MAX_PARAM_NAME, MAX);
+        params.put(INT_OPTION_PARAM_NAME, new BigDecimal("10.0"));
         params.put(DECIMAL_PARAM_NAME, null);
         params.put(DECIMAL_REQUIRED_PARAM_NAME, 0f);
         params.put(DECIMAL_WITH_LIMITED_OPTIONS_NAME, new BigDecimal("2.0"));


### PR DESCRIPTION
Reported on the forum. The problem is that on deserialization 255 is deserialized to a `BigDecimal` without scale. The validation the fails because the `BigDecimal` is converted to a `255.0` string, which is not equal to the `255` string from the config description option. The value is now properly normalized.

Signed-off-by: Jan N. Klug <github@klug.nrw>