### PR TITLE
Fix grep console not working

### DIFF
--- a/bundles/org.openhab.core.io.console.karaf/bnd.bnd
+++ b/bundles/org.openhab.core.io.console.karaf/bnd.bnd
@@ -1,1 +1,3 @@
 Karaf-Commands: org.openhab.core.io.console.karaf.internal
+Automatic-Module-Name: ${def;bsn}
+Bundle-SymbolicName: ${project.artifactId}

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -12,9 +12,11 @@
  */
 package org.openhab.core.io.console.karaf.internal;
 
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.felix.service.command.Process;
 import org.apache.karaf.shell.api.action.Action;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
@@ -66,8 +68,8 @@ public class CommandWrapper implements Command, Action {
     @Override
     public Object execute(Session session, List<Object> argList) throws Exception {
         String[] args = argList.stream().map(Object::toString).toArray(String[]::new);
-
-        final Console console = new OSGiConsole(getScope(), session.getConsole());
+        PrintStream out = Process.Utils.current().out();
+        final Console console = new OSGiConsole(getScope(), out);
 
         if (args.length == 1 && "--help".equals(args[0])) {
             for (final String usage : command.getUsages()) {


### PR DESCRIPTION
Fixes #3011 

I currently can't test if #1545 is back with this solution. The `PrintStream` is now determined in the same way as grep does and that at least makes grep work locally and for SSH connections. Maybe @robnielsen can test with the Insteon extension once it is merged.

Signed-off-by: Jan N. Klug <github@klug.nrw>