### PR TITLE
Remove OH2 leftover in Karaf Add-On service

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -95,9 +95,9 @@ public class FeatureInstaller implements ConfigurationListener {
     public static final String PREFIX = "openhab-";
     public static final String PREFIX_PACKAGE = "package-";
 
-    public static final String[] EXTENSION_TYPES = new String[] { EXTENSION_TYPE_AUTOMATION, EXTENSION_TYPE_BINDING,
+    public static final List<String> EXTENSION_TYPES = List.of(EXTENSION_TYPE_AUTOMATION, EXTENSION_TYPE_BINDING,
             EXTENSION_TYPE_MISC, EXTENSION_TYPE_PERSISTENCE, EXTENSION_TYPE_TRANSFORMATION, EXTENSION_TYPE_UI,
-            EXTENSION_TYPE_VOICE };
+            EXTENSION_TYPE_VOICE);
 
     private final Logger logger = LoggerFactory.getLogger(FeatureInstaller.class);
 


### PR DESCRIPTION
OH1 add-ons are not present in the OH3 distribution as they are not supported anyway, so we do not to filter them.

Signed-off-by: Jan N. Klug <github@klug.nrw>