### PR TITLE
Add a profile for converting Non-Undef/Null to ON

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemNonUndefProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemNonUndefProfile.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.thing.profiles.SystemProfiles;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
+
+/**
+ * This is profile to convert non-UNDEF non-NULL values from {@link ThingHandler} as ON/OFF.
+ *
+ * State updates from {@link ThingHandler} that are UNDEF or NULL are converted to OFF, while other values are converted
+ * to ON.
+ * Commands (never UNDEF/NULL) from {@link ThingHandler} towards items are always converted to ON.
+ * Commands from items are forwarded to the {@link ThingHandler} as-is.
+ *
+ * @author Sami Salonen - Initial contribution
+ */
+@NonNullByDefault
+public class SystemNonUndefProfile implements StateProfile {
+
+    private final ProfileCallback callback;
+
+    private static final String INVERTED_PARAM = "inverted";
+
+    private final boolean inverted;
+
+    public SystemNonUndefProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+
+        final Object paramValue = context.getConfiguration().get(INVERTED_PARAM);
+        inverted = paramValue == null ? false : Boolean.valueOf(paramValue.toString());
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.DEFAULT;
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand(command);
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        OnOffType convertedState = state instanceof UnDefType ? OnOffType.OFF : OnOffType.ON;
+        if (inverted) {
+            convertedState = convertedState == OnOffType.ON ? OnOffType.OFF : OnOffType.ON;
+        }
+        callback.sendUpdate(convertedState);
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        // Command cannot be of UndefType, so we do not need to inspect the command
+        callback.sendCommand(inverted ? OnOffType.OFF : OnOffType.ON);
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
@@ -63,7 +63,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     private final ChannelTypeRegistry channelTypeRegistry;
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Set.of(DEFAULT_TYPE, FOLLOW_TYPE, HYSTERESIS_TYPE,
-            OFFSET_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
+            OFFSET_TYPE, NON_UNDEF_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
             RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE,
             RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
             RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE,
@@ -71,7 +71,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             TIMESTAMP_UPDATE_TYPE);
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(DEFAULT, FOLLOW, HYSTERESIS, OFFSET,
-            RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
+            NON_UNDEF, RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
             RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE,
             RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TRIGGER_EVENT_STRING,
             TIMESTAMP_CHANGE, TIMESTAMP_OFFSET, TIMESTAMP_TRIGGER, TIMESTAMP_UPDATE);
@@ -101,6 +101,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemHysteresisStateProfile(callback, context);
         } else if (OFFSET.equals(profileTypeUID)) {
             return new SystemOffsetProfile(callback, context);
+        } else if (NON_UNDEF.equals(profileTypeUID)) {
+            return new SystemNonUndefProfile(callback, context);
         } else if (RANGE.equals(profileTypeUID)) {
             return new SystemRangeStateProfile(callback, context);
         } else if (RAWBUTTON_ON_OFF_SWITCH.equals(profileTypeUID)) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
@@ -30,6 +30,7 @@ public interface SystemProfiles {
     ProfileTypeUID FOLLOW = new ProfileTypeUID(SYSTEM_SCOPE, "follow");
     ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
     ProfileTypeUID HYSTERESIS = new ProfileTypeUID(SYSTEM_SCOPE, "hysteresis");
+    ProfileTypeUID NON_UNDEF = new ProfileTypeUID(SYSTEM_SCOPE, "non-undef");
     ProfileTypeUID RANGE = new ProfileTypeUID(SYSTEM_SCOPE, "range");
     ProfileTypeUID RAWBUTTON_ON_OFF_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-on-off-switch");
     ProfileTypeUID RAWBUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "rawbutton-toggle-player");
@@ -59,6 +60,16 @@ public interface SystemProfiles {
     ProfileType HYSTERESIS_TYPE = ProfileTypeBuilder.newState(HYSTERESIS, "Hysteresis") //
             .withSupportedItemTypesOfChannel(CoreItemFactory.DIMMER, CoreItemFactory.NUMBER) //
             .withSupportedItemTypes(CoreItemFactory.SWITCH) //
+            .build();
+
+    // We accept all item types that can receive ON/OFF. All channel types are accepted, even though some of them cannot
+    // pass UNDEF - the profile still behaves correctly and as expected.
+    ProfileType NON_UNDEF_TYPE = ProfileTypeBuilder.newState(NON_UNDEF, "Non-Undef/Undef to ON/OFF")
+            .withSupportedItemTypes(CoreItemFactory.COLOR, CoreItemFactory.DIMMER, CoreItemFactory.SWITCH)
+            .withSupportedItemTypesOfChannel(CoreItemFactory.CALL, CoreItemFactory.COLOR, CoreItemFactory.CONTACT,
+                    CoreItemFactory.DATETIME, CoreItemFactory.DIMMER, CoreItemFactory.IMAGE, CoreItemFactory.LOCATION,
+                    CoreItemFactory.NUMBER, CoreItemFactory.PLAYER, CoreItemFactory.ROLLERSHUTTER,
+                    CoreItemFactory.STRING, CoreItemFactory.SWITCH)
             .build();
 
     ProfileType RANGE_TYPE = ProfileTypeBuilder.newState(RANGE, "Range") //

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/nonUndefProfile.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/nonUndefProfile.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:system:non-undef">
+		<parameter name="inverted" type="boolean">
+			<label>Inverted</label>
+			<description>Inverts resulting mapping of ON / OFF, if true.</description>
+			<default>false</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemNonUndefProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemNonUndefProfileTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.types.UnDefType;
+
+/**
+ *
+ * @author Sami Salonen - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class SystemNonUndefProfileTest {
+
+    private @Mock @NonNullByDefault({}) ProfileCallback callbackMock;
+    private @Mock @NonNullByDefault({}) ProfileContext contextMock;
+
+    private SystemNonUndefProfile initProfile(boolean inverted) {
+        final Map<String, @Nullable Object> properties = new HashMap<>(2);
+        properties.put("inverted", inverted);
+        when(contextMock.getConfiguration()).thenReturn(new Configuration(properties));
+        SystemNonUndefProfile profile = new SystemNonUndefProfile(callbackMock, contextMock);
+        return profile;
+    }
+
+    //
+    // Command from item
+    //
+
+    @Test
+    public void testOnCommandFromItemSwitch() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromItem(OnOffType.ON);
+
+        verify(callbackMock).handleCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testOnCommandFromItemNumber() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(callbackMock).handleCommand(eq(DecimalType.ZERO));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    //
+    // Command from item (inverted)
+    // (no change in handleCommand calls)
+    //
+
+    @Test
+    public void testOnCommandFromItemSwitchInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onCommandFromItem(OnOffType.ON);
+
+        verify(callbackMock).handleCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testOnCommandFromItemNumberInverted() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromItem(DecimalType.ZERO);
+
+        verify(callbackMock).handleCommand(eq(DecimalType.ZERO));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    //
+    // State update from handler
+    //
+
+    @Test
+    public void testStateUpdatedFromHandlerSwitchOn() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onStateUpdateFromHandler(OnOffType.ON);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerSwitchOff() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onStateUpdateFromHandler(OnOffType.OFF);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerUndef() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onStateUpdateFromHandler(UnDefType.UNDEF);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerNull() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onStateUpdateFromHandler(UnDefType.NULL);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    //
+    // State update from handler (inverted)
+    // Same as above but inverted updates
+    //
+
+    @Test
+    public void testStateUpdatedFromHandlerSwitchOnInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onStateUpdateFromHandler(OnOffType.ON);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerSwitchOffInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onStateUpdateFromHandler(OnOffType.OFF);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerUndefInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onStateUpdateFromHandler(UnDefType.UNDEF);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testStateUpdatedFromHandlerNullInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onStateUpdateFromHandler(UnDefType.NULL);
+
+        verify(callbackMock).sendUpdate(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    //
+    // Command from handler
+    //
+
+    @Test
+    public void testCommandFromHandlerSwitchOn() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromHandler(OnOffType.ON);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testCommandFromHandlerSwitchOff() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromHandler(OnOffType.OFF);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testCommandFromHandlerNumber() {
+        SystemNonUndefProfile profile = initProfile(false);
+        profile.onCommandFromHandler(DecimalType.ZERO);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.ON));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    //
+    // Command from handler (inverted)
+    // Same as above but inverted updates
+    //
+
+    @Test
+    public void testCommandFromHandlerSwitchOnInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onCommandFromHandler(OnOffType.ON);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testCommandFromHandlerSwitchOffInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onCommandFromHandler(OnOffType.OFF);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testCommandFromHandlerNumberInverted() {
+        SystemNonUndefProfile profile = initProfile(true);
+        profile.onCommandFromHandler(DecimalType.ZERO);
+
+        verify(callbackMock).sendCommand(eq(OnOffType.OFF));
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+}


### PR DESCRIPTION
This is a profile to convert non-UNDEF non-NULL values from {@link ThingHandler} as ON/OFF.

State updates from `ThingHandler` that are UNDEF or NULL are converted to OFF, while other values are converted to ON.
- Commands (never UNDEF/NULL) from `ThingHandler` towards items are always converted to ON.
- Commands from items are forwarded to the `ThingHandler` as-is.


Docs updated in https://github.com/openhab/openhab-docs/pull/1856