### PR TITLE
Fix marketplace add-on uninstall

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -189,7 +189,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
                     .filter(t -> showUnpublished || Arrays.asList(t.tags).contains(PUBLISHED_TAG))
                     .map(t -> convertTopicItemToAddon(t, users)).forEach(addons::add);
         } catch (Exception e) {
-            logger.error("Unable to retrieve marketplace add-ons", e);
+            logger.warn("Unable to retrieve marketplace add-ons: {}", e.getMessage());
         }
         return addons;
     }
@@ -199,7 +199,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
         String fullId = ADDON_ID_PREFIX + id;
         // check if it is an installed add-on (cachedAddons also contains possibly incomplete results from the remote
         // side, we need to retrieve them from Discourse)
-        if (installedAddons.contains(id)) {
+        if (installedAddons.contains(fullId)) {
             return cachedAddons.stream().filter(e -> fullId.equals(e.getId())).findAny().orElse(null);
         }
 


### PR DESCRIPTION
Fixes #3040 

Instead of using the full id (`marketplace:123456`) the id without service prefix was used to lookup installed add-ons. This is not an issue if the network is available because then the information is request from the forum. If no network connection is present it obviously fails.

This also reduces the log level in the case of connection issues. ERROR is to much and the stack trace is not necessary.

Signed-off-by: Jan N. Klug <github@klug.nrw>