### PR TITLE
Fix build warnings in addons

### DIFF
--- a/bundles/org.openhab.core.test/pom.xml
+++ b/bundles/org.openhab.core.test/pom.xml
@@ -32,6 +32,12 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.11</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Related to #2982

This fixes the warning reported in the attached PR. Technically this dependency is not necessary but it's missing in the PMD class path if it is not explicitly added here.


Signed-off-by: Jan N. Klug <github@klug.nrw>