### PR TITLE
Improve FeatureInstaller

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -203,7 +203,7 @@ public class FeatureInstaller implements ConfigurationListener {
             }
             installAddons(config); // we don't have to wait even if the job is running, because method is synchronized
         }
-        
+
         processingConfigQueue.set(false);
     }
 

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -212,6 +212,12 @@ public class FeatureInstaller implements ConfigurationListener {
         }
 
         processingConfigQueue.set(false);
+
+        try {
+            featuresService.refreshFeatures(EnumSet.of(FeaturesService.Option.Upgrade));
+        } catch (Exception e) {
+            logger.error("Failed to refresh bundles after processing config update", e);
+        }
     }
 
     @Nullable
@@ -485,7 +491,8 @@ public class FeatureInstaller implements ConfigurationListener {
         try {
             Feature[] features = featuresService.listInstalledFeatures();
             if (!anyMatchingFeature(features, withName(name))) {
-                featuresService.installFeature(name);
+                featuresService.installFeature(name,
+                        EnumSet.of(FeaturesService.Option.Upgrade, FeaturesService.Option.NoAutoRefreshBundles));
                 features = featuresService.listInstalledFeatures();
                 if (anyMatchingFeature(features, withName(name))) {
                     logger.debug("Installed '{}'", name);

--- a/features/karaf/openhab-core/pom.xml
+++ b/features/karaf/openhab-core/pom.xml
@@ -17,7 +17,6 @@
 
   <properties>
     <jetty.version>9.4.46.v20220331</jetty.version>
-    <jna.version>5.11.0</jna.version>
   </properties>
 
   <build>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -37,6 +37,9 @@
 		<requirement>openhab.tp;filter:="(feature=httpclient)"</requirement>
 		<feature dependency="true">openhab.tp-httpclient</feature>
 
+		<requirement>openhab.tp;filter:="(feature=jna)"</requirement>
+		<feature dependency="true">openhab.tp-jna</feature>
+
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.core/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery/${project.version}</bundle>
@@ -408,7 +411,7 @@
 		<feature prerequisite="true">wrapper</feature>
 		<feature prerequisite="true">jaas</feature>
 		<!-- This bundle needs to be started early as it registers the 404 and startup pages on Jetty -->
-		<!-- It is temperarily disabled due to https://github.com/openhab/openhab-core/issues/422 -->
+		<!-- It is temporarily disabled due to https://github.com/openhab/openhab-core/issues/422 -->
 		<!-- <bundle start-level="30">mvn:org.openhab.core.bundles/org.openhab.ui.start/${project.version}</bundle> -->
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.karaf/${project.version}</bundle>
 		<config name="org.openhab.audio">
@@ -421,11 +424,6 @@
 
 	<feature name="openhab-runtime-certificate" description="SSL Certificate Generator" version="${project.version}">
 		<bundle start-level="20">mvn:org.openhab.core.bundles/org.openhab.core.io.jetty.certificate/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-runtime-jna" description="Java Native Access (JNA)" version="${project.version}">
-		<bundle>mvn:net.java.dev.jna/jna/${jna.version}</bundle>
-		<bundle>mvn:net.java.dev.jna/jna-platform/${jna.version}</bundle>
 	</feature>
 
 	<feature name="openhab-transport-coap" description="CoAP Transport" version="${project.version}">

--- a/features/karaf/openhab-tp/pom.xml
+++ b/features/karaf/openhab-tp/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <jetty.version>9.4.46.v20220331</jetty.version>
+    <jna.version>5.11.0</jna.version>
   </properties>
 
   <build>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -108,6 +108,12 @@
 		<bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.whiteboard/2.0.0</bundle>
 	</feature>
 
+	<feature name="openhab.tp-jna" description="Java Native Access (JNA)" version="${project.version}">
+		<capability>openhab.tp;feature=jna;version=${jna.version}</capability>
+		<bundle dependency="true">mvn:net.java.dev.jna/jna/${jna.version}</bundle>
+		<bundle dependency="true">mvn:net.java.dev.jna/jna-platform/${jna.version}</bundle>
+	</feature>
+
 	<feature name="openhab.tp-cxf" description="Apache CXF" version="${project.version}">
 		<capability>openhab.tp;feature=cxf;version=3.4.5</capability>
 		<feature dependency="true">openhab.tp-jaxws</feature>


### PR DESCRIPTION
There are some flaws in the `FeatureInstaller` which this PR tries to solve. While debugging #3025 I found that the periodic sync job sets the config cache before the configuration is applied. This might lead to issues if another call to `modified` re-sets the configuration to something else but does not update the configuration cache. It is also not ensured that all configuration updates are processed in the order they arrive, so the asynchronous processing of the updates might result in an older configuration overwriting a newer one. 

This PR 

- introduces a queue that holds the configuration supplied to `modified` and processes them in the correct order 
- ensures that configuration cache is properly updated when an update is processed (independent from the configuration source)
- removed nearly all synchronized as they are no longer needed
- some other code clean-up

Signed-off-by: Jan N. Klug <github@klug.nrw>