### PR TITLE
Add "time only"-Option for DateTimeTrigger in rules

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/DateTimeTrigger.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/DateTimeTrigger.json
@@ -13,6 +13,22 @@
 					"label": "Item",
 					"description": "the name of the item",
 					"required": true
+				},
+				{
+					"name": "timeOnly",
+					"type": "BOOLEAN",
+					"label": "Time only",
+					"description": "Specifies whether only the time of the item should be compared or the date and time.",
+					"options": [
+						{
+							"label": "Yes",
+							"value": "true"
+						},
+						{
+							"label": "No",
+							"value": "false"
+						}
+					]
 				}
 			]
 		}

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -389,6 +389,7 @@ public class DSLRuleProvider
             DateTimeTrigger tt = (DateTimeTrigger) t;
             Configuration cfg = new Configuration();
             cfg.put("itemName", tt.getItem());
+            cfg.put("timeOnly", tt.isTimeOnly());
             return TriggerBuilder.create().withId(Integer.toString((triggerId++))).withTypeUID("timer.DateTimeTrigger")
                     .withConfiguration(cfg).build();
         } else if (t instanceof EventEmittedTrigger) {

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/Rules.xtext
@@ -76,7 +76,7 @@ TimerTrigger:
 ;
 
 DateTimeTrigger:
-    'Time' 'is' item=ItemName
+    'Time' 'is' item=ItemName (timeOnly?='timeOnly')?
 ;
 
 SystemTrigger:


### PR DESCRIPTION
Extends the DateTimeTrigger introduced in ca94fd5 and dd13da5 to allow triggering only when the time matches to allow for daily triggers.

I tried to use "Time is time of item" as trigger for DSL-Rules first as that seems to better fit into the existing model but unfortunately that breaks the existing rules, so "Time matches time of" was chosen instead. Other ideas are very welcome.