### PR TITLE
Prevent crash on invalid entry in ManagedThingProvider

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ManagedThingProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ManagedThingProvider.java
@@ -55,7 +55,12 @@ public class ManagedThingProvider extends AbstractManagedProvider<Thing, ThingUI
 
     @Override
     protected @Nullable Thing toElement(String key, ThingStorageEntity persistableElement) {
-        return ThingDTOMapper.map(persistableElement, persistableElement.isBridge);
+        try {
+            return ThingDTOMapper.map(persistableElement, persistableElement.isBridge);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Failed to create thing with UID '{}' from stored entity: {}", key, e.getMessage());
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Invalid entries in the database (e.g. duplicate channels) result in an uncatched exception which prevents adding things from storage to the `ThingRegistry`. This PR adds a try-catch-block around the thing mapping and logs a warning. As a result only the affected thing will be missing.

Reported on the forum: https://community.openhab.org/t/issues-with-3-3-on-win10/137734

Signed-off-by: Jan N. Klug <github@klug.nrw>