### PR TITLE
Add additional `MqttBrokerConnectionConfig` options

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -62,6 +62,8 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 @NonNullByDefault
 public class MqttBrokerConnection {
     final Logger logger = LoggerFactory.getLogger(MqttBrokerConnection.class);
+    public static final Protocol DEFAULT_PROTOCOL = Protocol.TCP;
+    public static final MqttVersion DEFAULT_MQTT_VERSION = MqttVersion.V3;
     public static final int DEFAULT_KEEPALIVE_INTERVAL = 60;
     public static final int DEFAULT_QOS = 0;
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
@@ -14,6 +14,8 @@ package org.openhab.core.io.transport.mqtt;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection.MqttVersion;
+import org.openhab.core.io.transport.mqtt.MqttBrokerConnection.Protocol;
 
 /**
  * Contains configuration for a MqttBrokerConnection.
@@ -30,6 +32,9 @@ public class MqttBrokerConnectionConfig {
     public @Nullable Integer port;
     public boolean secure = true;
     public boolean hostnameValidated = true;
+    // Protocol parameters
+    public Protocol protocol = MqttBrokerConnection.DEFAULT_PROTOCOL;
+    public MqttVersion mqttVersion = MqttBrokerConnection.DEFAULT_MQTT_VERSION;
     // Authentication parameters
     public @Nullable String username;
     public @Nullable String password;


### PR DESCRIPTION
This allows for using some additional configuration parameters in MQTT broker configurations.

See: https://github.com/openhab/openhab-addons/pull/13303