### PR TITLE
Fix missing initial thing status event

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.core.thing.events;
 
+import java.util.Objects;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
@@ -75,5 +78,22 @@ public class ThingStatusInfoEvent extends AbstractEvent {
     @Override
     public String toString() {
         return String.format("Thing '%s' updated: %s", thingUID, thingStatusInfo);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        if (!super.equals(o))
+            return false;
+        ThingStatusInfoEvent that = (ThingStatusInfoEvent) o;
+        return thingUID.equals(that.thingUID) && thingStatusInfo.equals(that.thingStatusInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), thingUID, thingStatusInfo);
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -305,7 +305,6 @@ public class ThingManagerImpl
             if (channelType != null) {
                 URI configDescriptionURI = channelType.getConfigDescriptionURI();
                 if (configDescriptionURI != null) {
-                    configDescriptionValidator.validate(configurationParameters, configDescriptionURI);
                 }
             }
         }
@@ -1140,7 +1139,7 @@ public class ThingManagerImpl
                 }
             } else {
                 setThingStatus(thing, new ThingStatusInfo(ThingStatus.UNINITIALIZED,
-                        ThingStatusDetail.HANDLER_REGISTERING_ERROR, "Handler factory not found"));
+                        ThingStatusDetail.HANDLER_MISSING_ERROR, "Handler factory not found"));
                 logger.debug("Not registering a handler at this point. No handler factory for thing '{}' found.",
                         thing.getUID());
             }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -559,6 +559,7 @@ public class ThingManagerImpl
             logger.error("A thing with UID '{}' is already tracked by ThingManager. This is a bug.", thing.getUID());
         }
         this.things.put(thing.getUID(), thing);
+        eventPublisher.post(ThingEventFactory.createStatusInfoEvent(thing.getUID(), thing.getStatusInfo()));
         logger.debug("Thing '{}' is tracked by ThingManager.", thing.getUID());
         if (!isHandlerRegistered(thing)) {
             registerAndInitializeHandler(thing, getThingHandlerFactory(thing));
@@ -1125,7 +1126,7 @@ public class ThingManagerImpl
             final @Nullable ThingHandlerFactory thingHandlerFactory) {
         if (isDisabledByStorage(thing.getUID())) {
             logger.debug("Not registering a handler at this point. Thing is disabled.");
-            thing.setStatusInfo(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.DISABLED, null));
+            setThingStatus(thing, new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.DISABLED, null));
         } else {
             if (thingHandlerFactory != null) {
                 final String identifier = getBundleIdentifier(thingHandlerFactory);
@@ -1138,6 +1139,8 @@ public class ThingManagerImpl
                             identifier);
                 }
             } else {
+                setThingStatus(thing, new ThingStatusInfo(ThingStatus.UNINITIALIZED,
+                        ThingStatusDetail.HANDLER_REGISTERING_ERROR, "Handler factory not found"));
                 logger.debug("Not registering a handler at this point. No handler factory for thing '{}' found.",
                         thing.getUID());
             }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -305,6 +305,7 @@ public class ThingManagerImpl
             if (channelType != null) {
                 URI configDescriptionURI = channelType.getConfigDescriptionURI();
                 if (configDescriptionURI != null) {
+                    configDescriptionValidator.validate(configurationParameters, configDescriptionURI);
                 }
             }
         }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -33,6 +33,9 @@ import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
 import org.openhab.core.test.java.JavaTest;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.openhab.core.thing.i18n.ThingStatusInfoI18nLocalizationService;
@@ -77,6 +80,8 @@ public class ThingManagerImplTest extends JavaTest {
         when(bundleMock.getSymbolicName()).thenReturn("test");
         when(bundleResolverMock.resolveBundle(any())).thenReturn(bundleMock);
         when(thingMock.getUID()).thenReturn(new ThingUID("test", "thing"));
+        when(thingMock.getStatusInfo())
+                .thenReturn(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE, null));
     }
 
     private ThingManagerImpl createThingManager() {
@@ -187,6 +192,9 @@ public class ThingManagerImplTest extends JavaTest {
         Thing thingMock2 = mock(Thing.class);
 
         when(thingMock2.getUID()).thenReturn(new ThingUID("test", "thing2"));
+        when(thingMock2.getStatusInfo())
+                .thenReturn(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE, null));
+
         setupInterceptedLogger(ThingManagerImpl.class, LogLevel.DEBUG);
 
         ThingManagerImpl thingManager = createThingManager();

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -1240,16 +1240,18 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         registerService(thingStatusEventSubscriber);
 
-        // set status to INITIALIZING
+        // set status to UNINITIALIZED and INITIALIZING
+        ThingStatusInfo uninitializedNone = ThingStatusInfoBuilder
+                .create(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE).build();
         ThingStatusInfo initializingNone = ThingStatusInfoBuilder
                 .create(ThingStatus.INITIALIZING, ThingStatusDetail.NONE).build();
-        ThingStatusInfoEvent event = ThingEventFactory.createStatusInfoEvent(thing.getUID(), initializingNone);
+        ThingStatusInfoEvent event = ThingEventFactory.createStatusInfoEvent(thing.getUID(), uninitializedNone);
+        ThingStatusInfoEvent event1 = ThingEventFactory.createStatusInfoEvent(thing.getUID(), initializingNone);
         managedThingProvider.add(thing);
 
-        waitForAssert(() -> assertThat(receivedEvents.size(), is(1)));
-        assertThat(receivedEvents.get(0).getType(), is(event.getType()));
-        assertThat(receivedEvents.get(0).getPayload(), is(event.getPayload()));
-        assertThat(receivedEvents.get(0).getTopic(), is(event.getTopic()));
+        waitForAssert(() -> assertThat(receivedEvents.size(), is(2)));
+        assertThat(receivedEvents.get(0), is(equalTo(event)));
+        assertThat(receivedEvents.get(1), is(equalTo(event1)));
         receivedEvents.clear();
 
         // set status to ONLINE
@@ -1258,9 +1260,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         state.callback.statusUpdated(thing, onlineNone);
 
         waitForAssert(() -> assertThat(receivedEvents.size(), is(1)));
-        assertThat(receivedEvents.get(0).getType(), is(event.getType()));
-        assertThat(receivedEvents.get(0).getPayload(), is(event.getPayload()));
-        assertThat(receivedEvents.get(0).getTopic(), is(event.getTopic()));
+        assertThat(receivedEvents.get(0), is(equalTo(event)));
         receivedEvents.clear();
 
         // set status to OFFLINE
@@ -1270,9 +1270,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         state.callback.statusUpdated(thing, offlineCommError);
 
         waitForAssert(() -> assertThat(receivedEvents.size(), is(1)));
-        assertThat(receivedEvents.get(0).getType(), is(event.getType()));
-        assertThat(receivedEvents.get(0).getPayload(), is(event.getPayload()));
-        assertThat(receivedEvents.get(0).getTopic(), is(event.getTopic()));
+        assertThat(receivedEvents.get(0), is(equalTo(event)));
         receivedEvents.clear();
 
         // set status to UNINITIALIZED
@@ -1283,9 +1281,7 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
 
         waitForAssert(() -> {
             assertThat(receivedEvents.size(), is(2));
-            assertThat(receivedEvents.get(1).getType(), is(uninitializedEvent.getType()));
-            assertThat(receivedEvents.get(1).getPayload(), is(uninitializedEvent.getPayload()));
-            assertThat(receivedEvents.get(1).getTopic(), is(uninitializedEvent.getTopic()));
+            assertThat(receivedEvents.get(1), is(equalTo(uninitializedEvent)));
         });
     }
 
@@ -1442,15 +1438,21 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
 
         waitForAssert(() -> {
-            assertThat(infoEvents.size(), is(1));
+            assertThat(infoEvents.size(), is(2));
             assertThat(infoChangedEvents.size(), is(1));
         });
 
         assertThat(infoEvents.get(0).getType(), is(ThingStatusInfoEvent.TYPE));
         assertThat(infoEvents.get(0).getTopic(), is("openhab/things/binding:type:id/status"));
-        assertThat(infoEvents.get(0).getStatusInfo().getStatus(), is(ThingStatus.INITIALIZING));
+        assertThat(infoEvents.get(0).getStatusInfo().getStatus(), is(ThingStatus.UNINITIALIZED));
         assertThat(infoEvents.get(0).getStatusInfo().getStatusDetail(), is(ThingStatusDetail.NONE));
         assertThat(infoEvents.get(0).getStatusInfo().getDescription(), is(nullValue()));
+
+        assertThat(infoEvents.get(1).getType(), is(ThingStatusInfoEvent.TYPE));
+        assertThat(infoEvents.get(1).getTopic(), is("openhab/things/binding:type:id/status"));
+        assertThat(infoEvents.get(1).getStatusInfo().getStatus(), is(ThingStatus.INITIALIZING));
+        assertThat(infoEvents.get(1).getStatusInfo().getStatusDetail(), is(ThingStatusDetail.NONE));
+        assertThat(infoEvents.get(1).getStatusInfo().getDescription(), is(nullValue()));
 
         assertThat(infoChangedEvents.get(0).getType(), is(ThingStatusInfoChangedEvent.TYPE));
         assertThat(infoChangedEvents.get(0).getTopic(), is("openhab/things/binding:type:id/statuschanged"));


### PR DESCRIPTION
A thing always has a status. This status is not properly propagated to the event bus when the thing is added. This e.g. leads to a situation where a thing's first status that is received by am event subscriber is "INITIALIZING" instead of "UNINITIALIZED". The status should always be sent so that the thing lifecycle can properly be tracked by event listeners.

Signed-off-by: Jan N. Klug <github@klug.nrw>