### PR TITLE
Add visibility and color parameters to UI sitemap provider

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -85,8 +85,6 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
     private static final String SITEMAP_PREFIX = "uicomponents_";
     private static final String SITEMAP_SUFFIX = ".sitemap";
 
-    private static final String COMPARATOR_STRING = "==|!=|<=|>=|<|>";
-    private static final Pattern COMPARATOR = Pattern.compile(COMPARATOR_STRING);
     private static final Pattern VISIBILITY_PATTERN = Pattern
             .compile("(?<item>[A-Za-z]\\w*)\\s*(?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>\\S+)");
     private static final Pattern COLOR_PATTERN = Pattern.compile(
@@ -340,16 +338,12 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 if (sourceVisibility instanceof String) {
                     Matcher matcher = VISIBILITY_PATTERN.matcher(sourceVisibility.toString());
                     if (matcher.matches()) {
-                        String item = matcher.group("item");
-                        String condition = matcher.group("condition");
-                        String sign = matcher.group("sign");
-                        String state = matcher.group("state");
                         VisibilityRuleImpl visibilityRule = (VisibilityRuleImpl) SitemapFactory.eINSTANCE
                                 .createVisibilityRule();
-                        visibilityRule.setItem(item);
-                        visibilityRule.setCondition(condition);
-                        visibilityRule.setSign(sign);
-                        visibilityRule.setState(state);
+                        visibilityRule.setItem(matcher.group("item"));
+                        visibilityRule.setCondition(matcher.group("condition"));
+                        visibilityRule.setSign(matcher.group("sign"));
+                        visibilityRule.setState(matcher.group("state"));
                         visibility.add(visibilityRule);
                     } else {
                         logger.warn("Syntax error in visibility '{}' rule for widget {}", sourceVisibility,
@@ -378,17 +372,12 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 if (sourceColor instanceof String) {
                     Matcher matcher = COLOR_PATTERN.matcher(sourceColor.toString());
                     if (matcher.matches()) {
-                        String item = matcher.group("item");
-                        String condition = matcher.group("condition");
-                        String sign = matcher.group("sign");
-                        String state = matcher.group("state");
-                        String arg = matcher.group("arg");
                         ColorArrayImpl colorArray = (ColorArrayImpl) SitemapFactory.eINSTANCE.createColorArray();
-                        colorArray.setItem(item);
-                        colorArray.setCondition(condition);
-                        colorArray.setSign(sign);
-                        colorArray.setState(state);
-                        colorArray.setArg(arg);
+                        colorArray.setItem(matcher.group("item"));
+                        colorArray.setCondition(matcher.group("condition"));
+                        colorArray.setSign(matcher.group("sign"));
+                        colorArray.setState(matcher.group("state"));
+                        colorArray.setArg(matcher.group("arg"));
                         color.add(colorArray);
                     } else {
                         logger.warn("Syntax error in {} rule '{}' for widget {}", key, sourceColor,

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -346,7 +346,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                         visibilityRule.setState(matcher.group("state"));
                         visibility.add(visibilityRule);
                     } else {
-                        logger.warn("Syntax error in visibility '{}' rule for widget {}", sourceVisibility,
+                        logger.warn("Syntax error in visibility rule '{}' for widget {}", sourceVisibility,
                                 component.getType());
                     }
                 }


### PR DESCRIPTION
This adds the missing parameters to the sitemap provider. This allows the UI to be further extended in a follow-up PR and make the sitemap UI configuration support the same features as textual configuration.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>