### PR TITLE
[tls] Rethrow 'IOException' instead of swallowing it

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
@@ -40,6 +40,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -53,6 +54,8 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
 
     public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
     public static final String END_CERT = "-----END CERTIFICATE-----";
+
+    private final Logger logger = LoggerFactory.getLogger(PEMTrustManager.class);
 
     private final X509Certificate trustedCert;
 
@@ -71,7 +74,7 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
                 trustedCert = (X509Certificate) CertificateFactory.getInstance("X.509")
                         .generateCertificate(certInputStream);
             } catch (IOException e) {
-                LoggerFactory.getLogger(PEMTrustManager.class).debug("An IOException occurred: {}", e.getMessage());
+                logger.debug("An IOException occurred: {}", e.getMessage());
                 throw new CertificateInstantiationException(e);
             }
         } else {

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
@@ -62,7 +62,8 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
      * <code>"-----END CERTIFICATE-----"</code>. The base 64 encoded certificate information are placed in between.
      *
      * @param pemCert the PEM certificate
-     * @throws CertificateException
+     * @throws CertificateInstantiationException
+     * @throws CertificateParsingException
      */
     public PEMTrustManager(String pemCert) throws CertificateException {
         if (!pemCert.isBlank() && pemCert.startsWith(BEGIN_CERT)) {
@@ -70,7 +71,8 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
                 trustedCert = (X509Certificate) CertificateFactory.getInstance("X.509")
                         .generateCertificate(certInputStream);
             } catch (IOException e) {
-                throw new CertificateException(e);
+                LoggerFactory.getLogger(PEMTrustManager.class).debug("An IOException occurred: {}", e.getMessage());
+                throw new CertificateInstantiationException(e);
             }
         } else {
             throw new CertificateParsingException("Certificate is either empty or cannot be parsed correctly");
@@ -210,7 +212,10 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
                 return BEGIN_CERT + System.lineSeparator() + Base64.getEncoder().encodeToString(bytes)
                         + System.lineSeparator() + END_CERT;
             }
-        } catch (NoSuchAlgorithmException | KeyManagementException | IOException e) {
+        } catch (IOException e) {
+            LoggerFactory.getLogger(PEMTrustManager.class).debug("An IOException occurred: {}", e.getMessage());
+            throw new CertificateInstantiationException(e);
+        } catch (NoSuchAlgorithmException | KeyManagementException e) {
             LoggerFactory.getLogger(PEMTrustManager.class).error("An unexpected exception occurred: ", e);
         } finally {
             if (connection != null) {
@@ -246,6 +251,10 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
 
         public CertificateInstantiationException(String message) {
             super(message);
+        }
+
+        public CertificateInstantiationException(Throwable cause) {
+            super(cause);
         }
     }
 }


### PR DESCRIPTION
- Rethrow `IOException` instead of swallowing it

In case of unreachable servers there is an `IOException` leading to an error message in the log file. This case can be handled even better when rethrowing the thrown exception which allows the calling instance to react to server side errors.

https://community.openhab.org/t/vizio-tv-binding/138367/12

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>