### PR TITLE
Upgrade Californium to 2.7.3

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -17,6 +17,7 @@
   <description>The dependencies that are used to compile the core bundles</description>
 
   <properties>
+    <californium.version>2.7.3</californium.version>
     <jetty.version>9.4.46.v20220331</jetty.version>
     <swagger.version>2.1.9</swagger.version>
   </properties>
@@ -70,17 +71,28 @@
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>californium-core</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>scandium</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>element-connector</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.orbit.bundles</groupId>
+      <artifactId>net.i2p.crypto.eddsa</artifactId>
+      <version>0.3.0.v20220506-1020</version>
     </dependency>
 
     <!-- Gson -->

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -16,6 +16,7 @@
   <name>openHAB Core :: BOM :: Runtime</name>
 
   <properties>
+    <californium.version>2.7.3</californium.version>
     <cxf.version>3.4.5</cxf.version>
     <!-- revert version of jackson-databind to ${jackson.version} when versions are in-line again -->
     <jackson.version>2.12.6</jackson.version>
@@ -411,17 +412,28 @@
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>californium-core</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>scandium</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>element-connector</artifactId>
-      <version>2.0.0</version>
+      <version>${californium.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.i2p.crypto</groupId>
+          <artifactId>eddsa</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.orbit.bundles</groupId>
+      <artifactId>net.i2p.crypto.eddsa</artifactId>
+      <version>0.3.0.v20220506-1020</version>
     </dependency>
 
     <!-- Gson -->

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -40,11 +40,12 @@
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">
-		<capability>openhab.tp;feature=coap;version=2.0.0</capability>
-		<bundle>mvn:org.eclipse.californium/californium-osgi/2.0.0</bundle>
-		<bundle>mvn:org.eclipse.californium/californium-core/2.0.0</bundle>
-		<bundle>mvn:org.eclipse.californium/element-connector/2.0.0</bundle>
-		<bundle>mvn:org.eclipse.californium/scandium/2.0.0</bundle>
+		<capability>openhab.tp;feature=coap;version=2.7.3</capability>
+		<bundle>mvn:org.eclipse.californium/californium-osgi/2.7.3</bundle>
+		<bundle>mvn:org.eclipse.californium/californium-core/2.7.3</bundle>
+		<bundle>mvn:org.eclipse.californium/element-connector/2.7.3</bundle>
+		<bundle>mvn:org.eclipse.californium/scandium/2.7.3</bundle>
+		<bundle>mvn:org.eclipse.orbit.bundles/net.i2p.crypto.eddsa/0.3.0.v20220506-1020</bundle>
 	</feature>
 
 	<feature name="openhab.tp-commons-net" description="The Apache Commons Net library" version="${project.version}">


### PR DESCRIPTION
Upgrades Californium from 2.0.0 to 2.7.3 which has many fixes.

For release notes see:

* https://projects.eclipse.org/projects/iot.californium/governance

Replaces #3061, #3062

---

Feature verification only succeeds when using the Eclipse Orbit version of net.i2p.crypto.eddsa.
So [net.i2p.crypto.eddsa_0.3.0.v20220506-1020.jar](https://download.eclipse.org/releases/2022-06/202206151000/plugins/net.i2p.crypto.eddsa_0.3.0.v20220506-1020.jar) needs to be added to the OH Maven Repo before CI will succceed.
