### PR TITLE
Add new ParameterizedTransformationService interface

### DIFF
--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ParameterizedTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ParameterizedTransformationService.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.transform;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A ParameterizedTransformationService extends TransformationService in order to allow
+ * providing specific parameters to the transform function, instead of a single `value`.
+ *
+ * @author Cody Cutrer - Initial contribution
+ */
+@NonNullByDefault
+public interface ParameterizedTransformationService extends TransformationService {
+    @Nullable
+    String transform(String value, Map<String, @Nullable Object> parameters) throws TransformationException;
+}


### PR DESCRIPTION
This allows new uses for transformation services where more structured objects can be passed in. In my particular use case, the MQTT Home Assistant binding already depends on the Jinja transform service in order to comply with Home Assistant's behavior. But some use cases require passing more state to Jinja than a single `value`: https://www.home-assistant.io/integrations/light.mqtt/#command_on_template

https://github.com/openhab/openhab-addons/pull/13413 is my adding PR that will utilize this. In its state as of posting, I've just added the interface to the Jinja bundle, but it's being problematic (and introduces a hard dependency between the Home Assistant binding and the Jinja bundle, which could be problematic because the Home Assistant binding is part of the MQTT feature which many people install, but never use Home Assistant or Jinja). Also note that I considered adding a special syntax to the Jinja service to pass additional variables (similar to how the script transformation service does), but it's actually important to be able to pass typed data to Jinja, not just strings.