### PR TITLE
Fix StartLevelService "hanging" if config is changed.

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
@@ -172,6 +172,7 @@ public class StartLevelService {
         // clean up
         slmarker.clear();
         trackers.values().forEach(t -> readyService.unregisterTracker(t));
+        trackers.clear();
 
         // set up trackers and markers
         startlevels = parseConfig(configuration);


### PR DESCRIPTION
Unregistered trackers aren't clear, so then we never register new trackers, and thus never get notified of any changes.
