### PR TITLE
[rulesupport] sort JSR223 scripts by start level before filename

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileReference.java
@@ -105,6 +105,10 @@ public class ScriptFileReference implements Comparable<ScriptFileReference> {
             String name2 = path2.getFileName().toString();
             LOGGER.trace("o2 [{}], path2 [{}], name2 [{}]", other.scriptFileURL, path2, name2);
 
+            int startLevelCompare = Integer.compare(getStartLevel(), other.getStartLevel());
+            if (startLevelCompare != 0) {
+                return startLevelCompare;
+            }
             int nameCompare = name1.compareToIgnoreCase(name2);
             if (nameCompare != 0) {
                 return nameCompare;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcherTest.java
@@ -267,6 +267,33 @@ class ScriptFileWatcherTest {
     }
 
     @Test
+    public void testOrderingStartlevelFolders() {
+        when(scriptEngineManager.isSupported("js")).thenReturn(true);
+        ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
+        when(scriptEngineContainer.getScriptEngine()).thenReturn(mock(ScriptEngine.class));
+
+        when(scriptEngineManager.createScriptEngine(anyString(), anyString())).thenReturn(scriptEngineContainer);
+
+        Path p50 = getFile("a_script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p50);
+        Path p40 = getFile("sl40/b_script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p40);
+        Path p30 = getFile("sl30/script.js");
+        scriptFileWatcher.processWatchEvent(null, ENTRY_CREATE, p30);
+
+        updateStartLevel(70);
+
+        InOrder inOrder = inOrder(scriptEngineManager);
+
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
+                p30.toFile().toURI().toString());
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
+                p40.toFile().toURI().toString());
+        inOrder.verify(scriptEngineManager, timeout(10000).times(1)).createScriptEngine("js",
+                p50.toFile().toURI().toString());
+    }
+
+    @Test
     public void testReloadActiveWhenDependencyChanged() {
         when(scriptEngineManager.isSupported("js")).thenReturn(true);
         ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);


### PR DESCRIPTION
The docs say that JSR223 scripts will be loaded in order of start level (as defined by filename or containing folder). this works (mostly) fine when you're stepping through start levels sequentially on startup, but if you're already at SL100, and have scripts located in sl folders, and then install an addon for those scripts, they were loading in alphabetic order instead. This ensures they'll still respect start level order relative to each other.

This should also fix the case of script start levels not matching start levels OpenHAB actually steps through (which are all multiples of 10) - i.e. if you define scripts in sl30, sl31, and sl32, when OpenHAB jumps from 30 to 40, 31 should be executed before 32.
