### PR TITLE
[voice] Allow stop single dialogs and start dialog on an existing processor

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -386,15 +386,16 @@ public class DialogProcessor implements KSListener, STTListener {
     }
 
     /**
-     * Check if other DialogProcessor instance have same configuration ignoring the configured keyword
+     * Check if other DialogProcessor instance have same configuration ignoring the keyword spotting configuration
      *
      * @param dialogProcessor Other DialogProcessor instance
      */
     public boolean isCompatible(DialogProcessor dialogProcessor) {
         return this.sink.equals(dialogProcessor.sink) && this.source.equals(dialogProcessor.source)
-                && Objects.equals(this.ks, dialogProcessor.ks) && this.stt.equals(dialogProcessor.stt)
-                && this.tts.equals(dialogProcessor.tts) && this.hlis.size() == dialogProcessor.hlis.size()
-                && this.hlis.containsAll(dialogProcessor.hlis) && this.locale.equals(dialogProcessor.locale)
+                && this.stt.equals(dialogProcessor.stt) && this.tts.equals(dialogProcessor.tts)
+                && Objects.equals(this.prefVoice, dialogProcessor.prefVoice)
+                && this.hlis.size() == dialogProcessor.hlis.size() && this.hlis.containsAll(dialogProcessor.hlis)
+                && this.locale.equals(dialogProcessor.locale)
                 && Objects.equals(this.listeningItem, dialogProcessor.listeningItem);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -150,6 +150,10 @@ public class DialogProcessor implements KSListener, STTListener {
         this.ttsFormat = VoiceManagerImpl.getBestMatch(tts.getSupportedFormats(), sink.getSupportedFormats());
     }
 
+    public void startSingleDialog() {
+        executeSimpleDialog();
+    }
+
     public void start() {
         KSService ksService = ks;
         if (ksService != null) {
@@ -209,6 +213,10 @@ public class DialogProcessor implements KSListener, STTListener {
         abortKS();
         closeStreamKS();
         toggleProcessing(false);
+    }
+
+    public boolean isProcessing() {
+        return processing;
     }
 
     private void abortKS() {
@@ -375,5 +383,18 @@ public class DialogProcessor implements KSListener, STTListener {
                 logger.warn("Error saying '{}': {}", text, e.getMessage());
             }
         }
+    }
+
+    /**
+     * Check if other DialogProcessor instance have same configuration ignoring the configured keyword
+     *
+     * @param dialogProcessor Other DialogProcessor instance
+     */
+    public boolean isCompatible(DialogProcessor dialogProcessor) {
+        return this.sink.equals(dialogProcessor.sink) && this.source.equals(dialogProcessor.source)
+                && Objects.equals(this.ks, dialogProcessor.ks) && this.stt.equals(dialogProcessor.stt)
+                && this.tts.equals(dialogProcessor.tts) && this.hlis.size() == dialogProcessor.hlis.size()
+                && this.hlis.containsAll(dialogProcessor.hlis) && this.locale.equals(dialogProcessor.locale)
+                && Objects.equals(this.listeningItem, dialogProcessor.listeningItem);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -127,7 +127,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
     private final Map<String, String> defaultVoices = new HashMap<>();
 
     private Map<String, DialogProcessor> dialogProcessors = new HashMap<>();
-    private ConcurrentHashMap<String, DialogProcessor> singleDialogProcessors = new ConcurrentHashMap<>();
+    private Map<String, DialogProcessor> singleDialogProcessors = new ConcurrentHashMap<>();
 
     @Activate
     public VoiceManagerImpl(final @Reference LocaleProvider localeProvider, final @Reference AudioManager audioManager,
@@ -546,7 +546,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         AudioSource audioSource = (source == null) ? audioManager.getSource() : source;
         if (audioSource != null) {
             DialogProcessor processor = dialogProcessors.remove(audioSource.getId());
-            cleanSingleDialogProcessors();
+            singleDialogProcessors.values().removeIf(e -> !e.isProcessing());
             if (processor == null) {
                 processor = singleDialogProcessors.get(audioSource.getId());
             }
@@ -606,7 +606,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
         } else {
             boolean isSingleDialog = false;
             DialogProcessor activeProcessor = dialogProcessors.get(audioSource.getId());
-            cleanSingleDialogProcessors();
+            singleDialogProcessors.values().removeIf(e -> !e.isProcessing());
             if (activeProcessor == null) {
                 isSingleDialog = true;
                 activeProcessor = singleDialogProcessors.get(audioSource.getId());
@@ -879,9 +879,5 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
             }
         }
         return null;
-    }
-
-    private void cleanSingleDialogProcessors() {
-        singleDialogProcessors.values().removeIf(e -> !e.isProcessing());
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -603,7 +603,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
             throw new IllegalStateException(
                     "Cannot execute a simple dialog as provided locale is not supported by all services.");
         } else {
-            var isSingleDialog = false;
+            boolean isSingleDialog = false;
             DialogProcessor activeProcessor = dialogProcessors.get(audioSource.getId());
             cleanSingleDialogProcessors();
             if (activeProcessor == null) {


### PR DESCRIPTION
Introduces two small changes on the Voice manager:

* Register current running single shot dialog instances so they can be stoped by the voice manager stop method.
* Allow the execution of a single dialog when calling the listenAndAnswer method with the same configurations that other dialog processor running persistently. 

Explanation on the second point: Before, any call to this method that collide by source id with a registered processor was rejected, but if you are using same configurations (ignoring the keyword),I think that makes sense to trigger a dialog execution with the registered dialog processor and the DialogProcessor class implementation already ensures that the keyword will be ignored while processing so there should be no problems on doing so.

Let me know if anything needs to be changed or improved.

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>