### PR TITLE
allow vetoing ItemCommandEvents

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
@@ -124,7 +124,8 @@ public class ScriptedAutomationManager {
             }
         }
 
-        builder.withName(name).withDescription(element.getDescription()).withTags(element.getTags());
+        builder.withName(name).withDescription(element.getDescription()).withTags(element.getTags())
+                .withSynchronous(element.isSynchronous());
 
         // used for numbering the modules of the rule
         int moduleIndex = 1;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
@@ -54,6 +54,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
     protected @NonNullByDefault({}) Set<String> tags;
     protected @NonNullByDefault({}) Visibility visibility;
     protected @Nullable String description;
+    protected boolean synchronous = false;
 
     protected transient volatile RuleStatusInfo status = new RuleStatusInfo(RuleStatus.UNINITIALIZED,
             RuleStatusDetail.NONE);
@@ -213,6 +214,20 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
         modules.addAll(conditions);
         modules.addAll(actions);
         return Collections.unmodifiableList(modules);
+    }
+
+    /**
+     * This method is used to configure a {@link Rule} to run synchronously.
+     *
+     * @param synchronous the synchronicity preference
+     */
+    public void setSynchronous(boolean synchronous) {
+        this.synchronous = synchronous;
+    }
+
+    @Override
+    public boolean isSynchronous() {
+        return synchronous;
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Rule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Rule.java
@@ -154,4 +154,16 @@ public interface Rule extends Identifiable<String> {
         }
         return null;
     }
+
+    /**
+     * This method is used to determine if the rule should be run synchronously.
+     * A synchronous rule will run in the context of the thread triggering it
+     * (likely the EventHandler thread), and as such, should not block on
+     * anything and return speedily.
+     *
+     * @return the {@link Rule}'s synchronicity preference
+     */
+    default boolean isSynchronous() {
+        return false;
+    }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTO.java
@@ -37,4 +37,5 @@ public class RuleDTO {
     public Set<String> tags;
     public Visibility visibility;
     public String description;
+    public Boolean synchronous;
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
@@ -40,7 +40,8 @@ public class RuleDTOMapper {
                 .withConfiguration(new Configuration(ruleDto.configuration))
                 .withConfigurationDescriptions(ConfigDescriptionDTOMapper.map(ruleDto.configDescriptions))
                 .withTemplateUID(ruleDto.templateUID).withVisibility(ruleDto.visibility).withTags(ruleDto.tags)
-                .withName(ruleDto.name).withDescription(ruleDto.description).build();
+                .withName(ruleDto.name).withDescription(ruleDto.description).withSynchronous(ruleDto.synchronous)
+                .build();
     }
 
     protected static void fillProperties(final Rule from, final RuleDTO to) {
@@ -55,5 +56,6 @@ public class RuleDTOMapper {
         to.tags = from.getTags();
         to.visibility = from.getVisibility();
         to.description = from.getDescription();
+        to.synchronous = from.isSynchronous();
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -590,11 +590,11 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param rule rule object for which the callback is looking for.
      * @return a {@link TriggerHandlerCallback} corresponding to the passed {@link Rule} object.
      */
-    private synchronized TriggerHandlerCallbackImpl getTriggerHandlerCallback(String ruleUID) {
-        TriggerHandlerCallbackImpl result = thCallbacks.get(ruleUID);
+    private synchronized TriggerHandlerCallbackImpl getTriggerHandlerCallback(WrappedRule rule) {
+        TriggerHandlerCallbackImpl result = thCallbacks.get(rule.getUID());
         if (result == null) {
-            result = new TriggerHandlerCallbackImpl(this, ruleUID);
-            thCallbacks.put(ruleUID, result);
+            result = new TriggerHandlerCallbackImpl(this, rule.getUID(), rule.unwrap().isSynchronous());
+            thCallbacks.put(rule.getUID(), result);
         }
         return result;
     }
@@ -630,7 +630,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     private void register(WrappedRule rule) {
         final String ruleUID = rule.getUID();
 
-        TriggerHandlerCallback thCallback = getTriggerHandlerCallback(ruleUID);
+        TriggerHandlerCallback thCallback = getTriggerHandlerCallback(rule);
         rule.getTriggers().forEach(trigger -> {
             TriggerHandler triggerHandler = trigger.getModuleHandler();
             if (triggerHandler != null) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
@@ -53,6 +53,7 @@ public class RuleImpl implements Rule {
     protected Set<String> tags;
     protected Visibility visibility;
     protected @Nullable String description;
+    protected boolean synchronous;
 
     /**
      * Constructor for creating an empty {@link Rule} with a specified rule identifier.
@@ -62,7 +63,7 @@ public class RuleImpl implements Rule {
      * @param uid the rule's identifier, or {@code null} if a random identifier should be generated.
      */
     public RuleImpl(@Nullable String uid) {
-        this(uid, null, null, null, null, null, null, null, null, null, null);
+        this(uid, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     /**
@@ -86,11 +87,13 @@ public class RuleImpl implements Rule {
      *            {@link RuleRegistry} to validate the {@link Rule}'s configuration, as well as to create and configure
      *            the {@link Rule}'s modules, or null if the {@link Rule} should not be created from a template.
      * @param visibility the {@link Rule}'s visibility
+     * @param synchronous the {@link Rule}'s synchronicity'
      */
     public RuleImpl(@Nullable String uid, final @Nullable String name, final @Nullable String description,
             final @Nullable Set<String> tags, @Nullable List<Trigger> triggers, @Nullable List<Condition> conditions,
             @Nullable List<Action> actions, @Nullable List<ConfigDescriptionParameter> configDescriptions,
-            @Nullable Configuration configuration, @Nullable String templateUID, @Nullable Visibility visibility) {
+            @Nullable Configuration configuration, @Nullable String templateUID, @Nullable Visibility visibility,
+            @Nullable Boolean synchronous) {
         this.uid = uid == null ? UUID.randomUUID().toString() : uid;
         this.name = name;
         this.description = description;
@@ -103,6 +106,7 @@ public class RuleImpl implements Rule {
                 : new Configuration(configuration.getProperties());
         this.templateUID = templateUID;
         this.visibility = visibility == null ? Visibility.VISIBLE : visibility;
+        this.synchronous = synchronous == null ? false : synchronous;
     }
 
     @Override
@@ -258,6 +262,11 @@ public class RuleImpl implements Rule {
         modules.addAll(conditions);
         modules.addAll(actions);
         return Collections.unmodifiableList(modules);
+    }
+
+    @Override
+    public boolean isSynchronous() {
+        return synchronous;
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.Module;
+import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.handler.BaseModuleHandlerFactory;
 import org.openhab.core.automation.handler.ModuleHandler;
@@ -39,6 +40,7 @@ import org.openhab.core.automation.internal.module.handler.RuleEnablementActionH
 import org.openhab.core.automation.internal.module.handler.RunRuleActionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.VetoCommandActionHandler;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.ItemRegistry;
 import org.osgi.framework.BundleContext;
@@ -71,19 +73,21 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
             GenericEventTriggerHandler.MODULE_TYPE_ID, ChannelEventTriggerHandler.MODULE_TYPE_ID,
             GenericEventConditionHandler.MODULETYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
             CompareConditionHandler.MODULE_TYPE, SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID,
-            RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
+            RuleEnablementActionHandler.UID, RunRuleActionHandler.UID, VetoCommandActionHandler.VETO_COMMAND_ACTION);
 
     private ItemRegistry itemRegistry;
     private EventPublisher eventPublisher;
+    private RuleRegistry ruleRegistry;
 
     private BundleContext bundleContext;
 
     @Activate
     public CoreModuleHandlerFactory(BundleContext bundleContext, final @Reference EventPublisher eventPublisher,
-            final @Reference ItemRegistry itemRegistry) {
+            final @Reference ItemRegistry itemRegistry, final @Reference RuleRegistry ruleRegistry) {
         this.bundleContext = bundleContext;
         this.eventPublisher = eventPublisher;
         this.itemRegistry = itemRegistry;
+        this.ruleRegistry = ruleRegistry;
     }
 
     @Override
@@ -142,6 +146,8 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
                 return new RuleEnablementActionHandler((Action) module);
             } else if (RunRuleActionHandler.UID.equals(moduleTypeUID)) {
                 return new RunRuleActionHandler((Action) module);
+            } else if (VetoCommandActionHandler.VETO_COMMAND_ACTION.equals(moduleTypeUID)) {
+                return new VetoCommandActionHandler((Action) module, ruleUID, ruleRegistry);
             }
         }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/VetoCommandActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/VetoCommandActionHandler.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.Action;
+import org.openhab.core.automation.Rule;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.handler.BaseActionModuleHandler;
+import org.openhab.core.items.events.ItemCommandEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an implementation of an ActionHandler. It vetos commands.
+ *
+ * @author Cody Cutrer - Initial contribution
+ */
+@NonNullByDefault
+public class VetoCommandActionHandler extends BaseActionModuleHandler {
+
+    public static final String VETO_COMMAND_ACTION = "core.VetoCommandAction";
+
+    private final Logger logger = LoggerFactory.getLogger(VetoCommandActionHandler.class);
+
+    private final String ruleUID;
+    private final RuleRegistry ruleRegistry;
+
+    /**
+     * constructs a new VetoCommandActionHandler
+     *
+     * @param module
+     */
+    public VetoCommandActionHandler(Action module, String ruleUID, RuleRegistry ruleRegistry) {
+        super(module);
+        this.ruleUID = ruleUID;
+        this.ruleRegistry = ruleRegistry;
+    }
+
+    @Override
+    public @Nullable Map<String, Object> execute(Map<String, Object> inputs) {
+        Object event = inputs.get("event");
+        if (event instanceof ItemCommandEvent) {
+            Rule rule = ruleRegistry.get(ruleUID);
+            if (rule == null) {
+                return null;
+            }
+            if (!rule.isSynchronous()) {
+                logger.warn("VetoCommandActionHandler attached to rule {} that is not synchronous; ignoring.", ruleUID);
+                return null;
+            }
+            ItemCommandEvent commandEvent = (ItemCommandEvent) event;
+            logger.debug("Vetoing Command {} sent to Item {}", commandEvent.getItemCommand(),
+                    commandEvent.getItemName());
+            commandEvent.veto();
+        }
+        return null;
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/RuleBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/RuleBuilder.java
@@ -51,6 +51,7 @@ public class RuleBuilder {
     private Set<String> tags;
     private @Nullable Visibility visibility;
     private @Nullable String description;
+    private @Nullable Boolean synchronous;
 
     protected RuleBuilder(Rule rule) {
         this.triggers = new LinkedList<>(rule.getTriggers());
@@ -64,6 +65,7 @@ public class RuleBuilder {
         this.tags = new HashSet<>(rule.getTags());
         this.visibility = rule.getVisibility();
         this.description = rule.getDescription();
+        this.synchronous = rule.isSynchronous();
     }
 
     public static RuleBuilder create(String ruleId) {
@@ -75,7 +77,7 @@ public class RuleBuilder {
         return create(r.getUID()).withActions(r.getActions()).withConditions(r.getConditions())
                 .withTriggers(r.getTriggers()).withConfiguration(r.getConfiguration())
                 .withConfigurationDescriptions(r.getConfigurationDescriptions()).withDescription(r.getDescription())
-                .withName(r.getName()).withTags(r.getTags());
+                .withName(r.getName()).withTags(r.getTags()).withSynchronous(r.isSynchronous());
     }
 
     public static RuleBuilder create(RuleTemplate template, String uid, @Nullable String name,
@@ -165,8 +167,13 @@ public class RuleBuilder {
         return this;
     }
 
+    public RuleBuilder withSynchronous(@Nullable Boolean synchronous) {
+        this.synchronous = synchronous;
+        return this;
+    }
+
     public Rule build() {
         return new RuleImpl(uid, name, description, tags, triggers, conditions, actions, configDescriptions,
-                configuration, templateUID, visibility);
+                configuration, templateUID, visibility, synchronous);
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ItemActions.json
@@ -119,6 +119,21 @@
 					]
 				}
 			]
+		},
+		{
+			"uid": "core.VetoCommandAction",
+			"label": "veto a command",
+			"description": "Prevents a command from being processed.",
+			"visibility": "EXPERT",
+			"inputs": [
+				{
+					"name": "event",
+					"type": "org.openhab.core.events.Event",
+					"label": "Event",
+					"description": "The event which was sent.",
+					"reference": "event"
+				}
+			]
 		}
 	]
 }

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
@@ -339,6 +339,13 @@ module-type.core.TimeOfDayCondition.config.startTime.description = Start of the 
 module-type.core.TimeOfDayCondition.config.endTime.label = End Time
 module-type.core.TimeOfDayCondition.config.endTime.description = End of the time span (in hh:mm)
 
+# core.VetoCommandAction
+
+module-type.core.VetoCommandAction.label = veto a command
+module-type.core.VetoCommandAction.description = Prevents a command from being processed.
+module-type.core.VetoCommandAction.input.event.label = Event
+module-type.core.VetoCommandAction.input.event.description = The event which was sent.
+
 # ephemeris.DaysetCondition
 
 module-type.ephemeris.DaysetCondition.label = it is a day in a configured dayset
@@ -382,6 +389,10 @@ module-type.timer.DateTimeTrigger.label = it is a date and time specified in an 
 module-type.timer.DateTimeTrigger.description = Triggers at a time specified in an item
 module-type.timer.DateTimeTrigger.config.itemName.label = Item
 module-type.timer.DateTimeTrigger.config.itemName.description = the name of the item
+module-type.timer.DateTimeTrigger.config.timeOnly.label = Time only
+module-type.timer.DateTimeTrigger.config.timeOnly.description = Specifies whether only the time of the item should be compared or the date and time.
+module-type.timer.DateTimeTrigger.config.timeOnly.option.true = Yes
+module-type.timer.DateTimeTrigger.config.timeOnly.option.false = No
 
 # timer.DayOfWeekCondition
 

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
@@ -99,4 +99,9 @@ public class EventLogger implements EventSubscriber, ReadyTracker {
     public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
         loggingActive = false;
     }
+
+    @Override
+    public int getPriority() {
+        return -1;
+    }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -206,6 +206,11 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
         }
     }
 
+    @Override
+    public int getPriority() {
+        return -1;
+    }
+
     private @Nullable Thing getThing(ThingUID thingUID) {
         return thingRegistry.get(thingUID);
     }
@@ -336,6 +341,10 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     }
 
     private void receiveCommand(ItemCommandEvent commandEvent) {
+        if (commandEvent.isVetoed()) {
+            return;
+        }
+
         final String itemName = commandEvent.getItemName();
         final Command command = commandEvent.getItemCommand();
         final Item item = getItem(itemName);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
@@ -55,4 +55,15 @@ public interface EventSubscriber {
      * @param event the received event (not null)
      */
     void receive(Event event);
+
+    /**
+     * Allows a subscriber to declare their priority in relation to other subscribers. For example
+     * to ensure that they can process an event before or after other subscribers. Lower priorities
+     * are processed later.
+     *
+     * @return the relative priority of this subscriber; default of 0.
+     */
+    default int getPriority() {
+        return 0;
+    }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
@@ -13,9 +13,9 @@
 package org.openhab.core.internal.events;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -115,7 +115,14 @@ public class EventHandler implements AutoCloseable {
         Set<EventSubscriber> eventTypeSubscribers = typedEventSubscribers.get(eventType);
         Set<EventSubscriber> allEventTypeSubscribers = typedEventSubscribers.get(EventSubscriber.ALL_EVENT_TYPES);
 
-        Set<EventSubscriber> subscribers = new HashSet<>();
+        Set<EventSubscriber> subscribers = new TreeSet<>((s1, s2) -> {
+            // order is reversed so lower priorities sort later
+            int comparison = Integer.compare(s2.getPriority(), s1.getPriority());
+            if (comparison == 0) {
+                comparison = Integer.compare(s1.hashCode(), s2.hashCode());
+            }
+            return comparison;
+        });
         if (eventTypeSubscribers != null) {
             subscribers.addAll(eventTypeSubscribers);
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemUpdater.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemUpdater.java
@@ -50,6 +50,11 @@ public class ItemUpdater extends AbstractItemEventSubscriber {
     }
 
     @Override
+    public int getPriority() {
+        return -1;
+    }
+
+    @Override
     protected void receiveUpdate(ItemStateEvent updateEvent) {
         String itemName = updateEvent.getItemName();
         State newState = updateEvent.getItemState();
@@ -87,6 +92,10 @@ public class ItemUpdater extends AbstractItemEventSubscriber {
 
     @Override
     protected void receiveCommand(ItemCommandEvent commandEvent) {
+        if (commandEvent.isVetoed()) {
+            return;
+        }
+
         try {
             Item item = itemRegistry.getItem(commandEvent.getItemName());
             if (item instanceof GroupItem) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -32,6 +32,8 @@ public class ItemCommandEvent extends ItemEvent {
 
     private final Command command;
 
+    private boolean vetoed;
+
     /**
      * Constructs a new item command event object.
      *
@@ -45,6 +47,7 @@ public class ItemCommandEvent extends ItemEvent {
             @Nullable String source) {
         super(topic, payload, itemName, source);
         this.command = command;
+        vetoed = false;
     }
 
     @Override
@@ -63,6 +66,26 @@ public class ItemCommandEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' received command %s", itemName, command);
+        if (isVetoed()) {
+            return String.format("Command %s to Item '%s' was vetoed.", command, itemName);
+        } else {
+            return String.format("Item '%s' received command %s", itemName, command);
+        }
+    }
+
+    /**
+     * Veto this event.
+     */
+    public void veto() {
+        vetoed = true;
+    }
+
+    /**
+     * Gets the veto status of this event.
+     *
+     * @return if the event has been vetoed.
+     */
+    public boolean isVetoed() {
+        return vetoed;
     }
 }

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/VetoCommandModuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/VetoCommandModuleTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.Rule;
+import org.openhab.core.automation.RuleManager;
+import org.openhab.core.automation.RuleRegistry;
+import org.openhab.core.automation.RuleStatus;
+import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.util.ModuleBuilder;
+import org.openhab.core.automation.util.RuleBuilder;
+import org.openhab.core.common.registry.ProviderChangeListener;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.ItemProvider;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.events.ItemCommandEvent;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.types.UnDefType;
+import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This tests the VetoCommandAction
+ *
+ * @author Cody Cutrer - Initial contribution
+ */
+@NonNullByDefault
+public class VetoCommandModuleTest extends JavaOSGiTest {
+
+    private final Logger logger = LoggerFactory.getLogger(VetoCommandModuleTest.class);
+    private final VolatileStorageService volatileStorageService = new VolatileStorageService();
+
+    @BeforeEach
+    public void before() {
+        registerService(new ItemProvider() {
+            @Override
+            public void addProviderChangeListener(final ProviderChangeListener<Item> listener) {
+            }
+
+            @Override
+            public void removeProviderChangeListener(final ProviderChangeListener<Item> listener) {
+            }
+
+            @Override
+            public Collection<Item> getAll() {
+                return List.of(new SwitchItem("switch1"));
+            }
+        });
+        registerService(volatileStorageService);
+
+        // start rule engine
+        RuleEngineImpl ruleEngine = Objects.requireNonNull((RuleEngineImpl) getService(RuleManager.class));
+        ruleEngine.onReadyMarkerAdded(new ReadyMarker("", ""));
+        waitForAssert(() -> assertTrue(ruleEngine.isStarted()));
+    }
+
+    private Rule createRule() {
+        final Configuration triggerConfig = new Configuration(Map.ofEntries(entry("itemName", "switch1")));
+
+        final Rule vetoRule = RuleBuilder.create("exampleVetoRule")
+                .withTriggers(ModuleBuilder.createTrigger().withId("trigger1").withTypeUID("core.ItemCommandTrigger")
+                        .withConfiguration(triggerConfig).build())
+                .withActions(ModuleBuilder.createAction().withId("action1").withTypeUID("core.VetoCommandAction")
+                        .withInputs(Map.ofEntries(entry("event", "trigger1.event"))).build())
+                .withName("Example Veto").withSynchronous(true).build();
+
+        return vetoRule;
+    }
+
+    @Test
+    public void commandVetoed() throws ItemNotFoundException, InterruptedException {
+        final RuleRegistry ruleRegistry = getService(RuleRegistry.class);
+        final RuleManager ruleEngine = getService(RuleManager.class);
+        assertNotNull(ruleRegistry);
+
+        final Rule vetoRule = createRule();
+        logger.info("vetoRule created: {}", vetoRule.getUID());
+
+        ruleRegistry.add(vetoRule);
+        ruleEngine.setEnabled(vetoRule.getUID(), true);
+        waitForAssert(() -> {
+            assertEquals(RuleStatus.IDLE, ruleEngine.getStatusInfo(vetoRule.getUID()).getStatus());
+        });
+
+        final EventPublisher eventPublisher = getService(EventPublisher.class);
+        assertNotNull(eventPublisher);
+
+        final ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        assertNotNull(itemRegistry);
+
+        final Queue<Event> events = new LinkedList<>();
+        subscribeToEvents(ItemCommandEvent.TYPE, events);
+
+        // trigger rule
+        eventPublisher.post(ItemEventFactory.createCommandEvent("switch1", OnOffType.ON));
+        waitForAssert(() -> {
+            assertFalse(events.isEmpty());
+            ItemCommandEvent event = (ItemCommandEvent) events.remove();
+            assertEquals("openhab/items/switch1/command", event.getTopic());
+            assertEquals(OnOffType.ON, event.getItemCommand());
+        });
+
+        // wait a few milliseconds for any further commands to process
+        Thread.sleep(100);
+
+        final Item switch1 = itemRegistry.get("switch1");
+        // ensure the item didn't turn on
+        assertEquals(UnDefType.NULL, switch1.getState());
+    }
+
+    private void subscribeToEvents(String eventType, final Queue<Event> events) {
+        EventSubscriber eventSubscriber = new EventSubscriber() {
+            @Override
+            public void receive(final Event event) {
+                logger.info("Event: {}", event.getTopic());
+                events.add(event);
+            }
+
+            @Override
+            public Set<String> getSubscribedEventTypes() {
+                return Set.of(eventType);
+            }
+
+            @Override
+            public @Nullable EventFilter getEventFilter() {
+                return null;
+            }
+        };
+
+        ServiceReference<?> subscriberReference = registerService(eventSubscriber).getReference();
+        assertNotNull(getServices(EventSubscriber.class, (reference) -> reference.equals(subscriberReference)));
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -350,6 +350,16 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     }
 
     @Test
+    public void testItemCommandEventVetoed() {
+        var event = ItemEventFactory.createCommandEvent(ITEM_NAME_1, OnOffType.ON);
+        event.veto();
+        manager.receive(event);
+        verifyNoMoreInteractions(stateProfileMock);
+        verifyNoMoreInteractions(triggerProfileMock);
+        verifyNoMoreInteractions(autoUpdateManagerMock);
+    }
+
+    @Test
     public void testItemStateEventSingleLink() {
         manager.receive(ItemEventFactory.createStateEvent(ITEM_NAME_2, OnOffType.ON));
         waitForAssert(() -> {


### PR DESCRIPTION
Prevents ItemUpdater from forwarding a vetoed command to a group, and CommunicationManager from forwarding a vetoed command to a linked channel _or_ AutoUpdateManager.

This encompasses several components to enable it:

 * Adding a veto method to ItemCommandEvent
 * Having CommunicationManager and ItemUpdater ignore vetoed command events.
 * Ensuring CommunicationManager (and thus AutoUpdateManager) and ItemUpdater have a lower priority to process the event after rules have had a chance to veto the event.
   * This involves adding a priority concept to EventHandler/ EventSubscriber; it defaults to a priority of 0
 * Adding a way to make rules run synchronously, so that their veto can be processed before CommunicationManager et. al. without race conditions
   * This includes extending rule builder and DTO
 * Adding a VetoCommandAction module for use from rules.

Note that the event must be vetoed by another EventSubscriber with a higher priority than ItemUpdater or AutoUpdateManager. The intercepting subscriber must veto it synchronously. This is safe since EventHandler has a single thread for processing events to subscribers. That said, any rule that opts in to synchronous processing in order to be able to veto commands _must not_ use any blocking actions, since they're now run in the EventHandler thread.

As of yet there is limited UI support (the VetoCommandAction is set to EXPERT visibility, which means the rule must already have it -- or configure it in the Code view of a rule -- in order to be editable). And AFAICT zero possibility to set the rule as synchronous, in order for it to work. That leaves script-created rules that can access the setSynchronous method (my expected use case), and possibly editing rule configuration files directly. I think this is fine, since this is a potentially dangerous feature. You do NOT want to block on the event handler thread. A future direction that we may take is having module types declare themselves synchronous-safe, and only list those modules when you set a rule to synchronous. It's envisaged that rules that veto commands will be very simple - essentially just checking the state of some other item(s). No web requests, no execs, no timers, etc.