### PR TITLE
[auth] Grant implicit user role by network

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/restauth.xml
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/resources/OH-INF/config/restauth.xml
@@ -12,6 +12,12 @@
 				authentication to break.</description>
 			<default>true</default>
 		</parameter>
+		<parameter name="trustedNetworks" type="text">
+			<advanced>true</advanced>
+			<label>Trusted Networks</label>
+			<description>Comma separate list of CDIR, to grant implicit user role to request originated from these networks
+				(ignored if "Implicit User Role" is enabled).</description>
+		</parameter>
 		<parameter name="allowBasicAuth" type="boolean">
 			<advanced>true</advanced>
 			<label>Allow Basic Authentication</label>


### PR DESCRIPTION
This PR introduces a new advanced option on the Api Security settings to define a list comma separated CDIR, to grant the requests originated from those networks with an implicit user role.
 
This configuration is ignored when "implicit user role" option is enabled.

For me it covers to necessities:
* Allowing the Alexa skill to work the "implicit user role" option is disabled.
* Allowing me to have an "Implicit user role" when I'm inside my house but always require credentials when I'm accessing through my domine.

Hope everything is in place and let me know if any documentation update is needed.

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>