### PR TITLE
[core.thing] Prefer concurrent collector with parallel streams

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -184,7 +185,9 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             if (forLinkedUID == null) {
                 return Set.of();
             }
-            return forLinkedUID.parallelStream().map(link -> link.getItemName()).collect(Collectors.toSet());
+            return forLinkedUID.parallelStream().map(link -> link.getItemName())
+                    // collect to concurrent set, similar to collecting to ConcurrentHashMap.newKeySet()
+                    .collect(Collectors.toConcurrentMap(Function.identity(), x -> Boolean.TRUE)).keySet();
         } finally {
             toLinkLock.readLock().unlock();
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
@@ -99,7 +99,7 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
      * @return an unmodifiable set of bound things for the given item name
      */
     public Set<Thing> getBoundThings(final String itemName) {
-        return ((Stream<Thing>) getBoundChannels(itemName).parallelStream()// XX
+        return ((Stream<Thing>) getBoundChannels(itemName).parallelStream()
                 .map(channelUID -> thingRegistry.get(channelUID.getThingUID())).filter(Objects::nonNull))
                         // collect to concurrent set, similar to collecting to ConcurrentHashMap.newKeySet()
                         .collect(Collectors.toConcurrentMap(Function.identity(), x -> Boolean.TRUE)).keySet();

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
@@ -90,7 +90,6 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
                 .map(itemName -> itemRegistry.get(itemName)).filter(Objects::nonNull))
                         // collect to concurrent set, similar to collecting to ConcurrentHashMap.newKeySet()
                         .collect(Collectors.toConcurrentMap(Function.identity(), x -> Boolean.TRUE)).keySet();
-
     }
 
     /**


### PR DESCRIPTION
This should avoid behind-the-scenes serial behaviour when collecting to set (the assumption is that Collectors.toSet does not expose CONCURRENT characteristic).

See for more information https://stackoverflow.com/a/41045442

Signed-off-by: Sami Salonen <ssalonen@gmail.com>