### PR TITLE
[automation] Add more basic time-related classes for usage in script and rules

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
@@ -17,7 +17,9 @@ import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -159,7 +161,9 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
 
         // date time static functions
         elements.put("ChronoUnit", ChronoUnit.class);
+        elements.put("DayOfWeek", DayOfWeek.class);
         elements.put("Duration", Duration.class);
+        elements.put("Month", Month.class);
         elements.put("ZoneId", ZoneId.class);
         elements.put("ZonedDateTime", ZonedDateTime.class);
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -15,7 +15,9 @@ package org.openhab.core.model.script.scoping;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URLEncoder;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -104,7 +106,9 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
 
         // date time static functions
         result.add(ChronoUnit.class);
+        result.add(DayOfWeek.class);
         result.add(Duration.class);
+        result.add(Month.class);
         result.add(ZoneId.class);
         result.add(ZonedDateTime.class);
 


### PR DESCRIPTION
- Add more basic time-related classes for usage in script and rules

Allows comparisons like `new DateTimeType().zonedDateTime.getDayOfWeek() = DayOfWeek.MONDAY` or `new DateTimeType().zonedDateTime.getMonth() = Month.APRIL` in rules or scripts.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>