### PR TITLE
[mqtt] Properly process retained messages

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
@@ -76,7 +76,8 @@ public class Subscription {
     public void messageArrived(String topic, byte[] payload, boolean retain) {
         // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349265
         // Only the first message delivered will have the retain flag; subsequent messages
-        //
+        // will not have the flag set. So see if we retained it in the past, and continue
+        // to retain it (even if it's now empty - we need to know to continue to retain it)
         if (retain || retainedMessages.containsKey(topic)) {
             retainedMessages.put(topic, payload);
         }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -47,9 +47,14 @@ import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
 @NonNullByDefault
 public class MqttBrokerConnectionTests extends JavaTest {
     private static final byte[] HELLO_BYTES = "hello".getBytes();
+    private static final byte[] GOODBYE_BYTES = "goodbye".getBytes();
 
     private static byte[] eqHelloBytes() {
         return eq(HELLO_BYTES);
+    }
+
+    private static byte[] eqGoodbyeBytes() {
+        return eq(GOODBYE_BYTES);
     }
 
     @Test
@@ -138,6 +143,28 @@ public class MqttBrokerConnectionTests extends JavaTest {
 
         // Remove subscriber (while connected)
         assertTrue(connection.unsubscribe("topic", subscriber).get(200, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void retain()
+            throws ConfigurationException, MqttException, InterruptedException, ExecutionException, TimeoutException {
+        MqttBrokerConnectionEx connection = new MqttBrokerConnectionEx("123.123.123.123", null, false, false,
+                "MqttBrokerConnectionTests");
+
+        MqttMessageSubscriber subscriber1 = mock(MqttMessageSubscriber.class);
+        MqttMessageSubscriber subscriber2 = mock(MqttMessageSubscriber.class);
+        connection.subscribe("topic", subscriber1);
+
+        Mqtt3Publish publishMessage = Mqtt3Publish.builder().topic("topic").payload(HELLO_BYTES).retain(true).build();
+        connection.getSubscribers().get("topic").messageArrived(publishMessage);
+
+        publishMessage = Mqtt3Publish.builder().topic("topic").payload(GOODBYE_BYTES).build();
+        connection.getSubscribers().get("topic").messageArrived(publishMessage);
+
+        connection.subscribe("topic", subscriber2);
+
+        // the retained message was updated even though the subsequent message didn't have the retained flag
+        verify(subscriber2).processMessage(eq("topic"), eqGoodbyeBytes());
     }
 
     @Test


### PR DESCRIPTION
Only the _first_ message has the retained flag (always on MQTT3, there is a flag to forward the retain flag on all messages with MQTT5, but we don't set it), so we have to keep track of previously retained messages as well.

This shows up as when a thing comes back online and re-subscribes to a retained message that another thing subscribed to also, it won't see any changes that happened to that topic since the very first message was received.
