### PR TITLE
Fix ItemStateCondition for PercentType values

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -30,6 +30,7 @@ import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.events.ItemAddedEvent;
 import org.openhab.core.items.events.ItemRemovedEvent;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.State;
@@ -166,6 +167,12 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
             } else if (compareState instanceof QuantityType) {
                 return qtState.compareTo((QuantityType) compareState) <= 0;
             }
+        } else if (itemState instanceof PercentType && null != compareState) {
+            // we need to handle PercentType first, otherwise the comparison will fail
+            PercentType percentState = compareState.as(PercentType.class);
+            if (null != percentState) {
+                return ((PercentType) itemState).compareTo(percentState) <= 0;
+            }
         } else if (itemState instanceof DecimalType && null != compareState) {
             DecimalType decimalState = compareState.as(DecimalType.class);
             if (null != decimalState) {
@@ -194,6 +201,12 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
                         new QuantityType<>(((DecimalType) compareState).toBigDecimal(), qtState.getUnit())) >= 0;
             } else if (compareState instanceof QuantityType) {
                 return qtState.compareTo((QuantityType) compareState) >= 0;
+            }
+        } else if (itemState instanceof PercentType && null != compareState) {
+            // we need to handle PercentType first, otherwise the comparison will fail
+            PercentType percentState = compareState.as(PercentType.class);
+            if (null != percentState) {
+                return ((PercentType) itemState).compareTo(percentState) >= 0;
             }
         } else if (itemState instanceof DecimalType && null != compareState) {
             DecimalType decimalState = compareState.as(DecimalType.class);


### PR DESCRIPTION
Dimmer items return their state as PercentType. The code did not properly handle PercentType because PercentType is a subclass of DecimalType. One value was converted by casting the value to DecimalType (which leads to 40 for 40%) while the other one used `.as` (which results in 0.4 for 40%). A comparison "state <= 50" with state = 20 is therefore executed as "20 <= 0.5"  which is not what the user would expect.

Reported on the forum.

Signed-off-by: Jan N. Klug <github@klug.nrw>