### PR TITLE
Avoid parallel streams with common thread pool to avoid deadlocks

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
@@ -44,7 +44,7 @@ public class Subscription {
     public void add(MqttMessageSubscriber subscriber) {
         if (subscribers.add(subscriber)) {
             // new subscriber. deliver all known retained messages
-            retainedMessages.entrySet().parallelStream().forEach(entry -> {
+            retainedMessages.entrySet().stream().forEach(entry -> {
                 if (entry.getValue().length > 0) {
                     processMessage(subscriber, entry.getKey(), entry.getValue());
                 }
@@ -81,7 +81,7 @@ public class Subscription {
         if (retain || retainedMessages.containsKey(topic)) {
             retainedMessages.put(topic, payload);
         }
-        subscribers.parallelStream().forEach(subscriber -> processMessage(subscriber, topic, payload));
+        subscribers.stream().forEach(subscriber -> processMessage(subscriber, topic, payload));
     }
 
     private void processMessage(MqttMessageSubscriber subscriber, String topic, byte[] payload) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -135,8 +135,7 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             if (forItemName == null || forLinkedUID == null) {
                 return false;
             } else {
-                boolean commonItems = !Collections.disjoint(forItemName, forLinkedUID);
-                return commonItems;
+                return !Collections.disjoint(forItemName, forLinkedUID);
             }
         } finally {
             toLinkLock.readLock().unlock();

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.link;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -134,7 +135,8 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             if (forItemName == null || forLinkedUID == null) {
                 return false;
             } else {
-                return forItemName.parallelStream().anyMatch(forLinkedUID::contains);
+                boolean commonItems = !Collections.disjoint(forItemName, forLinkedUID);
+                return commonItems;
             }
         } finally {
             toLinkLock.readLock().unlock();
@@ -184,7 +186,7 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             if (forLinkedUID == null) {
                 return Set.of();
             }
-            return forLinkedUID.parallelStream().map(link -> link.getItemName()).collect(Collectors.toSet());
+            return forLinkedUID.stream().map(link -> link.getItemName()).collect(Collectors.toSet());
         } finally {
             toLinkLock.readLock().unlock();
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
@@ -67,12 +67,12 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
      * @return an unmodifiable set of bound channels for the given item name
      */
     public Set<ChannelUID> getBoundChannels(final String itemName) {
-        return getLinks(itemName).parallelStream().map(link -> link.getLinkedUID()).collect(Collectors.toSet());
+        return getLinks(itemName).stream().map(link -> link.getLinkedUID()).collect(Collectors.toSet());
     }
 
     @Override
     public Set<String> getLinkedItemNames(final UID uid) {
-        return super.getLinkedItemNames(uid).parallelStream().filter(itemName -> itemRegistry.get(itemName) != null)
+        return super.getLinkedItemNames(uid).stream().filter(itemName -> itemRegistry.get(itemName) != null)
                 .collect(Collectors.toSet());
     }
 
@@ -83,8 +83,8 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
      * @return an unmodifiable set of bound items for the given channel UID
      */
     public Set<Item> getLinkedItems(final UID uid) {
-        return ((Stream<Item>) super.getLinkedItemNames(uid).parallelStream()
-                .map(itemName -> itemRegistry.get(itemName)).filter(Objects::nonNull)).collect(Collectors.toSet());
+        return ((Stream<Item>) super.getLinkedItemNames(uid).stream().map(itemName -> itemRegistry.get(itemName))
+                .filter(Objects::nonNull)).collect(Collectors.toSet());
     }
 
     /**
@@ -94,7 +94,7 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
      * @return an unmodifiable set of bound things for the given item name
      */
     public Set<Thing> getBoundThings(final String itemName) {
-        return ((Stream<Thing>) getBoundChannels(itemName).parallelStream()
+        return ((Stream<Thing>) getBoundChannels(itemName).stream()
                 .map(channelUID -> thingRegistry.get(channelUID.getThingUID())).filter(Objects::nonNull))
                         .collect(Collectors.toSet());
     }


### PR DESCRIPTION
To mitigate issue #3125 (common thread pool exhaustion when combining parallel streams with `synchronization` or locks)

Signed-off-by: Sami Salonen <ssalonen@gmail.com>