### PR TITLE
Fix missing stateDescriptionProvider in Group items

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
@@ -293,14 +293,14 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setUnitProvider(UnitProvider unitProvider) {
+    public void setUnitProvider(UnitProvider unitProvider) {
         this.unitProvider = unitProvider;
         for (Item item : getItems()) {
             ((GenericItem) item).setUnitProvider(unitProvider);
         }
     }
 
-    protected void unsetUnitProvider(UnitProvider unitProvider) {
+    public void unsetUnitProvider(UnitProvider unitProvider) {
         this.unitProvider = null;
         for (Item item : getItems()) {
             ((GenericItem) item).setUnitProvider(null);
@@ -455,7 +455,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setStateDescriptionService(StateDescriptionService stateDescriptionService) {
+    public void setStateDescriptionService(StateDescriptionService stateDescriptionService) {
         this.stateDescriptionService = stateDescriptionService;
 
         for (Item item : getItems()) {
@@ -463,7 +463,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         }
     }
 
-    protected void unsetStateDescriptionService(StateDescriptionService stateDescriptionService) {
+    public void unsetStateDescriptionService(StateDescriptionService stateDescriptionService) {
         this.stateDescriptionService = null;
 
         for (Item item : getItems()) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -27,6 +27,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.service.CommandDescriptionService;
+import org.openhab.core.service.StateDescriptionService;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
@@ -225,14 +227,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         members.clear();
     }
 
-    @Override
-    public void setUnitProvider(@Nullable UnitProvider unitProvider) {
-        super.setUnitProvider(unitProvider);
-        if (baseItem != null && baseItem instanceof GenericItem) {
-            ((GenericItem) baseItem).setUnitProvider(unitProvider);
-        }
-    }
-
     /**
      * The accepted data types of a group item is the same as of the underlying base item.
      * If none is defined, the intersection of all sets of accepted data types of all group
@@ -393,6 +387,30 @@ public class GroupItem extends GenericItem implements StateChangeListener {
             this.state = state;
         }
         notifyListeners(oldState, state);
+    }
+
+    @Override
+    public void setStateDescriptionService(@Nullable StateDescriptionService stateDescriptionService) {
+        super.setStateDescriptionService(stateDescriptionService);
+        if (baseItem instanceof GenericItem) {
+            ((GenericItem) baseItem).setStateDescriptionService(stateDescriptionService);
+        }
+    }
+
+    @Override
+    public void setCommandDescriptionService(@Nullable CommandDescriptionService commandDescriptionService) {
+        super.setCommandDescriptionService(commandDescriptionService);
+        if (baseItem instanceof GenericItem) {
+            ((GenericItem) baseItem).setCommandDescriptionService(commandDescriptionService);
+        }
+    }
+
+    @Override
+    public void setUnitProvider(@Nullable UnitProvider unitProvider) {
+        super.setUnitProvider(unitProvider);
+        if (baseItem instanceof GenericItem) {
+            ((GenericItem) baseItem).setUnitProvider(unitProvider);
+        }
     }
 
     private void sendGroupStateChangedEvent(String memberName, State newState, State oldState) {

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -383,15 +383,11 @@ public class ItemRegistryImplTest extends JavaTest {
     public void assertStateDescriptionServiceGetsInjected() {
         GenericItem item = spy(new SwitchItem("Item1"));
         NumberItem baseItem = spy(new NumberItem("baseItem"));
-        GenericItem group = new GroupItem( "Group", baseItem);
+        GenericItem group = new GroupItem("Group", baseItem);
         itemProvider.add(item);
         itemProvider.add(group);
 
-        verify(item).setStateDescriptionService(null);
-
-        ((ItemRegistryImpl) itemRegistry).setStateDescriptionService(mock(StateDescriptionService.class));
         verify(item).setStateDescriptionService(any(StateDescriptionService.class));
-
         verify(baseItem).setStateDescriptionService(any(StateDescriptionService.class));
     }
 
@@ -399,15 +395,11 @@ public class ItemRegistryImplTest extends JavaTest {
     public void assertUnitProviderGetsInjected() {
         GenericItem item = spy(new SwitchItem("Item1"));
         NumberItem baseItem = spy(new NumberItem("baseItem"));
-        GenericItem group = new GroupItem( "Group", baseItem);
+        GenericItem group = new GroupItem("Group", baseItem);
         itemProvider.add(item);
         itemProvider.add(group);
 
-        verify(item).setUnitProvider(null);
-
-        ((ItemRegistryImpl) itemRegistry).setUnitProvider(mock(UnitProvider.class));
         verify(item).setUnitProvider(any(UnitProvider.class));
-
         verify(baseItem).setUnitProvider(any(UnitProvider.class));
     }
 
@@ -415,7 +407,7 @@ public class ItemRegistryImplTest extends JavaTest {
     public void assertCommandDescriptionServiceGetsInjected() {
         GenericItem item = spy(new SwitchItem("Item1"));
         NumberItem baseItem = spy(new NumberItem("baseItem"));
-        GenericItem group = new GroupItem( "Group", baseItem);
+        GenericItem group = new GroupItem("Group", baseItem);
         itemProvider.add(item);
         itemProvider.add(group);
 

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -380,14 +380,51 @@ public class ItemRegistryImplTest extends JavaTest {
     }
 
     @Test
+    public void assertStateDescriptionServiceGetsInjected() {
+        GenericItem item = spy(new SwitchItem("Item1"));
+        NumberItem baseItem = spy(new NumberItem("baseItem"));
+        GenericItem group = new GroupItem( "Group", baseItem);
+        itemProvider.add(item);
+        itemProvider.add(group);
+
+        verify(item).setStateDescriptionService(null);
+
+        ((ItemRegistryImpl) itemRegistry).setStateDescriptionService(mock(StateDescriptionService.class));
+        verify(item).setStateDescriptionService(any(StateDescriptionService.class));
+
+        verify(baseItem).setStateDescriptionService(any(StateDescriptionService.class));
+    }
+
+    @Test
+    public void assertUnitProviderGetsInjected() {
+        GenericItem item = spy(new SwitchItem("Item1"));
+        NumberItem baseItem = spy(new NumberItem("baseItem"));
+        GenericItem group = new GroupItem( "Group", baseItem);
+        itemProvider.add(item);
+        itemProvider.add(group);
+
+        verify(item).setUnitProvider(null);
+
+        ((ItemRegistryImpl) itemRegistry).setUnitProvider(mock(UnitProvider.class));
+        verify(item).setUnitProvider(any(UnitProvider.class));
+
+        verify(baseItem).setUnitProvider(any(UnitProvider.class));
+    }
+
+    @Test
     public void assertCommandDescriptionServiceGetsInjected() {
         GenericItem item = spy(new SwitchItem("Item1"));
+        NumberItem baseItem = spy(new NumberItem("baseItem"));
+        GenericItem group = new GroupItem( "Group", baseItem);
         itemProvider.add(item);
+        itemProvider.add(group);
 
         verify(item).setCommandDescriptionService(null);
 
         ((ItemRegistryImpl) itemRegistry).setCommandDescriptionService(mock(CommandDescriptionService.class));
         verify(item).setCommandDescriptionService(any(CommandDescriptionService.class));
+
+        verify(baseItem).setCommandDescriptionService(any(CommandDescriptionService.class));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2449 

The stateDescriptionProvider was not properly passed to the base item. Because of that units set in the state description were not properly used when setting the griup state after calculating aggregation functions.

Signed-off-by: Jan N. Klug <github@klug.nrw>