### PR TITLE
Allow profiles to access the entire context of the link they're applied to

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -65,6 +65,11 @@ public class ProfileCallbackImpl implements ProfileCallback {
     }
 
     @Override
+    public ItemChannelLink getItemChannelLink() {
+        return link;
+    }
+
+    @Override
     public void handleCommand(Command command) {
         Thing thing = thingProvider.apply(link.getLinkedUID().getThingUID());
         if (thing != null) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing.profiles;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -23,6 +24,13 @@ import org.openhab.core.types.State;
  */
 @NonNullByDefault
 public interface ProfileCallback {
+
+    /**
+     * Get the link that this profile is associated with.
+     * 
+     * @return The ItemChannelLink
+     */
+    ItemChannelLink getItemChannelLink();
 
     /**
      * Forward the given command to the respective thing handler.


### PR DESCRIPTION
So that they can vary their processing based on the item or channeluid itself, instead of (or in addition to) solely on the prior states passing through it.

This was inspired by/extracted from #3135, since that PR is still being discussed.