### PR TITLE
Strip unit if NumberItem has no dimension

### DIFF
--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
@@ -72,6 +72,10 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                     item = new NumberItem(ITEM_NAME);
                     ((NumberItem) item).setState(itemState);
                     break;
+                case "Number:Temperature":
+                    item = new NumberItem("Number:Temperature", ITEM_NAME);
+                    ((NumberItem) item).setState(itemState);
+                    break;
                 case "Dimmer":
                     item = new DimmerItem(ITEM_NAME);
                     ((DimmerItem) item).setState(itemState);
@@ -89,15 +93,16 @@ public class ItemStateConditionHandlerTest extends JavaTest {
         return Arrays.asList(new Object[][] { //
                 { new ParameterSet("Number", "5", new DecimalType(23), false) }, //
                 { new ParameterSet("Number", "5", new DecimalType(5), true) }, //
-                { new ParameterSet("Number", "5 °C", new DecimalType(23), false) }, //
-                { new ParameterSet("Number", "5 °C", new DecimalType(5), false) }, //
-                { new ParameterSet("Number", "0", new QuantityType<>(), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT), true) }, //
-                { new ParameterSet("Number", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) } });
+                { new ParameterSet("Number:Temperature", "5 °C", new DecimalType(23), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new DecimalType(5), false) }, //
+                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT),
+                        true) }, //
+                { new ParameterSet("Number:Temperature", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) } });
     }
 
     public static Collection<Object[]> greaterThanParameters() {
@@ -106,11 +111,11 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5", new DecimalType(5), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), false) }, //
-                { new ParameterSet("Number", "0", new QuantityType<>(), false) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), false) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Dimmer", "20", new PercentType(40), true) }, //
                 { new ParameterSet("Dimmer", "20", new PercentType(20), false) } });
     }
@@ -123,15 +128,16 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), false) }, //
-                { new ParameterSet("Number", "0", new QuantityType<>(), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(4, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT), true) }, //
-                { new ParameterSet("Number", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT),
+                        true) }, //
+                { new ParameterSet("Number:Temperature", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Dimmer", "20", new PercentType(40), true) }, //
                 { new ParameterSet("Dimmer", "40", new PercentType(20), false) } });
     }
@@ -142,11 +148,11 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5", new DecimalType(4), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), true) }, //
-                { new ParameterSet("Number", "0", new QuantityType<>(), false) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), false) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Dimmer", "40", new PercentType(20), true) }, //
                 { new ParameterSet("Dimmer", "20", new PercentType(20), false) } });
     }
@@ -159,15 +165,16 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), true) }, //
-                { new ParameterSet("Number", "0", new QuantityType<>(), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
-                { new ParameterSet("Number", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT), true) }, //
-                { new ParameterSet("Number", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
+                { new ParameterSet("Number:Temperature", "0 °C", new QuantityType<>(32, ImperialUnits.FAHRENHEIT),
+                        true) }, //
+                { new ParameterSet("Number:Temperature", "32 °F", new QuantityType<>(0, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Dimmer", "20", new PercentType(40), false) }, //
                 { new ParameterSet("Dimmer", "40", new PercentType(20), true) } });
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -81,7 +81,12 @@ public class NumberItem extends GenericItem {
     }
 
     public void send(QuantityType command) {
-        internalSend(command);
+        if (dimension == null) {
+            DecimalType strippedCommand = new DecimalType(command.toBigDecimal());
+            internalSend(strippedCommand);
+        } else {
+            internalSend(command);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -109,6 +109,13 @@ public class NumberItem extends GenericItem {
 
     @Override
     public void setState(State state) {
+        // QuantityType update to a NumberItem without, strip unit
+        if (state instanceof QuantityType && dimension == null) {
+            DecimalType plainState = new DecimalType(((QuantityType<?>) state).toBigDecimal());
+            super.setState(plainState);
+            return;
+        }
+
         // DecimalType update for a NumberItem with dimension, convert to QuantityType:
         if (state instanceof DecimalType && dimension != null) {
             Unit<?> unit = getUnit();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -160,8 +160,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
      *
      * @param value the non null measurement value.
      * @param unit the non null measurement unit.
-     * @param conversionUnits the optional unit map which is used to determine the {@link MeasurementSystem} specific
-     *            unit for conversion.
      */
     public QuantityType(Number value, Unit<T> unit) {
         // Avoid scientific notation for double

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
@@ -23,11 +23,14 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.PercentType;
@@ -129,6 +132,40 @@ public class NumberItemTest {
         item.setState(new QuantityType<>("10 A")); // should not be accepted as valid state
 
         assertThat(item.getState(), is(UnDefType.NULL));
+    }
+
+    @Test
+    public void testCommandUnitIsPassedForDimensionItem() {
+        NumberItem item = new NumberItem("Number:Temperature", ITEM_NAME);
+        UnitProvider unitProvider = mock(UnitProvider.class);
+        when(unitProvider.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+        item.setUnitProvider(unitProvider);
+        EventPublisher eventPublisher = mock(EventPublisher.class);
+        item.setEventPublisher(eventPublisher);
+
+        QuantityType<?> command = new QuantityType<>("15 °C");
+        item.send(new QuantityType<>("15 °C"));
+
+        ArgumentCaptor<ItemCommandEvent> captor = ArgumentCaptor.forClass(ItemCommandEvent.class);
+        verify(eventPublisher).post(captor.capture());
+
+        ItemCommandEvent event = captor.getValue();
+        assertThat(event.getItemCommand(), is(new QuantityType<>("15 °C")));
+    }
+
+    @Test
+    public void testCommandUnitIsStrippedForDimensionlessItem() {
+        NumberItem item = new NumberItem("Number", ITEM_NAME);
+        EventPublisher eventPublisher = mock(EventPublisher.class);
+        item.setEventPublisher(eventPublisher);
+
+        item.send(new QuantityType<>("15 °C"));
+
+        ArgumentCaptor<ItemCommandEvent> captor = ArgumentCaptor.forClass(ItemCommandEvent.class);
+        verify(eventPublisher).post(captor.capture());
+
+        ItemCommandEvent event = captor.getValue();
+        assertThat(event.getItemCommand(), is(new DecimalType("15")));
     }
 
     @SuppressWarnings("null")

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
@@ -105,6 +105,14 @@ public class NumberItemTest {
     }
 
     @Test
+    public void testSetQuantityOnPlainNumberStripsUnit() {
+        NumberItem item = new NumberItem(ITEM_NAME);
+        item.setState(new QuantityType<>("20 °C"));
+
+        assertThat(item.getState(), is(new DecimalType("20")));
+    }
+
+    @Test
     public void testSetQuantityTypeConverted() {
         NumberItem item = new NumberItem("Number:Temperature", ITEM_NAME);
         item.setState(new QuantityType<>(68, ImperialUnits.FAHRENHEIT));


### PR DESCRIPTION
Related to #3121 

As discussed in the linked issue: The state of a `Number` item (i.e. without dimension) is expected to be `DecimalType` without a unit. If a state update is posted or command received that is of `QuantityType` the unit should be stripped to ensure that.

Signed-off-by: Jan N. Klug <github@klug.nrw>