### PR TITLE
[auth] Fix wrong parameter on AuthorizePageServlet

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthorizePageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthorizePageServlet.java
@@ -133,7 +133,7 @@ public class AuthorizePageServlet extends AbstractAuthPageServlet {
 
             String baseRedirectUri = params.get("redirect_uri")[0];
             String responseType = params.get("response_type")[0];
-            String clientId = params.get("redirect_uri")[0];
+            String clientId = params.get("client_id")[0];
             String scope = params.get("scope")[0];
 
             if (!"code".equals(responseType)) {


### PR DESCRIPTION
Found this small bug while reading the authorization code.

Edit: couple of lines after is enforcing the client id to match the refresh token which is now always true. 

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>