### PR TITLE
Refactor ScriptExecution to plain Java ScriptExtension

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.action;
+
+import java.time.ZonedDateTime;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ScriptExecution} is a
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public interface ScriptExecution {
+    /**
+     * Calls a script which must be located in the configurations/scripts folder.
+     *
+     * @param scriptName the name of the script (if the name does not end with
+     *            the .script file extension it is added)
+     * @return the return value of the script
+     */
+    Object callScript(String scriptName);
+
+    /**
+     * Schedules a block of code for later execution.
+     *
+     * @param instant the point in time when the code should be executed
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    Timer createTimer(ZonedDateTime instant, Runnable closure);
+
+    /**
+     * Schedules a block of code for later execution.
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable closure);
+
+    /**
+     * Schedules a block of code (with argument) for later execution
+     *
+     * @param instant the point in time when the code should be executed
+     * @param arg1 the argument to pass to the code block
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> closure);
+
+    /**
+     * Schedules a block of code (with argument) for later execution
+     *
+     * @param identifier an optional identifier
+     * @param instant the point in time when the code should be executed
+     * @param arg1 the argument to pass to the code block
+     * @param closure the code block to execute
+     * @return a handle to the created timer, so that it can be canceled or rescheduled
+     */
+    Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
+            Consumer<Object> closure);
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
@@ -29,41 +29,41 @@ public interface ScriptExecution {
     /**
      * Schedules a block of code for later execution.
      *
-     * @param instant the point in time when the code should be executed
+     * @param zonedDateTime the point in time when the code should be executed
      * @param closure the code block to execute
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      */
-    Timer createTimer(ZonedDateTime instant, Runnable closure);
+    Timer createTimer(ZonedDateTime zonedDateTime, Runnable closure);
 
     /**
      * Schedules a block of code for later execution.
      *
      * @param identifier an optional identifier
-     * @param instant the point in time when the code should be executed
+     * @param zonedDateTime the point in time when the code should be executed
      * @param closure the code block to execute
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      */
-    Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable closure);
+    Timer createTimer(@Nullable String identifier, ZonedDateTime zonedDateTime, Runnable closure);
 
     /**
      * Schedules a block of code (with argument) for later execution
      *
-     * @param instant the point in time when the code should be executed
+     * @param zonedDateTime the point in time when the code should be executed
      * @param arg1 the argument to pass to the code block
      * @param closure the code block to execute
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      */
-    Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> closure);
+    Timer createTimerWithArgument(ZonedDateTime zonedDateTime, Object arg1, Consumer<Object> closure);
 
     /**
      * Schedules a block of code (with argument) for later execution
      *
      * @param identifier an optional identifier
-     * @param instant the point in time when the code should be executed
+     * @param zonedDateTime the point in time when the code should be executed
      * @param arg1 the argument to pass to the code block
      * @param closure the code block to execute
      * @return a handle to the created timer, so that it can be canceled or rescheduled
      */
-    Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
+    Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime zonedDateTime, Object arg1,
             Consumer<Object> closure);
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
@@ -19,20 +19,12 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * The {@link ScriptExecution} is a
+ * The {@link ScriptExecution} allows creating timers for asynchronous script execution
  *
  * @author Jan N. Klug - Initial contribution
  */
 @NonNullByDefault
 public interface ScriptExecution {
-    /**
-     * Calls a script which must be located in the configurations/scripts folder.
-     *
-     * @param scriptName the name of the script (if the name does not end with
-     *            the .script file extension it is added)
-     * @return the return value of the script
-     */
-    Object callScript(String scriptName);
 
     /**
      * Schedules a block of code for later execution.

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/Timer.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/Timer.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.model.script.actions;
+package org.openhab.core.automation.module.script.action;
 
 import java.time.ZonedDateTime;
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptActionScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptActionScriptScopeProvider.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.internal.action;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.ScriptExtensionProvider;
+import org.openhab.core.automation.module.script.action.ScriptExecution;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * This is a scope provider for script actions that were available in openHAB 1 DSL rules
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@Component(immediate = true)
+@NonNullByDefault
+public class ScriptActionScriptScopeProvider implements ScriptExtensionProvider {
+
+    private static final String PRESET_ACTIONS = "ScriptAction";
+
+    private final Map<String, Object> elements;
+
+    @Activate
+    public ScriptActionScriptScopeProvider(final @Reference ScriptExecution scriptExecution) {
+        elements = Map.of("scriptExecution", scriptExecution);
+    }
+
+    @Override
+    public Collection<String> getDefaultPresets() {
+        return Set.of();
+    }
+
+    @Override
+    public Collection<String> getPresets() {
+        return Set.of(PRESET_ACTIONS);
+    }
+
+    @Override
+    public Collection<String> getTypes() {
+        return elements.keySet();
+    }
+
+    @Override
+    public @Nullable Object get(String scriptIdentifier, String type) {
+        return elements.get(type);
+    }
+
+    @Override
+    public Map<String, Object> importPreset(String scriptIdentifier, String preset) {
+        if (PRESET_ACTIONS.equals(preset)) {
+            return elements;
+        }
+        return Map.of();
+    }
+
+    @Override
+    public void unload(String scriptIdentifier) {
+        // nothing todo
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
@@ -49,23 +49,23 @@ public class ScriptExecutionImpl implements ScriptExecution {
     }
 
     @Override
-    public Timer createTimer(ZonedDateTime instant, Runnable runnable) {
-        return createTimer(null, instant, runnable);
+    public Timer createTimer(ZonedDateTime zonedDateTime, Runnable runnable) {
+        return createTimer(null, zonedDateTime, runnable);
     }
 
     @Override
-    public Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable runnable) {
-        return new TimerImpl(scheduler, instant, runnable::run, identifier);
+    public Timer createTimer(@Nullable String identifier, ZonedDateTime zonedDateTime, Runnable runnable) {
+        return new TimerImpl(scheduler, zonedDateTime, runnable::run, identifier);
     }
 
     @Override
-    public Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> consumer) {
-        return createTimerWithArgument(null, instant, arg1, consumer);
+    public Timer createTimerWithArgument(ZonedDateTime zonedDateTime, Object arg1, Consumer<Object> consumer) {
+        return createTimerWithArgument(null, zonedDateTime, arg1, consumer);
     }
 
     @Override
-    public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
+    public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime zonedDateTime, Object arg1,
             Consumer<Object> consumer) {
-        return new TimerImpl(scheduler, instant, () -> consumer.accept(arg1), identifier);
+        return new TimerImpl(scheduler, zonedDateTime, () -> consumer.accept(arg1), identifier);
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
@@ -13,13 +13,12 @@
 package org.openhab.core.automation.module.script.internal.action;
 
 import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.RuleManager;
+import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.module.script.action.ScriptExecution;
 import org.openhab.core.automation.module.script.action.Timer;
 import org.openhab.core.scheduler.Scheduler;
@@ -39,18 +38,14 @@ public class ScriptExecutionImpl implements ScriptExecution {
 
     private final Scheduler scheduler;
     private final RuleManager ruleManager;
+    private final RuleRegistry ruleRegistry;
 
     @Activate
-    public ScriptExecutionImpl(@Reference RuleManager ruleManager, @Reference Scheduler scheduler) {
+    public ScriptExecutionImpl(@Reference RuleRegistry ruleRegistry, @Reference RuleManager ruleManager,
+            @Reference Scheduler scheduler) {
+        this.ruleRegistry = ruleRegistry;
         this.scheduler = scheduler;
         this.ruleManager = ruleManager;
-    }
-
-    @Override
-    public Object callScript(String scriptName) {
-        Map<String, Object> context = new HashMap<>();
-        ruleManager.runNow(scriptName, false, context);
-        return context;
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.internal.action;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.RuleManager;
+import org.openhab.core.automation.module.script.action.ScriptExecution;
+import org.openhab.core.automation.module.script.action.Timer;
+import org.openhab.core.scheduler.Scheduler;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The static methods of this class are made available as functions in the scripts.
+ * This allows a script to call another script, which is available as a file.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@Component(immediate = true, service = ScriptExecution.class)
+@NonNullByDefault
+public class ScriptExecutionImpl implements ScriptExecution {
+
+    private final Scheduler scheduler;
+    private final RuleManager ruleManager;
+
+    @Activate
+    public ScriptExecutionImpl(@Reference RuleManager ruleManager, @Reference Scheduler scheduler) {
+        this.scheduler = scheduler;
+        this.ruleManager = ruleManager;
+    }
+
+    @Override
+    public Object callScript(String scriptName) {
+        Map<String, Object> context = new HashMap<>();
+        ruleManager.runNow(scriptName, false, context);
+        return context;
+    }
+
+    @Override
+    public Timer createTimer(ZonedDateTime instant, Runnable runnable) {
+        return createTimer(null, instant, runnable);
+    }
+
+    @Override
+    public Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Runnable runnable) {
+        return new TimerImpl(scheduler, instant, runnable::run, identifier);
+    }
+
+    @Override
+    public Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Consumer<Object> consumer) {
+        return createTimerWithArgument(null, instant, arg1, consumer);
+    }
+
+    @Override
+    public Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime instant, Object arg1,
+            Consumer<Object> consumer) {
+        return new TimerImpl(scheduler, instant, () -> consumer.accept(arg1), identifier);
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
@@ -10,14 +10,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.model.script.internal.actions;
+package org.openhab.core.automation.module.script.internal.action;
 
 import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.model.script.actions.Timer;
+import org.openhab.core.automation.module.script.action.Timer;
 import org.openhab.core.scheduler.ScheduledCompletableFuture;
 import org.openhab.core.scheduler.Scheduler;
 import org.openhab.core.scheduler.SchedulerRunnable;

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/TimerImplTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/TimerImplTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.model.script.internal.actions;
+package org.openhab.core.automation.module.script;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,8 +21,9 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.automation.module.script.action.Timer;
+import org.openhab.core.automation.module.script.internal.action.TimerImpl;
 import org.openhab.core.internal.scheduler.SchedulerImpl;
-import org.openhab.core.model.script.actions.Timer;
 import org.openhab.core.scheduler.SchedulerRunnable;
 
 /**

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -20,6 +20,7 @@ Export-Package: org.openhab.core.model.script,\
 Import-Package: \
  org.openhab.core.audio,\
  org.openhab.core.common.registry,\
+ org.openhab.core.automation.module.script.action,\
  org.openhab.core.ephemeris,\
  org.openhab.core.events,\
  org.openhab.core.items,\

--- a/bundles/org.openhab.core.model.script/pom.xml
+++ b/bundles/org.openhab.core.model.script/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>org.openhab.core.io.net</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.automation.module.script</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -79,7 +79,7 @@ public class ScriptExecution {
     }
 
     @ActionDoc(text = "create an identifiable timer ")
-    public static Timer createTimer(@Nullable String identifier,  ZonedDateTime zonedDateTime, Procedures.Procedure0 closure) {
+    public static Timer createTimer(@Nullable String identifier, ZonedDateTime zonedDateTime, Procedures.Procedure0 closure) {
         return ScriptExecutionActionService.getScriptExecution().createTimer(identifier, zonedDateTime, closure::apply);
     }
 
@@ -89,7 +89,7 @@ public class ScriptExecution {
     }
 
     @ActionDoc(text = "create an identifiable timer with argument")
-    public static Timer createTimerWithArgument(@Nullable String identifier,  ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
+    public static Timer createTimerWithArgument(@Nullable String identifier, ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
         return ScriptExecutionActionService.getScriptExecution().createTimerWithArgument(identifier, zonedDateTime, arg1, closure::apply);
     }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -14,8 +14,14 @@ package org.openhab.core.model.script.actions;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.xtext.xbase.XExpression;
 import org.eclipse.xtext.xbase.lib.Procedures;
 import org.openhab.core.automation.module.script.action.Timer;
+import org.openhab.core.model.core.ModelRepository;
+import org.openhab.core.model.script.ScriptServiceUtil;
+import org.openhab.core.model.script.engine.Script;
+import org.openhab.core.model.script.engine.ScriptEngine;
+import org.openhab.core.model.script.engine.ScriptExecutionException;
 import org.openhab.core.model.script.engine.action.ActionDoc;
 import org.openhab.core.model.script.internal.engine.action.ScriptExecutionActionService;
 import org.slf4j.Logger;
@@ -24,16 +30,47 @@ import org.slf4j.LoggerFactory;
 import java.time.ZonedDateTime;
 
 /**
- * The {@link ScriptExecution} is a
+ * The {@link ScriptExecution} is a wrapper for the ScriptExecution actions
  *
  * @author Jan N. Klug - Initial contribution
  */
-@NonNullByDefault public class ScriptExecution {
+@NonNullByDefault
+public class ScriptExecution {
 
     private static final Logger logger = LoggerFactory.getLogger(ScriptExecution.class);
 
-    public static Object callScript(String scriptUid) {
-        return ScriptExecutionActionService.getScriptExecution().callScript(scriptUid);
+    /**
+     * Calls a script which must be located in the configurations/scripts folder.
+     *
+     * @param scriptName the name of the script (if the name does not end with
+     *            the .script file extension it is added)
+     *
+     * @return the return value of the script
+     * @throws ScriptExecutionException if an error occurs during the execution
+     */
+    @ActionDoc(text = "call a script file")
+    public static Object callScript(String scriptName) throws ScriptExecutionException {
+        ModelRepository repo = ScriptServiceUtil.getModelRepository();
+        if (repo != null) {
+            String scriptNameWithExt = scriptName;
+            if (!scriptName.endsWith(Script.SCRIPT_FILEEXT)) {
+                scriptNameWithExt = scriptName + "." + Script.SCRIPT_FILEEXT;
+            }
+            XExpression expr = (XExpression) repo.getModel(scriptNameWithExt);
+            if (expr != null) {
+                ScriptEngine scriptEngine = ScriptServiceUtil.getScriptEngine();
+                if (scriptEngine != null) {
+                    Script script = scriptEngine.newScriptFromXExpression(expr);
+                    return script.execute();
+                } else {
+                    throw new ScriptExecutionException("Script engine is not available.");
+                }
+            } else {
+                throw new ScriptExecutionException("Script '" + scriptName + "' cannot be found.");
+            }
+        } else {
+            throw new ScriptExecutionException("Model repository is not available.");
+        }
     }
 
     @ActionDoc(text = "create a timer")
@@ -41,14 +78,17 @@ import java.time.ZonedDateTime;
         return ScriptExecutionActionService.getScriptExecution().createTimer(zonedDateTime, closure::apply);
     }
 
+    @ActionDoc(text = "create an identifiable timer ")
     public static Timer createTimer(@Nullable String identifier,  ZonedDateTime zonedDateTime, Procedures.Procedure0 closure) {
         return ScriptExecutionActionService.getScriptExecution().createTimer(identifier, zonedDateTime, closure::apply);
     }
 
+    @ActionDoc(text = "create a timer with argument")
     public static Timer createTimerWithArgument(ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
         return ScriptExecutionActionService.getScriptExecution().createTimerWithArgument(zonedDateTime, arg1, closure::apply);
     }
 
+    @ActionDoc(text = "create an identifiable timer with argument")
     public static Timer createTimerWithArgument(@Nullable String identifier,  ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
         return ScriptExecutionActionService.getScriptExecution().createTimerWithArgument(identifier, zonedDateTime, arg1, closure::apply);
     }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -12,122 +12,44 @@
  */
 package org.openhab.core.model.script.actions;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.xtext.xbase.lib.Procedures;
+import org.openhab.core.automation.module.script.action.Timer;
+import org.openhab.core.model.script.engine.action.ActionDoc;
+import org.openhab.core.model.script.internal.engine.action.ScriptExecutionActionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.ZonedDateTime;
 
-import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.xtext.xbase.XExpression;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure0;
-import org.eclipse.xtext.xbase.lib.Procedures.Procedure1;
-import org.openhab.core.model.core.ModelRepository;
-import org.openhab.core.model.script.ScriptServiceUtil;
-import org.openhab.core.model.script.engine.Script;
-import org.openhab.core.model.script.engine.ScriptEngine;
-import org.openhab.core.model.script.engine.ScriptExecutionException;
-import org.openhab.core.model.script.internal.actions.TimerImpl;
-import org.openhab.core.scheduler.Scheduler;
-
 /**
- * The static methods of this class are made available as functions in the scripts.
- * This allows a script to call another script, which is available as a file.
+ * The {@link ScriptExecution} is a
  *
- * @author Kai Kreuzer - Initial contribution
+ * @author Jan N. Klug - Initial contribution
  */
-public class ScriptExecution {
+@NonNullByDefault public class ScriptExecution {
 
-    /**
-     * Calls a script which must be located in the configurations/scripts folder.
-     *
-     * @param scriptName the name of the script (if the name does not end with
-     *            the .script file extension it is added)
-     *
-     * @return the return value of the script
-     * @throws ScriptExecutionException if an error occurs during the execution
-     */
-    public static Object callScript(String scriptName) throws ScriptExecutionException {
-        ModelRepository repo = ScriptServiceUtil.getModelRepository();
-        if (repo != null) {
-            String scriptNameWithExt = scriptName;
-            if (!scriptName.endsWith(Script.SCRIPT_FILEEXT)) {
-                scriptNameWithExt = scriptName + "." + Script.SCRIPT_FILEEXT;
-            }
-            XExpression expr = (XExpression) repo.getModel(scriptNameWithExt);
-            if (expr != null) {
-                ScriptEngine scriptEngine = ScriptServiceUtil.getScriptEngine();
-                if (scriptEngine != null) {
-                    Script script = scriptEngine.newScriptFromXExpression(expr);
-                    return script.execute();
-                } else {
-                    throw new ScriptExecutionException("Script engine is not available.");
-                }
-            } else {
-                throw new ScriptExecutionException("Script '" + scriptName + "' cannot be found.");
-            }
-        } else {
-            throw new ScriptExecutionException("Model repository is not available.");
-        }
+    private static final Logger logger = LoggerFactory.getLogger(ScriptExecution.class);
+
+    public static Object callScript(String scriptUid) {
+        return ScriptExecutionActionService.getScriptExecution().callScript(scriptUid);
     }
 
-    /**
-     * Schedules a block of code for later execution.
-     *
-     * @param instant the point in time when the code should be executed
-     * @param closure the code block to execute
-     *
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     * @throws ScriptExecutionException if an error occurs during the execution
-     */
-    public static Timer createTimer(ZonedDateTime instant, Procedure0 closure) {
-        return createTimer(null, instant, closure);
+    @ActionDoc(text = "create a timer")
+    public static Timer createTimer(ZonedDateTime zonedDateTime, Procedures.Procedure0 closure) {
+        return ScriptExecutionActionService.getScriptExecution().createTimer(zonedDateTime, closure::apply);
     }
 
-    /**
-     * Schedules a block of code for later execution.
-     *
-     * @param identifier an optional identifier
-     * @param instant the point in time when the code should be executed
-     * @param closure the code block to execute
-     *
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     * @throws ScriptExecutionException if an error occurs during the execution
-     */
-    public static Timer createTimer(@Nullable String identifier, ZonedDateTime instant, Procedure0 closure) {
-        Scheduler scheduler = ScriptServiceUtil.getScheduler();
-
-        return new TimerImpl(scheduler, instant, () -> {
-            closure.apply();
-        }, identifier);
+    public static Timer createTimer(@Nullable String identifier,  ZonedDateTime zonedDateTime, Procedures.Procedure0 closure) {
+        return ScriptExecutionActionService.getScriptExecution().createTimer(identifier, zonedDateTime, closure::apply);
     }
 
-    /**
-     * Schedules a block of code (with argument) for later execution
-     *
-     * @param instant the point in time when the code should be executed
-     * @param arg1 the argument to pass to the code block
-     * @param closure the code block to execute
-     *
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     * @throws ScriptExecutionException if an error occurs during the execution
-     */
-    public static Timer createTimerWithArgument(ZonedDateTime instant, Object arg1, Procedure1<Object> closure) {
-        return createTimerWithArgument(null, instant, arg1, closure);
+    public static Timer createTimerWithArgument(ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
+        return ScriptExecutionActionService.getScriptExecution().createTimerWithArgument(zonedDateTime, arg1, closure::apply);
     }
 
-    /**
-     * Schedules a block of code (with argument) for later execution
-     *
-     * @param identifier an optional identifier
-     * @param instant the point in time when the code should be executed
-     * @param arg1 the argument to pass to the code block
-     * @param closure the code block to execute
-     *
-     * @return a handle to the created timer, so that it can be canceled or rescheduled
-     * @throws ScriptExecutionException if an error occurs during the execution
-     */
-    public static Timer createTimerWithArgument(@Nullable String identifier,  ZonedDateTime instant, Object arg1, Procedure1<Object> closure) {
-        Scheduler scheduler = ScriptServiceUtil.getScheduler();
-
-        return new TimerImpl(scheduler, instant, () -> {
-            closure.apply(arg1);
-        }, identifier);
+    public static Timer createTimerWithArgument(@Nullable String identifier,  ZonedDateTime zonedDateTime, Object arg1, Procedures.Procedure1 closure) {
+        return ScriptExecutionActionService.getScriptExecution().createTimerWithArgument(identifier, zonedDateTime, arg1, closure::apply);
     }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.script.internal.engine.action;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.action.ScriptExecution;
+import org.openhab.core.model.script.engine.action.ActionService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import java.util.Objects;
+
+@Component(immediate = true)
+@NonNullByDefault
+public class ScriptExecutionActionService implements ActionService {
+
+    private static @Nullable ScriptExecution scriptExecution;
+
+    @Activate
+    public ScriptExecutionActionService(final @Reference ScriptExecution scriptExecution) {
+        ScriptExecutionActionService.scriptExecution = scriptExecution;
+    }
+
+    @Override
+    public Class<?> getActionClass() {
+        return ScriptExecution.class;
+    }
+
+    public static ScriptExecution getScriptExecution() {
+        return Objects.requireNonNull(scriptExecution);
+    }
+}

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
@@ -22,6 +22,11 @@ import org.osgi.service.component.annotations.Reference;
 
 import java.util.Objects;
 
+/**
+ * This class registers an OSGi service for the ScriptExecution action.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
 @Component(immediate = true)
 @NonNullByDefault
 public class ScriptExecutionActionService implements ActionService {


### PR DESCRIPTION
JSR-223 automation add-ons often use the script actions from the `org.openhab.core.model.script` bundle. The downside is that the actions are tied to XText, making it impossible for the automation add-ons to modify/wrap these actions without explicit dependency on XText (see #3128).

This is the first step to refactor these actions to plain Java, making them available as `ScriptExtension` via an import-preset `ScriptAction` which is not imported by default to prevent unwanted shadowing of other components. They are wrapped for DSL rules, to stay backward compatible.

Signed-off-by: Jan N. Klug <github@klug.nrw>