### PR TITLE
Fix config normalization in ThingUpdatedEvent

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -610,6 +610,7 @@ public class ThingManagerImpl
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public void thingUpdated(Thing oldThing, Thing newThing, ThingTrackerEvent thingTrackerEvent) {
         ThingUID thingUID = newThing.getUID();
+        normalizeThingConfiguration(oldThing);
         normalizeThingConfiguration(newThing);
         if (thingUpdatedLock.contains(thingUID)) {
             // called from the thing handler itself, therefore


### PR DESCRIPTION
Fixes #3122 

The reason is that the "oldThing" is once again retrieved from the storage, not from the registry (where the normalized values are stored).

Signed-off-by: Jan N. Klug <github@klug.nrw>