### PR TITLE
[persistence] Clarify intention of FilterCriteria beginDate/endDate

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
@@ -67,10 +67,10 @@ public class FilterCriteria {
     /** filter result to only contain entries for the given item */
     private String itemName;
 
-    /** filter result to only contain entries that are newer than the given date */
+    /** filter result to only contain entries that are equal to or after the given datetime */
     private ZonedDateTime beginDate;
 
-    /** filter result to only contain entries that are older than the given date */
+    /** filter result to only contain entries that are equal to or before the given datetime */
     private ZonedDateTime endDate;
 
     /** return the result list from starting index pageNumber*pageSize only */


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/issues/9906#issuecomment-1317604058

Most persistence implementations filters by `beginDate` <=date <= `endDate` which contradicts the Javadoc comments with proposed changes in this PR. The exception is JDBC persistence which lead to openhab/openhab-addons#9906.

Therefore, I would propose to either:
- Close this PR and fix persistence services RRD4j, JPA and MongoDB.
- Consider/merge this PR and fix persistence service JDBC according to mentioned issue. openhab/openhab-addons#13734 prepared.