### PR TITLE
log full exception information when calling JSR223 scripts

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -198,7 +198,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     logger.trace("ScriptEngine does not support Invocable interface");
                 }
             } catch (Exception ex) {
-                logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
+                logger.error("Error during evaluation of script '{}'", engineIdentifier, ex);
             }
         }
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -198,7 +198,8 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                     logger.trace("ScriptEngine does not support Invocable interface");
                 }
             } catch (Exception ex) {
-                logger.error("Error during evaluation of script '{}'", engineIdentifier, ex);
+                logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
+                logger.debug("", ex);
             }
         }
     }


### PR DESCRIPTION
The scripts are user code, so in order to help them debug their code, the full stack trace is very useful.
