### PR TITLE
return the precise scheduled execution time for timers

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
@@ -13,7 +13,6 @@
 package org.openhab.core.automation.module.script.internal.action;
 
 import java.time.ZonedDateTime;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -64,7 +63,7 @@ public class TimerImpl implements Timer {
 
     @Override
     public @Nullable ZonedDateTime getExecutionTime() {
-        return future.isCancelled() ? null : ZonedDateTime.now().plusNanos(future.getDelay(TimeUnit.NANOSECONDS));
+        return future.isCancelled() ? null : future.getScheduledTime();
     }
 
     @Override


### PR DESCRIPTION
When writing tests and mocking time, it can be important that execution_time match _exactly_ with what was sent to reschedule(). When re-calculating based on now and the expected remaining delay, this might be off by a few milliseconds. We have the exact time that was requested already, so might as well use it.
