### PR TITLE
[voice] Fix start dialog with non default voice (broken recently)

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -538,6 +538,9 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         if (tts != null) {
             context = context.withTTS(tts);
         }
+        if (voice != null) {
+            context = context.withVoice(voice);
+        }
         if (!hlis.isEmpty()) {
             context = context.withHLIs(hlis);
         }


### PR DESCRIPTION
I broke the startDialog voice customization when creating the new methods on the VoiceManager.
Was merged few days ago.
Sorry for the troubles.

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>