### PR TITLE
Fix ThingManager is missing config description during normalization

### DIFF
--- a/bundles/org.openhab.core.thing/pom.xml
+++ b/bundles/org.openhab.core.thing/pom.xml
@@ -22,6 +22,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.config.xml</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.io.console</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openhab.core.common.SafeCaller;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.config.core.validation.ConfigDescriptionValidator;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.service.ReadyService;
@@ -82,6 +83,7 @@ public class ThingManagerImplTest extends JavaTest {
         when(thingMock.getUID()).thenReturn(new ThingUID("test", "thing"));
         when(thingMock.getStatusInfo())
                 .thenReturn(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE, null));
+        when(thingMock.getConfiguration()).thenReturn(new Configuration());
     }
 
     private ThingManagerImpl createThingManager() {
@@ -194,6 +196,7 @@ public class ThingManagerImplTest extends JavaTest {
         when(thingMock2.getUID()).thenReturn(new ThingUID("test", "thing2"));
         when(thingMock2.getStatusInfo())
                 .thenReturn(new ThingStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE, null));
+        when(thingMock2.getConfiguration()).thenReturn(new Configuration());
 
         setupInterceptedLogger(ThingManagerImpl.class, LogLevel.DEBUG);
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -41,6 +41,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.config.xml.ConfigXmlConfigDescriptionProvider;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.service.ReadyMarker;
@@ -169,8 +170,16 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         waitForAssert(() -> {
             try {
                 assertThat(
-                        bundleContext.getServiceReferences(ReadyMarker.class,
-                                "(openhab.xmlThingTypes=" + bundleContext.getBundle().getSymbolicName() + ")"),
+                        bundleContext
+                                .getServiceReferences(ReadyMarker.class,
+                                        "(" + ThingManagerImpl.XML_THING_TYPE + "="
+                                                + bundleContext.getBundle().getSymbolicName() + ")"),
+                        is(notNullValue()));
+                assertThat(
+                        bundleContext
+                                .getServiceReferences(ReadyMarker.class,
+                                        "(" + ConfigXmlConfigDescriptionProvider.READY_MARKER + "="
+                                                + bundleContext.getBundle().getSymbolicName() + ")"),
                         is(notNullValue()));
             } catch (InvalidSyntaxException e) {
                 throw new IllegalArgumentException(e);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -43,6 +43,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.config.core.ConfigDescriptionParameterBuilder;
 import org.openhab.core.config.core.ConfigDescriptionProvider;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.config.xml.ConfigXmlConfigDescriptionProvider;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventFilter;
 import org.openhab.core.events.EventPublisher;
@@ -175,6 +176,12 @@ public class ThingManagerOSGiTest extends JavaOSGiTest {
                         bundleContext
                                 .getServiceReferences(ReadyMarker.class,
                                         "(" + ThingManagerImpl.XML_THING_TYPE + "="
+                                                + bundleContext.getBundle().getSymbolicName() + ")"),
+                        is(notNullValue()));
+                assertThat(
+                        bundleContext
+                                .getServiceReferences(ReadyMarker.class,
+                                        "(" + ConfigXmlConfigDescriptionProvider.READY_MARKER + "="
                                                 + bundleContext.getBundle().getSymbolicName() + ")"),
                         is(notNullValue()));
             } catch (InvalidSyntaxException e) {


### PR DESCRIPTION
Reported on the forum. In some cases the `ThingManageImpl` tried to initialize the thing before all config descriptions are loaded.

This can happen because the `OH-INF/config` directory is processed in parallel to the thing descriptions. In case the handler factory is added and the thing description parser sets the corresponding `ReadyMarker` before the config descriptions are completly parsed this results in a warning because the config description cannot be found during normalization of the thing or channel configuration.

Signed-off-by: Jan N. Klug <github@klug.nrw>