### PR TITLE
Prevent NPE in SseResource

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
@@ -115,16 +115,19 @@ public class SseResource implements RESTResource, SsePublisher {
 
     private ExecutorService executorService;
 
+    @SuppressWarnings("null")
     @Activate
     public SseResource(@Reference SseItemStatesEventBuilder itemStatesEventBuilder) {
         this.executorService = Executors.newSingleThreadExecutor();
         this.itemStatesEventBuilder = itemStatesEventBuilder;
 
         cleanSubscriptionsJob = scheduler.scheduleWithFixedDelay(() -> {
-            logger.debug("Run clean SSE subscriptions job");
-            OutboundSseEvent outboundSseEvent = sse.newEventBuilder().name("event")
-                    .mediaType(MediaType.APPLICATION_JSON_TYPE).data(new ServerAliveEvent()).build();
-            topicBroadcaster.send(outboundSseEvent);
+            if (topicBroadcaster != null) {
+                logger.debug("Run clean SSE subscriptions job");
+                OutboundSseEvent outboundSseEvent = sse.newEventBuilder().name("event")
+                        .mediaType(MediaType.APPLICATION_JSON_TYPE).data(new ServerAliveEvent()).build();
+                topicBroadcaster.send(outboundSseEvent);
+            }
         }, 1, 2, TimeUnit.MINUTES);
     }
 


### PR DESCRIPTION
Simple attempt to fix #3192.
I am not really certain how the `topicBroadcaster` field could end up being `null`, but possibly the job is only executed after the `SseResource` has been destroyed already due to a service/bundle restart.

Signed-off-by: Kai Kreuzer <kai@openhab.org>