### PR TITLE
Prevent NPE in SseResource

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
@@ -123,11 +123,13 @@ public class SseResource implements RESTResource, SsePublisher {
         this.itemStatesEventBuilder = itemStatesEventBuilder;
 
         aliveEventJob = scheduler.scheduleWithFixedDelay(() -> {
-            logger.debug("Sending alive event to SSE connections");
-            OutboundSseEvent aliveEvent = sse.newEventBuilder().name("alive").mediaType(MediaType.APPLICATION_JSON_TYPE)
-                    .data(new AliveEvent()).build();
-            itemStatesBroadcaster.send(aliveEvent);
-            topicBroadcaster.send(aliveEvent);
+            if (sse != null) {
+                logger.debug("Sending alive event to SSE connections");
+                OutboundSseEvent aliveEvent = sse.newEventBuilder().name("alive")
+                        .mediaType(MediaType.APPLICATION_JSON_TYPE).data(new AliveEvent()).build();
+                itemStatesBroadcaster.send(aliveEvent);
+                topicBroadcaster.send(aliveEvent);
+            }
         }, 1, ALIVE_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Simple attempt to fix #3192.
I am not really certain how the `sse` field could end up being `null`, but possibly the job is only executed after the `SseResource` has been destroyed already due to a service/bundle restart.

Signed-off-by: Kai Kreuzer <kai@openhab.org>