### PR TITLE
[voice] Use a builder to configure the dialog context and remove some deprecated method usages

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -131,6 +131,12 @@ public interface AudioManager {
     void setVolume(PercentType volume, @Nullable String sinkId) throws IOException;
 
     /**
+     * Retrieves the default AudioSource id if any.
+     */
+    @Nullable
+    String getSourceId();
+
+    /**
      * Retrieves an AudioSource.
      * If a default name is configured and the service available, this is returned. If no default name is configured,
      * the first available service is returned, if one exists. If no service with the default name is found, null is
@@ -165,6 +171,12 @@ public interface AudioManager {
      * @return ids of matching sources
      */
     Set<String> getSourceIds(String pattern);
+
+    /**
+     * Retrieves the default AudioSink id if any.
+     */
+    @Nullable
+    String getSinkId();
 
     /**
      * Retrieves an AudioSink.

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -211,6 +211,11 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     }
 
     @Override
+    public @Nullable String getSourceId() {
+        return defaultSource;
+    }
+
+    @Override
     public @Nullable AudioSource getSource() {
         AudioSource source = null;
         if (defaultSource != null) {
@@ -248,6 +253,11 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
         }
 
         return matchedSources;
+    }
+
+    @Override
+    public @Nullable String getSinkId() {
+        return defaultSink;
     }
 
     @Override

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -252,59 +252,64 @@ public class VoiceResource implements RESTResource {
             @QueryParam("sinkId") @Parameter(description = "audio sink ID") @Nullable String sinkId,
             @QueryParam("keyword") @Parameter(description = "keyword") @Nullable String keyword,
             @QueryParam("listeningItem") @Parameter(description = "listening item") @Nullable String listeningItem) {
-        AudioSource source = null;
+        var dialogContextBuilder = voiceManager.getDialogContextBuilder();
         if (sourceId != null) {
-            source = audioManager.getSource(sourceId);
+            AudioSource source = audioManager.getSource(sourceId);
             if (source == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio source not found");
             }
+            dialogContextBuilder.withSource(source);
         }
-        KSService ks = null;
         if (ksId != null) {
-            ks = voiceManager.getKS(ksId);
+            KSService ks = voiceManager.getKS(ksId);
             if (ks == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Keyword spotter not found");
             }
+            dialogContextBuilder.withKS(ks);
         }
-        STTService stt = null;
         if (sttId != null) {
-            stt = voiceManager.getSTT(sttId);
+            STTService stt = voiceManager.getSTT(sttId);
             if (stt == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Speech-to-Text not found");
             }
+            dialogContextBuilder.withSTT(stt);
         }
-        TTSService tts = null;
         if (ttsId != null) {
-            tts = voiceManager.getTTS(ttsId);
+            TTSService tts = voiceManager.getTTS(ttsId);
             if (tts == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Text-to-Speech not found");
             }
+            dialogContextBuilder.withTTS(tts);
         }
-        Voice voice = null;
         if (voiceId != null) {
-            voice = getVoice(voiceId);
+            Voice voice = getVoice(voiceId);
             if (voice == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Voice not found");
             }
+            dialogContextBuilder.withVoice(voice);
         }
-        List<HumanLanguageInterpreter> interpreters = List.of();
         if (hliIds != null) {
-            interpreters = voiceManager.getHLIsByIds(hliIds);
+            List<HumanLanguageInterpreter> interpreters = voiceManager.getHLIsByIds(hliIds);
             if (interpreters.isEmpty()) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Interpreter not found");
             }
+            dialogContextBuilder.withHLIs(interpreters);
         }
-        AudioSink sink = null;
         if (sinkId != null) {
-            sink = audioManager.getSink(sinkId);
+            AudioSink sink = audioManager.getSink(sinkId);
             if (sink == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio sink not found");
             }
+            dialogContextBuilder.withSink(sink);
         }
-        final Locale locale = localeService.getLocale(language);
-
+        if (listeningItem != null) {
+            dialogContextBuilder.withListeningItem(listeningItem);
+        }
+        if (keyword != null) {
+            dialogContextBuilder.withKeyword(keyword);
+        }
         try {
-            voiceManager.startDialog(ks, stt, tts, voice, interpreters, source, sink, locale, keyword, listeningItem);
+            voiceManager.startDialog(dialogContextBuilder.withLocale(localeService.getLocale(language)));
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
@@ -320,16 +325,16 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "400", description = "No dialog processing is started for the audio source.") })
     public Response stopDialog(
             @QueryParam("sourceId") @Parameter(description = "source ID") @Nullable String sourceId) {
-        AudioSource source = null;
+        var dialogContextBuilder = voiceManager.getDialogContextBuilder();
         if (sourceId != null) {
-            source = audioManager.getSource(sourceId);
+            AudioSource source = audioManager.getSource(sourceId);
             if (source == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio source not found");
             }
+            dialogContextBuilder.withSource(source);
         }
-
         try {
-            voiceManager.stopDialog(source);
+            voiceManager.stopDialog(dialogContextBuilder);
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
@@ -352,52 +357,51 @@ public class VoiceResource implements RESTResource {
             @QueryParam("hliIds") @Parameter(description = "interpreter IDs") @Nullable List<String> hliIds,
             @QueryParam("sinkId") @Parameter(description = "audio sink ID") @Nullable String sinkId,
             @QueryParam("listeningItem") @Parameter(description = "listening item") @Nullable String listeningItem) {
-        AudioSource source = null;
+        var dialogContextBuilder = voiceManager.getDialogContextBuilder();
         if (sourceId != null) {
-            source = audioManager.getSource(sourceId);
+            AudioSource source = audioManager.getSource(sourceId);
             if (source == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio source not found");
             }
+            dialogContextBuilder.withSource(source);
         }
-        STTService stt = null;
         if (sttId != null) {
-            stt = voiceManager.getSTT(sttId);
+            STTService stt = voiceManager.getSTT(sttId);
             if (stt == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Speech-to-Text not found");
             }
+            dialogContextBuilder.withSTT(stt);
         }
-        TTSService tts = null;
         if (ttsId != null) {
-            tts = voiceManager.getTTS(ttsId);
+            TTSService tts = voiceManager.getTTS(ttsId);
             if (tts == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Text-to-Speech not found");
             }
+            dialogContextBuilder.withTTS(tts);
         }
-        Voice voice = null;
         if (voiceId != null) {
-            voice = getVoice(voiceId);
+            Voice voice = getVoice(voiceId);
             if (voice == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Voice not found");
             }
+            dialogContextBuilder.withVoice(voice);
         }
-        List<HumanLanguageInterpreter> interpreters = List.of();
         if (hliIds != null) {
-            interpreters = voiceManager.getHLIsByIds(hliIds);
+            List<HumanLanguageInterpreter> interpreters = voiceManager.getHLIsByIds(hliIds);
             if (interpreters.isEmpty()) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Interpreter not found");
             }
+            dialogContextBuilder.withHLIs(interpreters);
         }
-        AudioSink sink = null;
         if (sinkId != null) {
-            sink = audioManager.getSink(sinkId);
+            AudioSink sink = audioManager.getSink(sinkId);
             if (sink == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio sink not found");
             }
+            dialogContextBuilder.withSink(sink);
         }
-        final Locale locale = localeService.getLocale(language);
-
         try {
-            voiceManager.listenAndAnswer(stt, tts, voice, interpreters, source, sink, locale, listeningItem);
+            voiceManager.listenAndAnswer(dialogContextBuilder.withLocale(localeService.getLocale(language)));
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -309,7 +309,7 @@ public class VoiceResource implements RESTResource {
             dialogContextBuilder.withKeyword(keyword);
         }
         try {
-            voiceManager.startDialog(dialogContextBuilder.withLocale(localeService.getLocale(language)));
+            voiceManager.startDialog(dialogContextBuilder.withLocale(localeService.getLocale(language)).build());
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
@@ -334,7 +334,7 @@ public class VoiceResource implements RESTResource {
             dialogContextBuilder.withSource(source);
         }
         try {
-            voiceManager.stopDialog(dialogContextBuilder);
+            voiceManager.stopDialog(dialogContextBuilder.build());
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
@@ -401,7 +401,7 @@ public class VoiceResource implements RESTResource {
             dialogContextBuilder.withSink(sink);
         }
         try {
-            voiceManager.listenAndAnswer(dialogContextBuilder.withLocale(localeService.getLocale(language)));
+            voiceManager.listenAndAnswer(dialogContextBuilder.withLocale(localeService.getLocale(language)).build());
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -238,75 +238,82 @@ public class Voice {
             @ParamDoc(name = "source") @Nullable String source, @ParamDoc(name = "sink") @Nullable String sink,
             @ParamDoc(name = "locale") @Nullable String locale, @ParamDoc(name = "keyword") @Nullable String keyword,
             @ParamDoc(name = "listening item") @Nullable String listeningItem) {
-        AudioSource audioSource = null;
+        var dialogContextBuilder = VoiceActionService.voiceManager.getDialogContextBuilder();
         if (source != null) {
-            audioSource = VoiceActionService.audioManager.getSource(source);
+            AudioSource audioSource = VoiceActionService.audioManager.getSource(source);
             if (audioSource == null) {
                 logger.warn("Failed starting dialog processing: audio source '{}' not found", source);
                 return;
             }
+            dialogContextBuilder.withSource(audioSource);
         }
-        KSService ksService = null;
         if (ks != null) {
-            ksService = VoiceActionService.voiceManager.getKS(ks);
+            KSService ksService = VoiceActionService.voiceManager.getKS(ks);
             if (ksService == null) {
                 logger.warn("Failed starting dialog processing: keyword spotting service '{}' not found", ks);
                 return;
             }
+            dialogContextBuilder.withKS(ksService);
         }
-        STTService sttService = null;
+        if (keyword != null) {
+            dialogContextBuilder.withKeyword(keyword);
+        }
         if (stt != null) {
-            sttService = VoiceActionService.voiceManager.getSTT(stt);
+            STTService sttService = VoiceActionService.voiceManager.getSTT(stt);
             if (sttService == null) {
                 logger.warn("Failed starting dialog processing: speech-to-text service '{}' not found", stt);
                 return;
             }
+            dialogContextBuilder.withSTT(sttService);
         }
-        TTSService ttsService = null;
         if (tts != null) {
-            ttsService = VoiceActionService.voiceManager.getTTS(tts);
+            TTSService ttsService = VoiceActionService.voiceManager.getTTS(tts);
             if (ttsService == null) {
                 logger.warn("Failed starting dialog processing: text-to-speech service '{}' not found", tts);
                 return;
             }
+            dialogContextBuilder.withTTS(ttsService);
         }
-        org.openhab.core.voice.Voice prefVoice = null;
         if (voice != null) {
-            prefVoice = getVoice(voice);
+            org.openhab.core.voice.Voice prefVoice = getVoice(voice);
             if (prefVoice == null) {
                 logger.warn("Failed starting dialog processing: voice '{}' not found", voice);
                 return;
             }
+            dialogContextBuilder.withVoice(prefVoice);
         }
-        List<HumanLanguageInterpreter> hliServices = List.of();
         if (interpreters != null) {
-            hliServices = VoiceActionService.voiceManager.getHLIsByIds(interpreters);
+            List<HumanLanguageInterpreter> hliServices = VoiceActionService.voiceManager.getHLIsByIds(interpreters);
             if (hliServices.isEmpty()) {
                 logger.warn("Failed starting dialog processing: interpreters '{}' not found", interpreters);
                 return;
             }
+            dialogContextBuilder.withHLIs(hliServices);
         }
-        AudioSink audioSink = null;
         if (sink != null) {
-            audioSink = VoiceActionService.audioManager.getSink(sink);
+            AudioSink audioSink = VoiceActionService.audioManager.getSink(sink);
             if (audioSink == null) {
                 logger.warn("Failed starting dialog processing: audio sink '{}' not found", sink);
                 return;
             }
+            dialogContextBuilder.withSink(audioSink);
         }
-        Locale loc = null;
+        if (listeningItem != null) {
+            dialogContextBuilder.withListeningItem(listeningItem);
+        }
         if (locale != null) {
             String[] split = locale.split("-");
+            Locale loc = null;
             if (split.length == 2) {
                 loc = new Locale(split[0], split[1]);
             } else {
                 loc = new Locale(split[0]);
             }
+            dialogContextBuilder.withLocale(loc);
         }
 
         try {
-            VoiceActionService.voiceManager.startDialog(ksService, sttService, ttsService, prefVoice, hliServices,
-                    audioSource, audioSink, loc, keyword, listeningItem);
+            VoiceActionService.voiceManager.startDialog(dialogContextBuilder);
         } catch (IllegalStateException e) {
             logger.warn("Failed starting dialog processing: {}", e.getMessage());
         }
@@ -319,16 +326,17 @@ public class Voice {
      */
     @ActionDoc(text = "stops dialog processing for a given audio source")
     public static void stopDialog(@ParamDoc(name = "source") @Nullable String source) {
-        AudioSource audioSource = null;
-        if (source != null) {
-            audioSource = VoiceActionService.audioManager.getSource(source);
-            if (audioSource == null) {
-                logger.warn("Failed stopping dialog processing: audio source '{}' not found", source);
-                return;
-            }
-        }
         try {
-            VoiceActionService.voiceManager.stopDialog(audioSource);
+            var dialogContextBuilder = VoiceActionService.voiceManager.getDialogContextBuilder();
+            if (source != null) {
+                AudioSource audioSource = VoiceActionService.audioManager.getSource(source);
+                if (audioSource == null) {
+                    logger.warn("Failed stopping dialog processing: audio source '{}' not found", source);
+                    return;
+                }
+                dialogContextBuilder.withSource(audioSource);
+            }
+            VoiceActionService.voiceManager.stopDialog(dialogContextBuilder);
         } catch (IllegalStateException e) {
             logger.warn("Failed stopping dialog processing: {}", e.getMessage());
         }
@@ -369,67 +377,70 @@ public class Voice {
             @ParamDoc(name = "source") @Nullable String source, @ParamDoc(name = "sink") @Nullable String sink,
             @ParamDoc(name = "locale") @Nullable String locale,
             @ParamDoc(name = "listening item") @Nullable String listeningItem) {
-        AudioSource audioSource = null;
-        if (source != null) {
-            audioSource = VoiceActionService.audioManager.getSource(source);
-            if (audioSource == null) {
-                logger.warn("Failed executing simple dialog: audio source '{}' not found", source);
-                return;
-            }
-        }
-        STTService sttService = null;
-        if (stt != null) {
-            sttService = VoiceActionService.voiceManager.getSTT(stt);
-            if (sttService == null) {
-                logger.warn("Failed executing simple dialog: speech-to-text service '{}' not found", stt);
-                return;
-            }
-        }
-        TTSService ttsService = null;
-        if (tts != null) {
-            ttsService = VoiceActionService.voiceManager.getTTS(tts);
-            if (ttsService == null) {
-                logger.warn("Failed executing simple dialog: text-to-speech service '{}' not found", tts);
-                return;
-            }
-        }
-        org.openhab.core.voice.Voice prefVoice = null;
-        if (voice != null) {
-            prefVoice = getVoice(voice);
-            if (prefVoice == null) {
-                logger.warn("Failed executing simple dialog: voice '{}' not found", voice);
-                return;
-            }
-        }
-        List<HumanLanguageInterpreter> hliServices = List.of();
-        if (interpreters != null) {
-            hliServices = VoiceActionService.voiceManager.getHLIsByIds(interpreters);
-            if (hliServices.isEmpty()) {
-                logger.warn("Failed executing simple dialog: interpreters '{}' not found", interpreters);
-                return;
-            }
-        }
-        AudioSink audioSink = null;
-        if (sink != null) {
-            audioSink = VoiceActionService.audioManager.getSink(sink);
-            if (audioSink == null) {
-                logger.warn("Failed executing simple dialog: audio sink '{}' not found", sink);
-                return;
-            }
-        }
-        Locale loc = null;
-        if (locale != null) {
-            String[] split = locale.split("-");
-            if (split.length == 2) {
-                loc = new Locale(split[0], split[1]);
-            } else {
-                loc = new Locale(split[0]);
-            }
-        }
-
         try {
-            VoiceActionService.voiceManager.listenAndAnswer(sttService, ttsService, prefVoice, hliServices, audioSource,
-                    audioSink, loc, listeningItem);
+            var dialogContextBuilder = VoiceActionService.voiceManager.getDialogContextBuilder();
+            if (source != null) {
+                AudioSource audioSource = VoiceActionService.audioManager.getSource(source);
+                if (audioSource == null) {
+                    logger.warn("Failed executing simple dialog: audio source '{}' not found", source);
+                    return;
+                }
+                dialogContextBuilder.withSource(audioSource);
+            }
+            if (stt != null) {
+                STTService sttService = VoiceActionService.voiceManager.getSTT(stt);
+                if (sttService == null) {
+                    logger.warn("Failed executing simple dialog: speech-to-text service '{}' not found", stt);
+                    return;
+                }
+                dialogContextBuilder.withSTT(sttService);
+            }
+            if (tts != null) {
+                TTSService ttsService = VoiceActionService.voiceManager.getTTS(tts);
+                if (ttsService == null) {
+                    logger.warn("Failed executing simple dialog: text-to-speech service '{}' not found", tts);
+                    return;
+                }
+                dialogContextBuilder.withTTS(ttsService);
+            }
+            if (voice != null) {
+                org.openhab.core.voice.Voice prefVoice = getVoice(voice);
+                if (prefVoice == null) {
+                    logger.warn("Failed executing simple dialog: voice '{}' not found", voice);
+                    return;
+                }
+                dialogContextBuilder.withVoice(prefVoice);
+            }
+            if (interpreters != null) {
+                List<HumanLanguageInterpreter> hliServices = VoiceActionService.voiceManager.getHLIsByIds(interpreters);
+                if (hliServices.isEmpty()) {
+                    logger.warn("Failed executing simple dialog: interpreters '{}' not found", interpreters);
+                    return;
+                }
+                dialogContextBuilder.withHLIs(hliServices);
+            }
+            if (sink != null) {
+                AudioSink audioSink = VoiceActionService.audioManager.getSink(sink);
+                if (audioSink == null) {
+                    logger.warn("Failed executing simple dialog: audio sink '{}' not found", sink);
+                    return;
+                }
+                dialogContextBuilder.withSink(audioSink);
+            }
+            if (listeningItem != null) {
+                dialogContextBuilder.withListeningItem(listeningItem);
+            }
+            if (locale != null) {
+                Locale loc = null;
+                String[] split = locale.split("-");
+                if (split.length == 2) {
+                    loc = new Locale(split[0], split[1]);
+                } else {
+                    loc = new Locale(split[0]);
+                }
+                dialogContextBuilder.withLocale(loc);
+            }
+            VoiceActionService.voiceManager.listenAndAnswer(dialogContextBuilder);
         } catch (IllegalStateException e) {
             logger.warn("Failed executing simple dialog: {}", e.getMessage());
         }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -313,7 +313,7 @@ public class Voice {
         }
 
         try {
-            VoiceActionService.voiceManager.startDialog(dialogContextBuilder);
+            VoiceActionService.voiceManager.startDialog(dialogContextBuilder.build());
         } catch (IllegalStateException e) {
             logger.warn("Failed starting dialog processing: {}", e.getMessage());
         }
@@ -336,7 +336,7 @@ public class Voice {
                 }
                 dialogContextBuilder.withSource(audioSource);
             }
-            VoiceActionService.voiceManager.stopDialog(dialogContextBuilder);
+            VoiceActionService.voiceManager.stopDialog(dialogContextBuilder.build());
         } catch (IllegalStateException e) {
             logger.warn("Failed stopping dialog processing: {}", e.getMessage());
         }
@@ -440,7 +440,7 @@ public class Voice {
                 }
                 dialogContextBuilder.withLocale(loc);
             }
-            VoiceActionService.voiceManager.listenAndAnswer(dialogContextBuilder);
+            VoiceActionService.voiceManager.listenAndAnswer(dialogContextBuilder.build());
         } catch (IllegalStateException e) {
             logger.warn("Failed executing simple dialog: {}", e.getMessage());
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -22,8 +22,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioSink;
 import org.openhab.core.audio.AudioSource;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Describes dialog configured services and options.
@@ -103,7 +101,6 @@ public class DialogContext {
      * Allows to describe a dialog context without requiring the involved services to be loaded
      */
     public static class Builder {
-        private final Logger logger = LoggerFactory.getLogger(Builder.class);
         // services
         private @Nullable AudioSource source;
         private @Nullable AudioSink sink;
@@ -176,6 +173,12 @@ public class DialogContext {
             return this;
         }
 
+        /**
+         * Creates a new {@link DialogContext}
+         * 
+         * @return a {@link DialogContext} with the configured components and options
+         * @throws IllegalStateException if a required dialog component is missing
+         */
         public DialogContext build() throws IllegalStateException {
             KSService ksService = ks;
             STTService sttService = stt;
@@ -185,23 +188,22 @@ public class DialogContext {
             AudioSink audioSink = sink;
             List<String> errors = new ArrayList<>();
             if (sttService == null) {
-                errors.add("Missing stt service");
+                errors.add("missing stt service");
             }
             if (ttsService == null) {
-                errors.add("Missing tts service");
+                errors.add("missing tts service");
             }
             if (hliServices.isEmpty()) {
-                errors.add("Missing interpreters");
+                errors.add("missing interpreters");
             }
             if (audioSource == null) {
-                errors.add("Missing audio source");
+                errors.add("missing audio source");
             }
             if (audioSink == null) {
-                errors.add("Missing audio sink");
+                errors.add("missing audio sink");
             }
             if (!errors.isEmpty()) {
-                errors.forEach(logger::warn);
-                throw new IllegalStateException("Cannot build dialog context, services are missing");
+                throw new IllegalStateException("Cannot build dialog context: " + String.join(", ", errors) + ".");
             }
             return new DialogContext(ksService, keyword, sttService, ttsService, voice, hliServices, audioSource,
                     audioSink, locale, listeningItem);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -12,14 +12,19 @@
  */
 package org.openhab.core.voice;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioSink;
 import org.openhab.core.audio.AudioSource;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Describes dialog configured services and options.
@@ -95,72 +100,153 @@ public class DialogContext {
     }
 
     /**
-     * @return a new DialogContext instance with the provided source
+     * Builder for {@link DialogContext}
+     * Allows to describe a dialog context without requiring the involved services to be loaded
      */
-    public DialogContext withSource(AudioSource source) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+    public static class Builder {
+        private final Logger logger = LoggerFactory.getLogger(Builder.class);
+        // services
+        private @Nullable String sourceId = null;
+        private Supplier<@Nullable AudioSource> source = () -> null;
+        private @Nullable String sinkId = null;
+        private Supplier<@Nullable AudioSink> sink = () -> null;
+        private @Nullable String ksId = null;
+        private Supplier<@Nullable KSService> ks = () -> null;
+        private @Nullable String sttId = null;
+        private Supplier<@Nullable STTService> stt = () -> null;
+        private @Nullable String ttsId = null;
+        private Supplier<@Nullable TTSService> tts = () -> null;
+        private @Nullable Voice voice = null;
+        private List<String> hliIds = List.of();
+        private Supplier<List<HumanLanguageInterpreter>> hlis = List::of;
+        // options
+        private @Nullable String listeningItem = null;
+        private String keyword;
+        private Locale locale;
 
-    /**
-     * @return a new DialogContext instance with the provided sink
-     */
-    public DialogContext withSink(AudioSink sink) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder(String keyword, Locale locale) {
+            this.keyword = keyword;
+            this.locale = locale;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided stt
-     */
-    public DialogContext withSTT(STTService stt) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withSource(AudioSource service) {
+            withSource(service.getId(), () -> service);
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided tts
-     */
-    public DialogContext withTTS(TTSService tts) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withSource(String id, Supplier<@Nullable AudioSource> serviceResolver) {
+            sourceId = id;
+            source = serviceResolver;
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided voice
-     */
-    public DialogContext withVoice(Voice voice) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withSink(AudioSink service) {
+            withSink(service.getId(), () -> service);
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided list of interpreters
-     */
-    public DialogContext withHLIs(List<HumanLanguageInterpreter> hlis) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withSink(String id, Supplier<@Nullable AudioSink> serviceResolver) {
+            sinkId = id;
+            sink = serviceResolver;
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided locale
-     */
-    public DialogContext withLocale(Locale locale) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withKS(KSService service) {
+            withKS(service.getId(), () -> service);
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided listening item
-     */
-    public DialogContext withListeningItem(String listeningItem) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withKS(String id, Supplier<@Nullable KSService> serviceResolver) {
+            ksId = id;
+            ks = serviceResolver;
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided ks
-     */
-    public DialogContext withKS(@Nullable KSService ks) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
-    }
+        public Builder withSTT(STTService service) {
+            withSTT(service.getId(), () -> service);
+            return this;
+        }
 
-    /**
-     * @return a new DialogContext instance with the provided keyword
-     */
-    public DialogContext withKeyword(@Nullable String keyword) {
-        return new DialogContext(ks, keyword, stt, tts, voice, hlis, source, sink, locale, listeningItem);
+        public Builder withSTT(String id, Supplier<@Nullable STTService> serviceResolver) {
+            sttId = id;
+            stt = serviceResolver;
+            return this;
+        }
+
+        public Builder withTTS(TTSService service) {
+            withTTS(service.getId(), () -> service);
+            return this;
+        }
+
+        public Builder withTTS(String id, Supplier<@Nullable TTSService> serviceResolver) {
+            ttsId = id;
+            tts = serviceResolver;
+            return this;
+        }
+
+        public Builder withHLIs(List<HumanLanguageInterpreter> services) {
+            withHLIs(services.stream().map(HumanLanguageInterpreter::getId).collect(Collectors.toList()),
+                    () -> services);
+            return this;
+        }
+
+        public Builder withHLIs(List<String> ids, Supplier<List<HumanLanguageInterpreter>> serviceResolver) {
+            hliIds = ids;
+            hlis = serviceResolver;
+            return this;
+        }
+
+        public Builder withKeyword(String keyword) {
+            this.keyword = keyword;
+            return this;
+        }
+
+        public Builder withVoice(Voice voice) {
+            this.voice = voice;
+            return this;
+        }
+
+        public Builder withListeningItem(String listeningItem) {
+            this.listeningItem = listeningItem;
+            return this;
+        }
+
+        public Builder withLocale(Locale locale) {
+            this.locale = locale;
+            return this;
+        }
+
+        public DialogContext build() throws IllegalStateException {
+            KSService ksService = ks.get();
+            STTService sttService = stt.get();
+            TTSService ttsService = tts.get();
+            List<HumanLanguageInterpreter> hliServices = hlis.get();
+            AudioSource audioSource = source.get();
+            AudioSink audioSink = sink.get();
+            List<String> errors = new ArrayList<>();
+            if (sttService == null) {
+                errors.add("Missing stt service: " + sttId);
+            }
+            if (ttsService == null) {
+                errors.add("Missing tts service: " + ttsId);
+            }
+            if (hliServices.isEmpty() || hliIds.size() != hliServices.size()) {
+                var serviceIds = hliServices.stream().map(HumanLanguageInterpreter::getId).collect(Collectors.toList());
+                errors.add("Missing interpreters: "
+                        + hliIds.stream().filter(s -> !serviceIds.contains(s)).collect(Collectors.joining(", ")));
+            }
+            if (audioSource == null) {
+                errors.add("Missing audio source: " + sourceId);
+            }
+            if (audioSink == null) {
+                errors.add("Missing audio sink: " + sinkId);
+            }
+            if (!errors.isEmpty()) {
+                errors.forEach(logger::warn);
+                throw new IllegalStateException("Cannot build dialog context, services are missing");
+            }
+            return new DialogContext(ksService, keyword, sttService, ttsService, voice, hliServices, audioSource,
+                    audioSink, locale, listeningItem);
+        }
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -105,15 +105,15 @@ public class DialogContext {
     public static class Builder {
         private final Logger logger = LoggerFactory.getLogger(Builder.class);
         // services
-        private @Nullable AudioSource source = null;
-        private @Nullable AudioSink sink = null;
-        private @Nullable KSService ks = null;
-        private @Nullable STTService stt = null;
-        private @Nullable TTSService tts = null;
-        private @Nullable Voice voice = null;
+        private @Nullable AudioSource source;
+        private @Nullable AudioSink sink;
+        private @Nullable KSService ks;
+        private @Nullable STTService stt;
+        private @Nullable TTSService tts;
+        private @Nullable Voice voice;
         private List<HumanLanguageInterpreter> hlis = List.of();
         // options
-        private @Nullable String listeningItem = null;
+        private @Nullable String listeningItem;
         private String keyword;
         private Locale locale;
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -211,11 +211,11 @@ public interface VoiceManager {
      *
      * Only one dialog can be started for an audio source.
      *
-     * @param contextBuilder describing the configured services and options for the dialog
+     * @param context with the configured services and options for the dialog
      * @throws IllegalStateException if required services are not compatible or the provided locale is not supported
      *             by all these services or a dialog is already started for this audio source
      */
-    void startDialog(DialogContext.Builder contextBuilder) throws IllegalStateException;
+    void startDialog(DialogContext context) throws IllegalStateException;
 
     /**
      * Stop the dialog associated to an audio source
@@ -229,10 +229,10 @@ public interface VoiceManager {
     /**
      * Stop the dialog associated to the audio source
      *
-     * @param contextBuilder describing the configured services and options for the dialog
+     * @param context with the configured services and options for the dialog
      * @throws IllegalStateException if no dialog is started for the audio source
      */
-    void stopDialog(DialogContext.Builder contextBuilder) throws IllegalStateException;
+    void stopDialog(DialogContext context) throws IllegalStateException;
 
     /**
      * Executes a simple dialog sequence without keyword spotting using all default services: default audio source
@@ -279,11 +279,11 @@ public interface VoiceManager {
      *
      * Only possible if no dialog processor is already started for the audio source.
      *
-     * @param contextBuilder describing the configured services and options for the dialog
+     * @param context with the configured services and options for the dialog
      * @throws IllegalStateException the provided locale is not supported by all these services or a dialog is already
      *             started for this audio source
      */
-    void listenAndAnswer(DialogContext.Builder contextBuilder) throws IllegalStateException;
+    void listenAndAnswer(DialogContext context) throws IllegalStateException;
 
     /**
      * Retrieves a TTS service.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -124,11 +124,11 @@ public interface VoiceManager {
     Voice getPreferredVoice(Set<Voice> voices);
 
     /**
-     * Returns an object with the default required services and configurations for dialog processing
+     * Returns a dialog context builder with the default required services and configurations for dialog processing
      *
      * @throws IllegalStateException if some required service is not available
      */
-    DialogContext getDefaultDialogContext() throws IllegalStateException;
+    DialogContext.Builder getDialogContextBuilder();
 
     /**
      * Returns an object with the services and configurations last used for dialog processing if any.
@@ -211,11 +211,11 @@ public interface VoiceManager {
      *
      * Only one dialog can be started for an audio source.
      *
-     * @param context the record describing the configured services and options for the dialog
+     * @param contextBuilder describing the configured services and options for the dialog
      * @throws IllegalStateException if required services are not compatible or the provided locale is not supported
      *             by all these services or a dialog is already started for this audio source
      */
-    void startDialog(DialogContext context) throws IllegalStateException;
+    void startDialog(DialogContext.Builder contextBuilder) throws IllegalStateException;
 
     /**
      * Stop the dialog associated to an audio source
@@ -229,10 +229,10 @@ public interface VoiceManager {
     /**
      * Stop the dialog associated to the audio source
      *
-     * @param context the record describing the configured services and options for the dialog
+     * @param contextBuilder describing the configured services and options for the dialog
      * @throws IllegalStateException if no dialog is started for the audio source
      */
-    void stopDialog(DialogContext context) throws IllegalStateException;
+    void stopDialog(DialogContext.Builder contextBuilder) throws IllegalStateException;
 
     /**
      * Executes a simple dialog sequence without keyword spotting using all default services: default audio source
@@ -279,11 +279,11 @@ public interface VoiceManager {
      *
      * Only possible if no dialog processor is already started for the audio source.
      *
-     * @param context the record describing the configured services and options for the dialog
+     * @param contextBuilder describing the configured services and options for the dialog
      * @throws IllegalStateException the provided locale is not supported by all these services or a dialog is already
      *             started for this audio source
      */
-    void listenAndAnswer(DialogContext context) throws IllegalStateException;
+    void listenAndAnswer(DialogContext.Builder contextBuilder) throws IllegalStateException;
 
     /**
      * Retrieves a TTS service.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -601,13 +601,11 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         if (listeningItem != null) {
             builder.withListeningItem(listeningItem);
         }
-        startDialog(builder);
+        startDialog(builder.build());
     }
 
     @Override
-    public void startDialog(DialogContext.Builder contextBuilder) throws IllegalStateException {
-        // use defaults, if null
-        DialogContext context = contextBuilder.build();
+    public void startDialog(DialogContext context) throws IllegalStateException {
         var ksService = context.ks();
         var ksKeyword = context.keyword();
         if (ksService == null || ksKeyword == null) {
@@ -642,12 +640,12 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         if (source != null) {
             builder.withSource(source);
         }
-        stopDialog(builder);
+        stopDialog(builder.build());
     }
 
     @Override
-    public void stopDialog(DialogContext.Builder contextBuilder) throws IllegalStateException {
-        AudioSource audioSource = contextBuilder.build().source();
+    public void stopDialog(DialogContext context) throws IllegalStateException {
+        AudioSource audioSource = context.source();
         DialogProcessor processor = dialogProcessors.remove(audioSource.getId());
         singleDialogProcessors.values().removeIf(e -> !e.isProcessing());
         if (processor == null) {
@@ -700,12 +698,11 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         if (listeningItem != null) {
             builder.withListeningItem(listeningItem);
         }
-        listenAndAnswer(builder);
+        listenAndAnswer(builder.build());
     }
 
     @Override
-    public void listenAndAnswer(DialogContext.Builder contextBuilder) throws IllegalStateException {
-        DialogContext context = contextBuilder.build();
+    public void listenAndAnswer(DialogContext context) throws IllegalStateException {
         Bundle b = bundle;
         if (b == null) {
             throw new IllegalStateException("Cannot execute a simple dialog as services are missing.");

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -484,63 +484,15 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
 
     @Override
     public DialogContext.Builder getDialogContextBuilder() {
-        var builder = new DialogContext.Builder(keyword, localeProvider.getLocale());
-        var sinkId = audioManager.getSinkId();
-        if (sinkId != null) {
-            builder.withSink(sinkId, audioManager::getSink);
-        }
-        var sourceId = audioManager.getSourceId();
-        if (sourceId != null) {
-            builder.withSource(sourceId, audioManager::getSource);
-        }
-        var defaultKS = this.defaultKS;
-        if (defaultKS != null) {
-            builder.withKS(defaultKS, this::getKS);
-        } else {
-            var ks = this.getKS();
-            if (ks != null) {
-                builder.withKS(ks);
-            }
-        }
-        var defaultSTT = this.defaultSTT;
-        if (defaultSTT != null) {
-            builder.withSTT(defaultSTT, this::getSTT);
-        } else {
-            var stt = this.getSTT();
-            if (stt != null) {
-                builder.withSTT(stt);
-            }
-        }
-        var defaultTTS = this.defaultTTS;
-        if (defaultTTS != null) {
-            builder.withTTS(defaultTTS, this::getTTS);
-        } else {
-            var tts = this.getTTS();
-            if (tts != null) {
-                builder.withTTS(tts);
-            }
-        }
-        var defaultHLI = this.defaultHLI;
-        if (defaultHLI != null) {
-            builder.withHLIs(List.of(defaultHLI), () -> {
-                var hli = this.getHLI();
-                return hli != null ? List.of(hli) : List.of();
-            });
-        } else {
-            var hli = this.getHLI();
-            if (hli != null) {
-                builder.withHLIs(List.of(hli));
-            }
-        }
-        var voice = this.getDefaultVoice();
-        if (voice != null) {
-            builder.withVoice(voice);
-        }
-        var listeningItem = this.listeningItem;
-        if (listeningItem != null) {
-            builder.withListeningItem(listeningItem);
-        }
-        return builder;
+        return new DialogContext.Builder(keyword, localeProvider.getLocale()) //
+                .withSink(audioManager.getSink()) //
+                .withSource(audioManager.getSource()) //
+                .withKS(this.getKS()) //
+                .withSTT(this.getSTT()) //
+                .withTTS(this.getTTS()) //
+                .withHLIs(this.getHLIs()) //
+                .withVoice(this.getDefaultVoice()) //
+                .withListeningItem(listeningItem);
     }
 
     @Override


### PR DESCRIPTION
This is a follow up PR for [#3142](https://github.com/openhab/openhab-core/pull/3142) and related to issue [#3140](https://github.com/openhab/openhab-core/issues/3140).
I realize testing the code on that pr that it introduces and unwanted behavior. If you have setup a default sink/source that is not available (because of a binding uninstall in my case) it will prevent any call to the startDialog method to work.
This PR aims to fix that by introducing a builder for the DialogContext so services availability is checked in the correct moment.
This PR also contains the removal of some deprecated voice manager method usages.

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>