### PR TITLE
Improve UoM handling

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -80,7 +80,7 @@ public class NumberItem extends GenericItem {
         internalSend(command);
     }
 
-    public void send(QuantityType command) {
+    public void send(QuantityType<?> command) {
         if (dimension == null) {
             DecimalType strippedCommand = new DecimalType(command.toBigDecimal());
             internalSend(strippedCommand);
@@ -123,7 +123,7 @@ public class NumberItem extends GenericItem {
 
         // DecimalType update for a NumberItem with dimension, convert to QuantityType:
         if (state instanceof DecimalType && dimension != null) {
-            Unit<?> unit = getUnit();
+            Unit<?> unit = getUnit(dimension, false);
             if (unit != null) {
                 super.setState(new QuantityType<>(((DecimalType) state).doubleValue(), unit));
                 return;
@@ -132,7 +132,7 @@ public class NumberItem extends GenericItem {
 
         // QuantityType update, check unit and convert if necessary:
         if (state instanceof QuantityType) {
-            Unit<?> itemUnit = getUnit();
+            Unit<?> itemUnit = getUnit(dimension, true);
             Unit<?> stateUnit = ((QuantityType<?>) state).getUnit();
             if (itemUnit != null && (!stateUnit.getSystemUnit().equals(itemUnit.getSystemUnit())
                     || UnitUtils.isDifferentMeasurementSystem(itemUnit, stateUnit))) {
@@ -160,7 +160,7 @@ public class NumberItem extends GenericItem {
      * @return the optional unit symbol for this {@link NumberItem}.
      */
     public @Nullable String getUnitSymbol() {
-        Unit<?> unit = getUnit();
+        Unit<?> unit = getUnit(dimension, true);
         return unit != null ? unit.toString() : null;
     }
 
@@ -168,13 +168,14 @@ public class NumberItem extends GenericItem {
      * Derive the unit for this item by the following priority:
      * <ul>
      * <li>the unit parsed from the state description</li>
+     * <li>no unit if state description contains <code>%unit%</code></li>
      * <li>the default system unit from the item's dimension</li>
      * </ul>
      *
      * @return the {@link Unit} for this item if available, {@code null} otherwise.
      */
     public @Nullable Unit<? extends Quantity<?>> getUnit() {
-        return getUnit(dimension);
+        return getUnit(dimension, true);
     }
 
     /**
@@ -188,7 +189,7 @@ public class NumberItem extends GenericItem {
      */
     public @Nullable QuantityType<?> toQuantityType(DecimalType originalType,
             @Nullable Class<? extends Quantity<?>> dimension) {
-        Unit<? extends Quantity<?>> itemUnit = getUnit(dimension);
+        Unit<? extends Quantity<?>> itemUnit = getUnit(dimension, false);
         if (itemUnit != null) {
             return new QuantityType<>(originalType.toBigDecimal(), itemUnit);
         }
@@ -200,14 +201,18 @@ public class NumberItem extends GenericItem {
      * Derive the unit for this item by the following priority:
      * <ul>
      * <li>the unit parsed from the state description</li>
+     * <li>the unit from the value if <code>hasUnit = true</code> and state description has unit
+     * <code>%unit%</code></li>
      * <li>the default system unit from the (optional) dimension parameter</li>
      * </ul>
      *
      * @param dimension the (optional) dimension
+     * @param hasUnit if the value has a unit
      * @return the {@link Unit} for this item if available, {@code null} otherwise.
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private @Nullable Unit<? extends Quantity<?>> getUnit(@Nullable Class<? extends Quantity<?>> dimension) {
+    private @Nullable Unit<? extends Quantity<?>> getUnit(@Nullable Class<? extends Quantity<?>> dimension,
+            boolean hasUnit) {
         if (dimension == null) {
             // if it is a plain number without dimension, we do not have a unit.
             return null;
@@ -216,6 +221,10 @@ public class NumberItem extends GenericItem {
         if (stateDescription != null) {
             String pattern = stateDescription.getPattern();
             if (pattern != null) {
+                if (hasUnit && pattern.contains("%unit%")) {
+                    // use provided unit if present
+                    return null;
+                }
                 Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
                 if (stateDescriptionUnit != null) {
                     return stateDescriptionUnit;


### PR DESCRIPTION
Related to #3143

The logic for determining the unit is to first check if there is a state description. If the state description is present, try to parse a unit from that. In case a unit is found, use that. If no unit is found, use the default unit. Determine the unit from the state description fails if it is set to `%unit%`.

This change disables default units if the state description sets the unit to `%unit%` which effectively means "take the unit from the value" or use no unit.

@Hilbrand, do you think this will work?

Signed-off-by: Jan N. Klug <github@klug.nrw>