### PR TITLE
Fix AVG calculation in GroupFunction

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
@@ -13,7 +13,7 @@
 package org.openhab.core.library.types;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -231,7 +231,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
                 }
             }
             if (count > 0) {
-                return new DecimalType(sum.divide(BigDecimal.valueOf(count), RoundingMode.HALF_UP));
+                return new DecimalType(sum.divide(BigDecimal.valueOf(count), MathContext.DECIMAL128));
             } else {
                 return UnDefType.UNDEF;
             }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
@@ -13,7 +13,7 @@
 package org.openhab.core.library.types;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import java.util.Set;
 
 import javax.measure.Quantity;
@@ -103,7 +103,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
             }
 
             if (sum != null && count > 0) {
-                BigDecimal result = sum.toBigDecimal().divide(BigDecimal.valueOf(count), RoundingMode.HALF_UP);
+                BigDecimal result = sum.toBigDecimal().divide(BigDecimal.valueOf(count), MathContext.DECIMAL128);
                 return new QuantityType(result, sum.getUnit());
             }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -130,6 +130,14 @@ public class QuantityTypeArithmeticGroupFunctionTest {
         State state = function.calculate(items);
 
         assertEquals(new QuantityType<>("200 °C"), state);
+
+        items = new LinkedHashSet<>();
+        items.add(createNumberItem("TestItem1", Temperature.class, new QuantityType<>("19.5 °C")));
+        items.add(createNumberItem("TestItem2", Temperature.class, new QuantityType<>("19.5 °C")));
+
+        state = function.calculate(items);
+
+        assertEquals(new QuantityType<>("19.5 °C"), state);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Reported on the forum. Due to selection of the `RoundingMode` instead of a `MathContext` the average calculation is returning unexpected results: 19.0 °C / 19.5 °C results in 19.3 °C (instead of 19.25 °C) which might be acceptable, but 19.5 °C / 19.5 °C results in 20 °C (instead of 19.5 °C) which is obviously not what we want or expect. Setting the `MathContext` fixes this problem. I also corrected the same calculation for non-dimensional groups.

Signed-off-by: Jan N. Klug <github@klug.nrw>