### PR TITLE
[Binding Skeleton] Add doc code examples

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/README.md
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/README.md
@@ -71,6 +71,24 @@ _Provide a full usage example based on textual configuration files._
 _*.things, *.items examples are mandatory as textual configuration is well used by many users._
 _*.sitemap examples are optional._
 
+#[[###]]# Thing Configuration
+
+```java
+Example thing configuration goes here.
+```
+#[[###]]# Item Configuration
+
+```java
+Example item configuration goes here.
+```
+
+#[[###]]# Sitemap Configuration
+
+```perl
+Optional Sitemap configuration goes here.
+Remove this section, if not needed.
+```
+
 #[[##]]# Any custom content here!
 
 _Feel free to add additional sections for whatever you think should also be mentioned about your binding!_


### PR DESCRIPTION
This is mainly based on my workings for consistent markdown doc files, i am currently doing in the docs repo and also for the many addons.
Hopefully it will increase the consistency by providing predefined code examples.

I have adapted the templating simply from other headlines without further research and hope that it is correct already.

References:

openhab/openhab-addons#13858
openhab/openhab-docs#999
