### PR TITLE
Fix timer cancellation in automation cache

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
@@ -130,7 +130,8 @@ public class CacheScriptExtension implements ScriptExtensionProvider {
     }
 
     /**
-     * Check if object is {@link ScheduledFuture}, {@link java.util.Timer} or {@link org.openhab.core.automation.module.script.action.Timer} and schedule cancellation of those jobs
+     * Check if object is {@link ScheduledFuture}, {@link java.util.Timer} or
+     * {@link org.openhab.core.automation.module.script.action.Timer} and schedule cancellation of those jobs
      *
      * @param o the {@link Object} to check
      */
@@ -141,13 +142,12 @@ public class CacheScriptExtension implements ScriptExtensionProvider {
         } else if (o instanceof java.util.Timer) {
             cancelJob = () -> ((java.util.Timer) o).cancel();
         } else if (o instanceof org.openhab.core.automation.module.script.action.Timer) {
-            cancelJob =  () -> ((org.openhab.core.automation.module.script.action.Timer) o).cancel();
+            cancelJob = () -> ((org.openhab.core.automation.module.script.action.Timer) o).cancel();
         }
         if (cancelJob != null) {
             // not using execute so ensure this operates in another thread and we don't block here
             scheduler.schedule(cancelJob, 0, TimeUnit.SECONDS);
         }
-
     }
 
     private static class ValueCacheImpl implements ValueCache {


### PR DESCRIPTION
The check for scheduling a cancellation task did not include the `Timer` class of the automation bundle.

@florian-h05 Can you check if this works for you?

Signed-off-by: Jan N. Klug <github@klug.nrw>