### PR TITLE
[voice] avoid build a context to stop a dialog

### DIFF
--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -325,16 +325,15 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "400", description = "No dialog processing is started for the audio source.") })
     public Response stopDialog(
             @QueryParam("sourceId") @Parameter(description = "source ID") @Nullable String sourceId) {
-        var dialogContextBuilder = voiceManager.getDialogContextBuilder();
+        AudioSource source = null;
         if (sourceId != null) {
-            AudioSource source = audioManager.getSource(sourceId);
+            source = audioManager.getSource(sourceId);
             if (source == null) {
                 return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Audio source not found");
             }
-            dialogContextBuilder.withSource(source);
         }
         try {
-            voiceManager.stopDialog(dialogContextBuilder.build());
+            voiceManager.stopDialog(source);
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (IllegalStateException e) {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -327,16 +327,15 @@ public class Voice {
     @ActionDoc(text = "stops dialog processing for a given audio source")
     public static void stopDialog(@ParamDoc(name = "source") @Nullable String source) {
         try {
-            var dialogContextBuilder = VoiceActionService.voiceManager.getDialogContextBuilder();
+            AudioSource audioSource = null;
             if (source != null) {
-                AudioSource audioSource = VoiceActionService.audioManager.getSource(source);
+                audioSource = VoiceActionService.audioManager.getSource(source);
                 if (audioSource == null) {
                     logger.warn("Failed stopping dialog processing: audio source '{}' not found", source);
                     return;
                 }
-                dialogContextBuilder.withSource(audioSource);
             }
-            VoiceActionService.voiceManager.stopDialog(dialogContextBuilder.build());
+            VoiceActionService.voiceManager.stopDialog(audioSource);
         } catch (IllegalStateException e) {
             logger.warn("Failed stopping dialog processing: {}", e.getMessage());
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -223,7 +223,6 @@ public interface VoiceManager {
      * @param source the audio source or null to consider the default audio source
      * @throws IllegalStateException if no dialog is started for the audio source
      */
-    @Deprecated
     void stopDialog(@Nullable AudioSource source) throws IllegalStateException;
 
     /**


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>

I detected there is still a bug on the latest code.
Basically requiring build a context to stop a dialog is not a good idea as could cause a exception due to other service been missing (for example the default audio sink).