### PR TITLE
Fix DataAmount dimension units

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -166,6 +166,8 @@
     </dependency>
 
     <!-- Measurement -->
+    <!-- Attention: before upgrading this dependencies check that the dimension X is still not used, otherwise change the
+      dimension label for org.openhab.core.library.unit.Units.BIT -->
     <dependency>
       <groupId>javax.measure</groupId>
       <artifactId>unit-api</artifactId>

--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -166,7 +166,7 @@
     </dependency>
 
     <!-- Measurement -->
-    <!-- Attention: before upgrading this dependencies check that the dimension X is still not used, otherwise change the
+    <!-- Attention: before upgrading these dependencies check that the dimension X is still not used, otherwise change the
       dimension label for org.openhab.core.library.unit.Units.BIT -->
     <dependency>
       <groupId>javax.measure</groupId>

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -254,7 +254,7 @@ public final class Units extends CustomUnits {
         // "KiB" is wrong, but we keep it for backward compatibility
         SimpleUnitFormat.getInstance().alias(KIBIBYTE, "KiB");
         SimpleUnitFormat.getInstance().alias(KIBIBYTE, "kio");
-        // "KiO" is wrong, but we keep it for backward compatibility
+        // "Kio" is wrong, but we keep it for backward compatibility
         SimpleUnitFormat.getInstance().alias(KIBIBYTE, "Kio");
         SimpleUnitFormat.getInstance().label(KILOBIT, "kbit");
         SimpleUnitFormat.getInstance().label(KILOBIT_PER_SECOND, "kbit/s");

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -64,8 +64,10 @@ import tech.units.indriya.function.ExpConverter;
 import tech.units.indriya.function.LogConverter;
 import tech.units.indriya.function.MultiplyConverter;
 import tech.units.indriya.unit.AlternateUnit;
+import tech.units.indriya.unit.BaseUnit;
 import tech.units.indriya.unit.ProductUnit;
 import tech.units.indriya.unit.TransformedUnit;
+import tech.units.indriya.unit.UnitDimension;
 
 /**
  * Delegate common units to {@link Units} to hide this dependency from the rest of openHAB.
@@ -188,7 +190,7 @@ public final class Units extends CustomUnits {
             tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.HOUR)));
     public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_DAY = addUnit(new ProductUnit<VolumetricFlowRate>(
             tech.units.indriya.unit.Units.CUBIC_METRE.divide(tech.units.indriya.unit.Units.DAY)));
-    public static final Unit<DataAmount> BIT = addUnit(new AlternateUnit<>(ONE, "bit"));
+    public static final Unit<DataAmount> BIT = addUnit(new BaseUnit<>("bit", UnitDimension.parse('X')));
     public static final Unit<DataAmount> KILOBIT = addUnit(MetricPrefix.KILO(BIT));
     public static final Unit<DataAmount> MEGABIT = addUnit(MetricPrefix.MEGA(BIT));
     public static final Unit<DataAmount> GIGABIT = addUnit(MetricPrefix.GIGA(BIT));
@@ -245,8 +247,14 @@ public final class Units extends CustomUnits {
         SimpleUnitFormat.getInstance().label(GIGABIT, "Gbit");
         SimpleUnitFormat.getInstance().label(GIGABIT_PER_SECOND, "Gbit/s");
         SimpleUnitFormat.getInstance().label(IRRADIANCE, "W/m²");
-        SimpleUnitFormat.getInstance().label(KILOBYTE, "KB");
-        SimpleUnitFormat.getInstance().label(KIBIBYTE, "KiB");
+        SimpleUnitFormat.getInstance().label(KILOBYTE, "kB");
+        // "KB" is wrong, but we keep it for backward compatibility
+        SimpleUnitFormat.getInstance().alias(KILOBYTE, "KB");
+        SimpleUnitFormat.getInstance().label(KIBIBYTE, "kiB");
+        // "KiB" is wrong, but we keep it for backward compatibility
+        SimpleUnitFormat.getInstance().alias(KIBIBYTE, "KiB");
+        SimpleUnitFormat.getInstance().alias(KIBIBYTE, "kio");
+        // "KiO" is wrong, but we keep it for backward compatibility
         SimpleUnitFormat.getInstance().alias(KIBIBYTE, "Kio");
         SimpleUnitFormat.getInstance().label(KILOBIT, "kbit");
         SimpleUnitFormat.getInstance().label(KILOBIT_PER_SECOND, "kbit/s");

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.library.dimension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
+
+/**
+ * The {@link DataAmountTest} holds tests for {@link DataAmount}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class DataAmountTest {
+
+    @Test
+    public void testBToMB() {
+        QuantityType<DataAmount> quantityType = new QuantityType("1000 B");
+        QuantityType<DataAmount> converted = quantityType.toUnit("MB");
+
+        assertThat(converted.toString(), is(equalTo("0.001 MB")));
+    }
+
+    @Test
+    public void testKBToMB() {
+        QuantityType<DataAmount> quantityType = new QuantityType("1000 kB");
+        QuantityType<DataAmount> converted = quantityType.toUnit("MB");
+
+        assertThat(converted.toString(), is(equalTo("1 MB")));
+    }
+
+    @Test
+    public void testInvertibleUnit() {
+        QuantityType<DataAmount> quantityType = new QuantityType("1000 KB");
+        QuantityType<?> inverted = quantityType.toInvertibleUnit(Units.MEGABYTE);
+
+        assertThat(quantityType, is(equalTo(inverted)));
+    }
+}


### PR DESCRIPTION
Fixes #3207 (a regression from #3108). 

I also fixed the wrong case prefix for the "kilo"-Units (`K` instead of `k`) but kept the old ones for backward compatibility.

Signed-off-by: Jan N. Klug <github@klug.nrw>