### PR TITLE
Prevent compiler error in Eclipse due to potential null value

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1093,6 +1093,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      */
     private Map<String, Object> getContext(String ruleUID, @Nullable Set<Connection> connections) {
         Map<String, Object> context = contextMap.computeIfAbsent(ruleUID, k -> new HashMap<>());
+        if (context == null) {
+            throw new IllegalStateException("context cannot be null at that point - please report a bug.");
+        }
         if (connections != null) {
             StringBuffer sb = new StringBuffer();
             for (Connection c : connections) {


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>