### PR TITLE
Fix AbstractScriptFileWatcher missing deletes on Windows

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
@@ -207,10 +207,10 @@ public abstract class AbstractScriptFileWatcher extends AbstractWatchService imp
                     if (file.isDirectory()) {
                         if (watchSubDirectories()) {
                             synchronized (this) {
-                                String prefix = file.toString() + File.separator;
-                                var toRemove = loaded.stream()
+                                String prefix = file.toURI().toURL().getPath();
+                                Set<ScriptFileReference> toRemove = loaded.stream()
                                         .filter(f -> f.getScriptFileURL().getFile().startsWith(prefix))
-                                        .collect(Collectors.toList());
+                                        .collect(Collectors.toSet());
                                 toRemove.forEach(this::removeFile);
                             }
                         }


### PR DESCRIPTION
Fixes #3214 

Regression from #3185 

@wborn It would be great if you could check if it also fixes the issue in GHA builds.

Signed-off-by: Jan N. Klug <github@klug.nrw>