### PR TITLE
Fix BasicAuthentication for websockets

### DIFF
--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/EventWebSocketServlet.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/EventWebSocketServlet.java
@@ -146,7 +146,7 @@ public class EventWebSocketServlet extends WebSocketServlet implements EventSubs
                 credentials = new UserApiTokenCredentials(token);
             } else {
                 // try BasicAuthentication
-                String[] decodedParts = Base64.getDecoder().decode(token).toString().split(":");
+                String[] decodedParts = new String(Base64.getDecoder().decode(token)).split(":");
                 if (decodedParts.length == 2) {
                     credentials = new UsernamePasswordCredentials(decodedParts[0], decodedParts[1]);
                 }


### PR DESCRIPTION
Follow-Up to #2891

This fixes a bug in decoding the access token validation using basic authentication.

Signed-off-by: Jan N. Klug <github@klug.nrw>