### PR TITLE
increase ScriptEngineManager's load timeout to 2 minutes

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -58,7 +58,7 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
     /**
      * Timeout for scripts in milliseconds.
      */
-    static private final long TIMEOUT = TimeUnit.SECONDS.toMillis(30);
+    static private final long TIMEOUT = TimeUnit.SECONDS.toMillis(120);
 
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);


### PR DESCRIPTION
up from 30 seconds. low-powered devices such as Raspberry Pis can take a very long time to load scripts during initial boot, when many other things are going on at the same time.

see also discussion on the original PR starting at https://github.com/openhab/openhab-core/pull/3180#issuecomment-1346783426, and in the community starting at https://community.openhab.org/t/openhab-3-4-milestone-discussion/138093/135

cc @florian-h05