### PR TITLE
Add defaultUnit metadata for NumberItem

### DIFF
--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
@@ -13,12 +13,15 @@
 package org.openhab.core.automation.internal.module.handler;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+
+import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +37,7 @@ import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.util.ConditionBuilder;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
@@ -77,7 +81,9 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                     ((NumberItem) item).setState(itemState);
                     break;
                 case "Number:Temperature":
-                    item = new NumberItem("Number:Temperature", ITEM_NAME);
+                    UnitProvider unitProviderMock = mock(UnitProvider.class);
+                    when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+                    item = new NumberItem("Number:Temperature", ITEM_NAME, unitProviderMock);
                     ((NumberItem) item).setState(itemState);
                     break;
                 case "Dimmer":
@@ -103,7 +109,7 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5", new DecimalType(5), true) }, //
                 { new ParameterSet("Number:Temperature", "5 °C", new DecimalType(23), false) }, //
                 { new ParameterSet("Number:Temperature", "5 °C", new DecimalType(5), false) }, //
-                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new DecimalType(), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
@@ -119,7 +125,7 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5", new DecimalType(5), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), false) }, //
-                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), false) }, //
+                { new ParameterSet("Number:Temperature", "0", new DecimalType(), false) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
@@ -138,7 +144,7 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), false) }, //
-                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new DecimalType(), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), false) }, //
@@ -159,7 +165,7 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5", new DecimalType(4), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), true) }, //
-                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), false) }, //
+                { new ParameterSet("Number:Temperature", "0", new DecimalType(), false) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Number:Temperature", "5 °C", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
@@ -179,7 +185,7 @@ public class ItemStateConditionHandlerTest extends JavaTest {
                 { new ParameterSet("Number", "5 °C", new DecimalType(23), false) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(5), true) }, //
                 { new ParameterSet("Number", "5 °C", new DecimalType(4), true) }, //
-                { new ParameterSet("Number:Temperature", "0", new QuantityType<>(), true) }, //
+                { new ParameterSet("Number:Temperature", "0", new DecimalType(), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(23, SIUnits.CELSIUS), false) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(5, SIUnits.CELSIUS), true) }, //
                 { new ParameterSet("Number:Temperature", "5", new QuantityType<>(4, SIUnits.CELSIUS), true) }, //

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -15,10 +15,12 @@ package org.openhab.core.io.rest.core.item;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.library.CoreItemFactory;
@@ -38,7 +40,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
 
     @Test
     public void testFiltering() {
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(mock(UnitProvider.class));
 
         GroupItem group = new GroupItem("TestGroup");
         GroupItem subGroup = new GroupItem("TestSubGroup");

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.ItemNotFoundException;
@@ -43,20 +45,22 @@ import org.openhab.core.semantics.model.location.Indoor;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
 public class SemanticsTest {
 
-    private @Mock ItemRegistry mockedItemRegistry;
+    private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
-    private GroupItem indoorLocationItem;
-    private GroupItem bathroomLocationItem;
-    private GroupItem equipmentItem;
-    private GenericItem temperaturePointItem;
-    private GenericItem humidityPointItem;
-    private GenericItem subEquipmentItem;
+    private @NonNullByDefault({})GroupItem indoorLocationItem;
+    private @NonNullByDefault({})GroupItem bathroomLocationItem;
+    private @NonNullByDefault({})GroupItem equipmentItem;
+    private @NonNullByDefault({})GenericItem temperaturePointItem;
+    private @NonNullByDefault({})GenericItem humidityPointItem;
+    private @NonNullByDefault({})GenericItem subEquipmentItem;
 
     @BeforeEach
     public void setup() throws ItemNotFoundException {
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(unitProviderMock);
 
         indoorLocationItem = new GroupItem("TestHouse");
         indoorLocationItem.addTag("Indoor");
@@ -94,13 +98,13 @@ public class SemanticsTest {
         equipmentItem.addMember(subEquipmentItem);
         subEquipmentItem.addGroupName(equipmentItem.getName());
 
-        when(mockedItemRegistry.getItem("TestHouse")).thenReturn(indoorLocationItem);
-        when(mockedItemRegistry.getItem("TestBathRoom")).thenReturn(bathroomLocationItem);
-        when(mockedItemRegistry.getItem("Test08")).thenReturn(equipmentItem);
-        when(mockedItemRegistry.getItem("TestTemperature")).thenReturn(temperaturePointItem);
-        when(mockedItemRegistry.getItem("TestHumidity")).thenReturn(humidityPointItem);
+        when(itemRegistryMock.getItem("TestHouse")).thenReturn(indoorLocationItem);
+        when(itemRegistryMock.getItem("TestBathRoom")).thenReturn(bathroomLocationItem);
+        when(itemRegistryMock.getItem("Test08")).thenReturn(equipmentItem);
+        when(itemRegistryMock.getItem("TestTemperature")).thenReturn(temperaturePointItem);
+        when(itemRegistryMock.getItem("TestHumidity")).thenReturn(humidityPointItem);
 
-        new SemanticsActionService(mockedItemRegistry);
+        new SemanticsActionService(itemRegistryMock);
     }
 
     @Test

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -73,11 +73,10 @@ public class PersistenceExtensionsTest {
     public void setUp() {
         when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
 
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(unitProviderMock);
         numberItem = itemFactory.createItem(CoreItemFactory.NUMBER, TEST_NUMBER);
         quantityItem = itemFactory.createItem(CoreItemFactory.NUMBER + ItemUtil.EXTENSION_SEPARATOR + "Temperature",
                 TEST_QUANTITY_NUMBER);
-        quantityItem.setUnitProvider(unitProviderMock);
         switchItem = itemFactory.createItem(CoreItemFactory.SWITCH, TEST_SWITCH);
 
         when(itemRegistryMock.get(TEST_NUMBER)).thenReturn(numberItem);

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
@@ -13,12 +13,14 @@
 package org.openhab.core.semantics;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.library.CoreItemFactory;
@@ -41,7 +43,7 @@ public class SemanticTagsTest {
 
     @BeforeEach
     public void setup() {
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(mock(UnitProvider.class));
 
         locationItem = new GroupItem("TestBathRoom");
         locationItem.addTag("Bathroom");

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
@@ -13,10 +13,12 @@
 package org.openhab.core.semantics;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.library.CoreItemFactory;
@@ -24,7 +26,7 @@ import org.openhab.core.semantics.model.property.Humidity;
 import org.openhab.core.semantics.model.property.Temperature;
 
 /**
- * This are tests for {@link SemanticsPredicates}.
+ * These are tests for {@link SemanticsPredicates}.
  *
  * @author Christoph Weitkamp - Initial contribution
  */
@@ -37,7 +39,7 @@ public class SemanticsPredicatesTest {
 
     @BeforeEach
     public void setup() {
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(mock(UnitProvider.class));
 
         locationItem = new GroupItem("TestBathRoom");
         locationItem.addTag("Bathroom");

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsServiceImplTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsServiceImplTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
@@ -43,6 +44,7 @@ public class SemanticsServiceImplTest {
 
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) MetadataRegistry metadataRegistryMock;
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     private @NonNullByDefault({}) GroupItem locationItem;
     private @NonNullByDefault({}) GroupItem equipmentItem;
@@ -52,7 +54,7 @@ public class SemanticsServiceImplTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        CoreItemFactory itemFactory = new CoreItemFactory();
+        CoreItemFactory itemFactory = new CoreItemFactory(unitProviderMock);
         locationItem = new GroupItem("TestBathRoom");
         locationItem.addTag("Bathroom");
         locationItem.setLabel("Joe's Room");

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -142,12 +142,12 @@ public class I18nProviderImpl
     // UnitProvider
     static final String MEASUREMENT_SYSTEM = "measurementSystem";
     private @Nullable SystemOfUnits measurementSystem;
-    private final Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap = new HashMap<>();
+    private static final Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> DIMENSION_MAP = getDimensionMap();
 
     @Activate
     @SuppressWarnings("unchecked")
     public I18nProviderImpl(ComponentContext componentContext) {
-        initDimensionMap();
+        getDimensionMap();
         modified((Map<String, Object>) componentContext.getProperties());
 
         this.resourceBundleTracker = new ResourceBundleTracker(componentContext.getBundleContext(), this);
@@ -187,16 +187,12 @@ public class I18nProviderImpl
 
         final SystemOfUnits newMeasurementSystem;
         switch (ms) {
-            case SIUnits.MEASUREMENT_SYSTEM_NAME:
-                newMeasurementSystem = SIUnits.getInstance();
-                break;
-            case ImperialUnits.MEASUREMENT_SYSTEM_NAME:
-                newMeasurementSystem = ImperialUnits.getInstance();
-                break;
-            default:
+            case SIUnits.MEASUREMENT_SYSTEM_NAME -> newMeasurementSystem = SIUnits.getInstance();
+            case ImperialUnits.MEASUREMENT_SYSTEM_NAME -> newMeasurementSystem = ImperialUnits.getInstance();
+            default -> {
                 logger.debug("Error setting measurement system for value '{}'.", measurementSystem);
                 newMeasurementSystem = null;
-                break;
+            }
         }
         this.measurementSystem = newMeasurementSystem;
 
@@ -349,13 +345,13 @@ public class I18nProviderImpl
             return MessageFormat.format(text, arguments);
         }
 
-        return text;
+        return null;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Quantity<T>> @Nullable Unit<T> getUnit(@Nullable Class<T> dimension) {
-        Map<SystemOfUnits, Unit<? extends Quantity<?>>> map = dimensionMap.get(dimension);
+        Map<SystemOfUnits, Unit<? extends Quantity<?>>> map = DIMENSION_MAP.get(dimension);
         if (map == null) {
             return null;
         }
@@ -376,54 +372,62 @@ public class I18nProviderImpl
         return SIUnits.getInstance();
     }
 
-    private void initDimensionMap() {
-        addDefaultUnit(Acceleration.class, Units.METRE_PER_SQUARE_SECOND);
-        addDefaultUnit(AmountOfSubstance.class, Units.MOLE);
-        addDefaultUnit(Angle.class, Units.DEGREE_ANGLE, Units.DEGREE_ANGLE);
-        addDefaultUnit(Area.class, SIUnits.SQUARE_METRE, ImperialUnits.SQUARE_FOOT);
-        addDefaultUnit(ArealDensity.class, Units.DOBSON_UNIT);
-        addDefaultUnit(CatalyticActivity.class, Units.KATAL);
-        addDefaultUnit(DataAmount.class, Units.BYTE);
-        addDefaultUnit(DataTransferRate.class, Units.MEGABIT_PER_SECOND);
-        addDefaultUnit(Density.class, Units.KILOGRAM_PER_CUBICMETRE);
-        addDefaultUnit(Dimensionless.class, Units.ONE);
-        addDefaultUnit(ElectricCapacitance.class, Units.FARAD);
-        addDefaultUnit(ElectricCharge.class, Units.COULOMB);
-        addDefaultUnit(ElectricConductance.class, Units.SIEMENS);
-        addDefaultUnit(ElectricConductivity.class, Units.SIEMENS_PER_METRE);
-        addDefaultUnit(ElectricCurrent.class, Units.AMPERE);
-        addDefaultUnit(ElectricInductance.class, Units.HENRY);
-        addDefaultUnit(ElectricPotential.class, Units.VOLT);
-        addDefaultUnit(ElectricResistance.class, Units.OHM);
-        addDefaultUnit(Energy.class, Units.KILOWATT_HOUR);
-        addDefaultUnit(Force.class, Units.NEWTON);
-        addDefaultUnit(Frequency.class, Units.HERTZ);
-        addDefaultUnit(Illuminance.class, Units.LUX);
-        addDefaultUnit(Intensity.class, Units.IRRADIANCE);
-        addDefaultUnit(Length.class, SIUnits.METRE, ImperialUnits.FOOT);
-        addDefaultUnit(LuminousFlux.class, Units.LUMEN);
-        addDefaultUnit(LuminousIntensity.class, Units.CANDELA);
-        addDefaultUnit(MagneticFlux.class, Units.WEBER);
-        addDefaultUnit(MagneticFluxDensity.class, Units.TESLA);
-        addDefaultUnit(Mass.class, SIUnits.KILOGRAM, ImperialUnits.POUND);
-        addDefaultUnit(Power.class, Units.WATT);
-        addDefaultUnit(Pressure.class, HECTO(SIUnits.PASCAL), ImperialUnits.INCH_OF_MERCURY);
-        addDefaultUnit(RadiationDoseAbsorbed.class, Units.GRAY);
-        addDefaultUnit(RadiationDoseEffective.class, Units.SIEVERT);
-        addDefaultUnit(Radioactivity.class, Units.BECQUEREL);
-        addDefaultUnit(SolidAngle.class, Units.STERADIAN);
-        addDefaultUnit(Speed.class, SIUnits.KILOMETRE_PER_HOUR, ImperialUnits.MILES_PER_HOUR);
-        addDefaultUnit(Temperature.class, SIUnits.CELSIUS, ImperialUnits.FAHRENHEIT);
-        addDefaultUnit(Time.class, Units.SECOND);
-        addDefaultUnit(Volume.class, SIUnits.CUBIC_METRE, ImperialUnits.GALLON_LIQUID_US);
-        addDefaultUnit(VolumetricFlowRate.class, Units.LITRE_PER_MINUTE, ImperialUnits.GALLON_PER_MINUTE);
+    public static Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> getDimensionMap() {
+        Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap = new HashMap<>();
+
+        addDefaultUnit(dimensionMap, Acceleration.class, Units.METRE_PER_SQUARE_SECOND);
+        addDefaultUnit(dimensionMap, AmountOfSubstance.class, Units.MOLE);
+        addDefaultUnit(dimensionMap, Angle.class, Units.DEGREE_ANGLE, Units.DEGREE_ANGLE);
+        addDefaultUnit(dimensionMap, Area.class, SIUnits.SQUARE_METRE, ImperialUnits.SQUARE_FOOT);
+        addDefaultUnit(dimensionMap, ArealDensity.class, Units.DOBSON_UNIT);
+        addDefaultUnit(dimensionMap, CatalyticActivity.class, Units.KATAL);
+        addDefaultUnit(dimensionMap, DataAmount.class, Units.BYTE);
+        addDefaultUnit(dimensionMap, DataTransferRate.class, Units.MEGABIT_PER_SECOND);
+        addDefaultUnit(dimensionMap, Density.class, Units.KILOGRAM_PER_CUBICMETRE);
+        addDefaultUnit(dimensionMap, Dimensionless.class, Units.ONE);
+        addDefaultUnit(dimensionMap, ElectricCapacitance.class, Units.FARAD);
+        addDefaultUnit(dimensionMap, ElectricCharge.class, Units.COULOMB);
+        addDefaultUnit(dimensionMap, ElectricConductance.class, Units.SIEMENS);
+        addDefaultUnit(dimensionMap, ElectricConductivity.class, Units.SIEMENS_PER_METRE);
+        addDefaultUnit(dimensionMap, ElectricCurrent.class, Units.AMPERE);
+        addDefaultUnit(dimensionMap, ElectricInductance.class, Units.HENRY);
+        addDefaultUnit(dimensionMap, ElectricPotential.class, Units.VOLT);
+        addDefaultUnit(dimensionMap, ElectricResistance.class, Units.OHM);
+        addDefaultUnit(dimensionMap, Energy.class, Units.KILOWATT_HOUR);
+        addDefaultUnit(dimensionMap, Force.class, Units.NEWTON);
+        addDefaultUnit(dimensionMap, Frequency.class, Units.HERTZ);
+        addDefaultUnit(dimensionMap, Illuminance.class, Units.LUX);
+        addDefaultUnit(dimensionMap, Intensity.class, Units.IRRADIANCE);
+        addDefaultUnit(dimensionMap, Length.class, SIUnits.METRE, ImperialUnits.FOOT);
+        addDefaultUnit(dimensionMap, LuminousFlux.class, Units.LUMEN);
+        addDefaultUnit(dimensionMap, LuminousIntensity.class, Units.CANDELA);
+        addDefaultUnit(dimensionMap, MagneticFlux.class, Units.WEBER);
+        addDefaultUnit(dimensionMap, MagneticFluxDensity.class, Units.TESLA);
+        addDefaultUnit(dimensionMap, Mass.class, SIUnits.KILOGRAM, ImperialUnits.POUND);
+        addDefaultUnit(dimensionMap, Power.class, Units.WATT);
+        addDefaultUnit(dimensionMap, Pressure.class, HECTO(SIUnits.PASCAL), ImperialUnits.INCH_OF_MERCURY);
+        addDefaultUnit(dimensionMap, RadiationDoseAbsorbed.class, Units.GRAY);
+        addDefaultUnit(dimensionMap, RadiationDoseEffective.class, Units.SIEVERT);
+        addDefaultUnit(dimensionMap, Radioactivity.class, Units.BECQUEREL);
+        addDefaultUnit(dimensionMap, SolidAngle.class, Units.STERADIAN);
+        addDefaultUnit(dimensionMap, Speed.class, SIUnits.KILOMETRE_PER_HOUR, ImperialUnits.MILES_PER_HOUR);
+        addDefaultUnit(dimensionMap, Temperature.class, SIUnits.CELSIUS, ImperialUnits.FAHRENHEIT);
+        addDefaultUnit(dimensionMap, Time.class, Units.SECOND);
+        addDefaultUnit(dimensionMap, Volume.class, SIUnits.CUBIC_METRE, ImperialUnits.GALLON_LIQUID_US);
+        addDefaultUnit(dimensionMap, VolumetricFlowRate.class, Units.LITRE_PER_MINUTE, ImperialUnits.GALLON_PER_MINUTE);
+
+        return dimensionMap;
     }
 
-    private <T extends Quantity<T>> void addDefaultUnit(Class<T> dimension, Unit<T> siUnit, Unit<T> imperialUnit) {
+    private static <T extends Quantity<T>> void addDefaultUnit(
+            Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap,
+            Class<T> dimension, Unit<T> siUnit, Unit<T> imperialUnit) {
         dimensionMap.put(dimension, Map.of(SIUnits.getInstance(), siUnit, ImperialUnits.getInstance(), imperialUnit));
     }
 
-    private <T extends Quantity<T>> void addDefaultUnit(Class<T> dimension, Unit<T> unit) {
+    private static <T extends Quantity<T>> void addDefaultUnit(
+            Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap,
+            Class<T> dimension, Unit<T> unit) {
         dimensionMap.put(dimension, Map.of(SIUnits.getInstance(), unit, ImperialUnits.getInstance(), unit));
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
@@ -28,7 +28,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.AbstractRegistry;
 import org.openhab.core.common.registry.Provider;
 import org.openhab.core.events.EventPublisher;
-import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
@@ -78,7 +78,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     private @Nullable StateDescriptionService stateDescriptionService;
     private @Nullable CommandDescriptionService commandDescriptionService;
     private final MetadataRegistry metadataRegistry;
-    private @Nullable UnitProvider unitProvider;
+
     private @Nullable ItemStateConverter itemStateConverter;
 
     @Activate
@@ -199,7 +199,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
             genericItem.setEventPublisher(getEventPublisher());
             genericItem.setStateDescriptionService(stateDescriptionService);
             genericItem.setCommandDescriptionService(commandDescriptionService);
-            genericItem.setUnitProvider(unitProvider);
             genericItem.setItemStateConverter(itemStateConverter);
         }
         if (item instanceof NumberItem numberItem) {
@@ -301,21 +300,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     @Override
     protected void unsetReadyService(ReadyService readyService) {
         super.unsetReadyService(readyService);
-    }
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    public void setUnitProvider(UnitProvider unitProvider) {
-        this.unitProvider = unitProvider;
-        for (Item item : getItems()) {
-            ((GenericItem) item).setUnitProvider(unitProvider);
-        }
-    }
-
-    public void unsetUnitProvider(UnitProvider unitProvider) {
-        this.unitProvider = null;
-        for (Item item : getItems()) {
-            ((GenericItem) item).setUnitProvider(null);
-        }
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -83,8 +83,6 @@ public abstract class GenericItem implements ActiveItem {
 
     private @Nullable CommandDescriptionService commandDescriptionService;
 
-    protected @Nullable UnitProvider unitProvider;
-
     protected @Nullable ItemStateConverter itemStateConverter;
 
     public GenericItem(String type, String name) {
@@ -176,7 +174,6 @@ public abstract class GenericItem implements ActiveItem {
         this.eventPublisher = null;
         this.stateDescriptionService = null;
         this.commandDescriptionService = null;
-        this.unitProvider = null;
         this.itemStateConverter = null;
     }
 
@@ -190,10 +187,6 @@ public abstract class GenericItem implements ActiveItem {
 
     public void setCommandDescriptionService(@Nullable CommandDescriptionService commandDescriptionService) {
         this.commandDescriptionService = commandDescriptionService;
-    }
-
-    public void setUnitProvider(@Nullable UnitProvider unitProvider) {
-        this.unitProvider = unitProvider;
     }
 
     public void setItemStateConverter(@Nullable ItemStateConverter itemStateConverter) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.events.EventPublisher;
-import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.service.CommandDescriptionService;
 import org.openhab.core.service.StateDescriptionService;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.service.CommandDescriptionService;
 import org.openhab.core.service.StateDescriptionService;
@@ -402,14 +401,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         super.setCommandDescriptionService(commandDescriptionService);
         if (baseItem instanceof GenericItem) {
             ((GenericItem) baseItem).setCommandDescriptionService(commandDescriptionService);
-        }
-    }
-
-    @Override
-    public void setUnitProvider(@Nullable UnitProvider unitProvider) {
-        super.setUnitProvider(unitProvider);
-        if (baseItem instanceof GenericItem) {
-            ((GenericItem) baseItem).setUnitProvider(unitProvider);
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
@@ -71,34 +71,21 @@ public class CoreItemFactory implements ItemFactory {
         }
 
         String itemType = ItemUtil.getMainItemType(itemTypeName);
-        switch (itemType) {
-            case CALL:
-                return new CallItem(itemName);
-            case COLOR:
-                return new ColorItem(itemName);
-            case CONTACT:
-                return new ContactItem(itemName);
-            case DATETIME:
-                return new DateTimeItem(itemName);
-            case DIMMER:
-                return new DimmerItem(itemName);
-            case IMAGE:
-                return new ImageItem(itemName);
-            case LOCATION:
-                return new LocationItem(itemName);
-            case NUMBER:
-                return new NumberItem(itemTypeName, itemName, unitProvider);
-            case PLAYER:
-                return new PlayerItem(itemName);
-            case ROLLERSHUTTER:
-                return new RollershutterItem(itemName);
-            case STRING:
-                return new StringItem(itemName);
-            case SWITCH:
-                return new SwitchItem(itemName);
-            default:
-                return null;
-        }
+        return switch (itemType) {
+            case CALL -> new CallItem(itemName);
+            case COLOR -> new ColorItem(itemName);
+            case CONTACT -> new ContactItem(itemName);
+            case DATETIME -> new DateTimeItem(itemName);
+            case DIMMER -> new DimmerItem(itemName);
+            case IMAGE -> new ImageItem(itemName);
+            case LOCATION -> new LocationItem(itemName);
+            case NUMBER -> new NumberItem(itemTypeName, itemName, unitProvider);
+            case PLAYER -> new PlayerItem(itemName);
+            case ROLLERSHUTTER -> new RollershutterItem(itemName);
+            case STRING -> new StringItem(itemName);
+            case SWITCH -> new SwitchItem(itemName);
+            default -> null;
+        };
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
@@ -14,6 +14,7 @@ package org.openhab.core.library;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemFactory;
 import org.openhab.core.items.ItemUtil;
@@ -29,7 +30,9 @@ import org.openhab.core.library.items.PlayerItem;
 import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.items.StringItem;
 import org.openhab.core.library.items.SwitchItem;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * {@link CoreItemFactory}-Implementation for the core ItemTypes
@@ -54,6 +57,12 @@ public class CoreItemFactory implements ItemFactory {
     public static final String ROLLERSHUTTER = "Rollershutter";
     public static final String STRING = "String";
     public static final String SWITCH = "Switch";
+    private final UnitProvider unitProvider;
+
+    @Activate
+    public CoreItemFactory(final @Reference UnitProvider unitProvider) {
+        this.unitProvider = unitProvider;
+    }
 
     @Override
     public @Nullable GenericItem createItem(@Nullable String itemTypeName, String itemName) {
@@ -78,7 +87,7 @@ public class CoreItemFactory implements ItemFactory {
             case LOCATION:
                 return new LocationItem(itemName);
             case NUMBER:
-                return new NumberItem(itemTypeName, itemName);
+                return new NumberItem(itemTypeName, itemName, unitProvider);
             case PLAYER:
                 return new PlayerItem(itemName);
             case ROLLERSHUTTER:

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.i18n;
+
+import java.util.Map;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+import javax.measure.spi.SystemOfUnits;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.library.unit.SIUnits;
+
+/**
+ * The {@link TestUnitProvider} implements a {@link UnitProvider} for testing purposes
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class TestUnitProvider implements UnitProvider {
+
+    private final Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap = I18nProviderImpl
+            .getDimensionMap();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public @Nullable <T extends Quantity<T>> Unit<T> getUnit(@Nullable Class<T> dimension) {
+        return (Unit<T>) dimensionMap.getOrDefault(dimension, Map.of()).get(SIUnits.getInstance());
+    }
+
+    @Override
+    public SystemOfUnits getMeasurementSystem() {
+        return SIUnits.getInstance();
+    }
+}

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.internal.items.ExpireManager.ExpireConfig;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
@@ -341,7 +342,7 @@ class ExpireManagerTest {
             // expected as state is invalid
         }
 
-        testItem = new NumberItem("Number:Temperature", ITEMNAME);
+        testItem = new NumberItem("Number:Temperature", ITEMNAME, mock(UnitProvider.class));
         cfg = new ExpireManager.ExpireConfig(testItem, "1h,15 °C", Map.of());
         assertEquals(Duration.ofHours(1), cfg.duration);
         assertEquals(new QuantityType<Temperature>("15 °C"), cfg.expireState);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.openhab.core.events.EventPublisher;
-import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.events.ItemStateChangedEvent;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
@@ -131,7 +130,6 @@ public class GenericItemTest {
         item.setEventPublisher(mock(EventPublisher.class));
         item.setItemStateConverter(mock(ItemStateConverter.class));
         item.setStateDescriptionService(null);
-        item.setUnitProvider(mock(UnitProvider.class));
 
         item.addStateChangeListener(mock(StateChangeListener.class));
 
@@ -141,7 +139,6 @@ public class GenericItemTest {
         assertNull(item.itemStateConverter);
         // can not be tested as stateDescriptionProviders is private in GenericItem
         // assertThat(item.stateDescriptionProviders, is(nullValue()));
-        assertNull(item.unitProvider);
         assertEquals(0, item.listeners.size());
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/CoreItemFactoryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/CoreItemFactoryTest.java
@@ -22,6 +22,12 @@ import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.items.NumberItem;
 
@@ -29,11 +35,15 @@ import org.openhab.core.library.items.NumberItem;
  * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class CoreItemFactoryTest {
+
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     @Test
     public void shouldCreateItems() {
-        CoreItemFactory coreItemFactory = new CoreItemFactory();
+        CoreItemFactory coreItemFactory = new CoreItemFactory(unitProviderMock);
         List<String> itemTypeNames = List.of(coreItemFactory.getSupportedItemTypes());
         for (String itemTypeName : itemTypeNames) {
             GenericItem item = coreItemFactory.createItem(itemTypeName, itemTypeName.toLowerCase());
@@ -45,7 +55,7 @@ public class CoreItemFactoryTest {
 
     @Test
     public void createNumberItemWithDimension() {
-        CoreItemFactory coreItemFactory = new CoreItemFactory();
+        CoreItemFactory coreItemFactory = new CoreItemFactory(unitProviderMock);
         NumberItem numberItem = (NumberItem) coreItemFactory.createItem(CoreItemFactory.NUMBER + ":Temperature",
                 "myNumberItem");
 
@@ -54,7 +64,7 @@ public class CoreItemFactoryTest {
 
     @Test
     public void shouldReturnNullForUnsupportedItemTypeName() {
-        CoreItemFactory coreItemFactory = new CoreItemFactory();
+        CoreItemFactory coreItemFactory = new CoreItemFactory(unitProviderMock);
         GenericItem item = coreItemFactory.createItem("NoValidItemTypeName", "IWantMyItem");
 
         assertThat(item, is(nullValue()));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import javax.measure.quantity.Energy;
+import javax.measure.quantity.Mass;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -37,6 +38,7 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.ImperialUnits;
+import org.openhab.core.library.unit.MetricPrefix;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.service.StateDescriptionService;
@@ -285,5 +287,20 @@ public class NumberItemTest {
 
         assertThat(item.getState(), is(new QuantityType<>("329 kWh")));
         assertThat(item.getUnit(), is(nullValue()));
+    }
+
+    @Test
+    void testSetDefaultUnitIsUsedFirst() {
+        final UnitProvider unitProviderMock = mock(UnitProvider.class);
+        when(unitProviderMock.getUnit(Mass.class)).thenReturn(SIUnits.KILOGRAM);
+        when(stateDescriptionServiceMock.getStateDescription(any(), any())).thenReturn(
+                StateDescriptionFragmentBuilder.create().withPattern("%.0f mg").build().toStateDescription());
+
+        final NumberItem item = new NumberItem("Number:Mass", ITEM_NAME);
+        item.setUnitProvider(unitProviderMock);
+        item.setItemDefaultUnitProvider(() -> MetricPrefix.MEGA(SIUnits.GRAM));
+        item.setStateDescriptionService(stateDescriptionServiceMock);
+
+        assertThat(item.getUnit(), is(MetricPrefix.MEGA(SIUnits.GRAM)));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.internal.i18n.TestUnitProvider;
 import org.openhab.core.items.GroupFunction;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
@@ -39,6 +40,7 @@ import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.osgi.service.component.ComponentContext;
 
 /**
  * @author Henning Treu - Initial contribution
@@ -47,7 +49,8 @@ import org.openhab.core.types.UnDefType;
 @NonNullByDefault
 public class QuantityTypeArithmeticGroupFunctionTest {
 
-    private @NonNullByDefault({}) @Mock UnitProvider unitProvider;
+    private @Mock @NonNullByDefault({}) ComponentContext componentContext;
+    private final UnitProvider unitProvider = new TestUnitProvider();
 
     /**
      * Locales having a different decimal and grouping separators to test string parsing and generation.
@@ -313,16 +316,14 @@ public class QuantityTypeArithmeticGroupFunctionTest {
     }
 
     private NumberItem createNumberItem(String name, Class<? extends Quantity<?>> dimension, State state) {
-        NumberItem item = new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name);
-        item.setUnitProvider(unitProvider);
+        NumberItem item = new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name, unitProvider);
         item.setState(state);
         return item;
     }
 
     private GroupItem createGroupItem(String name, Class<? extends Quantity<?>> dimension, State state) {
         GroupItem item = new GroupItem(name,
-                new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name));
-        item.setUnitProvider(unitProvider);
+                new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name, unitProvider));
         item.setState(state);
         return item;
     }

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -112,4 +112,9 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	net.bytebuddy.byte-buddy;version='[1.12.1,1.12.2)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.1,1.12.2)',\
+	org.mockito.junit-jupiter;version='[4.1.0,4.1.1)',\
+	org.mockito.mockito-core;version='[4.1.0,4.1.1)',\
+	org.objenesis;version='[3.2.0,3.2.1)',\
+	org.openhab.core.model.thing.runtime;version='[4.0.0,4.0.1)'

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.model.script.engine;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,8 +27,14 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemProvider;
 import org.openhab.core.items.ItemRegistry;
@@ -48,6 +55,8 @@ import org.openhab.core.types.State;
  * @author Henning Treu - Initial contribution
  */
 @NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ScriptEngineOSGiTest extends JavaOSGiTest {
 
     private static final String ITEM_NAME = "Switch1";
@@ -58,9 +67,13 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
     private @NonNullByDefault({}) ItemProvider itemProvider;
     private @NonNullByDefault({}) ItemRegistry itemRegistry;
     private @NonNullByDefault({}) ScriptEngine scriptEngine;
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     @BeforeEach
     public void setup() {
+        when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+        when(unitProviderMock.getUnit(Length.class)).thenReturn(SIUnits.METRE);
+
         registerVolatileStorageService();
 
         EventPublisher eventPublisher = event -> {
@@ -351,7 +364,7 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
     }
 
     private Item createNumberItem(String numberItemName, Class<?> dimension) {
-        return new NumberItem("Number:" + dimension.getSimpleName(), numberItemName);
+        return new NumberItem("Number:" + dimension.getSimpleName(), numberItemName, unitProviderMock);
     }
 
     @SuppressWarnings("unchecked")

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
+import static org.openhab.core.library.unit.Units.ONE;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -64,6 +65,7 @@ import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -778,7 +780,6 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
         gfDTO.name = "sum";
         GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, baseItem);
         GroupItem groupItem = new GroupItem("number", baseItem, function);
-        groupItem.setUnitProvider(unitProviderMock);
 
         NumberItem celsius = createNumberItem("C", Temperature.class, new QuantityType<>("23 °C"));
         groupItem.addMember(celsius);
@@ -802,12 +803,14 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
 
     @Test
     public void assertThatNumberGroupItemWithDifferentDimensionsCalculatesCorrectState() {
+        when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+        when(unitProviderMock.getUnit(Pressure.class)).thenReturn(SIUnits.PASCAL);
+        when(unitProviderMock.getUnit(Dimensionless.class)).thenReturn(ONE);
         NumberItem baseItem = createNumberItem("baseItem", Temperature.class, UnDefType.NULL);
         GroupFunctionDTO gfDTO = new GroupFunctionDTO();
         gfDTO.name = "sum";
         GroupFunction function = groupFunctionHelper.createGroupFunction(gfDTO, baseItem);
         GroupItem groupItem = new GroupItem("number", baseItem, function);
-        groupItem.setUnitProvider(unitProviderMock);
         groupItem.setItemStateConverter(itemStateConverter);
 
         NumberItem celsius = createNumberItem("C", Temperature.class, new QuantityType<>("23 °C"));
@@ -826,8 +829,8 @@ public class GroupItemOSGiTest extends JavaOSGiTest {
     }
 
     private NumberItem createNumberItem(String name, Class<? extends Quantity<?>> dimension, State state) {
-        NumberItem item = new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name);
-        item.setUnitProvider(unitProviderMock);
+        NumberItem item = new NumberItem(CoreItemFactory.NUMBER + ":" + dimension.getSimpleName(), name,
+                unitProviderMock);
         item.setState(state);
 
         return item;

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -77,6 +77,7 @@ public class ItemRegistryImplTest extends JavaTest {
     private @NonNullByDefault({}) ManagedItemProvider itemProvider;
 
     private @Mock @NonNullByDefault({}) EventPublisher eventPublisherMock;
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     @BeforeEach
     public void beforeEach() {
@@ -92,7 +93,7 @@ public class ItemRegistryImplTest extends JavaTest {
 
         // setup ManageItemProvider with necessary dependencies:
         itemProvider = new ManagedItemProvider(new VolatileStorageService(),
-                new ItemBuilderFactoryImpl(new CoreItemFactory()));
+                new ItemBuilderFactoryImpl(new CoreItemFactory(unitProviderMock)));
 
         itemProvider.add(new SwitchItem(ITEM_NAME));
         itemProvider.add(cameraItem1);
@@ -107,7 +108,6 @@ public class ItemRegistryImplTest extends JavaTest {
                 setManagedProvider(itemProvider);
                 setEventPublisher(ItemRegistryImplTest.this.eventPublisherMock);
                 setStateDescriptionService(mock(StateDescriptionService.class));
-                setUnitProvider(mock(UnitProvider.class));
                 setItemStateConverter(mock(ItemStateConverter.class));
             }
         };
@@ -369,13 +369,11 @@ public class ItemRegistryImplTest extends JavaTest {
 
         assertNotNull(item.eventPublisher);
         assertNotNull(item.itemStateConverter);
-        assertNotNull(item.unitProvider);
 
         itemProvider.update(new SwitchItem("Item1"));
 
         assertNull(item.eventPublisher);
         assertNull(item.itemStateConverter);
-        assertNull(item.unitProvider);
         assertEquals(0, item.listeners.size());
     }
 
@@ -389,18 +387,6 @@ public class ItemRegistryImplTest extends JavaTest {
 
         verify(item).setStateDescriptionService(any(StateDescriptionService.class));
         verify(baseItem).setStateDescriptionService(any(StateDescriptionService.class));
-    }
-
-    @Test
-    public void assertUnitProviderGetsInjected() {
-        GenericItem item = spy(new SwitchItem("Item1"));
-        NumberItem baseItem = spy(new NumberItem("baseItem"));
-        GenericItem group = new GroupItem("Group", baseItem);
-        itemProvider.add(item);
-        itemProvider.add(group);
-
-        verify(item).setUnitProvider(any(UnitProvider.class));
-        verify(baseItem).setUnitProvider(any(UnitProvider.class));
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -149,6 +149,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     private @Mock @NonNullByDefault({}) ThingHandler thingHandlerMock;
     private @Mock @NonNullByDefault({}) ThingRegistry thingRegistryMock;
     private @Mock @NonNullByDefault({}) TriggerProfile triggerProfileMock;
+    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     private @NonNullByDefault({}) CommunicationManager manager;
     private @NonNullByDefault({}) SafeCaller safeCaller;
@@ -225,12 +226,10 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         THING.setHandler(thingHandlerMock);
 
         when(thingRegistryMock.get(eq(THING_UID))).thenReturn(THING);
-        manager.addItemFactory(new CoreItemFactory());
 
-        UnitProvider unitProvider = mock(UnitProvider.class);
-        when(unitProvider.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
-        ITEM_3.setUnitProvider(unitProvider);
-        ITEM_4.setUnitProvider(unitProvider);
+        when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+
+        manager.addItemFactory(new CoreItemFactory(unitProviderMock));
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -50,8 +50,8 @@ import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.ImperialUnits;
 import org.openhab.core.library.unit.SIUnits;
-import org.openhab.core.service.StateDescriptionService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -81,7 +81,6 @@ import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ChannelTypeUID;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
-import org.openhab.core.types.StateDescriptionFragmentBuilder;
 
 /**
  *
@@ -103,21 +102,27 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         }
     }
 
+    private static final UnitProvider unitProviderMock = mock(UnitProvider.class);
+
     private static final String EVENT = "event";
     private static final String ITEM_NAME_1 = "testItem1";
     private static final String ITEM_NAME_2 = "testItem2";
     private static final String ITEM_NAME_3 = "testItem3";
     private static final String ITEM_NAME_4 = "testItem4";
+    private static final String ITEM_NAME_5 = "testItem5";
     private static final SwitchItem ITEM_1 = new SwitchItem(ITEM_NAME_1);
     private static final SwitchItem ITEM_2 = new SwitchItem(ITEM_NAME_2);
     private static final NumberItem ITEM_3 = new NumberItem(ITEM_NAME_3);
     private static final NumberItem ITEM_4 = new NumberItem(ITEM_NAME_4);
+    private static final NumberItem ITEM_5 = new NumberItem("Number:Temperature", ITEM_NAME_5, unitProviderMock);
+
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("test", "type");
     private static final ThingUID THING_UID = new ThingUID("test", "thing");
     private static final ChannelUID STATE_CHANNEL_UID_1 = new ChannelUID(THING_UID, "state-channel1");
     private static final ChannelUID STATE_CHANNEL_UID_2 = new ChannelUID(THING_UID, "state-channel2");
     private static final ChannelUID STATE_CHANNEL_UID_3 = new ChannelUID(THING_UID, "state-channel3");
     private static final ChannelUID STATE_CHANNEL_UID_4 = new ChannelUID(THING_UID, "state-channel4");
+    private static final ChannelUID STATE_CHANNEL_UID_5 = new ChannelUID(THING_UID, "state-channel5");
     private static final ChannelTypeUID CHANNEL_TYPE_UID_4 = new ChannelTypeUID("test", "channeltype");
     private static final ChannelUID TRIGGER_CHANNEL_UID_1 = new ChannelUID(THING_UID, "trigger-channel1");
     private static final ChannelUID TRIGGER_CHANNEL_UID_2 = new ChannelUID(THING_UID, "trigger-channel2");
@@ -126,6 +131,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     private static final ItemChannelLink LINK_2_S2 = new ItemChannelLink(ITEM_NAME_2, STATE_CHANNEL_UID_2);
     private static final ItemChannelLink LINK_3_S3 = new ItemChannelLink(ITEM_NAME_3, STATE_CHANNEL_UID_3);
     private static final ItemChannelLink LINK_4_S4 = new ItemChannelLink(ITEM_NAME_4, STATE_CHANNEL_UID_4);
+    private static final ItemChannelLink LINK_5_S5 = new ItemChannelLink(ITEM_NAME_5, STATE_CHANNEL_UID_5);
     private static final ItemChannelLink LINK_1_T1 = new ItemChannelLink(ITEM_NAME_1, TRIGGER_CHANNEL_UID_1);
     private static final ItemChannelLink LINK_1_T2 = new ItemChannelLink(ITEM_NAME_1, TRIGGER_CHANNEL_UID_2);
     private static final ItemChannelLink LINK_2_T2 = new ItemChannelLink(ITEM_NAME_2, TRIGGER_CHANNEL_UID_2);
@@ -135,6 +141,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
             ChannelBuilder.create(STATE_CHANNEL_UID_3, "Number:Temperature").withKind(ChannelKind.STATE).build(),
             ChannelBuilder.create(STATE_CHANNEL_UID_4, CoreItemFactory.NUMBER).withKind(ChannelKind.STATE)
                     .withType(CHANNEL_TYPE_UID_4).build(),
+            ChannelBuilder.create(STATE_CHANNEL_UID_5, "Number:Temperature").withKind(ChannelKind.STATE).build(),
             ChannelBuilder.create(TRIGGER_CHANNEL_UID_1).withKind(ChannelKind.TRIGGER).build(),
             ChannelBuilder.create(TRIGGER_CHANNEL_UID_2).withKind(ChannelKind.TRIGGER).build()).build();
 
@@ -149,7 +156,6 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     private @Mock @NonNullByDefault({}) ThingHandler thingHandlerMock;
     private @Mock @NonNullByDefault({}) ThingRegistry thingRegistryMock;
     private @Mock @NonNullByDefault({}) TriggerProfile triggerProfileMock;
-    private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
 
     private @NonNullByDefault({}) CommunicationManager manager;
     private @NonNullByDefault({}) SafeCaller safeCaller;
@@ -170,7 +176,8 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         }
 
         manager = new CommunicationManager(autoUpdateManagerMock, channelTypeRegistryMock, profileFactory, iclRegistry,
-                itemRegistryMock, itemStateConverterMock, eventPublisherMock, safeCaller, thingRegistryMock);
+                itemRegistryMock, itemStateConverterMock, eventPublisherMock, safeCaller, thingRegistryMock,
+                unitProviderMock);
 
         doAnswer(invocation -> {
             switch (((Channel) invocation.getArguments()[0]).getKind()) {
@@ -209,7 +216,8 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
             @Override
             public Collection<ItemChannelLink> getAll() {
-                return List.of(LINK_1_S1, LINK_1_S2, LINK_2_S2, LINK_1_T1, LINK_1_T2, LINK_2_T2, LINK_3_S3, LINK_4_S4);
+                return List.of(LINK_1_S1, LINK_1_S2, LINK_2_S2, LINK_1_T1, LINK_1_T2, LINK_2_T2, LINK_3_S3, LINK_4_S4,
+                        LINK_5_S5);
             }
         });
 
@@ -217,6 +225,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         when(itemRegistryMock.get(eq(ITEM_NAME_2))).thenReturn(ITEM_2);
         when(itemRegistryMock.get(eq(ITEM_NAME_3))).thenReturn(ITEM_3);
         when(itemRegistryMock.get(eq(ITEM_NAME_4))).thenReturn(ITEM_4);
+        when(itemRegistryMock.get(eq(ITEM_NAME_5))).thenReturn(ITEM_5);
 
         ChannelType channelType4 = mock(ChannelType.class);
         when(channelType4.getItemType()).thenReturn("Number:Temperature");
@@ -296,20 +305,14 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
     @Test
     public void testItemCommandEventDecimal2Quantity2() {
-        // Take unit from state description
-        StateDescriptionService stateDescriptionService = mock(StateDescriptionService.class);
-        when(stateDescriptionService.getStateDescription(ITEM_NAME_3, null)).thenReturn(
-                StateDescriptionFragmentBuilder.create().withPattern("%.1f °F").build().toStateDescription());
-        ITEM_3.setStateDescriptionService(stateDescriptionService);
+        ITEM_5.setItemDefaultUnitProvider(() -> ImperialUnits.FAHRENHEIT);
 
-        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_3, DecimalType.valueOf("20")));
+        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_5, DecimalType.valueOf("20")));
         waitForAssert(() -> {
             verify(stateProfileMock).onCommandFromItem(eq(QuantityType.valueOf("20 °F")));
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);
-
-        ITEM_3.setStateDescriptionService(null);
     }
 
     @Test


### PR DESCRIPTION
Closes #3247 

Before merging we should discuss if we remove the "derive unit from state description" code. Looking at discussion [here](https://community.openhab.org/t/uom-default-units-and-consequences/142360), it seems that the majority would prefer to keep item-unit and representation (state description) completely separate. I'm fine with that, but it might be breaking for existing installations. 

Signed-off-by: Jan N. Klug <github@klug.nrw>