### PR TITLE
Allow inline scripts in SCRIPT transformation

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -96,13 +96,20 @@ public class ScriptTransformationService implements TransformationService, Regis
         scriptRecord.lock.lock();
         try {
             if (scriptRecord.script.isBlank()) {
-                Transformation transformation = transformationRegistry.get(scriptUid);
-                if (transformation != null) {
-                    if (!SUPPORTED_CONFIGURATION_TYPE.equals(transformation.getType())) {
-                        throw new TransformationException("Configuration does not have correct type 'script' but '"
-                                + transformation.getType() + "'.");
+                if (scriptUid.startsWith("|")) {
+                    // inline script -> strip inline-identifier
+                    scriptRecord.script = scriptUid.substring(1);
+                } else {
+                    // get script from transformation registry
+                    Transformation transformation = transformationRegistry.get(scriptUid);
+                    if (transformation != null) {
+                        if (!SUPPORTED_CONFIGURATION_TYPE.equals(transformation.getType())) {
+                            throw new TransformationException("Configuration does not have correct type 'script' but '"
+                                    + transformation.getType() + "'.");
+                        }
+                        scriptRecord.script = transformation.getConfiguration().getOrDefault(Transformation.FUNCTION,
+                                "");
                     }
-                    scriptRecord.script = transformation.getConfiguration().getOrDefault(Transformation.FUNCTION, "");
                 }
                 if (scriptRecord.script.isBlank()) {
                     throw new TransformationException("Could not get script for UID '" + scriptUid + "'.");

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -51,6 +51,8 @@ public class ScriptTransformationServiceTest {
     private static final String SCRIPT_UID = "scriptUid";
     private static final String INVALID_SCRIPT_UID = "invalidScriptUid";
 
+    private static final String INLINE_SCRIPT = "|inlineScript";
+
     private static final String SCRIPT = "script";
     private static final String SCRIPT_OUTPUT = "output";
 
@@ -175,5 +177,12 @@ public class ScriptTransformationServiceTest {
                 () -> service.transform(SCRIPT_LANGUAGE + ":" + INVALID_SCRIPT_UID, "input"));
 
         assertThat(e.getMessage(), is("Configuration does not have correct type 'script' but 'invalid'."));
+    }
+
+    @Test
+    public void inlineScriptProperlyProcessed() throws TransformationException, ScriptException {
+        service.transform(SCRIPT_LANGUAGE + ":" + INLINE_SCRIPT, "input");
+
+        verify(scriptEngine).eval(INLINE_SCRIPT.substring(1));
     }
 }


### PR DESCRIPTION
Closes #3243 

Inline scripts are identified by starting with `|` which is fine since that is neither an allowed character on nearly all file systems nor for UIDs. Additionally, the old JS transformation also defined inline scripts in this way, so it is already a known concept.

Signed-off-by: Jan N. Klug <github@klug.nrw>