### PR TITLE
Remove wrong DataAmount units

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -248,14 +248,8 @@ public final class Units extends CustomUnits {
         SimpleUnitFormat.getInstance().label(GIGABIT_PER_SECOND, "Gbit/s");
         SimpleUnitFormat.getInstance().label(IRRADIANCE, "W/m²");
         SimpleUnitFormat.getInstance().label(KILOBYTE, "kB");
-        // "KB" is wrong, but we keep it for backward compatibility
-        SimpleUnitFormat.getInstance().alias(KILOBYTE, "KB");
         SimpleUnitFormat.getInstance().label(KIBIBYTE, "kiB");
-        // "KiB" is wrong, but we keep it for backward compatibility
-        SimpleUnitFormat.getInstance().alias(KIBIBYTE, "KiB");
         SimpleUnitFormat.getInstance().alias(KIBIBYTE, "kio");
-        // "Kio" is wrong, but we keep it for backward compatibility
-        SimpleUnitFormat.getInstance().alias(KIBIBYTE, "Kio");
         SimpleUnitFormat.getInstance().label(KILOBIT, "kbit");
         SimpleUnitFormat.getInstance().label(KILOBIT_PER_SECOND, "kbit/s");
         SimpleUnitFormat.getInstance().label(KILOVAR, "kvar");

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
@@ -13,8 +13,7 @@
 package org.openhab.core.library.dimension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ public class DataAmountTest {
 
     @Test
     public void testInvertibleUnit() {
-        QuantityType<DataAmount> quantityType = new QuantityType("1000 KB");
+        QuantityType<DataAmount> quantityType = new QuantityType("1000 kB");
         QuantityType<?> inverted = quantityType.toInvertibleUnit(Units.MEGABYTE);
 
         assertThat(quantityType, is(equalTo(inverted)));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -456,7 +456,7 @@ public class QuantityTypeTest {
         assertEquals("1 GiB", bytes.toString());
         bytes = new QuantityType<DataAmount>(1, BinaryPrefix.GIBI(Units.BYTE));
         assertEquals("1 GiB", bytes.toString());
-        QuantityType<DataAmount> bigAmount = new QuantityType<>("1 Kio");
+        QuantityType<DataAmount> bigAmount = new QuantityType<>("1 kio");
         QuantityType<DataAmount> octets = bigAmount.toUnit(Units.OCTET);
         assertEquals(1024, octets.intValue());
         QuantityType<DataAmount> hugeAmount = new QuantityType<>("1024Gio");


### PR DESCRIPTION
These wrong DataAmount units were added in #3208 for backwards compatibility. In OH4 we can clean them up because this major version allows for breaking changes.