### PR TITLE
[voice] Support managed dialogs

### DIFF
--- a/bundles/org.openhab.core.voice/pom.xml
+++ b/bundles/org.openhab.core.voice/pom.xml
@@ -30,6 +30,17 @@
       <artifactId>org.openhab.core.io.console</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -137,17 +137,23 @@ public class DialogContext {
         }
 
         public Builder withKS(@Nullable KSService service) {
-            this.ks = service;
+            if (service != null) {
+                this.ks = service;
+            }
             return this;
         }
 
         public Builder withSTT(@Nullable STTService service) {
-            this.stt = service;
+            if (service != null) {
+                this.stt = service;
+            }
             return this;
         }
 
         public Builder withTTS(@Nullable TTSService service) {
-            this.tts = service;
+            if (service != null) {
+                this.tts = service;
+            }
             return this;
         }
 
@@ -156,32 +162,44 @@ public class DialogContext {
         }
 
         public Builder withHLIs(List<HumanLanguageInterpreter> services) {
-            this.hlis = services;
+            if (!services.isEmpty()) {
+                this.hlis = services;
+            }
             return this;
         }
 
-        public Builder withKeyword(String keyword) {
-            this.keyword = keyword;
+        public Builder withKeyword(@Nullable String keyword) {
+            if (keyword != null && !keyword.isBlank()) {
+                this.keyword = keyword;
+            }
             return this;
         }
 
         public Builder withVoice(@Nullable Voice voice) {
-            this.voice = voice;
+            if (voice != null) {
+                this.voice = voice;
+            }
             return this;
         }
 
         public Builder withListeningItem(@Nullable String listeningItem) {
-            this.listeningItem = listeningItem;
+            if (listeningItem != null) {
+                this.listeningItem = listeningItem;
+            }
             return this;
         }
 
         public Builder withMelody(@Nullable String listeningMelody) {
-            this.listeningMelody = listeningMelody;
+            if (listeningMelody != null) {
+                this.listeningMelody = listeningMelody;
+            }
             return this;
         }
 
-        public Builder withLocale(Locale locale) {
-            this.locale = locale;
+        public Builder withLocale(@Nullable Locale locale) {
+            if (locale != null) {
+                this.locale = locale;
+            }
             return this;
         }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Describes dialog desired services and options.
+ *
+ * @author Miguel Álvarez - Initial contribution
+ */
+@NonNullByDefault
+public class DialogRegistration {
+    /**
+     * Dialog audio source id
+     */
+    public String sourceId;
+    /**
+     * Dialog audio sink id
+     */
+    public String sinkId;
+    /**
+     * Preferred keyword-spotting service
+     */
+    public @Nullable String ksId;
+    /**
+     * Selected keyword for spotting
+     */
+    public @Nullable String keyword;
+    /**
+     * Preferred speech-to-text service id
+     */
+    public @Nullable String sttId;
+    /**
+     * Preferred text-to-speech service id
+     */
+    public @Nullable String ttsId;
+    /**
+     * Preferred voice id
+     */
+    public @Nullable String voiceId;
+    /**
+     * List of interpreters
+     */
+    public List<String> hliIds = List.of();
+    /**
+     * Dialog locale
+     */
+    public @Nullable Locale locale;
+    /**
+     * Linked listening item
+     */
+    public @Nullable String listeningItem;
+    /**
+     * Custom listening melody
+     */
+    public @Nullable String listeningMelody;
+    /**
+     * True if an associated dialog is running
+     */
+    public boolean running = false;
+
+    public DialogRegistration(String sourceId, String sinkId) {
+        this.sourceId = sourceId;
+        this.sinkId = sinkId;
+    }
+}

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -285,6 +285,38 @@ public interface VoiceManager {
     void listenAndAnswer(DialogContext context) throws IllegalStateException;
 
     /**
+     * Register a dialog, so it will be persisted and started any time the required services are available.
+     *
+     * Only one registration can be done for an audio source.
+     *
+     * @param registration with the desired services ids and options for the dialog
+     *
+     * @throws IllegalStateException if there is another registration for the same source
+     */
+    void registerDialog(DialogRegistration registration) throws IllegalStateException;
+
+    /**
+     * Removes a dialog registration and stops the associate dialog.
+     *
+     * @param registration with the desired services ids and options for the dialog
+     */
+    void unregisterDialog(DialogRegistration registration);
+
+    /**
+     * Removes a dialog registration and stops the associate dialog.
+     *
+     * @param sourceId the registration audio source id.
+     */
+    void unregisterDialog(String sourceId);
+
+    /**
+     * List current dialog registrations
+     *
+     * @return a list of {@link DialogRegistration}
+     */
+    List<DialogRegistration> getDialogRegistrations();
+
+    /**
      * Retrieves a TTS service.
      * If a default name is configured and the service available, this is returned. Otherwise, the first available
      * service is returned.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -76,7 +76,7 @@ public class DialogProcessor implements KSListener, STTListener {
 
     private final Logger logger = LoggerFactory.getLogger(DialogProcessor.class);
 
-    private final DialogContext dialogContext;
+    public final DialogContext dialogContext;
     private @Nullable List<ToneSynthesizer.Tone> listeningMelody;
     private final EventPublisher eventPublisher;
     private final TranslationProvider i18nProvider;
@@ -220,6 +220,7 @@ public class DialogProcessor implements KSListener, STTListener {
         closeStreamKS();
         toggleProcessing(false);
         playStopSound();
+        eventListener.onDialogStopped(dialogContext);
     }
 
     /**
@@ -458,5 +459,12 @@ public class DialogProcessor implements KSListener, STTListener {
          * @param context used by the dialog processor
          */
         void onBeforeDialogInterpretation(DialogContext context);
+
+        /**
+         * Runs whenever the dialog it stopped
+         *
+         * @param context used by the dialog processor
+         */
+        void onDialogStopped(DialogContext context);
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -354,8 +354,10 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         }
     }
 
-    private @Nullable Voice getVoice(String id) {
-        if (id.contains(":")) {
+    private @Nullable Voice getVoice(@Nullable String id) {
+        if (id == null) {
+            return null;
+        } else if (id.contains(":")) {
             // it is a fully qualified unique id
             String[] segments = id.split(":");
             TTSService tts = getTTS(segments[0]);
@@ -851,8 +853,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    public @Nullable TTSService getTTS(String id) {
-        return ttsServices.get(id);
+    public @Nullable TTSService getTTS(@Nullable String id) {
+        return id == null ? null : ttsServices.get(id);
     }
 
     private @Nullable TTSService getTTS(Voice voice) {
@@ -881,8 +883,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    public @Nullable STTService getSTT(String id) {
-        return sttServices.get(id);
+    public @Nullable STTService getSTT(@Nullable String id) {
+        return id == null ? null : sttServices.get(id);
     }
 
     @Override
@@ -907,8 +909,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    public @Nullable KSService getKS(String id) {
-        return ksServices.get(id);
+    public @Nullable KSService getKS(@Nullable String id) {
+        return id == null ? null : ksServices.get(id);
     }
 
     @Override
@@ -933,8 +935,8 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    public @Nullable HumanLanguageInterpreter getHLI(String id) {
-        return humanLanguageInterpreters.get(id);
+    public @Nullable HumanLanguageInterpreter getHLI(@Nullable String id) {
+        return id == null ? null : humanLanguageInterpreters.get(id);
     }
 
     @Override
@@ -1082,45 +1084,20 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
      * This method tries to start a dialog from a dialog registration.
      */
     private void tryBuildDialogRegistration(DialogRegistration dialogRegistration) {
-        var builder = getDialogContextBuilder().withSink(audioManager.getSink(dialogRegistration.sinkId))
-                .withSource(audioManager.getSource(dialogRegistration.sourceId));
-        String ksId = dialogRegistration.ksId;
-        if (ksId != null) {
-            builder.withKS(getKS(ksId));
-        }
-        String keyword = dialogRegistration.keyword;
-        if (keyword != null) {
-            builder.withKS(getKS(keyword));
-        }
-        String sttId = dialogRegistration.sttId;
-        if (sttId != null) {
-            builder.withSTT(getSTT(sttId));
-        }
-        String ttsId = dialogRegistration.ttsId;
-        if (ttsId != null) {
-            builder.withTTS(getTTS(ttsId));
-        }
-        String voiceId = dialogRegistration.voiceId;
-        if (voiceId != null) {
-            builder.withVoice(getVoice(voiceId));
-        }
-        if (!dialogRegistration.hliIds.isEmpty()) {
-            builder.withHLIs(getHLIsByIds(dialogRegistration.hliIds));
-        }
-        Locale locale = dialogRegistration.locale;
-        if (locale != null) {
-            builder.withLocale(locale);
-        }
-        var listeningItem = dialogRegistration.listeningItem;
-        if (listeningItem != null) {
-            builder.withListeningItem(listeningItem);
-        }
-        var listeningMelody = dialogRegistration.listeningMelody;
-        if (listeningMelody != null) {
-            builder.withMelody(listeningMelody);
-        }
         try {
-            startDialog(builder.build());
+            startDialog(getDialogContextBuilder() //
+                    .withSink(audioManager.getSink(dialogRegistration.sinkId)) //
+                    .withSource(audioManager.getSource(dialogRegistration.sourceId)) //
+                    .withKS(getKS(dialogRegistration.ksId)) //
+                    .withKeyword(dialogRegistration.keyword) //
+                    .withSTT(getSTT(dialogRegistration.sttId)) //
+                    .withTTS(getTTS(dialogRegistration.ttsId)) //
+                    .withVoice(getVoice(dialogRegistration.voiceId)) //
+                    .withHLIs(getHLIsByIds(dialogRegistration.hliIds)) //
+                    .withLocale(dialogRegistration.locale) //
+                    .withListeningItem(listeningItem) //
+                    .withMelody(listeningMelody) //
+                    .build());
         } catch (IllegalStateException e) {
             logger.debug("Unable to start dialog registration: {}", e.getMessage());
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -1058,8 +1058,9 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
      * and cancel the previous scheduled call if any.
      */
     private void scheduleDialogRegistrations() {
-        if (dialogRegistrationFuture != null) {
-            dialogRegistrationFuture.cancel(false);
+        ScheduledFuture<?> job = this.dialogRegistrationFuture;
+        if (job != null) {
+            job.cancel(false);
         }
         dialogRegistrationFuture = scheduledExecutorService.schedule(this::buildDialogRegistrations, 5,
                 TimeUnit.SECONDS);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -166,7 +166,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     protected void deactivate() {
         dialogProcessors.values().forEach(DialogProcessor::stop);
         dialogProcessors.clear();
-        var dialogRegistrationFuture = this.dialogRegistrationFuture;
+        ScheduledFuture<?> dialogRegistrationFuture = this.dialogRegistrationFuture;
         if (dialogRegistrationFuture != null) {
             dialogRegistrationFuture.cancel(true);
             this.dialogRegistrationFuture = null;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -1055,7 +1055,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     /**
      * In order to reduce the number of dialog registration builds
      * this method schedules a call to {@link #buildDialogRegistrations() buildDialogRegistrations} in five seconds
-     * and cancel the previous one.
+     * and cancel the previous scheduled call if any.
      */
     private void scheduleDialogRegistrations() {
         if (dialogRegistrationFuture != null) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -147,12 +147,12 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     @Activate
     public VoiceManagerImpl(final @Reference LocaleProvider localeProvider, final @Reference AudioManager audioManager,
             final @Reference EventPublisher eventPublisher, final @Reference TranslationProvider i18nProvider,
-            final @Reference StorageService StorageService) {
+            final @Reference StorageService storageService) {
         this.localeProvider = localeProvider;
         this.audioManager = audioManager;
         this.eventPublisher = eventPublisher;
         this.i18nProvider = i18nProvider;
-        this.dialogRegistrationStorage = StorageService.getStorage(DialogRegistration.class.getName(),
+        this.dialogRegistrationStorage = storageService.getStorage(DialogRegistration.class.getName(),
                 this.getClass().getClassLoader());
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -1074,32 +1074,25 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
         synchronized (dialogRegistrationStorage) {
             dialogRegistrationStorage.getValues().stream().forEach(dr -> {
                 if (dr != null && !dialogProcessors.containsKey(dr.sourceId)) {
-                    this.tryBuildDialogRegistration(dr);
+                    try {
+                        startDialog(getDialogContextBuilder() //
+                                .withSink(audioManager.getSink(dr.sinkId)) //
+                                .withSource(audioManager.getSource(dr.sourceId)) //
+                                .withKS(getKS(dr.ksId)) //
+                                .withKeyword(dr.keyword) //
+                                .withSTT(getSTT(dr.sttId)) //
+                                .withTTS(getTTS(dr.ttsId)) //
+                                .withVoice(getVoice(dr.voiceId)) //
+                                .withHLIs(getHLIsByIds(dr.hliIds)) //
+                                .withLocale(dr.locale) //
+                                .withListeningItem(dr.listeningItem) //
+                                .withMelody(dr.listeningMelody) //
+                                .build());
+                    } catch (IllegalStateException e) {
+                        logger.debug("Unable to start dialog registration: {}", e.getMessage());
+                    }
                 }
             });
-        }
-    }
-
-    /**
-     * This method tries to start a dialog from a dialog registration.
-     */
-    private void tryBuildDialogRegistration(DialogRegistration dialogRegistration) {
-        try {
-            startDialog(getDialogContextBuilder() //
-                    .withSink(audioManager.getSink(dialogRegistration.sinkId)) //
-                    .withSource(audioManager.getSource(dialogRegistration.sourceId)) //
-                    .withKS(getKS(dialogRegistration.ksId)) //
-                    .withKeyword(dialogRegistration.keyword) //
-                    .withSTT(getSTT(dialogRegistration.sttId)) //
-                    .withTTS(getTTS(dialogRegistration.ttsId)) //
-                    .withVoice(getVoice(dialogRegistration.voiceId)) //
-                    .withHLIs(getHLIsByIds(dialogRegistration.hliIds)) //
-                    .withLocale(dialogRegistration.locale) //
-                    .withListeningItem(listeningItem) //
-                    .withMelody(listeningMelody) //
-                    .build());
-        } catch (IllegalStateException e) {
-            logger.debug("Unable to start dialog registration: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -166,9 +166,10 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     protected void deactivate() {
         dialogProcessors.values().forEach(DialogProcessor::stop);
         dialogProcessors.clear();
+        var dialogRegistrationFuture = this.dialogRegistrationFuture;
         if (dialogRegistrationFuture != null) {
             dialogRegistrationFuture.cancel(true);
-            dialogRegistrationFuture = null;
+            this.dialogRegistrationFuture = null;
         }
     }
 

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -63,6 +63,7 @@ Fragment-Host: org.openhab.core.voice
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	org.openhab.core;version='[4.0.0,4.0.1)',\
 	org.openhab.core.audio;version='[4.0.0,4.0.1)',\
+	org.openhab.core;version='[4.0.0,4.0.1)',\
 	org.openhab.core.config.core;version='[4.0.0,4.0.1)',\
 	org.openhab.core.io.console;version='[4.0.0,4.0.1)',\
 	org.openhab.core.io.http;version='[4.0.0,4.0.1)',\

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -615,9 +615,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         // Wait some time to be sure dialog build has been fired and check dialog has been started
         Thread.sleep(6000);
         // Assert registration is available and running
-        var registrations  = voiceManager.getDialogRegistrations();
+        var registrations = voiceManager.getDialogRegistrations();
         assertThat(registrations.size(), is(1));
-        assertTrue(registrations.stream().findAny().map(r->r.running).orElse(false));
+        assertTrue(registrations.stream().findAny().map(r -> r.running).orElse(false));
         // Assert dialog has been stated
         assertTrue(ksService.isWordSpotted());
         assertTrue(sttService.isRecognized());

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
@@ -51,6 +51,7 @@ public class InterpretCommandTest extends VoiceConsoleCommandExtensionTest {
 
     @BeforeEach
     public void setUp() throws IOException, InterruptedException {
+        registerVolatileStorageService();
         ttsService = new TTSServiceStub();
         hliStub = new HumanLanguageInterpreterStub();
         voice = new VoiceStub();

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
@@ -61,6 +61,7 @@ public class SayCommandTest extends VoiceConsoleCommandExtensionTest {
 
     @BeforeEach
     public void setUp() {
+        registerVolatileStorageService();
         sink = new SinkStub();
         voice = new VoiceStub();
 

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoiceConsoleCommandExtensionTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoiceConsoleCommandExtensionTest.java
@@ -44,6 +44,7 @@ public abstract class VoiceConsoleCommandExtensionTest extends JavaOSGiTest {
 
     @BeforeEach
     public void setup() {
+        registerVolatileStorageService();
         voiceManager = getService(VoiceManager.class, VoiceManagerImpl.class);
         assertNotNull(voiceManager);
         audioManager = getService(AudioManager.class, AudioManager.class);

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
@@ -50,6 +50,7 @@ public class VoicesCommandTest extends VoiceConsoleCommandExtensionTest {
 
     @BeforeEach
     public void setUp() throws IOException {
+        registerVolatileStorageService();
         localeProvider = getService(LocaleProvider.class);
         assertNotNull(localeProvider);
 


### PR DESCRIPTION
This PR adds a new functionality to the voice manager for register/unregister dialog descriptions.
The voice manager will try to keep a started dialog for each registered description (and stop the dialog if it's unregistered).
The dialog descriptions are persisted using a storage.

This PR do not introduce any code breaking changes, but introduces the behavior to stop the dialogs whenever a service in use became unavailable. 

Related to https://github.com/openhab/openhab-core/issues/3265

<s>This is a draft because integration tests are missing.</s>

Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>