### PR TITLE
Initial contribution of an CLI upgrade-tool

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -19,6 +19,7 @@
   <modules>
     <module>archetype</module>
     <module>i18n-plugin</module>
+    <module>upgradetool</module>
   </modules>
 
 </project>

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -25,6 +25,11 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.thing</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.storage.json</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.tools</groupId>
+    <artifactId>org.openhab.core.reactor.tools</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>upgradetool</artifactId>
+
+  <packaging>jar</packaging>
+
+  <name>openHAB Core :: Tools :: Upgrade tool</name>
+  <description>A tool for upgrading openHAB from 3.4 to 4.0</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.storage.json</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.measure</groupId>
+      <artifactId>unit-api</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>si.uom</groupId>
+      <artifactId>si-units</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>tech.units</groupId>
+      <artifactId>indriya</artifactId>
+      <version>2.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
+      <version>2.2.600</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>unpack-eea</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.lastnpe.eea</groupId>
+                  <artifactId>eea-all</artifactId>
+                  <version>${eea.version}</version>
+                  <overWrite>true</overWrite>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>org.openhab.core.tools.UpgradeTool</mainClass>
+            </manifest>
+          </archive>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -92,6 +92,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -15,6 +15,7 @@ package org.openhab.core.tools;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import javax.measure.Unit;
 
@@ -26,10 +27,13 @@ import org.apache.commons.cli.OptionGroup;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.config.core.Configuration;
 import org.openhab.core.items.ManagedItemProvider.PersistedItem;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
 import org.openhab.core.storage.json.internal.JsonStorage;
+import org.openhab.core.thing.internal.link.ItemChannelLinkConfigDescriptionProvider;
+import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.types.util.UnitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +48,7 @@ public class UpgradeTool {
     private static final Logger LOGGER = LoggerFactory.getLogger("UpgradeTool");
 
     private static final String CMD_OPT_ITEM = "item";
+    private static final String CMD_OPT_LINK = "link";
     private static final String CMD_OPT_DIR = "dir";
 
     private static Options getOptions() {
@@ -57,15 +62,18 @@ public class UpgradeTool {
         operation.setRequired(true);
         operation.addOption(Option.builder().longOpt(CMD_OPT_ITEM).numberOfArgs(1)
                 .desc("perform the given operation on the item database").build());
+        operation.addOption(Option.builder().longOpt(CMD_OPT_LINK).numberOfArgs(1)
+                .desc("perform the given operation on the link database").build());
 
         options.addOptionGroup(operation);
 
         return options;
     }
 
-    private static void itemCopyDefaultUnit(String baseDir) {
+    private static void itemCopyUnitToMetadata(String baseDir) {
         Path itemJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Item.json");
         Path metadataJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Metadata.json");
+        LOGGER.info("Copying item unit from state description to metadata in database '{}'", itemJsonDatabasePath);
 
         if (!Files.isReadable(itemJsonDatabasePath)) {
             LOGGER.error("Cannot access item database '{}', check path and access rights.", itemJsonDatabasePath);
@@ -79,30 +87,33 @@ public class UpgradeTool {
 
         JsonStorage<PersistedItem> itemStorage = new JsonStorage<>(itemJsonDatabasePath.toFile(), null, 5, 0, 0,
                 List.of());
-
         JsonStorage<Metadata> metadataStorage = new JsonStorage<>(metadataJsonDatabasePath.toFile(), null, 5, 0, 0,
                 List.of());
 
         itemStorage.getKeys().forEach(itemName -> {
             PersistedItem item = itemStorage.get(itemName);
             if (item != null && item.itemType.startsWith("Number:")) {
-                Metadata metadata = metadataStorage.get("stateDescription:" + itemName);
-                if (metadata == null) {
-                    LOGGER.info("{}: Nothing to do, no state description found.", itemName);
+                if (metadataStorage.containsKey("unit:" + itemName)) {
+                    LOGGER.info("{}: already contains a 'unit' metadata, skipping it", itemName);
                 } else {
-                    String pattern = (String) metadata.getConfiguration().get("pattern");
-                    if (pattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
-                        LOGGER.info(
-                                "{}: State description contains unit place-holder '%unit%', check if 'defaultUnit' metadata is needed!",
-                                itemName);
+                    Metadata metadata = metadataStorage.get("stateDescription:" + itemName);
+                    if (metadata == null) {
+                        LOGGER.info("{}: Nothing to do, no state description found.", itemName);
                     } else {
-                        Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
-                        if (stateDescriptionUnit != null) {
-                            String defaultUnit = stateDescriptionUnit.toString();
-                            MetadataKey defaultUnitMetadataKey = new MetadataKey("defaultUnit", itemName);
-                            Metadata defaultUnitMetadata = new Metadata(defaultUnitMetadataKey, defaultUnit, null);
-                            metadataStorage.put(defaultUnitMetadataKey.toString(), defaultUnitMetadata);
-                            LOGGER.info("{}: Wrote 'defaultUnit={}' to metadata.", itemName, defaultUnit);
+                        String pattern = (String) metadata.getConfiguration().get("pattern");
+                        if (pattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
+                            LOGGER.info(
+                                    "{}: State description contains unit place-holder '%unit%', check if 'unit' metadata is needed!",
+                                    itemName);
+                        } else {
+                            Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
+                            if (stateDescriptionUnit != null) {
+                                String unit = stateDescriptionUnit.toString();
+                                MetadataKey defaultUnitMetadataKey = new MetadataKey("unit", itemName);
+                                Metadata defaultUnitMetadata = new Metadata(defaultUnitMetadataKey, unit, null);
+                                metadataStorage.put(defaultUnitMetadataKey.toString(), defaultUnitMetadata);
+                                LOGGER.info("{}: Wrote 'unit={}' to metadata.", itemName, unit);
+                            }
                         }
                     }
                 }
@@ -110,6 +121,38 @@ public class UpgradeTool {
         });
 
         metadataStorage.flush();
+    }
+
+    private static void upgradeJsProfile(String baseDir) {
+        Path linkJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.thing.link.ItemChannelLink.json");
+        LOGGER.info("Upgrading JS profile configuration in database '{}'", linkJsonDatabasePath);
+
+        if (!Files.isWritable(linkJsonDatabasePath)) {
+            LOGGER.error("Cannot access link database '{}', check path and access rights.", linkJsonDatabasePath);
+            return;
+        }
+        JsonStorage<ItemChannelLink> linkStorage = new JsonStorage<>(linkJsonDatabasePath.toFile(), null, 5, 0, 0,
+                List.of());
+
+        List.copyOf(linkStorage.getKeys()).forEach(linkUid -> {
+            ItemChannelLink link = Objects.requireNonNull(linkStorage.get(linkUid));
+            Configuration configuration = link.getConfiguration();
+            String profileName = (String) configuration.get(ItemChannelLinkConfigDescriptionProvider.PARAM_PROFILE);
+            if ("transform:JS".equals(profileName)) {
+                String function = (String) configuration.get("function");
+                if (function != null) {
+                    configuration.put("toItemScript", function);
+                    configuration.put("toHandlerScript", function);
+                    configuration.remove("function");
+
+                    linkStorage.put(linkUid, link);
+                    LOGGER.info("{}: rewrote JS profile link to new format", linkUid);
+                } else {
+                    LOGGER.info("{}: link already has correct configuration", linkUid);
+                }
+            }
+        });
+        linkStorage.flush();
     }
 
     public static void main(String[] args) {
@@ -121,16 +164,27 @@ public class UpgradeTool {
             if (commandLine.hasOption(CMD_OPT_ITEM)) {
                 String operation = commandLine.getOptionValue(CMD_OPT_ITEM);
                 switch (operation) {
-                    case "copyDefaultUnit":
-                        itemCopyDefaultUnit(baseDir);
+                    case "copyUnitToMetadata":
+                        itemCopyUnitToMetadata(baseDir);
                         break;
                     default:
-                        System.out.println("Available tasks for operation 'item': copyDefaultUnit");
+                        System.out.println("Available tasks for operation 'item': copyUnitToMetadata");
+                }
+            } else if (commandLine.hasOption(CMD_OPT_LINK)) {
+                String operation = commandLine.getOptionValue(CMD_OPT_LINK);
+                switch (operation) {
+                    case "upgradeJsProfile":
+                        upgradeJsProfile(baseDir);
+                        break;
+                    default:
+                        System.out.println("Available tasks for operation 'link': upgradeJsProfile");
                 }
             }
         } catch (ParseException e) {
             HelpFormatter formatter = new HelpFormatter();
             formatter.printHelp("upgradetool", options);
         }
+
+        System.exit(0);
     }
 }

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.tools;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.measure.Unit;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.items.ManagedItemProvider.PersistedItem;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.storage.json.internal.JsonStorage;
+import org.openhab.core.types.util.UnitUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link UpgradeTool} is a tool for upgrading openHAB to mitigate breaking changes
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class UpgradeTool {
+    private static final Logger LOGGER = LoggerFactory.getLogger("UpgradeTool");
+
+    private static final String CMD_OPT_ITEM = "item";
+    private static final String CMD_OPT_DIR = "dir";
+
+    private static Options getOptions() {
+        Options options = new Options();
+
+        options.addOption(
+                Option.builder().longOpt(CMD_OPT_DIR).desc("directory to process").numberOfArgs(1).required().build());
+
+        // add the group for available options
+        OptionGroup operation = new OptionGroup();
+        operation.setRequired(true);
+        operation.addOption(Option.builder().longOpt(CMD_OPT_ITEM).numberOfArgs(1)
+                .desc("perform the given operation on the item database").build());
+
+        options.addOptionGroup(operation);
+
+        return options;
+    }
+
+    private static void itemCopyDefaultUnit(String baseDir) {
+        Path itemJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Item.json");
+        Path metadataJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Metadata.json");
+
+        if (!Files.isReadable(itemJsonDatabasePath)) {
+            LOGGER.error("Cannot access item database '{}', check path and access rights.", itemJsonDatabasePath);
+            return;
+        }
+        if (!Files.isWritable(metadataJsonDatabasePath)) {
+            LOGGER.error("Cannot access metadata database '{}', check path and access rights.",
+                    metadataJsonDatabasePath);
+            return;
+        }
+
+        JsonStorage<PersistedItem> itemStorage = new JsonStorage<>(itemJsonDatabasePath.toFile(), null, 5, 0, 0,
+                List.of());
+
+        JsonStorage<Metadata> metadataStorage = new JsonStorage<>(metadataJsonDatabasePath.toFile(), null, 5, 0, 0,
+                List.of());
+
+        itemStorage.getKeys().forEach(itemName -> {
+            PersistedItem item = itemStorage.get(itemName);
+            if (item != null && item.itemType.startsWith("Number:")) {
+                Metadata metadata = metadataStorage.get("stateDescription:" + itemName);
+                if (metadata == null) {
+                    LOGGER.info("{}: Nothing to do, no state description found.", itemName);
+                } else {
+                    String pattern = (String) metadata.getConfiguration().get("pattern");
+                    if (pattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
+                        LOGGER.info(
+                                "{}: State description contains unit place-holder '%unit%', check if 'defaultUnit' metadata is needed!",
+                                itemName);
+                    } else {
+                        Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
+                        if (stateDescriptionUnit != null) {
+                            String defaultUnit = stateDescriptionUnit.toString();
+                            MetadataKey defaultUnitMetadataKey = new MetadataKey("defaultUnit", itemName);
+                            Metadata defaultUnitMetadata = new Metadata(defaultUnitMetadataKey, defaultUnit, null);
+                            metadataStorage.put(defaultUnitMetadataKey.toString(), defaultUnitMetadata);
+                            LOGGER.info("{}: Wrote 'defaultUnit={}' to metadata.", itemName, defaultUnit);
+                        }
+                    }
+                }
+            }
+        });
+
+        metadataStorage.flush();
+    }
+
+    public static void main(String[] args) {
+        Options options = getOptions();
+
+        try {
+            CommandLine commandLine = new DefaultParser().parse(options, args);
+            String baseDir = commandLine.hasOption(CMD_OPT_DIR) ? commandLine.getOptionValue(CMD_OPT_DIR) : "";
+            if (commandLine.hasOption(CMD_OPT_ITEM)) {
+                String operation = commandLine.getOptionValue(CMD_OPT_ITEM);
+                switch (operation) {
+                    case "copyDefaultUnit":
+                        itemCopyDefaultUnit(baseDir);
+                        break;
+                    default:
+                        System.out.println("Available tasks for operation 'item': copyDefaultUnit");
+                }
+            }
+        } catch (ParseException e) {
+            HelpFormatter formatter = new HelpFormatter();
+            formatter.printHelp("upgradetool", options);
+        }
+    }
+}

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -142,8 +142,9 @@ public class UpgradeTool {
                 String function = (String) configuration.get("function");
                 if (function != null) {
                     configuration.put("toItemScript", function);
-                    configuration.put("toHandlerScript", function);
+                    configuration.put("toHandlerScript", "|input");
                     configuration.remove("function");
+                    configuration.remove("sourceFormat");
 
                     linkStorage.put(linkUid, link);
                     LOGGER.info("{}: rewrote JS profile link to new format", linkUid);

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.tools.internal;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.items.ManagedItemProvider;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.storage.json.internal.JsonStorage;
+import org.openhab.core.thing.internal.link.ItemChannelLinkConfigDescriptionProvider;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.types.util.UnitUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link Upgrader} contains the implementation of the upgrade methods
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class Upgrader {
+    private final Logger logger = LoggerFactory.getLogger(Upgrader.class);
+
+    public void itemCopyUnitToMetadata(String baseDir) {
+        Path itemJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Item.json");
+        Path metadataJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.items.Metadata.json");
+        logger.info("Copying item unit from state description to metadata in database '{}'", itemJsonDatabasePath);
+
+        if (!Files.isReadable(itemJsonDatabasePath)) {
+            logger.error("Cannot access item database '{}', check path and access rights.", itemJsonDatabasePath);
+            return;
+        }
+        if (!Files.isWritable(metadataJsonDatabasePath)) {
+            logger.error("Cannot access metadata database '{}', check path and access rights.",
+                    metadataJsonDatabasePath);
+            return;
+        }
+
+        JsonStorage<ManagedItemProvider.PersistedItem> itemStorage = new JsonStorage<>(itemJsonDatabasePath.toFile(),
+                null, 5, 0, 0, List.of());
+        JsonStorage<Metadata> metadataStorage = new JsonStorage<>(metadataJsonDatabasePath.toFile(), null, 5, 0, 0,
+                List.of());
+
+        itemStorage.getKeys().forEach(itemName -> {
+            ManagedItemProvider.PersistedItem item = itemStorage.get(itemName);
+            if (item != null && item.itemType.startsWith("Number:")) {
+                if (metadataStorage.containsKey("unit" + ":" + itemName)) {
+                    logger.debug("{}: already contains a 'unit' metadata, skipping it", itemName);
+                } else {
+                    Metadata metadata = metadataStorage.get("stateDescription:" + itemName);
+                    if (metadata == null) {
+                        logger.debug("{}: Nothing to do, no state description found.", itemName);
+                    } else {
+                        String pattern = (String) metadata.getConfiguration().get("pattern");
+                        if (pattern.contains(UnitUtils.UNIT_PLACEHOLDER)) {
+                            logger.warn(
+                                    "{}: State description contains unit place-holder '%unit%', check if 'unit' metadata is needed!",
+                                    itemName);
+                        } else {
+                            Unit<?> stateDescriptionUnit = UnitUtils.parseUnit(pattern);
+                            if (stateDescriptionUnit != null) {
+                                String unit = stateDescriptionUnit.toString();
+                                MetadataKey defaultUnitMetadataKey = new MetadataKey("unit", itemName);
+                                Metadata defaultUnitMetadata = new Metadata(defaultUnitMetadataKey, unit, null);
+                                metadataStorage.put(defaultUnitMetadataKey.toString(), defaultUnitMetadata);
+                                logger.info("{}: Wrote 'unit={}' to metadata.", itemName, unit);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        metadataStorage.flush();
+    }
+
+    public void upgradeJsProfile(String baseDir) {
+        Path linkJsonDatabasePath = Path.of(baseDir, "jsondb", "org.openhab.core.thing.link.ItemChannelLink.json");
+        logger.info("Upgrading JS profile configuration in database '{}'", linkJsonDatabasePath);
+
+        if (!Files.isWritable(linkJsonDatabasePath)) {
+            logger.error("Cannot access link database '{}', check path and access rights.", linkJsonDatabasePath);
+            return;
+        }
+        JsonStorage<ItemChannelLink> linkStorage = new JsonStorage<>(linkJsonDatabasePath.toFile(), null, 5, 0, 0,
+                List.of());
+
+        List.copyOf(linkStorage.getKeys()).forEach(linkUid -> {
+            ItemChannelLink link = Objects.requireNonNull(linkStorage.get(linkUid));
+            Configuration configuration = link.getConfiguration();
+            String profileName = (String) configuration.get(ItemChannelLinkConfigDescriptionProvider.PARAM_PROFILE);
+            if ("transform:JS".equals(profileName)) {
+                String function = (String) configuration.get("function");
+                if (function != null) {
+                    configuration.put("toItemScript", function);
+                    configuration.put("toHandlerScript", "|input");
+                    configuration.remove("function");
+                    configuration.remove("sourceFormat");
+
+                    linkStorage.put(linkUid, link);
+                    logger.info("{}: rewrote JS profile link to new format", linkUid);
+                } else {
+                    logger.info("{}: link already has correct configuration", linkUid);
+                }
+            }
+        });
+
+        linkStorage.flush();
+    }
+}


### PR DESCRIPTION
This is the initial contribution for a tool that can perform more complex upgrade tasks. The idea is to provide an easy way for the user to perform one-time upgrade operations to the databases that are optional but useful.

The first task is the migration of the unit of a `NumberItem` with dimension from the state description to the new `defaultUnit` metadata introduced in #3248. Since there might be side-effects this should not be performed automatically. For textual configuration this can easily be done with a text editor or command line-tools. For UI defined items it's more difficult since two files need to be considered.

Other tasks might be automatically executed by the update script if necessary.

Signed-off-by: Jan N. Klug <github@klug.nrw>