### PR TITLE
Remove AccessController.doPrivileged calls

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.automation.internal;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -92,10 +90,7 @@ public class TriggerHandlerCallbackImpl implements TriggerHandlerCallback {
 
     public void dispose() {
         synchronized (this) {
-            AccessController.doPrivileged((PrivilegedAction<@Nullable Void>) () -> {
-                executor.shutdownNow();
-                return null;
-            });
+            executor.shutdownNow();
         }
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.config.discovery;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -175,12 +173,7 @@ public class DiscoveryResultBuilder {
     }
 
     private String getStackTrace(final Thread thread) {
-        StackTraceElement[] elements = AccessController.doPrivileged(new PrivilegedAction<StackTraceElement[]>() {
-            @Override
-            public StackTraceElement[] run() {
-                return thread.getStackTrace();
-            }
-        });
+        StackTraceElement[] elements = thread.getStackTrace();
         return Arrays.stream(elements).map(element -> "\tat " + element.toString()).collect(Collectors.joining("\n"));
     }
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.config.discovery.internal;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -254,13 +252,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
         }
         for (final DiscoveryListener listener : listeners) {
             try {
-                AccessController.doPrivileged(new PrivilegedAction<@Nullable Void>() {
-                    @Override
-                    public @Nullable Void run() {
-                        listener.thingDiscovered(source, result);
-                        return null;
-                    }
-                });
+                listener.thingDiscovered(source, result);
             } catch (Exception ex) {
                 logger.error("Cannot notify the DiscoveryListener '{}' on Thing discovered event!",
                         listener.getClass().getName(), ex);
@@ -280,13 +272,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
         }
         for (final DiscoveryListener listener : listeners) {
             try {
-                AccessController.doPrivileged(new PrivilegedAction<@Nullable Void>() {
-                    @Override
-                    public @Nullable Void run() {
-                        listener.thingRemoved(source, thingUID);
-                        return null;
-                    }
-                });
+                listener.thingRemoved(source, thingUID);
             } catch (Exception ex) {
                 logger.error("Cannot notify the DiscoveryListener '{}' on Thing removed event!",
                         listener.getClass().getName(), ex);
@@ -300,13 +286,8 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
         Set<ThingUID> removedResults = new HashSet<>();
         for (final DiscoveryListener listener : listeners) {
             try {
-                Collection<ThingUID> olderResults = AccessController
-                        .doPrivileged(new PrivilegedAction<@Nullable Collection<ThingUID>>() {
-                            @Override
-                            public @Nullable Collection<ThingUID> run() {
-                                return listener.removeOlderResults(source, timestamp, thingTypeUIDs, bridgeUID);
-                            }
-                        });
+                Collection<ThingUID> olderResults = listener.removeOlderResults(source, timestamp, thingTypeUIDs,
+                        bridgeUID);
                 if (olderResults != null) {
                     removedResults.addAll(olderResults);
                 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -13,8 +13,6 @@
 package org.openhab.core.thing.internal;
 
 import java.net.URI;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -454,23 +452,20 @@ public class ThingManagerImpl
             throw new IllegalArgumentException(MessageFormat.format(
                     "Cannot update thing {0} because it is not known to the registry", thing.getUID().getAsString()));
         }
-        AccessController.doPrivileged((PrivilegedAction<@Nullable Void>) () -> {
-            final Provider<Thing> provider = thingRegistry.getProvider(thing);
-            if (provider == null) {
-                throw new IllegalArgumentException(MessageFormat.format(
-                        "Provider for thing {0} cannot be determined because it is not known to the registry",
-                        thing.getUID().getAsString()));
-            }
-            if (provider instanceof ManagedProvider) {
-                final ManagedProvider<Thing, ThingUID> managedProvider = (ManagedProvider<Thing, ThingUID>) provider;
-                managedProvider.update(thing);
-            } else {
-                logger.debug("Only updating thing {} in the registry because provider {} is not managed.",
-                        thing.getUID().getAsString(), provider);
-                thingRegistry.updated(provider, oldThing, thing);
-            }
-            return null;
-        });
+        final Provider<Thing> provider = thingRegistry.getProvider(thing);
+        if (provider == null) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "Provider for thing {0} cannot be determined because it is not known to the registry",
+                    thing.getUID().getAsString()));
+        }
+        if (provider instanceof ManagedProvider) {
+            final ManagedProvider<Thing, ThingUID> managedProvider = (ManagedProvider<Thing, ThingUID>) provider;
+            managedProvider.update(thing);
+        } else {
+            logger.debug("Only updating thing {} in the registry because provider {} is not managed.",
+                    thing.getUID().getAsString(), provider);
+            thingRegistry.updated(provider, oldThing, thing);
+        }
         thingUpdatedLock.remove(thing.getUID());
     }
 
@@ -1119,10 +1114,7 @@ public class ThingManagerImpl
         // call asynchronous to avoid deadlocks in thing handler
         ThreadPoolManager.getPool(FORCE_REMOVE_THREAD_POOL_NAME).execute(() -> {
             try {
-                AccessController.doPrivileged((PrivilegedAction<@Nullable Void>) () -> {
-                    thingRegistry.forceRemove(thing.getUID());
-                    return null;
-                });
+                thingRegistry.forceRemove(thing.getUID());
             } catch (IllegalStateException ex) {
                 logger.debug("Could not remove thing {}. Most likely because it is not managed.", thing.getUID(), ex);
             } catch (Exception ex) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/AbstractInvocationHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/AbstractInvocationHandler.java
@@ -14,8 +14,6 @@ package org.openhab.core.internal.common;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
@@ -130,13 +128,8 @@ abstract class AbstractInvocationHandler<T> {
     }
 
     private String getStacktrace(final Thread thread) {
-        StackTraceElement[] elements = AccessController.doPrivileged(new PrivilegedAction<StackTraceElement[]>() {
-            @Override
-            public StackTraceElement[] run() {
-                return thread.getStackTrace();
-            }
-        });
-        return Arrays.stream(elements).map(element -> "\tat " + element.toString()).collect(Collectors.joining("\n"));
+        StackTraceElement[] elements = thread.getStackTrace();
+        return Arrays.stream(elements).map(element -> "\tat " + element).collect(Collectors.joining("\n"));
     }
 
     String toString(Method method) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerBuilderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerBuilderImpl.java
@@ -14,8 +14,6 @@ package org.openhab.core.internal.common;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -56,25 +54,23 @@ public class SafeCallerBuilderImpl<T> implements SafeCallerBuilder<T> {
     @SuppressWarnings("unchecked")
     @Override
     public T build() {
-        return AccessController.doPrivileged((PrivilegedAction<T>) () -> {
-            InvocationHandler handler;
-            if (async) {
-                handler = new InvocationHandlerAsync<>(manager, target, identifier, timeout, exceptionHandler,
-                        timeoutHandler);
-            } else {
-                handler = new InvocationHandlerSync<>(manager, target, identifier, timeout, exceptionHandler,
-                        timeoutHandler);
-            }
-            ClassLoader classLoader = getClass().getClassLoader();
-            if (classLoader == null) {
-                throw new IllegalStateException(
-                        "Cannot create proxy because '" + getClass().getName() + "' class loader is null");
-            }
-            return (T) Proxy.newProxyInstance(
-                    CombinedClassLoader.fromClasses(classLoader,
-                            Stream.concat(Stream.of(target.getClass()), Arrays.stream(interfaceTypes))),
-                    interfaceTypes, handler);
-        });
+        InvocationHandler handler;
+        if (async) {
+            handler = new InvocationHandlerAsync<>(manager, target, identifier, timeout, exceptionHandler,
+                    timeoutHandler);
+        } else {
+            handler = new InvocationHandlerSync<>(manager, target, identifier, timeout, exceptionHandler,
+                    timeoutHandler);
+        }
+        ClassLoader classLoader = getClass().getClassLoader();
+        if (classLoader == null) {
+            throw new IllegalStateException(
+                    "Cannot create proxy because '" + getClass().getName() + "' class loader is null");
+        }
+        return (T) Proxy.newProxyInstance(
+                CombinedClassLoader.fromClasses(classLoader,
+                        Stream.concat(Stream.of(target.getClass()), Arrays.stream(interfaceTypes))),
+                interfaceTypes, handler);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventPublisher.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventPublisher.java
@@ -12,9 +12,6 @@
  */
 package org.openhab.core.internal.events;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -54,23 +51,17 @@ public class OSGiEventPublisher implements EventPublisher {
 
     private void postAsOSGiEvent(final EventAdmin eventAdmin, final Event event) throws IllegalStateException {
         try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws Exception {
-                    Dictionary<String, Object> properties = new Hashtable<>(3);
-                    properties.put("type", event.getType());
-                    properties.put("payload", event.getPayload());
-                    properties.put("topic", event.getTopic());
-                    String source = event.getSource();
-                    if (source != null) {
-                        properties.put("source", source);
-                    }
-                    eventAdmin.postEvent(new org.osgi.service.event.Event("openhab", properties));
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException pae) {
-            Exception e = pae.getException();
+            Dictionary<String, Object> properties = new Hashtable<>(3);
+            properties.put("type", event.getType());
+            properties.put("payload", event.getPayload());
+            properties.put("topic", event.getTopic());
+            String source = event.getSource();
+            if (source != null) {
+                properties.put("source", source);
+            }
+            eventAdmin.postEvent(new org.osgi.service.event.Event("openhab", properties));
+
+        } catch (Exception e) {
             throw new IllegalStateException("Cannot post the event via the event bus. Error message: " + e.getMessage(),
                     e);
         }


### PR DESCRIPTION
The `AccessController` and the `SecurityManager` is deprecated for removal in Java 17. We don't make use of the `SecurityManager` anyway, so we can safely remove it.

Signed-off-by: Jan N. Klug <github@klug.nrw>