### PR TITLE
Ensure metadata available at startlevel 20

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -43,6 +43,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey, MetadataProvider>
         implements MetadataRegistry {
 
+    @Activate
     public MetadataRegistryImpl(final @Reference ReadyService readyService) {
         super(MetadataProvider.class);
         super.setReadyService(readyService);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -43,8 +43,9 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey, MetadataProvider>
         implements MetadataRegistry {
 
-    public MetadataRegistryImpl() {
+    public MetadataRegistryImpl(final @Reference ReadyService readyService) {
         super(MetadataProvider.class);
+        super.setReadyService(readyService);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.items.ManagedMetadataProvider;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
+import org.openhab.core.service.ReadyService;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.CommandOption;
 import org.osgi.framework.BundleContext;
@@ -52,6 +53,7 @@ public class MetadataCommandDescriptionProviderTest {
     private @Mock @NonNullByDefault({}) ManagedMetadataProvider managedProviderMock;
 
     private @Mock @NonNullByDefault({}) MetadataRegistryImpl metadataRegistryMock;
+    private @Mock@NonNullByDefault({}) ReadyService readyServiceMock;
     private @NonNullByDefault({}) MetadataCommandDescriptionProvider commandDescriptionProvider;
 
     private @NonNullByDefault({}) ServiceListener providerTracker;
@@ -61,7 +63,7 @@ public class MetadataCommandDescriptionProviderTest {
     public void setup() throws Exception {
         when(bundleContextMock.getService(same(managedProviderRefMock))).thenReturn(managedProviderMock);
 
-        metadataRegistryMock = new MetadataRegistryImpl();
+        metadataRegistryMock = new MetadataRegistryImpl(readyServiceMock);
         metadataRegistryMock.setManagedProvider(managedProviderMock);
         metadataRegistryMock.activate(bundleContextMock);
         metadataRegistryMock.waitForCompletedAsyncActivationTasks();

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -53,7 +53,7 @@ public class MetadataCommandDescriptionProviderTest {
     private @Mock @NonNullByDefault({}) ManagedMetadataProvider managedProviderMock;
 
     private @Mock @NonNullByDefault({}) MetadataRegistryImpl metadataRegistryMock;
-    private @Mock@NonNullByDefault({}) ReadyService readyServiceMock;
+    private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
     private @NonNullByDefault({}) MetadataCommandDescriptionProvider commandDescriptionProvider;
 
     private @NonNullByDefault({}) ServiceListener providerTracker;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
@@ -47,7 +47,6 @@ public class MetadataRegistryImplTest {
     private @Mock @NonNullByDefault({}) ManagedMetadataProvider managedProviderMock;
     private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
 
-
     private @NonNullByDefault({}) MetadataRegistryImpl registry;
     private @NonNullByDefault({}) ServiceListener providerTracker;
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.items.ManagedMetadataProvider;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
+import org.openhab.core.service.ReadyService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceEvent;
 import org.osgi.framework.ServiceListener;
@@ -44,6 +45,8 @@ public class MetadataRegistryImplTest {
     private @Mock @NonNullByDefault({}) ServiceReference managedProviderRefMock;
     private @Mock @NonNullByDefault({}) BundleContext bundleContextMock;
     private @Mock @NonNullByDefault({}) ManagedMetadataProvider managedProviderMock;
+    private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
+
 
     private @NonNullByDefault({}) MetadataRegistryImpl registry;
     private @NonNullByDefault({}) ServiceListener providerTracker;
@@ -53,7 +56,7 @@ public class MetadataRegistryImplTest {
     public void setup() throws Exception {
         when(bundleContextMock.getService(same(managedProviderRefMock))).thenReturn(managedProviderMock);
 
-        registry = new MetadataRegistryImpl();
+        registry = new MetadataRegistryImpl(readyServiceMock);
         registry.setManagedProvider(managedProviderMock);
         registry.activate(bundleContextMock);
         registry.waitForCompletedAsyncActivationTasks();

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.items.ManagedMetadataProvider;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
+import org.openhab.core.service.ReadyService;
 import org.openhab.core.types.StateDescriptionFragment;
 import org.openhab.core.types.StateOption;
 import org.osgi.framework.BundleContext;
@@ -53,6 +54,8 @@ public class MetadataStateDescriptionFragmentProviderTest {
     private @Mock @NonNullByDefault({}) ManagedMetadataProvider managedProviderMock;
 
     private @Mock @NonNullByDefault({}) MetadataRegistryImpl metadataRegistryMock;
+    private @Mock @NonNullByDefault({}) ReadyService readyServiceMock;
+
     private @NonNullByDefault({}) MetadataStateDescriptionFragmentProvider stateDescriptionFragmentProvider;
 
     private @NonNullByDefault({}) ServiceListener providerTracker;
@@ -62,7 +65,7 @@ public class MetadataStateDescriptionFragmentProviderTest {
     public void setup() throws Exception {
         when(bundleContextMock.getService(same(managedProviderRefMock))).thenReturn(managedProviderMock);
 
-        metadataRegistryMock = new MetadataRegistryImpl();
+        metadataRegistryMock = new MetadataRegistryImpl(readyServiceMock);
         metadataRegistryMock.setManagedProvider(managedProviderMock);
         metadataRegistryMock.activate(bundleContextMock);
         metadataRegistryMock.waitForCompletedAsyncActivationTasks();


### PR DESCRIPTION
This makes the `MetadataRegistry` report when the elements of the `ManagedMetadataProvider` is available via a ready marker (like other registries). This is needed to properly determine the unit for restoring values from persistence.  I labelled it as "bug" because I believe it could explain some strange behavior that has been reported in rare cases when restoring values during startup.

This is independent from the discussion in #3248.

Signed-off-by: Jan N. Klug <github@klug.nrw>