### PR TITLE
Trigger immediately when start level already reached

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -42,6 +42,7 @@ import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHan
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.service.StartLevelService;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -78,14 +79,17 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
     private final TimeZoneProvider timeZoneProvider;
     private final EventPublisher eventPublisher;
     private final BundleContext bundleContext;
+    private final StartLevelService startLevelService;
 
     @Activate
     public CoreModuleHandlerFactory(BundleContext bundleContext, final @Reference EventPublisher eventPublisher,
-            final @Reference ItemRegistry itemRegistry, final @Reference TimeZoneProvider timeZoneProvider) {
+            final @Reference ItemRegistry itemRegistry, final @Reference TimeZoneProvider timeZoneProvider,
+            final @Reference StartLevelService startLevelService) {
         this.bundleContext = bundleContext;
         this.eventPublisher = eventPublisher;
         this.itemRegistry = itemRegistry;
         this.timeZoneProvider = timeZoneProvider;
+        this.startLevelService = startLevelService;
     }
 
     @Override
@@ -112,7 +116,7 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
             } else if (ItemCommandTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
                 return new ItemCommandTriggerHandler(trigger, ruleUID, bundleContext, itemRegistry);
             } else if (SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                return new SystemTriggerHandler(trigger, bundleContext);
+                return new SystemTriggerHandler(trigger, bundleContext, startLevelService);
             } else if (ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
                     || ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
                 return new ThingStatusTriggerHandler(trigger, bundleContext);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -64,7 +64,7 @@ public class SystemTriggerHandler extends BaseTriggerModuleHandler implements Ev
             throw new IllegalArgumentException(module.getTypeUID() + " is no valid module type.");
         }
         eventSubscriberRegistration = bundleContext.registerService(EventSubscriber.class.getName(), this, null);
-      }
+    }
 
     @Override
     public void setCallback(ModuleHandlerCallback callback) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -47,14 +47,15 @@ public class SystemTriggerHandler extends BaseTriggerModuleHandler implements Ev
 
     private final Integer startlevel;
     private final Set<String> types;
-    private final BundleContext bundleContext;
+    private final StartLevelService startLevelService;
 
     private boolean triggered = false;
 
-    private ServiceRegistration<?> eventSubscriberRegistration;
+    private final ServiceRegistration<?> eventSubscriberRegistration;
 
-    public SystemTriggerHandler(Trigger module, BundleContext bundleContext) {
+    public SystemTriggerHandler(Trigger module, BundleContext bundleContext, StartLevelService startLevelService) {
         super(module);
+        this.startLevelService = startLevelService;
         this.startlevel = ((BigDecimal) module.getConfiguration().get(CFG_STARTLEVEL)).intValue();
         if (STARTLEVEL_MODULE_TYPE_ID.equals(module.getTypeUID())) {
             this.types = Set.of(StartlevelEvent.TYPE);
@@ -62,8 +63,18 @@ public class SystemTriggerHandler extends BaseTriggerModuleHandler implements Ev
             logger.warn("Module type '{}' is not (yet) handled by this class.", module.getTypeUID());
             throw new IllegalArgumentException(module.getTypeUID() + " is no valid module type.");
         }
-        this.bundleContext = bundleContext;
-        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this, null);
+        eventSubscriberRegistration = bundleContext.registerService(EventSubscriber.class.getName(), this, null);
+      }
+
+    @Override
+    public void setCallback(ModuleHandlerCallback callback) {
+        super.setCallback(callback);
+
+        // trigger immediately when start level is already reached
+        int currentStartLevel = startLevelService.getStartLevel();
+        if (currentStartLevel > StartLevelService.STARTLEVEL_RULEENGINE && currentStartLevel >= startlevel) {
+            trigger();
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.automation.Trigger;
+import org.openhab.core.automation.handler.TriggerHandlerCallback;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.system.SystemEventFactory;
+import org.openhab.core.service.StartLevelService;
+import org.osgi.framework.BundleContext;
+
+/**
+ * The {@link SystemTriggerHandlerTest} contains tests for the {@link SystemTriggerHandler}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SystemTriggerHandlerTest {
+    private static final int CFG_STARTLEVEL = 80;
+
+    private @Mock @NonNullByDefault({}) BundleContext bundleContextMock;
+    private @Mock @NonNullByDefault({}) StartLevelService startLevelServiceMock;
+    private @Mock @NonNullByDefault({}) TriggerHandlerCallback callbackMock;
+
+    private @Mock @NonNullByDefault({}) Trigger triggerMock;
+
+    @BeforeEach
+    public void setup() {
+        when(triggerMock.getConfiguration())
+                .thenReturn(new Configuration(Map.of(SystemTriggerHandler.CFG_STARTLEVEL, CFG_STARTLEVEL)));
+        when(triggerMock.getTypeUID()).thenReturn(SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID);
+    }
+
+    @Test
+    public void testDoesNotTriggerIfStartLevelTooLow() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(0);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        verifyNoInteractions(callbackMock);
+    }
+
+    @Test
+    public void testDoesTriggerImmediatelyIfStartLevelHigherOnInit() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(100);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        verify(callbackMock).triggered(eq(triggerMock), captor.capture());
+
+        Map<String, Object> configuration = (Map<String, Object>) captor.getValue();
+        assertThat(configuration.get(SystemTriggerHandler.OUT_STARTLEVEL), is(CFG_STARTLEVEL));
+    }
+
+    @Test
+    public void testDoesNotTriggerIfStartLevelEventLower() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(0);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        Event event = SystemEventFactory.createStartlevelEvent(70);
+        triggerHandler.receive(event);
+
+        verifyNoInteractions(callbackMock);
+    }
+
+    @Test
+    public void testDoesTriggerIfStartLevelEventHigher() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(0);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        Event event = SystemEventFactory.createStartlevelEvent(100);
+        triggerHandler.receive(event);
+
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        verify(callbackMock).triggered(eq(triggerMock), captor.capture());
+
+        Map<String, Object> configuration = (Map<String, Object>) captor.getValue();
+        assertThat(configuration.get(SystemTriggerHandler.OUT_STARTLEVEL), is(CFG_STARTLEVEL));
+    }
+
+    @Test
+    public void testDoesNotTriggerAfterInitialTrigger() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(100);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        verify(callbackMock).triggered(eq(triggerMock), captor.capture());
+
+        Map<String, Object> configuration = (Map<String, Object>) captor.getValue();
+        assertThat(configuration.get(SystemTriggerHandler.OUT_STARTLEVEL), is(CFG_STARTLEVEL));
+
+        Event event = SystemEventFactory.createStartlevelEvent(100);
+        triggerHandler.receive(event);
+
+        verifyNoMoreInteractions(callbackMock);
+    }
+
+    @Test
+    public void testDoesNotTriggerAfterEventTrigger() {
+        when(startLevelServiceMock.getStartLevel()).thenReturn(0);
+
+        SystemTriggerHandler triggerHandler = new SystemTriggerHandler(triggerMock, bundleContextMock,
+                startLevelServiceMock);
+        triggerHandler.setCallback(callbackMock);
+
+        Event event = SystemEventFactory.createStartlevelEvent(100);
+        triggerHandler.receive(event);
+
+        ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
+        verify(callbackMock).triggered(eq(triggerMock), captor.capture());
+
+        Map<String, Object> configuration = (Map<String, Object>) captor.getValue();
+        assertThat(configuration.get(SystemTriggerHandler.OUT_STARTLEVEL), is(CFG_STARTLEVEL));
+
+        triggerHandler.receive(event);
+
+        verifyNoMoreInteractions(callbackMock);
+    }
+}

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
@@ -345,6 +345,15 @@ public class JavaOSGiTest extends JavaTest {
     }
 
     /**
+     * Get the OSGi {@link BundleContext}
+     *
+     * @return the bundle context
+     */
+    protected BundleContext getBundleContext() {
+        return bundleContext;
+    }
+
+    /**
      * Registers a volatile storage service.
      */
     protected void registerVolatileStorageService() {

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -61,4 +61,9 @@ Fragment-Host: org.openhab.core.automation
 	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
 	junit-platform-commons;version='[1.9.2,1.9.3)',\
 	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)'
+	junit-platform-launcher;version='[1.9.2,1.9.3)',\
+	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
+	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.automation.integration.test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -36,6 +37,7 @@ import org.openhab.core.automation.RuleStatusInfo;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.events.RuleStatusInfoEvent;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.type.ActionType;
 import org.openhab.core.automation.type.Input;
 import org.openhab.core.automation.type.ModuleTypeRegistry;
@@ -46,6 +48,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
@@ -55,6 +58,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.storage.StorageService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
@@ -90,7 +94,12 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
     public void before() {
         logger.info("@Before.begin");
 
-        getService(ItemRegistry.class);
+        eventPublisher = getService(EventPublisher.class);
+        itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
 
         ItemProvider itemProvider = new ItemProvider() {
 
@@ -136,8 +145,6 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
 
         StorageService storageService = getService(StorageService.class);
         managedRuleProvider = getService(ManagedRuleProvider.class);
-        eventPublisher = getService(EventPublisher.class);
-        itemRegistry = getService(ItemRegistry.class);
         ruleRegistry = getService(RuleRegistry.class);
         ruleManager = getService(RuleManager.class);
         moduleTypeRegistry = getService(ModuleTypeRegistry.class);

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -49,6 +51,7 @@ import org.openhab.core.automation.events.RuleRemovedEvent;
 import org.openhab.core.automation.events.RuleStatusInfoEvent;
 import org.openhab.core.automation.events.RuleUpdatedEvent;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.template.RuleTemplate;
 import org.openhab.core.automation.template.RuleTemplateProvider;
 import org.openhab.core.automation.template.Template;
@@ -67,6 +70,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
@@ -76,6 +80,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.storage.StorageService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.slf4j.Logger;
@@ -106,7 +111,13 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
     public void before() {
         logger.info("@Before.begin");
 
-        getService(ItemRegistry.class);
+        eventPublisher = getService(EventPublisher.class);
+        itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                Objects.requireNonNull(eventPublisher), Objects.requireNonNull(itemRegistry),
+                mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
 
         ItemProvider itemProvider = new ItemProvider() {
             @Override
@@ -148,8 +159,6 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         registerVolatileStorageService();
 
         StorageService storageService = getService(StorageService.class);
-        eventPublisher = getService(EventPublisher.class);
-        itemRegistry = getService(ItemRegistry.class);
         ruleRegistry = getService(RuleRegistry.class);
         ruleEngine = getService(RuleManager.class);
         managedRuleProvider = getService(ManagedRuleProvider.class);

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -61,4 +61,9 @@ Fragment-Host: org.openhab.core.automation
 	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
 	junit-platform-commons;version='[1.9.2,1.9.3)',\
 	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)'
+	junit-platform-launcher;version='[1.9.2,1.9.3)',\
+	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
+	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.internal.module;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,6 +33,7 @@ import org.openhab.core.automation.RuleManager;
 import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.RuleStatus;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.util.ModuleBuilder;
 import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.common.registry.ProviderChangeListener;
@@ -39,6 +41,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
@@ -48,6 +51,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
 import org.osgi.framework.ServiceReference;
@@ -68,6 +72,13 @@ public class RunRuleModuleTest extends JavaOSGiTest {
 
     @BeforeEach
     public void before() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
+
         registerService(new ItemProvider() {
             @Override
             public void addProviderChangeListener(final ProviderChangeListener<Item> listener) {

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.internal.module;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -38,6 +39,7 @@ import org.openhab.core.automation.RuleStatus;
 import org.openhab.core.automation.RuleStatusDetail;
 import org.openhab.core.automation.events.RuleStatusInfoEvent;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.internal.module.handler.CompareConditionHandler;
 import org.openhab.core.automation.type.ModuleTypeRegistry;
 import org.openhab.core.automation.util.ModuleBuilder;
@@ -47,6 +49,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
@@ -56,6 +59,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
 import org.openhab.core.types.Command;
@@ -78,6 +82,13 @@ public class RuntimeRuleTest extends JavaOSGiTest {
 
     @BeforeEach
     public void before() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
+
         registerService(new ItemProvider() {
             @Override
             public void addProviderChangeListener(final ProviderChangeListener<Item> listener) {

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -61,4 +61,9 @@ Fragment-Host: org.openhab.core.automation
 	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
 	junit-platform-commons;version='[1.9.2,1.9.3)',\
 	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)'
+	junit-platform-launcher;version='[1.9.2,1.9.3)',\
+	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
+	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +39,7 @@ import org.openhab.core.automation.RuleStatus;
 import org.openhab.core.automation.RuleStatusInfo;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.internal.module.handler.ItemCommandActionHandler;
 import org.openhab.core.automation.internal.module.handler.ItemStateTriggerHandler;
 import org.openhab.core.automation.util.ModuleBuilder;
@@ -47,14 +49,17 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
+import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
 import org.slf4j.Logger;
@@ -81,6 +86,13 @@ public abstract class BasicConditionHandlerTest extends JavaOSGiTest {
      */
     @BeforeEach
     public void beforeBase() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
+
         ItemProvider itemProvider = new ItemProvider() {
             @Override
             public void addProviderChangeListener(ProviderChangeListener<Item> listener) {

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.automation.module.timer.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.text.SimpleDateFormat;
 import java.time.ZonedDateTime;
@@ -24,12 +25,18 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.internal.module.handler.DayOfWeekConditionHandler;
 import org.openhab.core.automation.type.ModuleTypeRegistry;
 import org.openhab.core.automation.util.ModuleBuilder;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.service.StartLevelService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +55,16 @@ public class DayOfWeekConditionHandlerTest extends BasicConditionHandlerTest {
 
     public DayOfWeekConditionHandlerTest() {
         logger.info("Today is {}", dayOfWeek);
+    }
+
+    @BeforeEach
+    public void before() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
     }
 
     @Test

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ import org.openhab.core.automation.RuleStatusDetail;
 import org.openhab.core.automation.RuleStatusInfo;
 import org.openhab.core.automation.Trigger;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.internal.module.handler.GenericCronTriggerHandler;
 import org.openhab.core.automation.type.ModuleTypeRegistry;
 import org.openhab.core.automation.util.ModuleBuilder;
@@ -44,12 +46,16 @@ import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemProvider;
+import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
 import org.slf4j.Logger;
@@ -72,6 +78,13 @@ public class RuntimeRuleTest extends JavaOSGiTest {
 
     @BeforeEach
     public void before() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
+
         ItemProvider itemProvider = new TestItemProvider(Set.of(new SwitchItem("myLampItem")));
         registerService(itemProvider);
         registerService(volatileStorageService);

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -61,4 +61,9 @@ Fragment-Host: org.openhab.core.automation
 	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
 	junit-platform-commons;version='[1.9.2,1.9.3)',\
 	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)'
+	junit-platform-launcher;version='[1.9.2,1.9.3)',\
+	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
+	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
@@ -16,6 +16,7 @@ import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +42,7 @@ import org.openhab.core.automation.events.RuleRemovedEvent;
 import org.openhab.core.automation.events.RuleStatusInfoEvent;
 import org.openhab.core.automation.events.RuleUpdatedEvent;
 import org.openhab.core.automation.internal.RuleEngineImpl;
+import org.openhab.core.automation.internal.module.factory.CoreModuleHandlerFactory;
 import org.openhab.core.automation.util.ModuleBuilder;
 import org.openhab.core.automation.util.RuleBuilder;
 import org.openhab.core.common.registry.ProviderChangeListener;
@@ -48,6 +50,7 @@ import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemProvider;
@@ -57,6 +60,7 @@ import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +84,13 @@ public class RuleEventTest extends JavaOSGiTest {
 
     @BeforeEach
     public void before() {
+        EventPublisher eventPublisher = getService(EventPublisher.class);
+        ItemRegistry itemRegistry = getService(ItemRegistry.class);
+        CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
+                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+        mock(CoreModuleHandlerFactory.class);
+        registerService(coreModuleHandlerFactory);
+
         ItemProvider itemProvider = new ItemProvider() {
 
             @Override
@@ -148,9 +159,7 @@ public class RuleEventTest extends JavaOSGiTest {
         ruleRegistry.add(rule);
         ruleEngine.setEnabled(rule.getUID(), true);
 
-        waitForAssert(() -> {
-            assertThat(ruleEngine.getStatusInfo(rule.getUID()).getStatus(), is(RuleStatus.IDLE));
-        });
+        waitForAssert(() -> assertThat(ruleEngine.getStatusInfo(rule.getUID()).getStatus(), is(RuleStatus.IDLE)));
 
         // TEST RULE
 


### PR DESCRIPTION
Fixes #3199

The `StartLevelTrigger` did not fire when the start level was already above the desired start level. Also added some tests.

Signed-off-by: Jan N. Klug <github@klug.nrw>