### PR TITLE
Update Jackson to 2.14.1

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -19,7 +19,7 @@
     <californium.version>2.7.4</californium.version>
     <cxf.version>3.4.5</cxf.version>
     <!-- revert version of jackson-databind to ${jackson.version} when versions are in-line again -->
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
     <jetty.version>9.4.46.v20220331</jetty.version>
     <pax.logging.version>2.0.16</pax.logging.version>
     <pax.web.version>7.3.25</pax.web.version>
@@ -962,8 +962,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <!-- revert to ${jackson.version} when versions are in-line again -->
-      <version>2.12.7.1</version>
+      <version>${jackson.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -83,18 +83,18 @@
 	</feature>
 
 	<feature name="openhab.tp-jackson" description="FasterXML Jackson bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jackson;version=2.12.7</capability>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.12.7.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.12.7</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.12.7</bundle>
-		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.27</bundle>
+		<capability>openhab.tp;feature=jackson;version=2.14.1</capability>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.14.1</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.14.1</bundle>
+		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.33</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jax-rs-whiteboard" description="Aries JAX-RS Whiteboard" version="${project.version}">

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -45,7 +45,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	tech.units.indriya;version='[2.1.2,2.1.3)',\
 	uom-lib-common;version='[2.1.0,2.1.1)',\
-	com.fasterxml.woodstox.woodstox-core;version='[6.2.6,6.2.7)',\
 	org.apache.cxf.cxf-core;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.4.5,3.4.6)',\
 	org.apache.cxf.cxf-rt-rs-client;version='[3.4.5,3.4.6)',\
@@ -101,4 +100,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	org.openhab.core.transform;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)',\
+	com.fasterxml.woodstox.woodstox-core;version='[6.4.0,6.4.1)'

--- a/itests/org.openhab.core.model.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.core.tests/itest.bndrun
@@ -102,7 +102,6 @@ Fragment-Host: org.openhab.core.model.core
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	io.github.classgraph;version='[4.8.149,4.8.150)',\
-	org.apache.log4j;version='[1.2.19,1.2.20)',\
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.xtend.lib;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtend.lib.macro;version='[2.29.0,2.29.1)',\
@@ -111,5 +110,4 @@ Fragment-Host: org.openhab.core.model.core
 	org.eclipse.xtext.util;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -100,7 +100,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	io.github.classgraph;version='[4.8.149,4.8.150)',\
-	org.apache.log4j;version='[1.2.19,1.2.20)',\
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.xtend.lib;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtend.lib.macro;version='[2.29.0,2.29.1)',\
@@ -109,5 +108,4 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.xtext.util;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -101,7 +101,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	io.github.classgraph;version='[4.8.149,4.8.150)',\
-	org.apache.log4j;version='[1.2.19,1.2.20)',\
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.xtend.lib;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtend.lib.macro;version='[2.29.0,2.29.1)',\
@@ -110,6 +109,5 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.xtext.util;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)'
 -runblacklist: bnd.identity;id='jakarta.activation-api'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -102,7 +102,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	io.github.classgraph;version='[4.8.149,4.8.150)',\
-	org.apache.log4j;version='[1.2.19,1.2.20)',\
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.xtend.lib;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtend.lib.macro;version='[2.29.0,2.29.1)',\
@@ -111,5 +110,4 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.xtext.util;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -113,7 +113,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	io.github.classgraph;version='[4.8.149,4.8.150)',\
-	org.apache.log4j;version='[1.2.19,1.2.20)',\
 	org.eclipse.equinox.common;version='[3.16.200,3.16.201)',\
 	org.eclipse.xtend.lib;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtend.lib.macro;version='[2.29.0,2.29.1)',\
@@ -122,5 +121,4 @@ Fragment-Host: org.openhab.core.model.thing
 	org.eclipse.xtext.util;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
-	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.0.0,4.0.1)'
+	org.objectweb.asm;version='[9.4.0,9.4.1)'


### PR DESCRIPTION
Updates Jackson from 2.12.7 to 2.14.1

For release notes, see:

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14