### PR TITLE
[core] Add DateTimeType method for returning Instant

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -119,6 +119,15 @@ public class DateTimeType implements PrimitiveType, State, Command {
         return zonedDateTime;
     }
 
+    /**
+     * Get curent object represented as an {@link Instant}
+     *
+     * @return an {@link Instant} representation of the current object
+     */
+    public Instant getInstant() {
+        return zonedDateTime.toInstant();
+    }
+
     public static DateTimeType valueOf(String value) {
         return new DateTimeType(value);
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -242,11 +243,12 @@ public class DateTimeTypeTest {
 
         assertTrue(dt1.toString().equals(dt2.toFullString()));
         assertTrue(dt1.getZonedDateTime().equals(dt2.getZonedDateTime()));
+        assertTrue(dt1.getInstant().equals(dt2.getInstant()));
         assertTrue(dt1.equals(dt2));
     }
 
     @Test
-    public void parsingTest() {
+    public void zonedParsingTest() {
         DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
         DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");
         DateTimeType dt3 = new DateTimeType("2019-06-12T19:30:00+0200");
@@ -259,6 +261,20 @@ public class DateTimeTypeTest {
         assertThat(zdt1, is(zdt2));
         assertThat(zdt1, is(zdt3.withZoneSameInstant(zdt1.getZone())));
         assertThat(zdt2, is(zdt3.withZoneSameInstant(zdt2.getZone())));
+    }
+
+    @Test
+    public void instantParsingTest() {
+        DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
+        DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");
+        DateTimeType dt3 = new DateTimeType("2019-06-12T19:30:00+0200");
+        assertThat(dt1, is(dt2));
+
+        Instant i1 = dt1.getInstant();
+        Instant i2 = dt2.getInstant();
+        Instant i3 = dt3.getInstant();
+        assertThat(i1, is(i2));
+        assertThat(i1, is(i3));
     }
 
     @Test


### PR DESCRIPTION
Wish from forum post:
- **Original post:** https://community.openhab.org/t/openhab-4-0-wishlist/142388/78
- **Conclusion:** https://community.openhab.org/t/openhab-4-0-wishlist/142388/107

In relation to #2898 the plan would be to internally switch from `ZonedDateTime` to `Instant` while preserving backwards compatibility. This means `getZonedDateTime()` will stay, but it will eventually be changed to return a `ZonedDateTime` with the currently configured time-zone based on the internal `Instant`.

Therefore it would only be natural to also add a method for returning the `Instant` representation of the current object. This does not need to wait for the additional refactoring as it will provide user value right away, but implementation will of course change when we figure out how to make `TimeZoneProvider` accessible from `DateTimeType`.