### PR TITLE
Fix Marketplace add-on range pattern matching

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/BundleVersion.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/BundleVersion.java
@@ -31,6 +31,7 @@ public class BundleVersion {
     public static final Pattern RANGE_PATTERN = Pattern.compile(
             "\\[(?<start>\\d+\\.\\d+(?<startmicro>\\.\\d+(\\.\\w+)?)?);(?<end>\\d+\\.\\d+(?<endmicro>\\.\\d+(\\.\\w+)?)?)(?<endtype>[)\\]])");
 
+    private final String version;
     private final int major;
     private final int minor;
     private final int micro;
@@ -39,6 +40,7 @@ public class BundleVersion {
     public BundleVersion(String version) {
         Matcher matcher = VERSION_PATTERN.matcher(version);
         if (matcher.matches()) {
+            this.version = version;
             this.major = Integer.parseInt(matcher.group("major"));
             this.minor = Integer.parseInt(matcher.group("minor"));
             this.micro = Integer.parseInt(matcher.group("micro"));
@@ -147,5 +149,10 @@ public class BundleVersion {
 
         // both versions are milestones, we can compare them
         return Long.compare(qualifier, other.qualifier);
+    }
+
+    @Override
+    public String toString() {
+        return version;
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -296,6 +296,8 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
                 try {
                     compatible = coreVersion.inRange(potentialRange);
                     title = topic.title.substring(0, compatibilityStart).trim();
+                    logger.debug("{} is {}compatible with core version {}", topic.title, compatible ? "" : "NOT ",
+                            coreVersion);
                 } catch (IllegalArgumentException e) {
                     logger.debug("Failed to determine compatibility for addon {}: {}", topic.title, e.getMessage());
                     compatible = true;

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -290,7 +290,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
         int compatibilityStart = topic.title.lastIndexOf("["); // version range always starts with [
         if (topic.title.lastIndexOf(" ") < compatibilityStart) { // check includes [ not present
-            String potentialRange = topic.title.substring(compatibilityStart + 1);
+            String potentialRange = topic.title.substring(compatibilityStart);
             Matcher matcher = BundleVersion.RANGE_PATTERN.matcher(potentialRange);
             if (matcher.matches()) {
                 try {
@@ -300,6 +300,8 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
                     logger.debug("Failed to determine compatibility for addon {}: {}", topic.title, e.getMessage());
                     compatible = true;
                 }
+            } else {
+                logger.debug("Range pattern does not match '{}'", potentialRange);
             }
         }
 


### PR DESCRIPTION
With this fix it will use the correct string for pattern matching add-on version ranges introduced in #2811.