### PR TITLE
[serial] Ability to use /dev/serial/ symlinks for usb serial device

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
@@ -37,6 +37,10 @@ public class DeltaUsbSerialScanner {
         this.usbSerialScanner = usbSerialScanner;
     }
 
+    public Set<UsbSerialDeviceInformation> getLastScanResult() {
+        return lastScanResult;
+    }
+
     /**
      * Scans for USB-Serial devices, and returns the delta to the last scan result.
      * <p/>

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -143,6 +143,9 @@ public class PollingUsbSerialScanner implements UsbSerialDiscovery {
     @Override
     public void registerDiscoveryListener(UsbSerialDiscoveryListener listener) {
         discoveryListeners.add(listener);
+        for (UsbSerialDeviceInformation deviceInfo : deltaUsbSerialScanner.getLastScanResult()) {
+            listener.usbSerialDeviceDiscovered(deviceInfo);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -16,6 +16,7 @@ import static java.nio.file.Files.*;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -52,6 +53,8 @@ import org.slf4j.LoggerFactory;
  * {@link UsbSerialDeviceInformation}.
  *
  * @author Henning Sudbrock - Initial contribution
+ * @author Gwendal Roulleau - Adding /serial/by-id scan to discover the symlinks inside and use their more
+ *         human-readable links
  */
 @Component(configurationPid = "discovery.usbserial.linuxsysfs.usbserialscanner")
 @NonNullByDefault
@@ -64,6 +67,7 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
 
     private static final String SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT = "/sys/class/tty";
     private static final String DEV_DIRECTORY_DEFAULT = "/dev";
+    private static final String DEV_SERIAL_BY_ID_DIRECTORY = DEV_DIRECTORY_DEFAULT + "/serial/by-id";
 
     private String sysfsTtyDevicesDirectory = SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT;
     private String devDirectory = DEV_DIRECTORY_DEFAULT;
@@ -128,6 +132,7 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
     /**
      * Gets the set of all found serial ports, by searching through the tty devices directory in the sysfs and
      * checking for each found serial port if the device file in the devices folder is both readable and writable.
+     * Also search in the serial/by-id directory for symlinks with more user-friendly name.
      *
      * @throws IOException If there is a problem reading files from the sysfs tty devices directory.
      */
@@ -138,9 +143,29 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
             for (Path sysfsTtyPath : sysfsTtyPaths) {
                 String serialPortName = sysfsTtyPath.getFileName().toString();
                 Path devicePath = Paths.get(devDirectory).resolve(serialPortName);
-                Path sysfsDevicePath = getSysfsDevicePath(sysfsTtyPath);
+                Path sysfsDevicePath = getRealDevicePath(sysfsTtyPath);
                 if (sysfsDevicePath != null && isReadable(devicePath) && isWritable(devicePath)) {
                     result.add(new SerialPortInfo(devicePath, sysfsDevicePath));
+                }
+            }
+        }
+
+        // optionally compute links and their corresponding SerialInfo :
+        Path devSerialDir = Path.of(DEV_SERIAL_BY_ID_DIRECTORY);
+        if (exists(devSerialDir) && isDirectory(devSerialDir) && isReadable(devSerialDir)) {
+            // browse serial/by-id directory :
+            for (Path devLinkPath : newDirectoryStream(devSerialDir)) {
+                if (Files.isSymbolicLink(devLinkPath)) {
+                    Path devicePath = getRealDevicePath(devLinkPath);
+                    if (devicePath != null) {
+                        String serialPortName = devicePath.getFileName().toString();
+                        // get the corresponding real sysinfo special dir :
+                        Path sysfsDevicePath = getRealDevicePath(
+                                Paths.get(sysfsTtyDevicesDirectory).resolve(serialPortName));
+                        if (sysfsDevicePath != null && isReadable(devicePath) && isWritable(devicePath)) {
+                            result.add(new SerialPortInfo(devLinkPath, sysfsDevicePath));
+                        }
+                    }
                 }
             }
         }
@@ -149,17 +174,18 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
     }
 
     /**
-     * In the sysfs, the directory 'class/tty' contains a symbolic link for every serial port style device, i.e., also
-     * for serial devices. This symbolic link points to the directory for that device within the sysfs device tree. This
-     * method returns the directory to which this symbolic link points for a given serial port.
+     * In the sysfs or serial-by-id directory, we can found a symbolic link for every serial port style device, i.e.,
+     * also for serial devices. This symbolic link points to the directory for that device within the sysfs device tree,
+     * or directly to the device in the case of serial-by-id directory. This method returns the real path to which this
+     * symbolic link points for a given serial port.
      * <p/>
      * If the symbolic link cannot be converted to the real path, null is returned and a warning is logged.
      */
-    private @Nullable Path getSysfsDevicePath(Path ttyFile) {
+    private @Nullable Path getRealDevicePath(Path ttyFile) {
         try {
             return ttyFile.toRealPath();
         } catch (IOException e) {
-            logger.warn("Could not find the device path for {} in the sysfs: {}", ttyFile, e.getMessage());
+            logger.warn("Could not find the device path for {}. Error is: {}", ttyFile, e.getMessage());
             return null;
         }
     }

--- a/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/main/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/main/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscovery.java
@@ -85,6 +85,9 @@ public class Ser2NetUsbSerialDiscovery implements ServiceListener, UsbSerialDisc
     @Override
     public void registerDiscoveryListener(UsbSerialDiscoveryListener listener) {
         discoveryListeners.add(listener);
+        for (UsbSerialDeviceInformation deviceInfo : lastScanResult) {
+            listener.usbSerialDeviceDiscovered(deviceInfo);
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
@@ -184,12 +184,14 @@ public class Ser2NetUsbSerialDiscoveryTest {
         discovery.registerDiscoveryListener(discoveryListenerMock);
         discovery.doSingleScan();
 
-        // Expectation: discovery listener called once for removing usb1, and once for adding usb2/usb3 each.
+        // Expectation: discovery listener called once for adding usb1 and usb2 (on registration)
+        // then once for removing usb1, and once again for adding usb2 (another registration)
+        // and once for usb3
 
-        verify(discoveryListenerMock, never()).usbSerialDeviceDiscovered(usb1);
+        verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb1);
         verify(discoveryListenerMock, times(1)).usbSerialDeviceRemoved(usb1);
 
-        verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb2);
+        verify(discoveryListenerMock, times(2)).usbSerialDeviceDiscovered(usb2);
         verify(discoveryListenerMock, never()).usbSerialDeviceRemoved(usb2);
 
         verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb3);

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscovery.java
@@ -42,7 +42,8 @@ public interface UsbSerialDiscovery {
     void stopBackgroundScanning();
 
     /**
-     * Registers an {@link UsbSerialDiscoveryListener} that is then notified about discovered serial ports and USB
+     * Registers an {@link UsbSerialDiscoveryListener} that is then notified about discovered serial ports and USB,
+     * including those already found during previous scan.
      * devices.
      */
     void registerDiscoveryListener(UsbSerialDiscoveryListener listener);

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScannerTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScannerTest.java
@@ -104,12 +104,14 @@ public class PollingUsbSerialScannerTest {
         pollingScanner.registerDiscoveryListener(discoveryListenerMock);
         pollingScanner.doSingleScan();
 
-        // Expectation: discovery listener called once for removing usb1, and once for adding usb2/usb3 each.
+        // Expectation: discovery listener called once for adding usb1 and usb2 (on registration)
+        // then once for removing usb1, and once again for adding usb2 (another registration)
+        // and once for usb3
 
-        verify(discoveryListenerMock, never()).usbSerialDeviceDiscovered(usb1);
+        verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb1);
         verify(discoveryListenerMock, times(1)).usbSerialDeviceRemoved(usb1);
 
-        verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb2);
+        verify(discoveryListenerMock, times(2)).usbSerialDeviceDiscovered(usb2);
         verify(discoveryListenerMock, never()).usbSerialDeviceRemoved(usb2);
 
         verify(discoveryListenerMock, times(1)).usbSerialDeviceDiscovered(usb3);


### PR DESCRIPTION
The rxtx serial port provider is now able to scan symlink in /dev/serial/by-id and use them as valid identifier.
Benefit : users won't have to fix the path of their USB serial device  with udev anymore, they can now use the explicit and stable symlink directly.

EDIT: explaining how: 

 **OLD, not relevant anymore ---------------**
~~1. First, we get as usual all the `CommPortIdentifier` by scan and properties. (I modified these methods to return list instead of stream to avoid unnecessary conversion)
2. Then if we are on linux (to do this I use `System.getProperty("os.name")` and check if "linux" is present, is there something better ?), we add the result of the new scan. What does this new scan ? : 
a - list symlinks inside `/dev/serial/by-id/`
b- trying to resolve each of them against the already scanned ports in step 1 : if it resolves to a real port, then it is valid and we can add it. I add it as a `SerialPortIdentifierImpl` with, as a name, the symlink. So it is basically the same port as those gotten in 1, but with a different name.

To do so I also needed to change `SerialPortIdentifierImpl` to allow using another name than the id of the `CommPortIdentifier` (i.e. i now use the link itself).~~
**------------ OLD**

(complete rewrite after comment)

1- The DiscoveryService signals to listener (including the RXTX provider) the serial devices found, by scanning /sys/ and now also by scanning /dev/serial-by-id
2- The RXTX provider is able to handle symlink but has a bug with long name (80+ char) (which is sometimes the case of symlink). I did a workaround by resolving the symlink before passing it to the native nrserial library.

Result :
- Now when querying to get a serial port by the symlink, it works by giving the real device.
- And also in the GUI, all parameters of context-type serial are pre-filled with plain old /dev/tty* and also symlinks.

Signed-off-by: Gwendal Roulleau <gwendal.roulleau@gmail.com>