### PR TITLE
Fixes and enhancements for add-on services

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -106,8 +106,8 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     public void install(Addon addon) throws MarketplaceHandlerException {
         try {
             URL sourceUrl = new URL((String) addon.getProperties().get(KAR_DOWNLOAD_URL_PROPERTY));
-            addKarToCache(addon.getId(), sourceUrl);
-            installFromCache(addon.getId());
+            addKarToCache(addon.getUid(), sourceUrl);
+            installFromCache(addon.getUid());
         } catch (MalformedURLException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }
@@ -116,7 +116,7 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
         try {
-            Path addonPath = getAddonCacheDirectory(addon.getId());
+            Path addonPath = getAddonCacheDirectory(addon.getUid());
             List<String> repositories = karService.list();
             for (Path path : karFilesStream(addonPath).collect(Collectors.toList())) {
                 String karRepoName = pathToKarRepoName(path);

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -23,6 +23,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -56,6 +58,8 @@ import com.google.gson.GsonBuilder;
 public abstract class AbstractRemoteAddonService implements AddonService {
     static final String CONFIG_REMOTE_ENABLED = "remote";
     static final String CONFIG_INCLUDE_INCOMPATIBLE = "includeIncompatible";
+
+    protected static final Pattern BUNDLE_NAME_PATTERN = Pattern.compile(".*/(.*)-\\d+\\.\\d+\\.\\d+.*");
 
     protected static final Map<String, AddonType> TAG_ADDON_TYPE_MAP = Map.of( //
             "automation", new AddonType("automation", "Automation"), //
@@ -250,6 +254,15 @@ public abstract class AbstractRemoteAddonService implements AddonService {
         } catch (IOException e) {
             return false;
         }
+    }
+
+    protected @Nullable String determineTechnicalIdFromUrl(String url) {
+        Matcher matcher = BUNDLE_NAME_PATTERN.matcher(url);
+        if (matcher.matches()) {
+            String bundleName = matcher.group(1);
+            return bundleName.substring(bundleName.lastIndexOf(".") + 1);
+        }
+        return null;
     }
 
     private void postInstalledEvent(String extensionId) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -23,8 +23,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -58,8 +56,6 @@ import com.google.gson.GsonBuilder;
 public abstract class AbstractRemoteAddonService implements AddonService {
     static final String CONFIG_REMOTE_ENABLED = "remote";
     static final String CONFIG_INCLUDE_INCOMPATIBLE = "includeIncompatible";
-
-    protected static final Pattern BUNDLE_NAME_PATTERN = Pattern.compile(".*/(.*)-\\d+\\.\\d+\\.\\d+.*");
 
     protected static final Map<String, AddonType> TAG_ADDON_TYPE_MAP = Map.of( //
             "automation", new AddonType("automation", "Automation"), //
@@ -255,17 +251,6 @@ public abstract class AbstractRemoteAddonService implements AddonService {
         } catch (IOException e) {
             return false;
         }
-    }
-
-    protected @Nullable String determineTechnicalIdFromUrl(String url) {
-        Matcher matcher = BUNDLE_NAME_PATTERN.matcher(url);
-        if (matcher.matches()) {
-            String bundleName = matcher.group(1);
-            return bundleName.substring(bundleName.lastIndexOf(".") + 1);
-        } else {
-            logger.warn("Could not determine bundle name from url: {}", url);
-        }
-        return null;
     }
 
     private void postInstalledEvent(String extensionId) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -79,9 +79,9 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
             String yamlContent = (String) addon.getProperties().get(YAML_CONTENT_PROPERTY);
 
             if (yamlDownloadUrl != null) {
-                addWidgetAsYAML(addon.getId(), getWidgetFromURL(yamlDownloadUrl));
+                addWidgetAsYAML(addon.getUid(), getWidgetFromURL(yamlDownloadUrl));
             } else if (yamlContent != null) {
-                addWidgetAsYAML(addon.getId(), yamlContent);
+                addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
                 throw new IllegalArgumentException("Couldn't find the block library in the add-on entry");
             }
@@ -96,7 +96,7 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
 
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
-        blocksRegistry.getAll().stream().filter(w -> w.hasTag(addon.getId())).forEach(w -> {
+        blocksRegistry.getAll().stream().filter(w -> w.hasTag(addon.getUid())).forEach(w -> {
             blocksRegistry.remove(w.getUID());
         });
     }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -75,8 +75,8 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
     public void install(Addon addon) throws MarketplaceHandlerException {
         try {
             URL sourceUrl = new URL((String) addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY));
-            addBundleToCache(addon.getId(), sourceUrl);
-            installFromCache(bundleContext, addon.getId());
+            addBundleToCache(addon.getUid(), sourceUrl);
+            installFromCache(bundleContext, addon.getUid());
         } catch (MalformedURLException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }
@@ -84,7 +84,7 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
 
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
-        uninstallBundle(bundleContext, addon.getId());
+        uninstallBundle(bundleContext, addon.getUid());
     }
 
     @Override

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
@@ -77,13 +77,13 @@ public class CommunityRuleTemplateAddonHandler implements MarketplaceAddonHandle
             String yamlContent = (String) addon.getProperties().get(YAML_CONTENT_PROPERTY);
 
             if (jsonDownloadUrl != null) {
-                marketplaceRuleTemplateProvider.addTemplateAsJSON(addon.getId(), getTemplateFromURL(jsonDownloadUrl));
+                marketplaceRuleTemplateProvider.addTemplateAsJSON(addon.getUid(), getTemplateFromURL(jsonDownloadUrl));
             } else if (yamlDownloadUrl != null) {
-                marketplaceRuleTemplateProvider.addTemplateAsYAML(addon.getId(), getTemplateFromURL(yamlDownloadUrl));
+                marketplaceRuleTemplateProvider.addTemplateAsYAML(addon.getUid(), getTemplateFromURL(yamlDownloadUrl));
             } else if (jsonContent != null) {
-                marketplaceRuleTemplateProvider.addTemplateAsJSON(addon.getId(), jsonContent);
+                marketplaceRuleTemplateProvider.addTemplateAsJSON(addon.getUid(), jsonContent);
             } else if (yamlContent != null) {
-                marketplaceRuleTemplateProvider.addTemplateAsYAML(addon.getId(), yamlContent);
+                marketplaceRuleTemplateProvider.addTemplateAsYAML(addon.getUid(), yamlContent);
             }
         } catch (IOException e) {
             logger.error("Rule template from marketplace cannot be downloaded: {}", e.getMessage());
@@ -96,7 +96,7 @@ public class CommunityRuleTemplateAddonHandler implements MarketplaceAddonHandle
 
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
-        marketplaceRuleTemplateProvider.getAll().stream().filter(t -> t.getTags().contains(addon.getId()))
+        marketplaceRuleTemplateProvider.getAll().stream().filter(t -> t.getTags().contains(addon.getUid()))
                 .forEach(w -> {
                     marketplaceRuleTemplateProvider.remove(w.getUID());
                 });

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -79,9 +79,9 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
             String yamlContent = (String) addon.getProperties().get(YAML_CONTENT_PROPERTY);
 
             if (yamlDownloadUrl != null) {
-                addWidgetAsYAML(addon.getId(), getWidgetFromURL(yamlDownloadUrl));
+                addWidgetAsYAML(addon.getUid(), getWidgetFromURL(yamlDownloadUrl));
             } else if (yamlContent != null) {
-                addWidgetAsYAML(addon.getId(), yamlContent);
+                addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
                 throw new IllegalArgumentException("Couldn't find the widget in the add-on entry");
             }
@@ -96,7 +96,7 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
 
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
-        widgetRegistry.getAll().stream().filter(w -> w.hasTag(addon.getId())).forEach(w -> {
+        widgetRegistry.getAll().stream().filter(w -> w.hasTag(addon.getUid())).forEach(w -> {
             widgetRegistry.remove(w.getUID());
         });
     }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -151,11 +151,14 @@ public class JsonAddonService extends AbstractRemoteAddonService {
         boolean installed = addonHandlers.stream().anyMatch(
                 handler -> handler.supports(addonEntry.type, addonEntry.contentType) && handler.isInstalled(fullId));
 
+        String technicalId = null;
         Map<String, Object> properties = new HashMap<>();
         if (addonEntry.url.endsWith(".jar")) {
             properties.put("jar_download_url", addonEntry.url);
+            technicalId = determineTechnicalIdFromUrl(addonEntry.url);
         } else if (addonEntry.url.endsWith(".kar")) {
             properties.put("kar_download_url", addonEntry.url);
+            technicalId = determineTechnicalIdFromUrl(addonEntry.url);
         } else if (addonEntry.url.endsWith(".json")) {
             properties.put("json_download_url", addonEntry.url);
         } else if (addonEntry.url.endsWith(".yaml")) {
@@ -169,12 +172,18 @@ public class JsonAddonService extends AbstractRemoteAddonService {
             logger.debug("Failed to determine compatibility for addon {}: {}", addonEntry.id, e.getMessage());
         }
 
-        return Addon.create(fullId).withType(addonEntry.type).withInstalled(installed)
+        Addon.Builder addon = Addon.create(fullId).withType(addonEntry.type).withInstalled(installed)
                 .withDetailedDescription(addonEntry.description).withContentType(addonEntry.contentType)
                 .withAuthor(addonEntry.author).withVersion(addonEntry.version).withLabel(addonEntry.title)
                 .withCompatible(compatible).withMaturity(addonEntry.maturity).withProperties(properties)
                 .withLink(addonEntry.link).withImageLink(addonEntry.imageUrl)
-                .withConfigDescriptionURI(addonEntry.configDescriptionURI).withLoggerPackages(addonEntry.loggerPackages)
-                .build();
+                .withConfigDescriptionURI(addonEntry.configDescriptionURI)
+                .withLoggerPackages(addonEntry.loggerPackages);
+
+        if (technicalId != null) {
+            addon.withTechnicalName(technicalId);
+        }
+
+        return addon.build();
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -146,19 +146,15 @@ public class JsonAddonService extends AbstractRemoteAddonService {
     }
 
     private Addon fromAddonEntry(AddonEntryDTO addonEntry) {
-        String uid = ADDON_ID_PREFIX + addonEntry.id;
+        String uid = ADDON_ID_PREFIX + addonEntry.uid;
         boolean installed = addonHandlers.stream().anyMatch(
                 handler -> handler.supports(addonEntry.type, addonEntry.contentType) && handler.isInstalled(uid));
-
-        String id = addonEntry.id; // this is a fallback if we don't find a better name later on
 
         Map<String, Object> properties = new HashMap<>();
         if (addonEntry.url.endsWith(".jar")) {
             properties.put("jar_download_url", addonEntry.url);
-            id = determineTechnicalIdFromUrl(addonEntry.url);
         } else if (addonEntry.url.endsWith(".kar")) {
             properties.put("kar_download_url", addonEntry.url);
-            id = determineTechnicalIdFromUrl(addonEntry.url);
         } else if (addonEntry.url.endsWith(".json")) {
             properties.put("json_download_url", addonEntry.url);
         } else if (addonEntry.url.endsWith(".yaml")) {
@@ -172,7 +168,7 @@ public class JsonAddonService extends AbstractRemoteAddonService {
             logger.debug("Failed to determine compatibility for addon {}: {}", addonEntry.id, e.getMessage());
         }
 
-        return Addon.create(uid).withType(addonEntry.type).withId(id).withInstalled(installed)
+        return Addon.create(uid).withType(addonEntry.type).withId(addonEntry.id).withInstalled(installed)
                 .withDetailedDescription(addonEntry.description).withContentType(addonEntry.contentType)
                 .withAuthor(addonEntry.author).withVersion(addonEntry.version).withLabel(addonEntry.title)
                 .withCompatible(compatible).withMaturity(addonEntry.maturity).withProperties(properties)

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
  * @author Jan N. Klug - Initial contribution
  */
 public class AddonEntryDTO {
+    public String uid = "";
     public String id = "";
     public String type = "";
     public String description = "";

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -121,7 +121,7 @@ public class AbstractRemoteAddonServiceTest {
     public void testAddonIsReportedAsInstalledIfStorageEntryMissing() {
         addonService.setInstalled(TEST_ADDON);
         List<Addon> addons = addonService.getAddons(null);
-        Addon addon = addons.stream().filter(a -> getFullAddonId(TEST_ADDON).equals(a.getId())).findAny().orElse(null);
+        Addon addon = addons.stream().filter(a -> getFullAddonId(TEST_ADDON).equals(a.getUid())).findAny().orElse(null);
 
         assertThat(addon, notNullValue());
         assertThat(addon.isInstalled(), is(true));
@@ -142,7 +142,7 @@ public class AbstractRemoteAddonServiceTest {
         // check only the installed addon is present
         addons = addonService.getAddons(null);
         assertThat(addons, hasSize(1));
-        assertThat(addons.get(0).getId(), is(getFullAddonId(TEST_ADDON)));
+        assertThat(addons.get(0).getUid(), is(getFullAddonId(TEST_ADDON)));
     }
 
     @Test

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonHandler.java
@@ -63,17 +63,17 @@ public class TestAddonHandler implements MarketplaceAddonHandler {
 
     @Override
     public void install(Addon addon) throws MarketplaceHandlerException {
-        if (addon.getId().endsWith(":" + INSTALL_EXCEPTION_ADDON)) {
+        if (addon.getUid().endsWith(":" + INSTALL_EXCEPTION_ADDON)) {
             throw new MarketplaceHandlerException("Installation failed", null);
         }
-        installedAddons.add(addon.getId());
+        installedAddons.add(addon.getUid());
     }
 
     @Override
     public void uninstall(Addon addon) throws MarketplaceHandlerException {
-        if (addon.getId().endsWith(":" + UNINSTALL_EXCEPTION_ADDON)) {
+        if (addon.getUid().endsWith(":" + UNINSTALL_EXCEPTION_ADDON)) {
             throw new MarketplaceHandlerException("Uninstallation failed", null);
         }
-        installedAddons.remove(addon.getId());
+        installedAddons.remove(addon.getUid());
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonService.java
@@ -71,11 +71,9 @@ public class TestAddonService extends AbstractRemoteAddonService {
     @Override
     protected List<Addon> getRemoteAddons() {
         remoteCalls++;
-        return REMOTE_ADDONS.stream()
-                .map(id -> Addon.create(SERVICE_PID + ":" + id).withType("binding")
-                        .withContentType(TestAddonHandler.TEST_ADDON_CONTENT_TYPE)
-                        .withCompatible(!id.equals(INCOMPATIBLE_VERSION)).build())
-                .collect(Collectors.toList());
+        return REMOTE_ADDONS.stream().map(id -> Addon.create(SERVICE_PID + ":" + id).withType("binding")
+                .withId(id.substring("binding-".length())).withContentType(TestAddonHandler.TEST_ADDON_CONTENT_TYPE)
+                .withCompatible(!id.equals(INCOMPATIBLE_VERSION)).build()).collect(Collectors.toList());
     }
 
     @Override
@@ -91,7 +89,7 @@ public class TestAddonService extends AbstractRemoteAddonService {
     @Override
     public @Nullable Addon getAddon(String id, @Nullable Locale locale) {
         String remoteId = SERVICE_PID + ":" + id;
-        return cachedAddons.stream().filter(a -> remoteId.equals(a.getId())).findAny().orElse(null);
+        return cachedAddons.stream().filter(a -> remoteId.equals(a.getUid())).findAny().orElse(null);
     }
 
     @Override
@@ -114,7 +112,7 @@ public class TestAddonService extends AbstractRemoteAddonService {
      * @param id id of the addon to install
      */
     public void setInstalled(String id) {
-        Addon addon = Addon.create(SERVICE_PID + ":" + id).withType("binding")
+        Addon addon = Addon.create(SERVICE_PID + ":" + id).withType("binding").withId(id.substring("binding-".length()))
                 .withContentType(TestAddonHandler.TEST_ADDON_CONTENT_TYPE).build();
 
         addonHandlers.forEach(addonHandler -> {
@@ -132,7 +130,7 @@ public class TestAddonService extends AbstractRemoteAddonService {
      * @param id id of the addon to add
      */
     public void addToStorage(String id) {
-        Addon addon = Addon.create(SERVICE_PID + ":" + id).withType("binding")
+        Addon addon = Addon.create(SERVICE_PID + ":" + id).withType("binding").withId(id.substring("binding-".length()))
                 .withContentType(TestAddonHandler.TEST_ADDON_CONTENT_TYPE).build();
 
         addon.setInstalled(true);

--- a/bundles/org.openhab.core.addon.sample/src/main/java/org/openhab/core/addon/sample/internal/SampleAddonService.java
+++ b/bundles/org.openhab.core.addon.sample/src/main/java/org/openhab/core/addon/sample/internal/SampleAddonService.java
@@ -82,7 +82,7 @@ public class SampleAddonService implements AddonService {
                         .withMaturity("stable").withContentType("example/vnd.openhab.addon").withLink(link)
                         .withAuthor("John Doe", false).withInstalled(installed).withDescription(description)
                         .withBackgroundColor(backgroundColor).build();
-                extensions.put(extension.getId(), extension);
+                extensions.put(extension.getUid(), extension);
             }
         }
     }

--- a/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoConverter.java
+++ b/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoConverter.java
@@ -105,6 +105,7 @@ public class AddonInfoConverter extends GenericUnmarshaller<AddonInfoXmlResult> 
                 }
             }
         }
+
         addonInfo.withConfigDescriptionURI(configDescriptionURI);
 
         nodeIterator.assertEndOfType();

--- a/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoConverter.java
+++ b/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoConverter.java
@@ -87,7 +87,7 @@ public class AddonInfoConverter extends GenericUnmarshaller<AddonInfoXmlResult> 
         AddonInfo.Builder addonInfo = AddonInfo.builder(id, type).withName(name).withDescription(description);
         addonInfo.withAuthor((String) nodeIterator.nextValue("author", false));
         addonInfo.withConnection((String) nodeIterator.nextValue("connection", false));
-
+        addonInfo.withCountries((String) nodeIterator.nextValue("countries", false));
         addonInfo.withServiceId((String) nodeIterator.nextValue("service-id", false));
 
         String configDescriptionURI = nodeIterator.nextAttribute("config-description-ref", "uri", false);

--- a/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoReader.java
+++ b/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoReader.java
@@ -74,6 +74,8 @@ public class AddonInfoReader extends XmlDocumentReader<AddonInfoXmlResult> {
         xstream.alias("description", NodeValue.class);
         xstream.alias("author", NodeValue.class);
         xstream.alias("type", NodeValue.class);
+        xstream.alias("connection", NodeValue.class);
+        xstream.alias("countries", NodeValue.class);
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);
         xstream.alias("parameter", ConfigDescriptionParameter.class);

--- a/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoXmlProvider.java
+++ b/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoXmlProvider.java
@@ -76,7 +76,8 @@ public class AddonInfoXmlProvider implements XmlDocumentProvider<AddonInfoXmlRes
             }
         }
 
-        AddonInfo addonInfo = AddonInfo.builder(addonInfoXmlResult.addonInfo()).withSourceBundle(bundle.getSymbolicName()).build();
+        AddonInfo addonInfo = AddonInfo.builder(addonInfoXmlResult.addonInfo())
+                .withSourceBundle(bundle.getSymbolicName()).build();
         addonInfoProvider.add(bundle, addonInfo);
     }
 

--- a/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoXmlProvider.java
+++ b/bundles/org.openhab.core.addon.xml/src/main/java/org/openhab/core/addon/xml/internal/AddonInfoXmlProvider.java
@@ -13,6 +13,7 @@
 package org.openhab.core.addon.xml.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.addon.AddonInfo;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.xml.AbstractXmlConfigDescriptionProvider;
 import org.openhab.core.config.xml.osgi.XmlDocumentProvider;
@@ -75,7 +76,8 @@ public class AddonInfoXmlProvider implements XmlDocumentProvider<AddonInfoXmlRes
             }
         }
 
-        addonInfoProvider.add(bundle, addonInfoXmlResult.addonInfo());
+        AddonInfo addonInfo = AddonInfo.builder(addonInfoXmlResult.addonInfo()).withSourceBundle(bundle.getSymbolicName()).build();
+        addonInfoProvider.add(bundle, addonInfo);
     }
 
     @Override

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.Collator;
-import java.util.Comparator;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -376,18 +376,13 @@ public class AddonResource implements RESTResource {
     }
 
     private Stream<Addon> getAllAddons(Locale locale) {
-        return addonServices.stream().map(s -> s.getAddons(locale)).flatMap(l -> l.stream());
+        return addonServices.stream().map(s -> s.getAddons(locale)).flatMap(Collection::stream);
     }
 
     private Set<AddonType> getAllAddonTypes(Locale locale) {
         final Collator coll = Collator.getInstance(locale);
         coll.setStrength(Collator.PRIMARY);
-        Set<AddonType> ret = new TreeSet<>(new Comparator<AddonType>() {
-            @Override
-            public int compare(AddonType o1, AddonType o2) {
-                return coll.compare(o1.getLabel(), o2.getLabel());
-            }
-        });
+        Set<AddonType> ret = new TreeSet<>((o1, o2) -> coll.compare(o1.getLabel(), o2.getLabel()));
         for (AddonService addonService : addonServices) {
             ret.addAll(addonService.getTypes(locale));
         }

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -127,19 +127,18 @@ public class KarafAddonService implements AddonService {
     private Addon getAddon(Feature feature) {
         String name = getName(feature.getName());
         String type = getType(feature.getName());
-        String id = type + Addon.ADDON_SEPARATOR + name;
+        String uid = type + Addon.ADDON_SEPARATOR + name;
         boolean isInstalled = featuresService.isInstalled(feature);
 
-        Addon.Builder addon = Addon.create(id).withContentType(ADDONS_CONTENT_TYPE).withType(type)
+        Addon.Builder addon = Addon.create(uid).withType(type).withId(name).withContentType(ADDONS_CONTENT_TYPE)
                 .withVersion(feature.getVersion()).withAuthor(ADDONS_AUTHOR, true).withInstalled(isInstalled);
 
-        AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(id);
+        AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid);
 
         if (isInstalled && addonInfo != null) {
             // only enrich if this add-on is installed, otherwise wrong data might be added
-            addon = addon.withTechnicalName(addonInfo.getId()).withLabel(addonInfo.getName())
-                    .withDescription(addonInfo.getDescription()).withCountries(addonInfo.getCountries())
-                    .withLink(getDefaultDocumentationLink(type, name))
+            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
+                    .withCountries(addonInfo.getCountries()).withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {
             addon = addon.withLabel(feature.getDescription()).withLink(getDefaultDocumentationLink(type, name));

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -137,8 +137,9 @@ public class KarafAddonService implements AddonService {
 
         if (isInstalled && addonInfo != null) {
             // only enrich if this add-on is installed, otherwise wrong data might be added
-            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
-                    .withCountries(addonInfo.getCountries()).withLink(getDefaultDocumentationLink(type, name))
+            addon = addon.withTechnicalName(addonInfo.getId()).withLabel(addonInfo.getName())
+                    .withDescription(addonInfo.getDescription()).withCountries(addonInfo.getCountries())
+                    .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {
             addon = addon.withLabel(feature.getDescription()).withLink(getDefaultDocumentationLink(type, name));

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
@@ -15,6 +15,7 @@ package org.openhab.core.addon;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -29,9 +30,9 @@ public class Addon {
     public static final Set<String> CODE_MATURITY_LEVELS = Set.of("alpha", "beta", "mature", "stable");
     public static final String ADDON_SEPARATOR = "-";
 
-    private final String id;
+    private final String uid;
 
-    private final @Nullable String technicalName;
+    private final String id;
     private final String label;
     private final String version;
     private final @Nullable String maturity;
@@ -57,9 +58,9 @@ public class Addon {
     /**
      * Creates a new Addon instance
      *
-     * @param id the id of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
+     * @param uid the id of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
      * @param type the type id of the add-on (e.g. "automation")
-     * @param technicalName the technical name of the add-on (e.g. "influxdb")
+     * @param uid the technical name of the add-on (e.g. "influxdb")
      * @param label the label of the add-on
      * @param version the version of the add-on
      * @param maturity the maturity level of this version
@@ -81,15 +82,28 @@ public class Addon {
      * @param imageLink the link to an image (png/svg) (may be null)
      * @param properties a {@link Map} containing addition information
      * @param loggerPackages a {@link List} containing the package names belonging to this add-on
+     * @throws IllegalArgumentException when a mandatory parameter is invalid
      */
-    private Addon(String id, String type, @Nullable String technicalName, String label, String version,
-            @Nullable String maturity, boolean compatible, String contentType, @Nullable String link, String author,
-            boolean verifiedAuthor, boolean installed, @Nullable String description,
-            @Nullable String detailedDescription, String configDescriptionURI, String keywords, List<String> countries,
-            @Nullable String license, String connection, @Nullable String backgroundColor, @Nullable String imageLink,
+    private Addon(String uid, String type, String id, String label, String version, @Nullable String maturity,
+            boolean compatible, String contentType, @Nullable String link, String author, boolean verifiedAuthor,
+            boolean installed, @Nullable String description, @Nullable String detailedDescription,
+            String configDescriptionURI, String keywords, List<String> countries, @Nullable String license,
+            String connection, @Nullable String backgroundColor, @Nullable String imageLink,
             @Nullable Map<String, Object> properties, List<String> loggerPackages) {
+        if (uid.isBlank()) {
+            throw new IllegalArgumentException("uid must not be empty");
+        }
+        if (type.isBlank()) {
+            throw new IllegalArgumentException("type must not be empty");
+        }
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("id must not be empty");
+        }
+
+        this.uid = uid;
+        this.type = type;
         this.id = id;
-        this.technicalName = technicalName;
+
         this.label = label;
         this.version = version;
         this.maturity = maturity;
@@ -108,30 +122,29 @@ public class Addon {
         this.author = author;
         this.verifiedAuthor = verifiedAuthor;
         this.installed = installed;
-        this.type = type;
         this.properties = properties == null ? Map.of() : properties;
         this.loggerPackages = loggerPackages;
     }
 
     /**
-     * The id of the {@AddonType} of the add-on
+     * The type of the addon (same as id of {@link AddonType})
      */
     public String getType() {
         return type;
     }
 
     /**
-     * The id of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
+     * The uid of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
      */
-    public String getId() {
-        return id;
+    public String getUid() {
+        return uid;
     }
 
     /**
-     * The technical name of the add-on (e.g. "influxdb")
+     * The id of the add-on (e.g. "influxdb")
      */
-    public String getTechnicalName() {
-        return technicalName;
+    public String getId() {
+        return id;
     }
 
     /**
@@ -281,13 +294,20 @@ public class Addon {
         return loggerPackages;
     }
 
-    public static Builder create(String id) {
-        return new Builder(id);
+    /**
+     * Create a builder for an {@link Addon}
+     *
+     * @param uid the UID of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
+     *
+     * @return
+     */
+    public static Builder create(String uid) {
+        return new Builder(uid);
     }
 
     public static class Builder {
+        private final String uid;
         private String id;
-        private @Nullable String technicalName;
         private String label;
         private String version = "";
         private @Nullable String maturity;
@@ -310,12 +330,17 @@ public class Addon {
         private Map<String, Object> properties = new HashMap<>();
         private List<String> loggerPackages = List.of();
 
-        private Builder(String id) {
-            this.id = id;
+        private Builder(String uid) {
+            this.uid = uid;
         }
 
-        public Builder withTechnicalName(String technicalName) {
-            this.technicalName = technicalName;
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withId(String id) {
+            this.id = id;
             return this;
         }
 
@@ -349,8 +374,8 @@ public class Addon {
             return this;
         }
 
-        public Builder withAuthor(String author) {
-            this.author = author;
+        public Builder withAuthor(@Nullable String author) {
+            this.author = Objects.requireNonNullElse(author, "");
             return this;
         }
 
@@ -365,11 +390,6 @@ public class Addon {
             return this;
         }
 
-        public Builder withType(String type) {
-            this.type = type;
-            return this;
-        }
-
         public Builder withDescription(String description) {
             this.description = description;
             return this;
@@ -380,8 +400,8 @@ public class Addon {
             return this;
         }
 
-        public Builder withConfigDescriptionURI(String configDescriptionURI) {
-            this.configDescriptionURI = configDescriptionURI;
+        public Builder withConfigDescriptionURI(@Nullable String configDescriptionURI) {
+            this.configDescriptionURI = Objects.requireNonNullElse(configDescriptionURI, "");
             return this;
         }
 
@@ -431,7 +451,7 @@ public class Addon {
         }
 
         public Addon build() {
-            return new Addon(id, type, technicalName, label, version, maturity, compatible, contentType, link, author,
+            return new Addon(uid, type, id, label, version, maturity, compatible, contentType, link, author,
                     verifiedAuthor, installed, description, detailedDescription, configDescriptionURI, keywords,
                     countries, license, connection, backgroundColor, imageLink,
                     properties.isEmpty() ? null : properties, loggerPackages);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/Addon.java
@@ -30,6 +30,8 @@ public class Addon {
     public static final String ADDON_SEPARATOR = "-";
 
     private final String id;
+
+    private final @Nullable String technicalName;
     private final String label;
     private final String version;
     private final @Nullable String maturity;
@@ -55,8 +57,9 @@ public class Addon {
     /**
      * Creates a new Addon instance
      *
-     * @param id the id of the add-on
-     * @param type the type id of the add-on
+     * @param id the id of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
+     * @param type the type id of the add-on (e.g. "automation")
+     * @param technicalName the technical name of the add-on (e.g. "influxdb")
      * @param label the label of the add-on
      * @param version the version of the add-on
      * @param maturity the maturity level of this version
@@ -79,13 +82,14 @@ public class Addon {
      * @param properties a {@link Map} containing addition information
      * @param loggerPackages a {@link List} containing the package names belonging to this add-on
      */
-    private Addon(String id, String type, String label, String version, @Nullable String maturity, boolean compatible,
-            String contentType, @Nullable String link, String author, boolean verifiedAuthor, boolean installed,
-            @Nullable String description, @Nullable String detailedDescription, String configDescriptionURI,
-            String keywords, List<String> countries, @Nullable String license, String connection,
-            @Nullable String backgroundColor, @Nullable String imageLink, @Nullable Map<String, Object> properties,
-            List<String> loggerPackages) {
+    private Addon(String id, String type, @Nullable String technicalName, String label, String version,
+            @Nullable String maturity, boolean compatible, String contentType, @Nullable String link, String author,
+            boolean verifiedAuthor, boolean installed, @Nullable String description,
+            @Nullable String detailedDescription, String configDescriptionURI, String keywords, List<String> countries,
+            @Nullable String license, String connection, @Nullable String backgroundColor, @Nullable String imageLink,
+            @Nullable Map<String, Object> properties, List<String> loggerPackages) {
         this.id = id;
+        this.technicalName = technicalName;
         this.label = label;
         this.version = version;
         this.maturity = maturity;
@@ -117,14 +121,17 @@ public class Addon {
     }
 
     /**
-     * The id of the add-on
+     * The id of the add-on (e.g. "binding-dmx", "json:transform-format" or "marketplace:123456")
      */
     public String getId() {
         return id;
     }
 
-    public String getUID() {
-        return type + ADDON_SEPARATOR + id;
+    /**
+     * The technical name of the add-on (e.g. "influxdb")
+     */
+    public String getTechnicalName() {
+        return technicalName;
     }
 
     /**
@@ -280,6 +287,7 @@ public class Addon {
 
     public static class Builder {
         private String id;
+        private @Nullable String technicalName;
         private String label;
         private String version = "";
         private @Nullable String maturity;
@@ -304,6 +312,11 @@ public class Addon {
 
         private Builder(String id) {
             this.id = id;
+        }
+
+        public Builder withTechnicalName(String technicalName) {
+            this.technicalName = technicalName;
+            return this;
         }
 
         public Builder withLabel(String label) {
@@ -418,9 +431,10 @@ public class Addon {
         }
 
         public Addon build() {
-            return new Addon(id, type, label, version, maturity, compatible, contentType, link, author, verifiedAuthor,
-                    installed, description, detailedDescription, configDescriptionURI, keywords, countries, license,
-                    connection, backgroundColor, imageLink, properties.isEmpty() ? null : properties, loggerPackages);
+            return new Addon(id, type, technicalName, label, version, maturity, compatible, contentType, link, author,
+                    verifiedAuthor, installed, description, detailedDescription, configDescriptionURI, keywords,
+                    countries, license, connection, backgroundColor, imageLink,
+                    properties.isEmpty() ? null : properties, loggerPackages);
         }
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
@@ -53,6 +53,7 @@ public class AddonI18nLocalizationService {
         String name = addonI18NUtil.getName(bundle, addonInfoUID, addonInfo.getName(), locale);
         String description = addonI18NUtil.getDescription(bundle, addonInfoUID, addonInfo.getDescription(), locale);
 
-        return AddonInfo.builder(addonInfo).withName(name).withDescription(description).withSourceBundle(addonInfo.getSourceBundle()).build();
+        return AddonInfo.builder(addonInfo).withName(name).withDescription(description)
+                .withSourceBundle(addonInfo.getSourceBundle()).build();
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
@@ -53,6 +53,6 @@ public class AddonI18nLocalizationService {
         String name = addonI18NUtil.getName(bundle, addonInfoUID, addonInfo.getName(), locale);
         String description = addonI18NUtil.getDescription(bundle, addonInfoUID, addonInfo.getDescription(), locale);
 
-        return AddonInfo.builder(addonInfo).withName(name).withDescription(description).build();
+        return AddonInfo.builder(addonInfo).withName(name).withDescription(description).withSourceBundle(addonInfo.getSourceBundle()).build();
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.addon;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -209,7 +210,7 @@ public class AddonInfo implements Identifiable<String> {
         }
 
         public Builder withCountries(@Nullable String countries) {
-            this.countries = List.of(Objects.requireNonNull(countries, "").split(","));
+            this.countries = Arrays.asList(Objects.requireNonNullElse(countries, "").split(","));
             return this;
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -44,10 +44,11 @@ public class AddonInfo implements Identifiable<String> {
     private final List<String> countries;
     private final @Nullable String configDescriptionURI;
     private final String serviceId;
+    private @Nullable String sourceBundle;
 
     private AddonInfo(String id, String type, String name, String description, @Nullable String author,
             @Nullable String connection, List<String> countries, @Nullable String configDescriptionURI,
-            @Nullable String serviceId) throws IllegalArgumentException {
+            @Nullable String serviceId, @Nullable String sourceBundle) throws IllegalArgumentException {
         // mandatory fields
         if (id.isBlank()) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
@@ -73,6 +74,7 @@ public class AddonInfo implements Identifiable<String> {
         this.countries = countries;
         this.configDescriptionURI = configDescriptionURI;
         this.serviceId = Objects.requireNonNullElse(serviceId, type + "." + id);
+        this.sourceBundle = sourceBundle;
     }
 
     /**
@@ -139,6 +141,10 @@ public class AddonInfo implements Identifiable<String> {
         return configDescriptionURI;
     }
 
+    public @Nullable String getSourceBundle() {
+        return sourceBundle;
+    }
+
     public List<String> getCountries() {
         return countries;
     }
@@ -162,6 +168,7 @@ public class AddonInfo implements Identifiable<String> {
         private List<String> countries = List.of();
         private @Nullable String configDescriptionURI = "";
         private @Nullable String serviceId;
+        private @Nullable String sourceBundle;
 
         private Builder(String id, String type) {
             this.id = id;
@@ -178,6 +185,7 @@ public class AddonInfo implements Identifiable<String> {
             this.countries = addonInfo.countries;
             this.configDescriptionURI = addonInfo.configDescriptionURI;
             this.serviceId = addonInfo.serviceId;
+            this.sourceBundle = addonInfo.sourceBundle;
         }
 
         public Builder withName(String name) {
@@ -220,6 +228,11 @@ public class AddonInfo implements Identifiable<String> {
             return this;
         }
 
+        public Builder withSourceBundle(@Nullable String sourceBundle) {
+            this.sourceBundle = sourceBundle;
+            return this;
+        }
+
         /**
          * Build an {@link AddonInfo} from this builder
          * 
@@ -228,7 +241,7 @@ public class AddonInfo implements Identifiable<String> {
          */
         public AddonInfo build() throws IllegalArgumentException {
             return new AddonInfo(id, type, name, description, author, connection, countries, configDescriptionURI,
-                    serviceId);
+                    serviceId, sourceBundle);
         }
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/BundleAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/BundleAddonService.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.internal.addon;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.addon.Addon;
+import org.openhab.core.addon.AddonInfo;
+import org.openhab.core.addon.AddonInfoRegistry;
+import org.openhab.core.addon.AddonService;
+import org.openhab.core.addon.AddonType;
+import org.openhab.core.common.ThreadPoolManager;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link BundleAddonService} is a
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true, service = AddonService.class, name = BundleAddonService.SERVICE_NAME)
+public class BundleAddonService extends BundleTracker<Bundle> implements AddonService {
+    public static final String SERVICE_ID = "file";
+    public static final String SERVICE_NAME = "File based add-on service";
+
+    private static final Map<String, AddonType> TAG_ADDON_TYPE_MAP = Map.of( //
+            "automation", new AddonType("automation", "Automation"), //
+            "binding", new AddonType("binding", "Bindings"), //
+            "misc", new AddonType("misc", "Misc"), //
+            "persistence", new AddonType("persistence", "Persistence"), //
+            "transformation", new AddonType("transformation", "Transformations"), //
+            "ui", new AddonType("ui", "User Interfaces"), //
+            "voice", new AddonType("voice", "Voice"));
+    private static final String ADDON_ID_PREFIX = SERVICE_ID + ":";
+    private final Logger logger = LoggerFactory.getLogger(BundleAddonService.class);
+
+    private final AddonInfoRegistry addonInfoRegistry;
+    private final ScheduledExecutorService scheduler;
+
+    private final Set<Bundle> trackedBundles = new HashSet<>();
+    private Map<String, Addon> addons = Map.of();
+
+    @Activate
+    public BundleAddonService(final @Reference AddonInfoRegistry addonInfoRegistry, BundleContext context) {
+        super(context, Bundle.ACTIVE, null);
+
+        this.addonInfoRegistry = addonInfoRegistry;
+        this.scheduler = ThreadPoolManager.getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
+
+        open();
+
+        Arrays.stream(context.getBundles()).filter(this::isRelevant).forEach(trackedBundles::add);
+        scheduler.execute(this::refreshSource);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        close();
+    }
+
+    /**
+     * Checks if a bundle is loaded from a file and if add-on information is available
+     *
+     * @param bundle the bundle to check
+     * @return <code>true</code> if bundle is considered, <code>false</code> otherwise
+     */
+    public boolean isRelevant(Bundle bundle) {
+        return bundle.getLocation().startsWith("file:") && bundle.getEntry("OH-INF/binding/binding.xml") != null;
+    }
+
+    @Override
+    public final synchronized Bundle addingBundle(@NonNullByDefault({}) Bundle bundle,
+            @NonNullByDefault({}) BundleEvent event) {
+        if (isRelevant(bundle) && trackedBundles.add(bundle)) {
+            logger.debug("Added {} to add-on list", bundle.getSymbolicName());
+        }
+
+        scheduler.execute(this::refreshSource);
+        return bundle;
+    }
+
+    @Override
+    public final synchronized void modifiedBundle(@NonNullByDefault({}) Bundle bundle, @Nullable BundleEvent event,
+            @NonNullByDefault({}) Bundle object) {
+        if (isRelevant(bundle)) {
+            scheduler.execute(this::refreshSource);
+        }
+    }
+
+    @Override
+    public final synchronized void removedBundle(@NonNullByDefault({}) Bundle bundle,
+            @NonNullByDefault({}) BundleEvent event, Bundle object) {
+        if (trackedBundles.remove(bundle)) {
+            logger.debug("Removed {} from add-on list", bundle.getSymbolicName());
+        }
+        scheduler.execute(this::refreshSource);
+    }
+
+    @Override
+    public String getId() {
+        return SERVICE_ID;
+    }
+
+    @Override
+    public String getName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public synchronized void refreshSource() {
+        addons = trackedBundles.stream().map(this::toAddon).filter(Objects::nonNull).map(Objects::requireNonNull)
+                .collect(Collectors.toMap(Addon::getId, addon -> addon));
+    }
+
+    private @Nullable Addon toAddon(Bundle bundle) {
+        return addonInfoRegistry.getAddonInfos().stream()
+                .filter(info -> bundle.getSymbolicName().equals(info.getSourceBundle())).findAny()
+                .map(info -> toAddon(bundle, info)).orElse(null);
+    }
+
+    private Addon toAddon(Bundle bundle, AddonInfo addonInfo) {
+        String fullId = ADDON_ID_PREFIX + addonInfo.getUID();
+        Addon.Builder addon = Addon.create(fullId).withType("binding").withInstalled(true)
+                .withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
+                .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()));
+        String author = addonInfo.getAuthor();
+        if (author != null) {
+            addon = addon.withAuthor(author);
+        }
+        String configDescriptionURI = addonInfo.getConfigDescriptionURI();
+        if (configDescriptionURI != null) {
+            addon = addon.withConfigDescriptionURI(configDescriptionURI);
+        }
+
+        return addon.build();
+    }
+
+    @Override
+    public List<Addon> getAddons(@Nullable Locale locale) {
+        return new ArrayList<>(addons.values());
+    }
+
+    @Override
+    public @Nullable Addon getAddon(String id, @Nullable Locale locale) {
+        return addons.get(ADDON_ID_PREFIX + id);
+    }
+
+    @Override
+    public List<AddonType> getTypes(@Nullable Locale locale) {
+        return new ArrayList<>(TAG_ADDON_TYPE_MAP.values());
+    }
+
+    @Override
+    public void install(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void uninstall(String id) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable String getAddonId(URI addonURI) {
+        return null;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
@@ -141,7 +141,7 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
     @Override
     public synchronized void refreshSource() {
         addons = trackedBundles.stream().map(this::toAddon).filter(Objects::nonNull).map(Objects::requireNonNull)
-                .collect(Collectors.toMap(Addon::getId, addon -> addon));
+                .collect(Collectors.toMap(Addon::getUid, addon -> addon));
     }
 
     private @Nullable Addon toAddon(Bundle bundle) {
@@ -151,20 +151,12 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
     }
 
     private Addon toAddon(Bundle bundle, AddonInfo addonInfo) {
-        String fullId = ADDON_ID_PREFIX + addonInfo.getUID();
-        Addon.Builder addon = Addon.create(fullId).withTechnicalName(addonInfo.getId()).withType(addonInfo.getType())
-                .withInstalled(true).withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
-                .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()));
-        String author = addonInfo.getAuthor();
-        if (author != null) {
-            addon = addon.withAuthor(author);
-        }
-        String configDescriptionURI = addonInfo.getConfigDescriptionURI();
-        if (configDescriptionURI != null) {
-            addon = addon.withConfigDescriptionURI(configDescriptionURI);
-        }
-
-        return addon.build();
+        String uid = ADDON_ID_PREFIX + addonInfo.getUID();
+        return Addon.create(uid).withId(addonInfo.getId()).withType(addonInfo.getType())
+                .withAuthor(addonInfo.getAuthor()).withInstalled(true).withVersion(bundle.getVersion().toString())
+                .withLabel(addonInfo.getName()).withConfigDescriptionURI(addonInfo.getConfigDescriptionURI())
+                .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()))
+                .build();
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
@@ -44,8 +44,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link JarFileAddonService} is an add-on service that provides add-ons that are placed a .jar files in the
- * openHAB
- * addons folder
+ * openHAB addons folder
  *
  * @author Jan N. Klug - Initial contribution
  */

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
@@ -169,7 +169,7 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
 
     @Override
     public @Nullable Addon getAddon(String id, @Nullable Locale locale) {
-        return addons.get(ADDON_ID_PREFIX + id);
+        return addons.get(id);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
@@ -152,8 +152,8 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
 
     private Addon toAddon(Bundle bundle, AddonInfo addonInfo) {
         String fullId = ADDON_ID_PREFIX + addonInfo.getUID();
-        Addon.Builder addon = Addon.create(fullId).withType(addonInfo.getType()).withInstalled(true)
-                .withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
+        Addon.Builder addon = Addon.create(fullId).withTechnicalName(addonInfo.getId()).withType(addonInfo.getType())
+                .withInstalled(true).withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
                 .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()));
         String author = addonInfo.getAuthor();
         if (author != null) {
@@ -169,6 +169,9 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
 
     @Override
     public List<Addon> getAddons(@Nullable Locale locale) {
+        if (trackedBundles.size() != addons.size()) {
+            refreshSource();
+        }
         return List.copyOf(addons.values());
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/addon/JarFileAddonService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.addon;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -44,17 +43,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The {@link BundleAddonService} is a
+ * The {@link JarFileAddonService} is an add-on service that provides add-ons that are placed a .jar files in the
+ * openHAB
+ * addons folder
  *
  * @author Jan N. Klug - Initial contribution
  */
 @NonNullByDefault
-@Component(immediate = true, service = AddonService.class, name = BundleAddonService.SERVICE_NAME)
-public class BundleAddonService extends BundleTracker<Bundle> implements AddonService {
-    public static final String SERVICE_ID = "file";
-    public static final String SERVICE_NAME = "File based add-on service";
+@Component(immediate = true, service = AddonService.class, name = JarFileAddonService.SERVICE_NAME)
+public class JarFileAddonService extends BundleTracker<Bundle> implements AddonService {
+    public static final String SERVICE_ID = "jar";
+    public static final String SERVICE_NAME = "JAR-File add-on service";
 
-    private static final Map<String, AddonType> TAG_ADDON_TYPE_MAP = Map.of( //
+    private static final Map<String, AddonType> ADDON_TYPE_MAP = Map.of( //
             "automation", new AddonType("automation", "Automation"), //
             "binding", new AddonType("binding", "Bindings"), //
             "misc", new AddonType("misc", "Misc"), //
@@ -63,7 +64,7 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
             "ui", new AddonType("ui", "User Interfaces"), //
             "voice", new AddonType("voice", "Voice"));
     private static final String ADDON_ID_PREFIX = SERVICE_ID + ":";
-    private final Logger logger = LoggerFactory.getLogger(BundleAddonService.class);
+    private final Logger logger = LoggerFactory.getLogger(JarFileAddonService.class);
 
     private final AddonInfoRegistry addonInfoRegistry;
     private final ScheduledExecutorService scheduler;
@@ -72,7 +73,7 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
     private Map<String, Addon> addons = Map.of();
 
     @Activate
-    public BundleAddonService(final @Reference AddonInfoRegistry addonInfoRegistry, BundleContext context) {
+    public JarFileAddonService(final @Reference AddonInfoRegistry addonInfoRegistry, BundleContext context) {
         super(context, Bundle.ACTIVE, null);
 
         this.addonInfoRegistry = addonInfoRegistry;
@@ -90,13 +91,13 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
     }
 
     /**
-     * Checks if a bundle is loaded from a file and if add-on information is available
+     * Checks if a bundle is loaded from a file and add-on information is available
      *
      * @param bundle the bundle to check
      * @return <code>true</code> if bundle is considered, <code>false</code> otherwise
      */
     public boolean isRelevant(Bundle bundle) {
-        return bundle.getLocation().startsWith("file:") && bundle.getEntry("OH-INF/binding/binding.xml") != null;
+        return bundle.getLocation().startsWith("file:") && bundle.getEntry("OH-INF/addon/addon.xml") != null;
     }
 
     @Override
@@ -151,7 +152,7 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
 
     private Addon toAddon(Bundle bundle, AddonInfo addonInfo) {
         String fullId = ADDON_ID_PREFIX + addonInfo.getUID();
-        Addon.Builder addon = Addon.create(fullId).withType("binding").withInstalled(true)
+        Addon.Builder addon = Addon.create(fullId).withType(addonInfo.getType()).withInstalled(true)
                 .withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
                 .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()));
         String author = addonInfo.getAuthor();
@@ -168,7 +169,7 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
 
     @Override
     public List<Addon> getAddons(@Nullable Locale locale) {
-        return new ArrayList<>(addons.values());
+        return List.copyOf(addons.values());
     }
 
     @Override
@@ -178,7 +179,7 @@ public class BundleAddonService extends BundleTracker<Bundle> implements AddonSe
 
     @Override
     public List<AddonType> getTypes(@Nullable Locale locale) {
-        return new ArrayList<>(TAG_ADDON_TYPE_MAP.values());
+        return List.copyOf(ADDON_TYPE_MAP.values());
     }
 
     @Override


### PR DESCRIPTION
Follow-Up to #3050 
Fixes #3323 
Needs to be merged together with https://github.com/openhab/openhab-webui/pull/1651

- Adds an add-on service that provides add-ons from JARs in the addons-folder. This is needed to show manually added add-ons in the UI. It's useful because then add-ons can be configured from UI or their log-level changed (see https://github.com/openhab/openhab-webui/pull/1452). It is also needed to install things from bindings installed via .jar files
- Fixes issues with community-marketplace and JSON 3rd party add-on services. Due to inconsistent use of add-on ids throughout core and Main UI add-ons from these services could not be installed. 
- Fixes issues with parsing addon.xml (connection and countries)

For better handling the id and the uid of an add-on has been splitter. The id (e.g. `dmx`) is used to determine the thing-type. The uid (`binding-dmx`) is used for installation and identification of the binding. For a binding named `foo` this would result in

- Karaf (distribution) add-on service: id `foo`, uid `binding-foo`
- Community-Marketplace add-on service: id `foo`, uid `marketplace:123456`
- JSON 3rd party add-on service: id `foo`, uid `json:arbitrary-identifier-foo-addon`
- JAR file add-on service: id `foo`, uid `jar:binding-foo`
