### PR TITLE
QuantityType.as(PercentType.class) fixes with dimensionless units

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -306,7 +306,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
 
     @SuppressWarnings("unchecked")
     public @Nullable QuantityType<?> toInvertibleUnit(String targetUnit) {
-        Unit<?> unit = (Unit<?>) AbstractUnit.parse(targetUnit);
+        Unit<?> unit = AbstractUnit.parse(targetUnit);
         if (unit != null) {
             return toInvertibleUnit(unit);
         }
@@ -336,7 +336,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
         }
         Quantity<?> result = quantity.to(targetUnit);
 
-        return new QuantityType<T>(result.getValue(), (Unit<T>) targetUnit);
+        return new QuantityType<T>(result.getValue(), targetUnit);
     }
 
     public BigDecimal toBigDecimal() {
@@ -457,6 +457,11 @@ public class QuantityType<T extends Quantity<T>> extends Number
         } else if (target == PercentType.class) {
             if (Units.PERCENT.equals(getUnit())) {
                 return target.cast(new PercentType(toBigDecimal()));
+            } else {
+                QuantityType<T> inPercent = toUnit(Units.PERCENT);
+                if (inPercent != null) {
+                    return inPercent.as(target);
+                }
             }
             return target.cast(new PercentType(toBigDecimal().multiply(BIG_DECIMAL_HUNDRED)));
         } else if (target == DecimalType.class) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -290,7 +290,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
 
     /**
      * Convert this QuantityType to a new {@link QuantityType} using the given target unit.
-     * 
+     *
      * Implicit conversions using inverse units are allowed (i.e. mired <=> Kelvin). This may
      * change the dimension.
      *
@@ -455,15 +455,13 @@ public class QuantityType<T extends Quantity<T>> extends Number
             return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO,
                     new PercentType(toBigDecimal().multiply(BIG_DECIMAL_HUNDRED))));
         } else if (target == PercentType.class) {
-            if (Units.PERCENT.equals(getUnit())) {
-                return target.cast(new PercentType(toBigDecimal()));
+            QuantityType<T> inPercent = toUnit(Units.PERCENT);
+            if (inPercent == null) {
+                // incompatible unit
+                return null;
             } else {
-                QuantityType<T> inPercent = toUnit(Units.PERCENT);
-                if (inPercent != null) {
-                    return inPercent.as(target);
-                }
+                return target.cast(new PercentType(inPercent.toBigDecimal()));
             }
-            return target.cast(new PercentType(toBigDecimal().multiply(BIG_DECIMAL_HUNDRED)));
         } else if (target == DecimalType.class) {
             return target.cast(new DecimalType(toBigDecimal()));
         } else {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -307,6 +307,10 @@ public class QuantityTypeTest {
 
         assertEquals(PercentType.HUNDRED, new QuantityType<>("100 %").as(PercentType.class));
         assertEquals(PercentType.ZERO, new QuantityType<>("0 %").as(PercentType.class));
+        assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("10 %").as(PercentType.class));
+        assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("0.1").as(PercentType.class));
+        assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("100 %/10").as(PercentType.class));
+        assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("100000 ppm").as(PercentType.class));
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -307,10 +307,19 @@ public class QuantityTypeTest {
 
         assertEquals(PercentType.HUNDRED, new QuantityType<>("100 %").as(PercentType.class));
         assertEquals(PercentType.ZERO, new QuantityType<>("0 %").as(PercentType.class));
+
+        // Test QuantityType (different ways to refer to 10%) conversion to PercentType
         assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("10 %").as(PercentType.class));
         assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("0.1").as(PercentType.class));
         assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("100 %/10").as(PercentType.class));
         assertEquals(new PercentType(BigDecimal.valueOf(10)), new QuantityType<>("100000 ppm").as(PercentType.class));
+
+        // Known caveat: bare unit, different dimension. Still gets converted to %
+        assertEquals(new PercentType(BigDecimal.valueOf(10)),
+                new QuantityType<>(0.1, Units.RADIAN).as(PercentType.class));
+
+        // incompatible units
+        assertEquals(null, new QuantityType<>("0.5 m").as(PercentType.class));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Resolves #3296

~Note: this is not changing behaviour of silly things like `QuantityType("0.05 m")` converted to `PercentType`.~ (changed in https://github.com/openhab/openhab-core/pull/3297/commits/169bd4c4263758f4bd2d23511cc1ea0af8d56476)
Note2: this is changing behaviour in backwards-compatible way with dimensionless `QuantityType`s

Signed-off-by: Sami Salonen <ssalonen@gmail.com>