### PR TITLE
Add method to get namespaces to MetadataRegistry and ItemResource

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -330,8 +330,8 @@ public class ItemResource implements RESTResource {
     public Response getBinaryItemState(@HeaderParam("Accept") @Nullable String mediaType,
             @PathParam("itemname") @Parameter(description = "item name") String itemname) {
         List<String> acceptedMediaTypes = Arrays.stream(Objects.requireNonNullElse(mediaType, "").split(","))
-                .peek(String::trim).collect(Collectors.toList());
-        // get item
+                .map(String::trim).collect(Collectors.toList());
+
         Item item = getItem(itemname);
 
         // if it exists

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -241,14 +241,14 @@ public class ItemResource implements RESTResource {
     public Response getItemNamespaces(@PathParam("itemname") @Parameter(description = "item name") String itemname,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("exclude") @Parameter(description = "exclude the given namespaces") @Nullable String excludeNamespaces) {
-        Item item = getItem(itemname);
+        final Item item = getItem(itemname);
         final Locale locale = localeService.getLocale(language);
         final Set<String> excludedNamespaces = splitAndFilterNamespaces(excludeNamespaces, locale);
 
         if (item != null) {
-            Set<String> allItemMetadataNamespaces = metadataRegistry.getAllNamespaces(itemname).stream()
-                    .filter(n -> !excludedNamespaces.contains(n)).collect(Collectors.toSet());
-            return Response.ok(allItemMetadataNamespaces.toString()).build();
+            final String allItemMetadataNamespaces = metadataRegistry.getAllNamespaces(itemname).stream()
+                    .filter(n -> !excludedNamespaces.contains(n)).collect(Collectors.joining(","));
+            return Response.ok(allItemMetadataNamespaces).build();
         } else {
             return getItemNotFoundResponse(itemname);
         }
@@ -290,8 +290,8 @@ public class ItemResource implements RESTResource {
 
     /**
      *
-     * @param itemname
-     * @return
+     * @param itemname item name to get the state from
+     * @return the state of the item as mime-type text/plain
      */
     @GET
     @RolesAllowed({ Role.USER, Role.ADMIN })
@@ -316,8 +316,8 @@ public class ItemResource implements RESTResource {
 
     /**
      *
-     * @param itemname
-     * @return
+     * @param itemname the item from which to get the binary state
+     * @return the binary state of the item
      */
     @GET
     @RolesAllowed({ Role.USER, Role.ADMIN })
@@ -663,9 +663,9 @@ public class ItemResource implements RESTResource {
     /**
      * Create or Update an item by supplying an item bean.
      *
-     * @param itemname
+     * @param itemname the item name
      * @param item the item bean.
-     * @return
+     * @return Response configured to represent the Item in depending on the status
      */
     @PUT
     @RolesAllowed({ Role.ADMIN })
@@ -857,9 +857,9 @@ public class ItemResource implements RESTResource {
     }
 
     /**
-     * helper: Response to be sent to client if a Thing cannot be found
+     * helper: Response to be sent to client if an item cannot be found
      *
-     * @param itemname
+     * @param itemname item name that could not be found
      * @return Response configured for 'item not found'
      */
     private static Response getItemNotFoundResponse(String itemname) {
@@ -868,10 +868,10 @@ public class ItemResource implements RESTResource {
     }
 
     /**
-     * Prepare a response representing the Item depending in the status.
+     * Prepare a response representing the Item depending on the status.
      *
      * @param uriBuilder the URI builder
-     * @param status
+     * @param status http status
      * @param item can be null
      * @param locale the locale
      * @param errormessage optional message in case of error
@@ -886,7 +886,7 @@ public class ItemResource implements RESTResource {
     /**
      * convenience shortcut
      *
-     * @param itemname
+     * @param itemname the name of the item to be retrieved
      * @return Item addressed by itemname
      */
     private @Nullable Item getItem(String itemname) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -234,21 +234,17 @@ public class ItemResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}/metadata/namespaces")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getItemNamespaces", summary = "Gets the namespace of an item.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "Item not found") })
     public Response getItemNamespaces(@PathParam("itemname") @Parameter(description = "item name") String itemname,
-            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
-            @QueryParam("exclude") @Parameter(description = "exclude the given namespaces") @Nullable String excludeNamespaces) {
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Item item = getItem(itemname);
-        final Locale locale = localeService.getLocale(language);
-        final Set<String> excludedNamespaces = splitAndFilterNamespaces(excludeNamespaces, locale);
 
         if (item != null) {
-            final String allItemMetadataNamespaces = metadataRegistry.getAllNamespaces(itemname).stream()
-                    .filter(n -> !excludedNamespaces.contains(n)).collect(Collectors.joining(","));
-            return Response.ok(allItemMetadataNamespaces).build();
+            final Collection<String> namespaces = metadataRegistry.getAllNamespaces(itemname);
+            return Response.ok(new Stream2JSONInputStream(namespaces.stream())).build();
         } else {
             return getItemNotFoundResponse(itemname);
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.internal.items;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -70,10 +70,9 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
      * @param itemname the name of the item for which the namespaces should be searched.
      */
     @Override
-    public Set<String> getAllNamespaces(String itemname) {
-        return stream().map(Metadata::getUID).
-            filter(key -> key.getItemName().equals(itemname)).
-            map(MetadataKey::getNamespace).collect(Collectors.toSet());
+    public Collection getAllNamespaces(String itemname) {
+        return stream().map(Metadata::getUID).filter(key -> key.getItemName().equals(itemname))
+                .map(MetadataKey::getNamespace).collect(Collectors.toSet());
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.core.internal.items;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.AbstractRegistry;
 import org.openhab.core.events.EventPublisher;
@@ -59,6 +62,18 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
     @Override
     public boolean isInternalNamespace(String namespace) {
         return namespace.startsWith(INTERNAL_NAMESPACE_PREFIX);
+    }
+
+    /**
+     * Provides all namespaces of a particular item
+     *
+     * @param itemname the name of the item for which the namespaces should be searched.
+     */
+    @Override
+    public Set<String> getAllNamespaces(String itemname) {
+        return getAll().stream().filter(n -> {
+            return n.getUID().getItemName().equals(itemname);
+        }).map(n -> n.getUID().getNamespace()).collect(Collectors.toSet());
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -71,9 +71,8 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
      */
     @Override
     public Set<String> getAllNamespaces(String itemname) {
-        return getAll().stream().filter(n -> {
-            return n.getUID().getItemName().equals(itemname);
-        }).map(n -> n.getUID().getNamespace()).collect(Collectors.toSet());
+        return getAll().stream().filter(n -> n.getUID().getItemName().equals(itemname))
+                .map(n -> n.getUID().getNamespace()).collect(Collectors.toSet());
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -71,8 +71,9 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
      */
     @Override
     public Set<String> getAllNamespaces(String itemname) {
-        return getAll().stream().filter(n -> n.getUID().getItemName().equals(itemname))
-                .map(n -> n.getUID().getNamespace()).collect(Collectors.toSet());
+        return stream().map(Metadata::getUID).
+            filter(key -> key.getItemName().equals(itemname)).
+            map(MetadataKey::getNamespace).collect(Collectors.toSet());
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.items;
 
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.Registry;
 
@@ -37,9 +39,16 @@ public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
     boolean isInternalNamespace(String namespace);
 
     /**
+     * Provides all namespaces of a particular item
+     *
+     * @param itemname the name of the item for which the namespaces should be searched.
+     */
+    public Set<String> getAllNamespaces(String itemname);
+
+    /**
      * Remove all metadata of a given item
      *
      * @param itemname the name of the item for which the metadata is to be removed.
      */
-    void removeItemMetadata(String name);
+    void removeItemMetadata(String itemname);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.items;
 
-import java.util.Set;
+import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.Registry;
@@ -43,7 +43,7 @@ public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
      *
      * @param itemname the name of the item for which the namespaces should be searched.
      */
-    public Set<String> getAllNamespaces(String itemname);
+    public Collection<String> getAllNamespaces(String itemname);
 
     /**
      * Remove all metadata of a given item


### PR DESCRIPTION
This adds a new method to ItemResource to retrieve all namespaces of an item via the path "/{itemname: [a-zA-Z_0-9]+}/metadata/namespaces" which will eventually allow us to show even the custom namespaces in the UI (the PR for that is also already in the making).
It also extends the Item-Registry to provide a getAllNamespaces()-method which could also be exposed via other languages (e.g. jsscripting)

