### PR TITLE
prevent a provider from removing an element from another provider

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -244,6 +244,14 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
                         element.getClass().getSimpleName(), uid, provider.getClass().getSimpleName());
                 return;
             }
+            Provider<E> elementProvider = elementToProvider.get(existingElement);
+            if (!elementProvider.equals(provider)) {
+                logger.debug(
+                        "Cannot remove \"{}\" with key \"{}\" from provider \"{}\" because the instance in the registry is from provider \"{}\"!",
+                        element.getClass().getSimpleName(), uid, provider.getClass().getSimpleName(),
+                        elementProvider.getClass().getSimpleName());
+                return;
+            }
             try {
                 onRemoveElement(existingElement);
             } catch (final RuntimeException ex) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -246,9 +246,9 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
             }
             Provider<E> elementProvider = elementToProvider.get(existingElement);
             if (!elementProvider.equals(provider)) {
-                logger.debug(
-                        "Cannot remove \"{}\" with key \"{}\" from provider \"{}\" because the instance in the registry is from provider \"{}\"!",
-                        element.getClass().getSimpleName(), uid, provider.getClass().getSimpleName(),
+                logger.error(
+                        "Provider '{}' is not allowed to remove element '{}' with key '{}' from the registry because it was added by provider '{}'.",
+                        provider.getClass().getSimpleName(), element.getClass().getSimpleName(), uid,
                         elementProvider.getClass().getSimpleName());
                 return;
             }


### PR DESCRIPTION
if multiple providers provide the same element, the added callback simply ignores the duplicates. but the provider has no idea its element was ignored, so it may try to remove it in the future, and things will get all out of whack if the element is removed from the registry even if another provider thinks it's still there

this is easily reproducible by creating an item in the UI, then creating the same item via a .items file, and then removing the item from the .items file. The item will seem like it is gone to most of openHAB, but will come back after reboot when the managed provider re-adds.
