### PR TITLE
Move config description URI to type-base class

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
@@ -12,9 +12,12 @@
  */
 package org.openhab.core.thing.type;
 
+import java.net.URI;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.Identifiable;
+import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.thing.UID;
 
 /**
@@ -29,23 +32,24 @@ import org.openhab.core.thing.UID;
 @NonNullByDefault
 public abstract class AbstractDescriptionType implements Identifiable<UID> {
 
-    private UID uid;
-    private String label;
-    private @Nullable String description;
+    private final UID uid;
+    private final String label;
+    private final @Nullable String description;
+    private final @Nullable URI configDescriptionURI;
 
     /**
      * Creates a new instance of this class with the specified parameters.
      *
      * @param uid the unique identifier which identifies the according type within
      *            the overall system (must neither be null, nor empty)
-     * @param label the human readable label for the according type
+     * @param label the human-readable label for the according type
      *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
+     * @param description the human-readable description for the according type
      *            (could be null or empty)
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
-    public AbstractDescriptionType(UID uid, String label, @Nullable String description)
-            throws IllegalArgumentException {
+    public AbstractDescriptionType(UID uid, String label, @Nullable String description,
+            @Nullable URI configDescriptionURI) throws IllegalArgumentException {
         if (label.isEmpty()) {
             throw new IllegalArgumentException("The label must neither be null nor empty!");
         }
@@ -53,6 +57,7 @@ public abstract class AbstractDescriptionType implements Identifiable<UID> {
         this.uid = uid;
         this.label = label;
         this.description = description;
+        this.configDescriptionURI = configDescriptionURI;
     }
 
     /**
@@ -67,20 +72,29 @@ public abstract class AbstractDescriptionType implements Identifiable<UID> {
     }
 
     /**
-     * Returns the human readable label for the according type.
+     * Returns the human-readable label for the according type.
      *
-     * @return the human readable label for the according type (neither null, nor empty)
+     * @return the human-readable label for the according type (neither null, nor empty)
      */
     public String getLabel() {
         return this.label;
     }
 
     /**
-     * Returns the human readable description for the according type.
+     * Returns the human-readable description for the according type.
      *
-     * @return the human readable description for the according type (could be null or empty)
+     * @return the human-readable description for the according type (could be null or empty)
      */
     public @Nullable String getDescription() {
         return this.description;
+    }
+
+    /**
+     * Returns the link to a concrete {@link ConfigDescription}.
+     *
+     * @return the link to a concrete ConfigDescription
+     */
+    public @Nullable URI getConfigDescriptionURI() {
+        return configDescriptionURI;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
@@ -38,15 +38,15 @@ public class ChannelGroupType extends AbstractDescriptionType {
      * Creates a new instance of this class with the specified parameters.
      *
      * @param uid the unique identifier which identifies this channel group type within the
-     * @param label the human readable label for the according type
-     * @param description the human readable description for the according type
+     * @param label the human-readable label for the according type
+     * @param description the human-readable description for the according type
      * @param category the category of this channel group type, e.g. Temperature
      * @param channelDefinitions the channel definitions this channel group forms
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
     ChannelGroupType(ChannelGroupTypeUID uid, String label, @Nullable String description, @Nullable String category,
             @Nullable List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
-        super(uid, label, description);
+        super(uid, label, description, null);
 
         this.category = category;
         this.channelDefinitions = channelDefinitions == null ? Collections.emptyList()

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
@@ -17,14 +17,13 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.EventDescription;
 import org.openhab.core.types.StateDescription;
 
 /**
- * The {@link ChannelType} describes a concrete type of a {@link Channel}.
+ * The {@link ChannelType} describes a concrete type of {@link Channel}.
  * <p>
  * This description is used as template definition for the creation of the according concrete {@link Channel} object.
  * Use the {@link ChannelTypeBuilder} for building channel types.
@@ -45,7 +44,6 @@ public class ChannelType extends AbstractDescriptionType {
     private final @Nullable StateDescription state;
     private final @Nullable CommandDescription commandDescription;
     private final @Nullable EventDescription event;
-    private final @Nullable URI configDescriptionURI;
     private final @Nullable AutoUpdatePolicy autoUpdatePolicy;
 
     /**
@@ -56,15 +54,15 @@ public class ChannelType extends AbstractDescriptionType {
      * @param advanced true if this channel type contains advanced features, otherwise false
      * @param itemType the item type of this Channel type, e.g. {@code ColorItem}
      * @param kind the channel kind.
-     * @param label the human readable label for the according type
+     * @param label the human-readable label for the according type
      *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
+     * @param description the human-readable description for the according type
      *            (could be null or empty)
      * @param category the category of this Channel type, e.g. {@code TEMPERATURE} (could be null or empty)
      * @param tags all tags of this {@link ChannelType}, e.g. {@code Alarm} (could be null or empty)
      * @param state a {@link StateDescription} of an items state which gives information how to interpret it.
      * @param commandDescription a {@link CommandDescription} which should be rendered as push-buttons. The command
-     *            values will be send to the channel from this {@link ChannelType}.
+     *            values will be sent to the channel from this {@link ChannelType}.
      * @param configDescriptionURI the link to the concrete ConfigDescription (could be null)
      * @param autoUpdatePolicy the {@link AutoUpdatePolicy} to use.
      * @throws IllegalArgumentException if the UID or the item type is null or empty,
@@ -75,7 +73,7 @@ public class ChannelType extends AbstractDescriptionType {
             @Nullable StateDescription state, @Nullable CommandDescription commandDescription,
             @Nullable EventDescription event, @Nullable URI configDescriptionURI,
             @Nullable AutoUpdatePolicy autoUpdatePolicy) throws IllegalArgumentException {
-        super(uid, label, description);
+        super(uid, label, description, configDescriptionURI);
 
         if (kind == ChannelKind.STATE && (itemType == null || itemType.isBlank())) {
             throw new IllegalArgumentException("If the kind is 'state', the item type must be set!");
@@ -86,7 +84,6 @@ public class ChannelType extends AbstractDescriptionType {
 
         this.itemType = itemType;
         this.kind = kind;
-        this.configDescriptionURI = configDescriptionURI;
 
         this.tags = tags == null ? Set.of() : Set.copyOf(tags);
         this.advanced = advanced;
@@ -136,15 +133,6 @@ public class ChannelType extends AbstractDescriptionType {
     }
 
     /**
-     * Returns the link to a concrete {@link ConfigDescription}.
-     *
-     * @return the link to a concrete ConfigDescription
-     */
-    public @Nullable URI getConfigDescriptionURI() {
-        return this.configDescriptionURI;
-    }
-
-    /**
      * Returns the {@link StateDescription} of an items state which gives information how to interpret it.
      *
      * @return the {@link StateDescription}
@@ -154,7 +142,7 @@ public class ChannelType extends AbstractDescriptionType {
     }
 
     /**
-     * Returns informations about the supported events.
+     * Returns information about the supported events.
      *
      * @return the event information. Can be null if the channel is a state channel.
      */

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
@@ -19,12 +19,11 @@ import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
 
 /**
- * The {@link ThingType} describes a concrete type of a {@link Thing}.
+ * The {@link ThingType} describes a concrete type of {@link Thing}.
  * <p>
  * This description is used as template definition for the creation of the according concrete {@link Thing} object.
  * <p>
@@ -46,7 +45,6 @@ public class ThingType extends AbstractDescriptionType {
     private final List<String> supportedBridgeTypeUIDs;
     private final Map<String, String> properties;
     private final @Nullable String representationProperty;
-    private final @Nullable URI configDescriptionURI;
     private final boolean listed;
     private final @Nullable String category;
 
@@ -57,9 +55,9 @@ public class ThingType extends AbstractDescriptionType {
      *            (must neither be null, nor empty)
      * @param supportedBridgeTypeUIDs the unique identifiers of the bridges this Thing type supports
      *            (could be null or empty)
-     * @param label the human readable label for the according type
+     * @param label the human-readable label for the according type
      *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
+     * @param description the human-readable description for the according type
      *            (could be null or empty)
      * @param listed determines whether it should be listed for manually pairing or not
      * @param representationProperty name of the property that uniquely identifies this Thing
@@ -69,7 +67,7 @@ public class ThingType extends AbstractDescriptionType {
      * @param properties the properties this Thing type provides (could be null)
      * @param configDescriptionURI the link to the concrete ConfigDescription (could be null)
      * @param extensibleChannelTypeIds the channel-type ids this thing-type is extensible with (could be null or empty).
-     * @throws IllegalArgumentException if the UID is null or empty, or the the meta information is null
+     * @throws IllegalArgumentException if the UID is null or empty, or the meta information is null
      */
     ThingType(ThingTypeUID uid, @Nullable List<String> supportedBridgeTypeUIDs, String label,
             @Nullable String description, @Nullable String category, boolean listed,
@@ -77,7 +75,7 @@ public class ThingType extends AbstractDescriptionType {
             @Nullable List<ChannelGroupDefinition> channelGroupDefinitions, @Nullable Map<String, String> properties,
             @Nullable URI configDescriptionURI, @Nullable List<String> extensibleChannelTypeIds)
             throws IllegalArgumentException {
-        super(uid, label, description);
+        super(uid, label, description, configDescriptionURI);
 
         this.category = category;
         this.listed = listed;
@@ -91,7 +89,6 @@ public class ThingType extends AbstractDescriptionType {
         this.extensibleChannelTypeIds = extensibleChannelTypeIds == null ? Collections.emptyList()
                 : Collections.unmodifiableList(extensibleChannelTypeIds);
         this.properties = properties == null ? Collections.emptyMap() : Collections.unmodifiableMap(properties);
-        this.configDescriptionURI = configDescriptionURI;
     }
 
     /**
@@ -146,15 +143,6 @@ public class ThingType extends AbstractDescriptionType {
      */
     public List<ChannelGroupDefinition> getChannelGroupDefinitions() {
         return this.channelGroupDefinitions;
-    }
-
-    /**
-     * Returns the link to a concrete {@link ConfigDescription}.
-     *
-     * @return the link to a concrete ConfigDescription (could be null)
-     */
-    public @Nullable URI getConfigDescriptionURI() {
-        return this.configDescriptionURI;
     }
 
     /**


### PR DESCRIPTION
This allows simplifying methods dealing with config descriptions because they can be re-used for different types.

Signed-off-by: Jan N. Klug <github@klug.nrw>