### PR TITLE
Prevent thing initialization with missing bridge

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/resources/OH-INF/i18n/validation.properties
+++ b/bundles/org.openhab.core.config.core/src/main/resources/OH-INF/i18n/validation.properties
@@ -11,3 +11,5 @@ min_value_numeric_violated=The value must not be less than {0}.
 pattern_violated=The value {0} does not match the pattern {1}.
 options_violated=The value {0} does not match allowed parameter options. Allowed options are: {1}
 multiple_limit_violated=Only {0} elements are allowed but {1} are provided.
+
+bridge_not_configured=Configuring a bridge is mandatory.

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -28,6 +28,7 @@ import org.openhab.core.common.SafeCaller;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.config.core.validation.ConfigDescriptionValidator;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.service.ReadyService;
 import org.openhab.core.storage.Storage;
 import org.openhab.core.storage.StorageService;
@@ -46,6 +47,7 @@ import org.openhab.core.thing.type.ChannelTypeRegistry;
 import org.openhab.core.thing.type.ThingTypeRegistry;
 import org.openhab.core.util.BundleResolver;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 
 /**
  * @author Simon Kaufmann - Initial contribution
@@ -71,6 +73,8 @@ public class ThingManagerImplTest extends JavaTest {
     private @Mock @NonNullByDefault({}) StorageService storageServiceMock;
     private @Mock @NonNullByDefault({}) Thing thingMock;
     private @Mock @NonNullByDefault({}) ThingRegistryImpl thingRegistryMock;
+    private @Mock @NonNullByDefault({}) TranslationProvider translationProviderMock;
+    private @Mock @NonNullByDefault({}) BundleContext bundleContextMock;
 
     // This class is final so it cannot be mocked
     private final ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService = new ThingStatusInfoI18nLocalizationService();
@@ -88,7 +92,8 @@ public class ThingManagerImplTest extends JavaTest {
         return new ThingManagerImpl(bundleResolverMock, channelGroupTypeRegistryMock, channelTypeRegistryMock,
                 communicationManagerMock, configDescriptionRegistryMock, configDescriptionValidatorMock,
                 eventPublisherMock, itemChannelLinkRegistryMock, readyServiceMock, safeCallerMock, storageServiceMock,
-                thingRegistryMock, thingStatusInfoI18nLocalizationService, thingTypeRegistryMock);
+                thingRegistryMock, thingStatusInfoI18nLocalizationService, thingTypeRegistryMock,
+                translationProviderMock, bundleContextMock);
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -416,7 +416,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
 
         waitForAssert(() -> {
             assertEquals(ThingStatus.UNINITIALIZED, thing.getStatus());
-            assertEquals(ThingStatusDetail.HANDLER_CONFIGURATION_PENDING, thing.getStatusInfo().getStatusDetail());
+            assertEquals(ThingStatusDetail.BRIDGE_UNINITIALIZED, thing.getStatusInfo().getStatusDetail());
         });
 
         managedThingProvider.remove(thing.getUID());


### PR DESCRIPTION
If a thing type has `supported-bridge-type-refs` set, a configured bridge is mandatory. In addition to the already existing config validations a check for that has been added.

Related to https://github.com/openhab/openhab-addons/issues/10802

@openhab/add-ons-maintainers If this is merged, things don't need to check whether a bridge is configured.

Signed-off-by: Jan N. Klug <github@klug.nrw>