### PR TITLE
[transport.upnp] Slightly decrease risk of removing callback without calling end()

### DIFF
--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -269,11 +269,10 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
                     logger.trace("Removing an UPNP service subscription '{}' for particpant '{}'", serviceID,
                             participant.getUDN());
 
-                    UpnpSubscriptionCallback callback = subscriptionCallbacks.get(subService);
+                    UpnpSubscriptionCallback callback = subscriptionCallbacks.remove(subService);
                     if (callback != null) {
                         callback.end();
                     }
-                    subscriptionCallbacks.remove(subService);
                 } else {
                     logger.trace("Could not find service '{}' for device '{}'", serviceID,
                             device.getIdentity().getUdn());


### PR DESCRIPTION
Call `callback.end()` after removal to avoid concurrency situation of subscription being created right between looking for callback and removing it. Implementation uses `ConcurrentHashMap` without explicit locking. In this case `end()` would not be called, but callback would still be removed.

I have no proof of this situation happening but was reviewing some of the code while working on openhab/openhab-addons#14163.