### PR TITLE
Fix CommunicationManager erroring on unusual item<->channel link

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -505,6 +505,14 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     private @Nullable QuantityType<?> convertToQuantityType(DecimalType originalType, Item item,
             @Nullable String acceptedItemType) {
+        if (!(item instanceof NumberItem)) {
+            // PercentType command sent via DimmerItem to a channel that's dimensioned
+            // (such as Number:Dimensionless, expecting a %).
+            // We can't know the proper units to add, so just pass it through and assume
+            // The binding can deal with it.
+            return null;
+        }
+
         NumberItem numberItem = (NumberItem) item;
 
         // DecimalType command sent via a NumberItem with dimension:


### PR DESCRIPTION
Some bindings that dynamically create channels (mqtt.homie) might create a channel that declares itself as Number:Dimensionless because the end-device metadata has a unit of "%". But a savvy user might want to link that to a Dimmer or Rollershutter item depending on what the device actually is. This actually works just fine since QuantityType (with unit PERCENT) and PercentType implicitly convert between each other. Except this odd compatibility code in CommunicationManager that tries to assist bindings that _aren't_ QuantityType compatible. It assumes if the channel's item type is a dimensioned item, that the actual Item is a NumberItem, and casts without checking. All this does is checks for that case to avoid a ClassCastException.

The actual stack trace before this fix:

```
2023-01-21 10:12:44.025 [WARN ] [ab.core.internal.events.EventHandler] - Dispatching/filtering event for subscriber 'org.openhab.core.events.EventSubscriber' failed: class org.openhab.core.library.items.DimmerItem cannot be cast to class org.openhab.core.library.items.NumberItem (org.openhab.core.library.items.DimmerItem and org.openhab.core.library.items.NumberItem are in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @32b56aff)
java.lang.ClassCastException: class org.openhab.core.library.items.DimmerItem cannot be cast to class org.openhab.core.library.items.NumberItem (org.openhab.core.library.items.DimmerItem and org.openhab.core.library.items.NumberItem are in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @32b56aff)
        at org.openhab.core.thing.internal.CommunicationManager.convertToQuantityType(CommunicationManager.java:514) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.toAcceptedType(CommunicationManager.java:442) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.lambda$11(CommunicationManager.java:412) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183) ~[?:?]
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179) ~[?:?]
        at java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707) ~[?:?]
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:?]
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:?]
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.handleEvent(CommunicationManager.java:405) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.receiveCommand(CommunicationManager.java:347) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.receive(CommunicationManager.java:191) ~[?:?]
        at org.openhab.core.internal.events.EventHandler.lambda$0(EventHandler.java:151) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```