### PR TITLE
Properly handle failure when parsing marketplace add-ons

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -286,7 +286,11 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
             String uid = ADDON_ID_PREFIX + topic.id.toString();
             AddonType addonType = getAddonType(topic.categoryId, tags);
-            String type = (addonType != null) ? addonType.getId() : "";
+            if (addonType == null) {
+                logger.debug("Ignoring topic '{}' because no add-on type could be found", topic.id);
+                return null;
+            }
+            String type = addonType.getId();
             String id = topic.id.toString(); // this will be replaced after installation by the correct id if available
             String contentType = getContentType(topic.categoryId, tags);
 

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -343,8 +343,8 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
             return Addon.create(uid).withType(type).withId(id).withContentType(contentType)
                     .withImageLink(topic.imageUrl).withAuthor(author).withProperties(properties).withLabel(title)
                     .withInstalled(installed).withMaturity(maturity).withCompatible(compatible).withLink(link).build();
-        } catch (Exception e) {
-            logger.warn("Ignoring marketplace add-on '{}' due: {}", topic.title, e.getMessage());
+        } catch (RuntimeException e) {
+            logger.debug("Ignoring marketplace add-on '{}' due: {}", topic.title, e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
When parsing marketplace addons, if one fails, none is loaded. This change ignores those that fail.

Fixes https://github.com/openhab/openhab-core/issues/3338.

Signed-off-by: Boris Krivonog boris.krivonog@inova.si