### PR TITLE
fix(sec): upgrade com.thoughtworks.xstream:xstream to 1.4.20

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -277,7 +277,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -533,7 +533,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
       <scope>compile</scope>
     </dependency>
 

--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.thoughtworks.xstream:xstream 1.4.19
- [CVE-2022-41966](https://www.oscs1024.com/hd/CVE-2022-41966)


### What did I do？
Upgrade com.thoughtworks.xstream:xstream from 1.4.19 to 1.4.20 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS