### PR TITLE
Actions: Add method overloads for `PercentType` to Audio & Voice

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -128,7 +128,7 @@ public class Audio {
     @ActionDoc(text = "increases the master volume")
     public static void increaseMasterVolume(@ParamDoc(name = "percent") final float percent) throws IOException {
         if (percent <= 0 || percent > 100) {
-            throw new IllegalArgumentException("Percent must be in the range (0,100]!");
+            throw new IllegalArgumentException("Percent must be in the range (0;100]!");
         }
         Float volume = getMasterVolume();
         if (volume == 0) {
@@ -150,7 +150,7 @@ public class Audio {
     @ActionDoc(text = "decreases the master volume")
     public static void decreaseMasterVolume(@ParamDoc(name = "percent") final float percent) throws IOException {
         if (percent <= 0 || percent > 100) {
-            throw new IllegalArgumentException("Percent must be in the range (0,100]!");
+            throw new IllegalArgumentException("Percent must be in the range (0;100]!");
         }
         float volume = getMasterVolume();
         float newVolume = volume * (1f - percent / 100f);

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -47,7 +47,7 @@ public class Audio {
 
     @ActionDoc(text = "plays a sound with the given volume from the sounds folder to the default sink")
     public static void playSound(@ParamDoc(name = "filename", text = "the filename with extension") String filename,
-            @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
+                                 @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
         try {
             AudioActionService.audioManager.playFile(filename, volume);
         } catch (AudioException e) {
@@ -63,7 +63,7 @@ public class Audio {
 
     @ActionDoc(text = "plays a sound from the sounds folder to the given sink(s)")
     public static void playSound(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
-            @ParamDoc(name = "filename", text = "the filename with extension") String filename) {
+                                 @ParamDoc(name = "filename", text = "the filename with extension") String filename) {
         try {
             AudioActionService.audioManager.playFile(filename, sink);
         } catch (AudioException e) {
@@ -73,8 +73,8 @@ public class Audio {
 
     @ActionDoc(text = "plays a sound with the given volume from the sounds folder to the given sink(s)")
     public static void playSound(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
-            @ParamDoc(name = "filename", text = "the filename with extension") String filename,
-            @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
+                                 @ParamDoc(name = "filename", text = "the filename with extension") String filename,
+                                 @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
         try {
             AudioActionService.audioManager.playFile(filename, sink, volume);
         } catch (AudioException e) {
@@ -109,18 +109,15 @@ public class Audio {
         }
     }
 
-    @ActionDoc(text = "gets the master volume", returns = "volume as a float in the range [0,1]")
+    @ActionDoc(text = "gets the master volume", returns = "volume as a float in the range [0;1]")
     public static float getMasterVolume() throws IOException {
         return AudioActionService.audioManager.getVolume(null).floatValue() / 100f;
     }
 
     @ActionDoc(text = "sets the master volume")
     public static void setMasterVolume(
-            @ParamDoc(name = "volume", text = "volume in the range [0,1]") final float volume) throws IOException {
-        if (volume < 0 || volume > 1) {
-            throw new IllegalArgumentException("Volume value must be in the range [0,1]!");
-        }
-        setMasterVolume(new PercentType(new BigDecimal(volume * 100f)));
+            @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) throws IOException {
+        setMasterVolume(floatVolumeToPercentType(volume));
     }
 
     @ActionDoc(text = "sets the master volume")
@@ -158,7 +155,7 @@ public class Audio {
         float volume = getMasterVolume();
         float newVolume = volume * (1f - percent / 100f);
         if (newVolume > 0 && volume - newVolume < .01) {
-            // the getMasterVolume() may only returns integers, so we have to make sure that we
+            // the getMasterVolume() may only return integers, so we have to make sure that we
             // decrease the volume level at least by 1%.
             newVolume -= .01;
         }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -116,7 +116,7 @@ public class Audio {
 
     @ActionDoc(text = "sets the master volume")
     public static void setMasterVolume(
-            @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) throws IOException {
+            @ParamDoc(name = "volume", text = "volume in the range [0;1]") final float volume) throws IOException {
         setMasterVolume(floatVolumeToPercentType(volume));
     }
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -55,6 +55,12 @@ public class Audio {
         }
     }
 
+    @ActionDoc(text = "plays a sound with the given volume from the sounds folder to the default sink")
+    public static void playSound(@ParamDoc(name = "filename", text = "the filename with extension") String filename,
+                                 @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) {
+        playSound(filename, floatVolumeToPercentType(volume));
+    }
+
     @ActionDoc(text = "plays a sound from the sounds folder to the given sink(s)")
     public static void playSound(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
             @ParamDoc(name = "filename", text = "the filename with extension") String filename) {
@@ -74,6 +80,13 @@ public class Audio {
         } catch (AudioException e) {
             logger.warn("Failed playing audio file: {}", e.getMessage());
         }
+    }
+
+    @ActionDoc(text = "plays a sound with the given volume from the sounds folder to the given sink(s)")
+    public static void playSound(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
+                                 @ParamDoc(name = "filename", text = "the filename with extension") String filename,
+                                 @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) {
+        playSound(sink, filename, floatVolumeToPercentType(volume));
     }
 
     @ActionDoc(text = "plays an audio stream from a url to the default sink")
@@ -155,4 +168,15 @@ public class Audio {
         setMasterVolume(newVolume);
     }
 
+    /**
+     * Converts a float volume to a {@link PercentType} volume and checks if float volume is in the [0;1] range.
+     * @param volume
+     * @return
+     */
+    private static PercentType floatVolumeToPercentType(float volume) {
+        if (volume < 0 || volume > 1) {
+            throw new IllegalArgumentException("Volume value must be in the range [0;1]!");
+        }
+        return new PercentType(new BigDecimal(volume * 100f));
+    }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.model.script.actions;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -70,6 +71,12 @@ public class Voice {
         say(text, null, null, volume);
     }
 
+    @ActionDoc(text = "says a given text with the default voice and the given volume")
+    public static void say(@ParamDoc(name = "text") Object text,
+                           @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) {
+        say(text, null, null, floatVolumeToPercentType(volume));
+    }
+
     /**
      * Says the given text with a given voice.
      *
@@ -100,6 +107,13 @@ public class Voice {
     public static void say(@ParamDoc(name = "text") Object text, @ParamDoc(name = "voice") @Nullable String voice,
             @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
         say(text, voice, null, volume);
+    }
+
+    @ActionDoc(text = "says a given text with a given voice and the given volume")
+    public static void say(@ParamDoc(name = "text") Object text,
+                           @ParamDoc(name = "voice") @Nullable String voice,
+                           @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) {
+        say(text, voice, null, floatVolumeToPercentType(volume));
     }
 
     /**
@@ -137,6 +151,13 @@ public class Voice {
         if (!output.isBlank()) {
             VoiceActionService.voiceManager.say(output, voice, sink, volume);
         }
+    }
+
+    @ActionDoc(text = "says a given text with a given voice and the given volume through the given sink")
+    public static void say(@ParamDoc(name = "text") Object text, @ParamDoc(name = "voice") @Nullable String voice,
+                           @ParamDoc(name = "sink") @Nullable String sink,
+                           @ParamDoc(name = "volume", text = "volume in the range [0;1]") float volume) {
+        say(text, voice, sink, floatVolumeToPercentType(volume));
     }
 
     /**
@@ -448,5 +469,17 @@ public class Voice {
     private static org.openhab.core.voice.@Nullable Voice getVoice(String id) {
         return VoiceActionService.voiceManager.getAllVoices().stream().filter(voice -> voice.getUID().equals(id))
                 .findAny().orElse(null);
+    }
+
+    /**
+     * Converts a float volume to a {@link PercentType} volume and checks if float volume is in the [0;1] range.
+     * @param volume
+     * @return
+     */
+    private static PercentType floatVolumeToPercentType(float volume) {
+        if (volume < 0 || volume > 1) {
+            throw new IllegalArgumentException("Volume value must be in the range [0;1]!");
+        }
+        return new PercentType(new BigDecimal(volume * 100f));
     }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -67,7 +67,7 @@ public class Voice {
      */
     @ActionDoc(text = "says a given text with the default voice and the given volume")
     public static void say(@ParamDoc(name = "text") Object text,
-            @ParamDoc(name = "volume", text = "the volume to be used") @Nullable PercentType volume) {
+                           @ParamDoc(name = "volume", text = "the volume to be used") @Nullable PercentType volume) {
         say(text, null, null, volume);
     }
 
@@ -104,8 +104,9 @@ public class Voice {
      * @param volume The volume to be used
      */
     @ActionDoc(text = "says a given text with a given voice and the given volume")
-    public static void say(@ParamDoc(name = "text") Object text, @ParamDoc(name = "voice") @Nullable String voice,
-            @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
+    public static void say(@ParamDoc(name = "text") Object text,
+                           @ParamDoc(name = "voice") @Nullable String voice,
+                           @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
         say(text, voice, null, volume);
     }
 
@@ -127,8 +128,9 @@ public class Voice {
      *            be used
      */
     @ActionDoc(text = "says a given text with a given voice through the given sink")
-    public static void say(@ParamDoc(name = "text") Object text, @ParamDoc(name = "voice") @Nullable String voice,
-            @ParamDoc(name = "sink") @Nullable String sink) {
+    public static void say(@ParamDoc(name = "text") Object text,
+                           @ParamDoc(name = "voice") @Nullable String voice,
+                           @ParamDoc(name = "sink") @Nullable String sink) {
         say(text, voice, sink, null);
     }
 
@@ -145,8 +147,8 @@ public class Voice {
      */
     @ActionDoc(text = "says a given text with a given voice and the given volume through the given sink")
     public static void say(@ParamDoc(name = "text") Object text, @ParamDoc(name = "voice") @Nullable String voice,
-            @ParamDoc(name = "sink") @Nullable String sink,
-            @ParamDoc(name = "volume", text = "the volume to be used") @Nullable PercentType volume) {
+                           @ParamDoc(name = "sink") @Nullable String sink,
+                           @ParamDoc(name = "volume", text = "the volume to be used") @Nullable PercentType volume) {
         String output = text.toString();
         if (!output.isBlank()) {
             VoiceActionService.voiceManager.say(output, voice, sink, volume);
@@ -183,7 +185,7 @@ public class Voice {
      */
     @ActionDoc(text = "interprets a given text by given human language interpreter(s)", returns = "human language response")
     public static String interpret(@ParamDoc(name = "text") Object text,
-            @ParamDoc(name = "interpreters") @Nullable String interpreters) {
+                                   @ParamDoc(name = "interpreters") @Nullable String interpreters) {
         String response;
         try {
             response = VoiceActionService.voiceManager.interpret(text.toString(), interpreters);
@@ -207,7 +209,8 @@ public class Voice {
      */
     @ActionDoc(text = "interprets a given text by given human language interpreter(s) and using the given sink", returns = "human language response")
     public static String interpret(@ParamDoc(name = "text") Object text,
-            @ParamDoc(name = "interpreters") String interpreters, @ParamDoc(name = "sink") @Nullable String sink) {
+                                   @ParamDoc(name = "interpreters") String interpreters,
+                                   @ParamDoc(name = "sink") @Nullable String sink) {
         String response;
         try {
             response = VoiceActionService.voiceManager.interpret(text.toString(), interpreters);
@@ -230,7 +233,7 @@ public class Voice {
      */
     @ActionDoc(text = "starts dialog processing for a given audio source")
     public static void startDialog(@ParamDoc(name = "source") @Nullable String source,
-            @ParamDoc(name = "sink") @Nullable String sink) {
+                                   @ParamDoc(name = "sink") @Nullable String sink) {
         startDialog(null, null, null, null, null, source, sink, null, null, null);
     }
 


### PR DESCRIPTION
Closes #3331.
Related to https://github.com/openhab/openhab-js/issues/98.

This PR adds method overloads for Audio and Voice actions to accept float as volume in addition to `PercentType`.
This is especially useful when accessing these actions from the JSR223 languages because you do not need to import and construct a `PercentType` then.

I also aligned the params for the methods to increase readability of code and corrected the mathematical notation of intervals in strings (correct is `;` instead of `,`).
