### PR TITLE
[State/Command Metadata] Allow using '=' in a double quoted value/label

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataCommandDescriptionProvider.java
@@ -63,8 +63,18 @@ public class MetadataCommandDescriptionProvider implements CommandDescriptionPro
                 if (metadata.getConfiguration().containsKey("options")) {
                     Stream.of(metadata.getConfiguration().get("options").toString().split(",")).forEach(o -> {
                         if (o.contains("=")) {
-                            commandDescription.addCommandOption(
-                                    new CommandOption(o.split("=")[0].trim(), o.split("=")[1].trim()));
+                            String command;
+                            String label;
+                            if (o.startsWith("\"")) {
+                                String[] parts = o.trim().split("\"=\"");
+                                command = removeSurroundingQuotes(parts[0]);
+                                label = removeSurroundingQuotes(parts[1]);
+                            } else {
+                                String[] parts = o.trim().split("=");
+                                command = parts[0];
+                                label = parts[1];
+                            }
+                            commandDescription.addCommandOption(new CommandOption(command.trim(), label.trim()));
                         } else {
                             commandDescription.addCommandOption(new CommandOption(o.trim(), null));
                         }
@@ -79,5 +89,16 @@ public class MetadataCommandDescriptionProvider implements CommandDescriptionPro
         }
 
         return null;
+    }
+
+    public static String removeSurroundingQuotes(String input) {
+        String output = input;
+        if (input.startsWith("\"")) {
+            output = output.substring(1);
+        }
+        if (input.endsWith("\"")) {
+            output = output.substring(0, output.length() - 1);
+        }
+        return output;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.internal.items;
 
+import static org.openhab.core.internal.items.MetadataCommandDescriptionProvider.removeSurroundingQuotes;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
@@ -103,9 +105,22 @@ public class MetadataStateDescriptionFragmentProvider implements StateDescriptio
                 if (metadata.getConfiguration().containsKey("options")) {
                     List<StateOption> stateOptions = Stream
                             .of(metadata.getConfiguration().get("options").toString().split(",")).map(o -> {
-                                return (o.contains("="))
-                                        ? new StateOption(o.split("=")[0].trim(), o.split("=")[1].trim())
-                                        : new StateOption(o.trim(), null);
+                                if (o.contains("=")) {
+                                    String value;
+                                    String label;
+                                    if (o.startsWith("\"")) {
+                                        String[] parts = o.trim().split("\"=\"");
+                                        value = removeSurroundingQuotes(parts[0]);
+                                        label = removeSurroundingQuotes(parts[1]);
+                                    } else {
+                                        String[] parts = o.trim().split("=");
+                                        value = parts[0];
+                                        label = parts[1];
+                                    }
+                                    return new StateOption(value.trim(), label.trim());
+                                } else {
+                                    return new StateOption(o.trim(), null);
+                                }
                             }).collect(Collectors.toList());
                     builder.withOptions(stateOptions);
                 }


### PR DESCRIPTION
Signed-off-by: Miguel Álvarez <miguelwork92@gmail.com>

Related to UI issue https://github.com/openhab/openhab-webui/issues/1641.

The current implementation for parsing the stateDescription and commandDescription metadata value could fail if the characters = or , are used on the value or label.

This PR introduces the use of a regex to split the stateDescription and commandDescription metadata value in the same way but discarding the split characters wrapped by double quotes.

This implementation still could fail if a single " character gets introduced in a label or value, but as this have not syntactic sense I think the solution is good enough.