### PR TITLE
Add nullable annotation to avoid error marker in Eclipse

### DIFF
--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
@@ -293,6 +293,7 @@ public class ThingUpdateOSGiTest extends JavaOSGiTest {
         assertThat(updatedThing.getStatus(), is(ThingStatus.ONLINE));
 
         // check thing type version is upgraded
+        @Nullable
         String thingTypeVersion = updatedThing.getProperties().get(PROPERTY_THING_TYPE_VERSION);
         assertThat(thingTypeVersion, is(Integer.toString(expectedNewThingTypeVersion)));
 


### PR DESCRIPTION
This got lost in the review process of https://github.com/openhab/openhab-core/pull/3330.