### PR TITLE
Extend sitemap syntax for icon

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -156,7 +156,11 @@ GroupItemRef:
     ID;
 
 Icon returns ecore::EString:
-    STRING | ID;
+    STRING | (ID ':' (ID ':')?)? IconName;
+
+// Allow hyphen inside an icon name
+IconName:
+    (ID '-')* ID;
 
 ColorArray:
     ((item=ID)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState) '=')?


### PR DESCRIPTION
The icon value can now contain until 3 segments separated by a semi-column.
First segment is the icon source. Example: oh, if, iconify, material, f7, ...
Second segment is the icon set (and can be empty). Example: classic
Third segment is the icon name (and can contain hyphen). Example: temperature

In case only two segments are provided, the first segment is the icon source and the second the icon name. "classic" icon set is assumed if icon source is "oh".
In case only one segment is provided, the icon source is assumed to be the openHAB server and its classic icon set and the value is then the icon name.

Ability to surround the value with simple or double quotes is kept for better backward compatibility.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>