### PR TITLE
Fix ConfigDispatcherFileWatcher

### DIFF
--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -79,7 +79,7 @@ public class ConfigDispatcherFileWatcher implements WatchService.WatchEventListe
                 configDispatcher.fileRemoved(fullPath.toString());
             }
         } catch (IOException e) {
-            logger.error("Failed to process watch event {} for {}", kind, path);
+            logger.error("Failed to process watch event {} for {}", kind, path, e);
         }
     }
 }

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.config.dispatch.internal;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,19 +64,19 @@ public class ConfigDispatcherFileWatcher implements WatchService.WatchEventListe
 
     @Override
     public void processWatchEvent(WatchService.Kind kind, Path path) {
+        Path fullPath = watchService.getWatchPath().resolve(path);
         try {
             if (kind == WatchService.Kind.CREATE || kind == WatchService.Kind.MODIFY) {
-                if (!Files.isHidden(path) && path.toString().endsWith(".cfg")) {
-                    configDispatcher.processConfigFile(path.toFile());
+                if (!Files.isHidden(fullPath) && fullPath.toString().endsWith(".cfg")) {
+                    configDispatcher.processConfigFile(fullPath.toFile());
                 }
             } else if (kind == WatchService.Kind.DELETE) {
                 // Detect if a service specific configuration file was removed. We want to
                 // notify the service in this case with an updated empty configuration.
-                File configFile = path.toFile();
-                if (Files.isHidden(path) || Files.isDirectory(path) || !path.toString().endsWith(".cfg")) {
+                if (Files.isHidden(fullPath) || Files.isDirectory(fullPath) || !fullPath.toString().endsWith(".cfg")) {
                     return;
                 }
-                configDispatcher.fileRemoved(configFile.getAbsolutePath());
+                configDispatcher.fileRemoved(fullPath.toString());
             }
         } catch (IOException e) {
             logger.error("Failed to process watch event {} for {}", kind, path);

--- a/bundles/org.openhab.core.config.dispatch/src/test/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcherTest.java
+++ b/bundles/org.openhab.core.config.dispatch/src/test/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcherTest.java
@@ -40,6 +40,8 @@ public class ConfigDispatcherFileWatcherTest {
     public void setUp() {
         configDispatcherFileWatcher = new ConfigDispatcherFileWatcher(configDispatcherMock, watchService);
         verify(configDispatcherMock).processConfigFile(any());
+
+        when(watchService.getWatchPath()).thenReturn(Path.of("").toAbsolutePath());
     }
 
     @Test
@@ -47,7 +49,7 @@ public class ConfigDispatcherFileWatcherTest {
         Path path = Path.of("myPath.cfg");
         configDispatcherFileWatcher.processWatchEvent(WatchService.Kind.CREATE, path);
 
-        verify(configDispatcherMock).processConfigFile(path.toFile());
+        verify(configDispatcherMock).processConfigFile(path.toAbsolutePath().toFile());
     }
 
     @Test
@@ -55,7 +57,7 @@ public class ConfigDispatcherFileWatcherTest {
         Path path = Path.of("myPath.cfg");
         configDispatcherFileWatcher.processWatchEvent(WatchService.Kind.MODIFY, path);
 
-        verify(configDispatcherMock).processConfigFile(path.toFile());
+        verify(configDispatcherMock).processConfigFile(path.toAbsolutePath().toFile());
     }
 
     @Test


### PR DESCRIPTION
Fixes #3383

I'm not 100% sure if this would have been an issue in a real-world setup, because the tests failed when the file was not existing. It seems that `Files.isHidden` behaves differently on *nix and Windows for non-existing files.