### PR TITLE
Fix IllegalStateException in WatchServiceImpl

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -149,7 +149,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
         }
 
         ServiceRegistration<?> localReg = this.reg;
-        if (localReg != null) {
+        if (localReg != null && bundleContext.getService(localReg.getReference()) != null) {
             localReg.unregister();
             this.reg = null;
         }


### PR DESCRIPTION
Fixes #3387 

Added a check to prevent attempts to unregister already unregistered service. I don't fully understand why this happens, but probably it's a race condition on shutdown where the framework unregisters the service before the deactivate method is called.