### PR TITLE
Add support for channel-groups to update instructions

### DIFF
--- a/bundles/org.openhab.core.thing/schema/update/update-description-1.0.0.xsd
+++ b/bundles/org.openhab.core.thing/schema/update/update-description-1.0.0.xsd
@@ -54,6 +54,7 @@
             <xs:element name="tags" type="thing-description:tags" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="id" type="update-description:channelId" use="required"/>
+        <xs:attribute name="groupIds" type="update-description:groupIds" />
     </xs:complexType>
 
     <xs:complexType name="updateChannel">
@@ -73,6 +74,7 @@
             </xs:element>
         </xs:sequence>
         <xs:attribute name="id" type="update-description:channelId" use="required"/>
+        <xs:attribute name="groupIds" type="update-description:groupIds" />
         <xs:attribute name="preserveConfiguration" type="xs:boolean" default="true"/>
     </xs:complexType>
 
@@ -81,6 +83,7 @@
             <xs:documentation>Remove a channel from a thing.</xs:documentation>
         </xs:annotation>
         <xs:attribute name="id" type="update-description:channelId" use="required"/>
+        <xs:attribute name="groupIds" type="update-description:groupIds" />
     </xs:complexType>
 
     <xs:simpleType name="channelId">
@@ -88,6 +91,13 @@
             <xs:documentation>The simple id of the channel (i.e. without the thing UID).</xs:documentation>
         </xs:annotation>
         <xs:restriction base="config-description:idRestrictionPattern"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="groupIds">
+        <xs:annotation>
+            <xs:documentation>A comma-separated list of channel-group-ids.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="thing-description:namespaceIdListRestrictionPattern"/>
     </xs:simpleType>
 
     <xs:simpleType name="channelTypeUid">

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
@@ -12,10 +12,14 @@
  */
 package org.openhab.core.thing.internal.update;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.internal.update.dto.XmlRemoveChannel;
 
 /**
  * The {@link RemoveChannelInstructionImpl} implements a {@link ThingUpdateInstruction} that removes a channel from a
@@ -26,11 +30,14 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 @NonNullByDefault
 public class RemoveChannelInstructionImpl implements ThingUpdateInstruction {
     private final int thingTypeVersion;
+    private final List<String> groupIds;
     private final String channelId;
 
-    RemoveChannelInstructionImpl(int thingTypeVersion, String channelId) {
+    RemoveChannelInstructionImpl(int thingTypeVersion, XmlRemoveChannel removeChannel) {
         this.thingTypeVersion = thingTypeVersion;
-        this.channelId = channelId;
+        String rawGroupIds = removeChannel.getGroupIds();
+        this.groupIds = rawGroupIds != null ? Arrays.asList(rawGroupIds.split(",")) : List.of();
+        this.channelId = removeChannel.getId();
     }
 
     @Override
@@ -40,7 +47,11 @@ public class RemoveChannelInstructionImpl implements ThingUpdateInstruction {
 
     @Override
     public void perform(Thing thing, ThingBuilder thingBuilder) {
-        ChannelUID affectedChannelUid = new ChannelUID(thing.getUID(), channelId);
-        thingBuilder.withoutChannel(affectedChannelUid);
+        if (groupIds.isEmpty()) {
+            thingBuilder.withoutChannel(new ChannelUID(thing.getUID(), channelId));
+        } else {
+            groupIds.forEach(
+                    groupId -> thingBuilder.withoutChannel(new ChannelUID(thing.getUID(), groupId + "#" + channelId)));
+        }
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
@@ -50,8 +50,8 @@ public class RemoveChannelInstructionImpl implements ThingUpdateInstruction {
         if (groupIds.isEmpty()) {
             thingBuilder.withoutChannel(new ChannelUID(thing.getUID(), channelId));
         } else {
-            groupIds.forEach(
-                    groupId -> thingBuilder.withoutChannel(new ChannelUID(thing.getUID(), groupId + "#" + channelId)));
+            groupIds.forEach(groupId -> thingBuilder.withoutChannel(
+                    new ChannelUID(thing.getUID(), groupId + ChannelUID.CHANNEL_GROUP_SEPARATOR + channelId)));
         }
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
@@ -87,8 +87,8 @@ public class ThingUpdateInstructionReader {
                                     instructions
                                             .add(new UpdateChannelInstructionImpl(targetVersion, updateChannelType));
                                 } else if (instruction instanceof XmlRemoveChannel removeChannelType) {
-                                    instructions.add(
-                                            new RemoveChannelInstructionImpl(targetVersion, removeChannelType));
+                                    instructions
+                                            .add(new RemoveChannelInstructionImpl(targetVersion, removeChannelType));
                                 } else {
                                     logger.warn("Instruction type '{}' is unknown.", instruction.getClass());
                                 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
@@ -88,7 +88,7 @@ public class ThingUpdateInstructionReader {
                                             .add(new UpdateChannelInstructionImpl(targetVersion, updateChannelType));
                                 } else if (instruction instanceof XmlRemoveChannel removeChannelType) {
                                     instructions.add(
-                                            new RemoveChannelInstructionImpl(targetVersion, removeChannelType.getId()));
+                                            new RemoveChannelInstructionImpl(targetVersion, removeChannelType));
                                 } else {
                                     logger.warn("Instruction type '{}' is unknown.", instruction.getClass());
                                 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
@@ -83,7 +83,7 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
             doChannel(thing, thingBuilder, new ChannelUID(thing.getUID(), channelId));
         } else {
             groupIds.forEach(groupId -> doChannel(thing, thingBuilder,
-                    new ChannelUID(thing.getUID(), groupId + "#" + channelId)));
+                    new ChannelUID(thing.getUID(), groupId + ChannelUID.CHANNEL_SEGMENT_PATTERN + channelId)));
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.internal.update;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -38,6 +39,7 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
     private final boolean removeOldChannel;
     private final int thingTypeVersion;
     private final boolean preserveConfig;
+    private final List<String> groupIds;
     private final String channelId;
     private final String channelTypeUid;
     private final @Nullable String label;
@@ -49,6 +51,8 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
         this.thingTypeVersion = thingTypeVersion;
         this.channelId = updateChannel.getId();
         this.channelTypeUid = updateChannel.getType();
+        String rawGroupIds = updateChannel.getGroupIds();
+        this.groupIds = rawGroupIds != null ? Arrays.asList(rawGroupIds.split(",")) : List.of();
         this.label = updateChannel.getLabel();
         this.description = updateChannel.getDescription();
         this.tags = updateChannel.getTags();
@@ -60,6 +64,8 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
         this.thingTypeVersion = thingTypeVersion;
         this.channelId = addChannel.getId();
         this.channelTypeUid = addChannel.getType();
+        String rawGroupIds = addChannel.getGroupIds();
+        this.groupIds = rawGroupIds != null ? Arrays.asList(rawGroupIds.split(",")) : List.of();
         this.label = addChannel.getLabel();
         this.description = addChannel.getDescription();
         this.tags = addChannel.getTags();
@@ -73,7 +79,15 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
 
     @Override
     public void perform(Thing thing, ThingBuilder thingBuilder) {
-        ChannelUID affectedChannelUid = new ChannelUID(thing.getUID(), channelId);
+        if (groupIds.isEmpty()) {
+            doChannel(thing, thingBuilder, new ChannelUID(thing.getUID(), channelId));
+        } else {
+            groupIds.forEach(groupId -> doChannel(thing, thingBuilder,
+                    new ChannelUID(thing.getUID(), groupId + "#" + channelId)));
+        }
+    }
+
+    private void doChannel(Thing thing, ThingBuilder thingBuilder, ChannelUID affectedChannelUid) {
 
         if (removeOldChannel) {
             thingBuilder.withoutChannel(affectedChannelUid);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
@@ -83,7 +83,7 @@ public class UpdateChannelInstructionImpl implements ThingUpdateInstruction {
             doChannel(thing, thingBuilder, new ChannelUID(thing.getUID(), channelId));
         } else {
             groupIds.forEach(groupId -> doChannel(thing, thingBuilder,
-                    new ChannelUID(thing.getUID(), groupId + ChannelUID.CHANNEL_SEGMENT_PATTERN + channelId)));
+                    new ChannelUID(thing.getUID(), groupId + ChannelUID.CHANNEL_GROUP_SEPARATOR + channelId)));
         }
     }
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import static org.openhab.core.thing.internal.ThingManagerImpl.PROPERTY_THING_TYPE_VERSION;
 
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -80,6 +81,9 @@ public class ThingUpdateOSGiTest extends JavaOSGiTest {
     private static final String TEST_BUNDLE_NAME = "thingUpdateTest.bundle";
     private static final String BINDING_ID = "testBinding";
     private static final ThingTypeUID ADD_CHANNEL_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "testThingTypeAdd");
+    private static final ThingTypeUID ADD_GROUP_CHANNEL_THING_TYPE_UID = new ThingTypeUID(BINDING_ID,
+            "testThingTypeGroupAdd");
+
     private static final ThingTypeUID UPDATE_CHANNEL_THING_TYPE_UID = new ThingTypeUID(BINDING_ID,
             "testThingTypeUpdate");
     private static final ThingTypeUID REMOVE_CHANNEL_THING_TYPE_UID = new ThingTypeUID(BINDING_ID,
@@ -260,6 +264,30 @@ public class ThingUpdateOSGiTest extends JavaOSGiTest {
 
         Channel channel1 = updatedThing.getChannel("testChannel1");
         assertChannel(channel1, channelTypeOldUID, null, null);
+    }
+
+    @Test
+    public void testSingleChannelAdditionGroup() {
+        registerThingType(ADD_GROUP_CHANNEL_THING_TYPE_UID);
+
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(BINDING_ID, "testChannelTypeId");
+        registerChannelTypes(channelTypeUID);
+
+        ThingUID thingUID = new ThingUID(ADD_GROUP_CHANNEL_THING_TYPE_UID, THING_ID);
+        Thing thing = ThingBuilder.create(ADD_GROUP_CHANNEL_THING_TYPE_UID, thingUID).build();
+        managedThingProvider.add(thing);
+
+        Thing updatedThing = assertThing(thing, 1);
+
+        assertThat(updatedThing.getChannels(), hasSize(2));
+
+        List<Channel> channels1 = updatedThing.getChannelsOfGroup("group1");
+        assertThat(channels1, hasSize(1));
+        assertChannel(channels1.get(0), channelTypeUID, null, null);
+
+        List<Channel> channels2 = updatedThing.getChannelsOfGroup("group2");
+        assertThat(channels2, hasSize(1));
+        assertChannel(channels2.get(0), channelTypeUID, null, null);
     }
 
     @Test

--- a/itests/org.openhab.core.thing.tests/src/main/resources/test-bundle-pool/thingUpdateTest.bundle/OH-INF/update/singleInstructions.xml
+++ b/itests/org.openhab.core.thing.tests/src/main/resources/test-bundle-pool/thingUpdateTest.bundle/OH-INF/update/singleInstructions.xml
@@ -42,4 +42,12 @@
 		</instruction-set>
 	</thing-type>
 
+	<thing-type uid="testBinding:testThingTypeGroupAdd">
+		<instruction-set targetVersion="1">
+			<add-channel id="testChannel1" groupIds="group1,group2">
+				<type>testBinding:testChannelTypeId</type>
+			</add-channel>
+		</instruction-set>
+	</thing-type>
+
 </update:update-descriptions>


### PR DESCRIPTION
Follow-up to #3330 

https://github.com/openhab/openhab-addons/pull/14460 shows that we need channel-group support for the update instructions.