### PR TITLE
add sitemap Input type

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -15,7 +15,7 @@ Widget:
     (LinkableWidget | NonLinkableWidget);
 
 NonLinkableWidget:
-    Switch | Selection | Slider | List | Setpoint | Video | Chart | Webview | Colorpicker | Mapview | Default;
+    Switch | Selection | Slider | List | Setpoint | Video | Chart | Webview | Colorpicker | Mapview | Input | Default;
 
 LinkableWidget:
     (Text | Group | Image | Frame)
@@ -118,6 +118,12 @@ Setpoint:
 Colorpicker:
     'Colorpicker' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? & ('sendFrequency='
     frequency=INT)? &
+    ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
+    ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
+    ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);
+
+Input:
+    'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);


### PR DESCRIPTION
So far, it has not been possible to have text or numeric input in a sitemap. This can be useful to do simple updating of items, for instance for manual meter readings.
The workaround so far has been to use a Webview element and some javascript, see forum: https://community.openhab.org/t/input-field-for-number-free-text-for-openhab-uis/12461.

This PR adds an sitemap input widget. A second PR will add this to Basic UI.

If these PR's would be accepted, I will also update the main UI sitemap configuration pages to include the input widget. I have not done any app development (Android, IOS) so far, but would hope this is interesting enough for someone to also consider adding it to the apps.

Some configuration options could definitely be added in follow-up PR's for the input field, but my testing shows it is already working well in Basic UI for String, Number and QuantityType items.