### PR TITLE
Allow configurable access per metadata namespace for user role

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -928,6 +928,7 @@ public class ItemResource implements RESTResource {
                 MetadataDTO mdDto = new MetadataDTO();
                 mdDto.value = md.getValue();
                 mdDto.config = md.getConfiguration().isEmpty() ? null : md.getConfiguration();
+                mdDto.userAccessAllowed = md.getUserAccessAllowed();
                 metadata.put(namespace, mdDto);
             }
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
@@ -98,7 +98,8 @@ public class ManagedMetadataProviderImpl extends AbstractManagedProvider<Metadat
 
     private Metadata normalizeMetadata(Metadata metadata) {
         return new Metadata(metadata.getUID(), metadata.getValue(), metadata.getConfiguration().entrySet().stream()
-                .map(this::normalizeConfigEntry).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                .map(this::normalizeConfigEntry).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)),
+                metadata.getUserAccessAllowed());
     }
 
     private Map.Entry<String, Object> normalizeConfigEntry(Map.Entry<String, Object> entry) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
@@ -33,6 +33,7 @@ public final class Metadata implements Identifiable<MetadataKey> {
     private final MetadataKey key;
     private final String value;
     private final Map<String, Object> configuration;
+    private final boolean userAccessAllowed;
 
     /**
      * Package protected default constructor to allow reflective instantiation.
@@ -43,6 +44,7 @@ public final class Metadata implements Identifiable<MetadataKey> {
         key = new MetadataKey();
         value = "";
         configuration = Collections.emptyMap();
+        userAccessAllowed = false;
     }
 
     public Metadata(MetadataKey key, String value, @Nullable Map<String, Object> configuration) {
@@ -50,6 +52,16 @@ public final class Metadata implements Identifiable<MetadataKey> {
         this.value = value;
         this.configuration = configuration != null ? Collections.unmodifiableMap(new HashMap<>(configuration))
                 : Collections.emptyMap();
+        this.userAccessAllowed = false;
+    }
+
+    public Metadata(MetadataKey key, String value, @Nullable Map<String, Object> configuration,
+            @Nullable Boolean userAccessAllowed) {
+        this.key = key;
+        this.value = value;
+        this.configuration = configuration != null ? Collections.unmodifiableMap(new HashMap<>(configuration))
+                : Collections.emptyMap();
+        this.userAccessAllowed = userAccessAllowed != null ? userAccessAllowed : false;
     }
 
     @Override
@@ -73,6 +85,15 @@ public final class Metadata implements Identifiable<MetadataKey> {
      */
     public String getValue() {
         return value;
+    }
+
+    /**
+     * Provides the user access allowed flag of the meta-data.
+     *
+     * @return
+     */
+    public boolean getUserAccessAllowed() {
+        return userAccessAllowed;
     }
 
     @Override
@@ -110,6 +131,8 @@ public final class Metadata implements Identifiable<MetadataKey> {
         builder.append(value);
         builder.append(", configuration=");
         builder.append(Arrays.toString(configuration.entrySet().toArray()));
+        builder.append(", userAccessAllowed=");
+        builder.append(userAccessAllowed);
         builder.append("]");
         return builder.toString();
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/MetadataDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/MetadataDTO.java
@@ -27,4 +27,5 @@ public class MetadataDTO {
 
     public @Nullable String value;
     public @Nullable Map<String, Object> config;
+    public @Nullable Boolean userAccessAllowed;
 }

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
@@ -94,6 +95,7 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
     private @Mock @NonNullByDefault({}) ItemProvider itemProviderMock;
     private @Mock @NonNullByDefault({}) UriBuilder uriBuilderMock;
     private @Mock @NonNullByDefault({}) UriInfo uriInfoMock;
+    private @Mock @NonNullByDefault({}) SecurityContext securityContext;
 
     @BeforeEach
     public void beforeEach() {


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-webui/pull/1725.

This:
- adds a boolean `userAccessAllowed` property to the Metadata class (defaults to `false`)
- updates the metadata create/update REST endpoint to allow the user role to update an existing metadata namespace if `userAccessAllowed` is true
- updates the tests for the added REST endpoint logic