### PR TITLE
Prevent duplicate events in WatchService

### DIFF
--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -53,7 +53,7 @@ public class ConfigDispatcherFileWatcher implements WatchService.WatchEventListe
 
         this.watchService = watchService;
 
-        watchService.registerListener(this, Path.of(servicesFolder));
+        watchService.registerListener(this, Path.of(servicesFolder), false);
         configDispatcher.processConfigFile(Path.of(OpenHAB.getConfigFolder(), servicesFolder).toFile());
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -242,6 +242,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
         if (kinds.size() == 1) {
             // we have only one event
             doNotify(path, kinds.get(0));
+            return;
         }
 
         Kind firstElement = kinds.get(0);


### PR DESCRIPTION
Closes #3400 

On Samba shares a single MODIFY event may result in different sequences of CREATE/DELETE/MODIFY events. Unfortunately this is not properly handled by the underlying library and we have to re-introduce our ugly workaround. The solution itself is a bit improved over the old one as it not only keeps the last event but determines the correct event by examining the sequence of received events.