### PR TITLE
Fix overriding Jetty's User-Agent in HttpUtil

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -213,7 +213,11 @@ public class HttpUtil {
 
         if (httpHeaders != null) {
             for (String httpHeaderKey : httpHeaders.stringPropertyNames()) {
-                request.header(httpHeaderKey, httpHeaders.getProperty(httpHeaderKey));
+                if (httpHeaderKey.equalsIgnoreCase(HttpHeader.USER_AGENT.toString())) {
+                    request.agent(httpHeaders.getProperty(httpHeaderKey));
+                } else {
+                    request.header(httpHeaderKey, httpHeaders.getProperty(httpHeaderKey));
+                }
             }
         }
 


### PR DESCRIPTION
[request.header](https://github.com/eclipse/jetty.project/blob/4563f7a90e6ca11efeb1a48b5475e9853e6e2bcf/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java#L309-L316) just _adds_ the header, resulting in multiple 'User-Agent' headers, whereas [request.agent](https://github.com/eclipse/jetty.project/blob/4563f7a90e6ca11efeb1a48b5475e9853e6e2bcf/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRequest.java#L286-L290) _replaces_ it.

Looking at the implementation of headers.add, a workaround could be done (without this PR) by giving a 'User-Agent' of nil, and the second 'User-Agent' header containing the intended value. The nil entry would cause headers.add to remove existing headers of the same name.