### PR TITLE
Fix service folder resolution path

### DIFF
--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -64,7 +64,7 @@ public class ConfigDispatcherFileWatcher implements WatchService.WatchEventListe
 
     @Override
     public void processWatchEvent(WatchService.Kind kind, Path path) {
-        Path fullPath = watchService.getWatchPath().resolve(path);
+        Path fullPath = watchService.getWatchPath().resolve(SERVICES_FOLDER).resolve(path);
         try {
             if (kind == WatchService.Kind.CREATE || kind == WatchService.Kind.MODIFY) {
                 if (!Files.isHidden(fullPath) && fullPath.toString().endsWith(".cfg")) {


### PR DESCRIPTION
The latest snapshot logs the following on the initial startup:
```
22:45:38.553 [INFO ] [org.openhab.core.Activator           ] - Starting openHAB 4.0.0 (build Build #3336)
22:45:46.826 [INFO ] [b.core.model.lsp.internal.ModelServer] - Started Language Server Protocol (LSP) service on port 5007
22:45:51.811 [INFO ] [re.automation.internal.RuleEngineImpl] - Rule engine started.
22:45:53.144 [WARN ] [ig.dispatch.internal.ConfigDispatcher] - Could not process config file 'basicui.cfg': /Users/kai/oh4/conf/basicui.cfg
22:45:53.663 [WARN ] [ig.dispatch.internal.ConfigDispatcher] - Could not process config file 'rrd4j.cfg': /Users/kai/oh4/conf/rrd4j.cfg
22:45:53.683 [INFO ] [hab.ui.habpanel.internal.HABPanelTile] - Started HABPanel at /habpanel
```
This shows that the config files are tried to be loaded from the wrong path - this PR fixes the look-up.