### PR TITLE
Add inputHint param to sitemap Input element

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -129,6 +129,7 @@ Colorpicker:
 
 Input:
     'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
+    ('inputHint=' inputHint=(STRING))? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -129,7 +129,7 @@ Colorpicker:
 
 Input:
     'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('inputHint=' inputHint=INPUT_HINT)? &
+    ('inputHint=' inputHint=STRING)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -147,7 +147,7 @@ Mapping:
     cmd=Command '=' label=(ID | STRING);
 
 VisibilityRule:
-    (item=ID) (condition=("==" | ">" | "<" | ">=" | "<=" | "!=")) (sign=('-' | '+'))? (state=XState);
+    (item=ID) (condition=('==' | '>' | '<' | '>=' | '<=' | '!=')) (sign=('-' | '+'))? (state=XState);
 
 ItemRef:
     ID;
@@ -159,7 +159,7 @@ Icon returns ecore::EString:
     STRING | ID;
 
 ColorArray:
-    ((item=ID)? (condition=("==" | ">" | "<" | ">=" | "<=" | "!="))? (sign=('-' | '+'))? (state=XState) '=')?
+    ((item=ID)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState) '=')?
     (arg=STRING);
 
 Command returns ecore::EString:
@@ -170,10 +170,6 @@ Number returns ecore::EBigDecimal:
 
 XState returns ecore::EString:
     INT | ID | STRING | FLOAT;
-
-terminal INPUT_HINT returns ecore::EString:
-    ('"' ("text" | "number" | "date" | "time" | "datetime") '"') |
-    ("'" ("text" | "number" | "date" | "time" | "datetime") "'");
 
 @Override 
 terminal ID:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -172,8 +172,8 @@ XState returns ecore::EString:
     INT | ID | STRING | FLOAT;
 
 terminal INPUT_HINT returns ecore::EString:
-            ('"' ("text" | "number" | "date" | "time" | "datetime") '"') |
-            ("'" ("text" | "number" | "date" | "time" | "datetime") "'");
+    ('"' ("text" | "number" | "date" | "time" | "datetime") '"') |
+    ("'" ("text" | "number" | "date" | "time" | "datetime") "'");
 
 @Override 
 terminal ID:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -54,7 +54,7 @@ Image:
 
 Video:
     'Video' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('url=' url=(STRING)) & ('encoding=' encoding=(STRING))? &
+    ('url=' url=STRING) & ('encoding=' encoding=STRING)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -62,7 +62,7 @@ Video:
 
 Chart:
     'Chart' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('service=' service=(STRING))? & ('refresh=' refresh=INT)? & ('period=' period=ID) &
+    ('service=' service=STRING)? & ('refresh=' refresh=INT)? & ('period=' period=ID) &
     ('legend=' legend=BOOLEAN_OBJECT)? & ('forceasitem=' forceAsItem=BOOLEAN_OBJECT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -72,7 +72,7 @@ Chart:
 
 Webview:
     'Webview' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('height=' height=INT)? & ('url=' url=(STRING)) &
+    ('height=' height=INT)? & ('url=' url=STRING) &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -129,7 +129,7 @@ Colorpicker:
 
 Input:
     'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('inputHint=' inputHint=(STRING))? &
+    ('inputHint=' inputHint=STRING)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -171,6 +171,7 @@ Number returns ecore::EBigDecimal:
 XState returns ecore::EString:
     INT | ID | STRING | FLOAT;
 
+@Override 
 terminal ID:
     ('^'? ('a'..'z' | 'A'..'Z' | '_') ('a'..'z' | 'A'..'Z' | '_' | '0'..'9')*) |
     (('0'..'9')+ ('a'..'z' | 'A'..'Z' | '_') ('0'..'9' | 'a'..'z' | 'A'..'Z' | '_')*);

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -129,7 +129,7 @@ Colorpicker:
 
 Input:
     'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('inputHint=' inputHint=STRING)? &
+    ('inputHint=' inputHint=INPUT_HINT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -170,6 +170,10 @@ Number returns ecore::EBigDecimal:
 
 XState returns ecore::EString:
     INT | ID | STRING | FLOAT;
+
+terminal INPUT_HINT returns ecore::EString:
+            '"' ("text" | "number" | "date" | "time" | "datetime") '"' |
+            "'" ("text" | "number" | "date" | "time" | "datetime") "'";
 
 @Override 
 terminal ID:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -172,8 +172,8 @@ XState returns ecore::EString:
     INT | ID | STRING | FLOAT;
 
 terminal INPUT_HINT returns ecore::EString:
-            '"' ("text" | "number" | "date" | "time" | "datetime") '"' |
-            "'" ("text" | "number" | "date" | "time" | "datetime") "'";
+            ('"' ("text" | "number" | "date" | "time" | "datetime") '"') |
+            ("'" ("text" | "number" | "date" | "time" | "datetime") "'");
 
 @Override 
 terminal ID:

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -23,6 +23,9 @@ import org.openhab.core.model.sitemap.sitemap.SitemapPackage
 import org.openhab.core.model.sitemap.sitemap.Widget
 import org.eclipse.xtext.validation.Check
 import java.math.BigDecimal
+import org.openhab.core.model.sitemap.sitemap.Input
+import org.eclipse.xtext.nodemodel.INode
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 
 //import org.eclipse.xtext.validation.Check
 /**
@@ -32,6 +35,8 @@ import java.math.BigDecimal
  */
 class SitemapValidator extends AbstractSitemapValidator {
 
+    val ALLOWED_HINTS = #["text", "number", "date", "time", "datetime"]
+    
     @Check
     def void checkFramesInFrame(Frame frame) {
         for (Widget w : frame.children) {
@@ -100,6 +105,16 @@ class SitemapValidator extends AbstractSitemapValidator {
         if (sp.minValue !== null && sp.maxValue !== null && sp.minValue > sp.maxValue) {
             error("Setpoint on item '" + sp.item + "' has larger minValue than maxValue",
                 SitemapPackage.Literals.SETPOINT.getEStructuralFeature(SitemapPackage.SETPOINT__MIN_VALUE));
+        }
+    }
+    
+    @Check
+    def void checkInputHintParameter(Input i) {
+        if (i.inputHint !== null && !ALLOWED_HINTS.contains(i.inputHint)) {
+            val node = NodeModelUtils.getNode(i)
+            val line = node.getStartLine()
+            error("Input on item '" + i.item + "' has invalid inputHint '" + i.inputHint + "' at line " + line,
+                SitemapPackage.Literals.INPUT.getEStructuralFeature(SitemapPackage.INPUT__INPUT_HINT))
         }
     }
 }


### PR DESCRIPTION
See discussion in https://github.com/openhab/openhab-core/pull/3398.
See implementation of usage in BasicUI https://github.com/openhab/openhab-webui/pull/1787.

This is a first step of work to be done in the respective sitemap based UI's.

This PR adds a new inputHint parameter that can take a string that describes behaviour of the UI widget.
Right now, I propose to develop support for following values in the UI's:
-  `text`: default for non numeric item types, would show a standard keyboard on touch devices with on screen keyboard
-  `number`: show a numeric only keyboard on touch devices, default if item type is Numeric
-  `date`: show a date picker
-  `time`: show a time picker
-  `datetime`: show a combined date/time picker (or sequence of two pickers), default for DateTime type items

Using `number` on QuantityType items would still show a numeric keypad. Therefore the Unit cannot be changed in the input and the Unit of the current value is kept.