### PR TITLE
Add Input widget to main UI sitemap configuration and REST API

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -75,6 +75,7 @@ import org.openhab.core.model.sitemap.sitemap.Chart;
 import org.openhab.core.model.sitemap.sitemap.ColorArray;
 import org.openhab.core.model.sitemap.sitemap.Frame;
 import org.openhab.core.model.sitemap.sitemap.Image;
+import org.openhab.core.model.sitemap.sitemap.Input;
 import org.openhab.core.model.sitemap.sitemap.LinkableWidget;
 import org.openhab.core.model.sitemap.sitemap.Mapping;
 import org.openhab.core.model.sitemap.sitemap.Mapview;
@@ -557,6 +558,10 @@ public class SitemapResource
                 mappingBean.label = mapping.getLabel();
                 bean.mappings.add(mappingBean);
             }
+        }
+        if (widget instanceof Input) {
+            Input inputWidget = (Input) widget;
+            bean.inputHint = inputWidget.getInputHint();
         }
         if (widget instanceof Slider) {
             Slider sliderWidget = (Slider) widget;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -47,6 +47,7 @@ public class WidgetDTO {
     public BigDecimal minValue;
     public BigDecimal maxValue;
     public BigDecimal step;
+    public String inputHint;
     public String url;
     public String encoding;
     public String service;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -45,6 +45,7 @@ import org.openhab.core.model.sitemap.sitemap.impl.DefaultImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.FrameImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.GroupImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.ImageImpl;
+import org.openhab.core.model.sitemap.sitemap.impl.InputImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.MappingImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.MapviewImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.SelectionImpl;
@@ -234,6 +235,10 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 SelectionImpl selectionWidget = (SelectionImpl) SitemapFactory.eINSTANCE.createSelection();
                 addWidgetMappings(selectionWidget.getMappings(), component);
                 widget = selectionWidget;
+                break;
+            case "Input":
+                InputImpl inputWidget = (InputImpl) SitemapFactory.eINSTANCE.createInput();
+                widget = inputWidget;
                 break;
             case "Setpoint":
                 SetpointImpl setpointWidget = (SetpointImpl) SitemapFactory.eINSTANCE.createSetpoint();

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -239,6 +239,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             case "Input":
                 InputImpl inputWidget = (InputImpl) SitemapFactory.eINSTANCE.createInput();
                 widget = inputWidget;
+                setWidgetPropertyFromComponentConfig(widget, component, "inputHint", SitemapPackage.INPUT__INPUT_HINT);
                 break;
             case "Setpoint":
                 SetpointImpl setpointWidget = (SetpointImpl) SitemapFactory.eINSTANCE.createSetpoint();


### PR DESCRIPTION
Recreated https://github.com/openhab/openhab-core/pull/3419 as there was a mixup in my local branches.

This was missed in https://github.com/openhab/openhab-webui/pull/1735

Extended to cover REST API and inputHint parameter to the Input element.