### PR TITLE
Fix ISE during WatchService disposal

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -162,8 +162,12 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
         }
 
         ServiceRegistration<?> localReg = this.reg;
-        if (localReg != null && bundleContext.getService(localReg.getReference()) != null) {
-            localReg.unregister();
+        if (localReg != null) {
+            try {
+                localReg.unregister();
+            } catch (IllegalStateException e) {
+                logger.debug("WatchService '{}' was already unregistered.", name, e);
+            }
             this.reg = null;
         }
     }


### PR DESCRIPTION
Fix #3387. After #3389 the ISE instead occurred inside `localReg.getReference()`.