### PR TITLE
Fix WatchQueueReader on new multi-level subdirectories

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchQueueReader.java
@@ -279,8 +279,7 @@ public class WatchQueueReader implements Runnable {
                                 for (AbstractWatchService service : services) {
                                     if (service.watchSubDirectories()
                                             && service.getWatchEventKinds(resolvedPath) != null) {
-                                        registerDirectoryInternal(service, service.getWatchEventKinds(resolvedPath),
-                                                resolvedPath);
+                                        registerWithSubDirectories(service, resolvedPath);
                                     }
                                 }
                             } else if (ENTRY_DELETE.equals(kind)) {


### PR DESCRIPTION
WatchQueueReader ignored subdirectories created through atomic `mkdir -p` operation involving multiple level subdirectories.

e.g.:
When `/openhab/conf/automation/ruby/a` didn't exist, `mkdir -p /openhab/conf/automation/ruby/a/b/c` would cause only `/openhab/conf/automation/ruby/a` (the direct subdirectory under the existing directory) to be monitored.

Changes inside `/openhab/conf/automation/ruby/a/b` and any further subdirectories won't be monitored.

This PR fixed that by registering the new directory recursively.

Obviously this only applies to openhab 3.x since 4.x had refactored this class out.