### PR TITLE
AbstractCachedTTSService: make synthesize method non final

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
@@ -32,13 +32,13 @@ public abstract class AbstractCachedTTSService implements CachedTTSService {
 
     private TTSCache ttsCache;
 
-    @Override
-    public final AudioStream synthesize(String text, Voice voice, AudioFormat requestedFormat) throws TTSException {
-        return ttsCache.get(this, text, voice, requestedFormat);
-    }
-
     public AbstractCachedTTSService(@Reference TTSCache ttsCache) {
         this.ttsCache = ttsCache;
+    }
+
+    @Override
+    public AudioStream synthesize(String text, Voice voice, AudioFormat requestedFormat) throws TTSException {
+        return ttsCache.get(this, text, voice, requestedFormat);
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
@@ -30,9 +30,9 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public abstract class AbstractCachedTTSService implements CachedTTSService {
 
-    private TTSCache ttsCache;
+    private final TTSCache ttsCache;
 
-    public AbstractCachedTTSService(@Reference TTSCache ttsCache) {
+    public AbstractCachedTTSService(final @Reference TTSCache ttsCache) {
         this.ttsCache = ttsCache;
     }
 


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/3057#issuecomment-1460729131

We need the ability to override this method when extending `AbstractCachedTTSService`.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>