### PR TITLE
Fix race condition in AbstractScriptFileWatcher

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
@@ -111,7 +111,7 @@ public abstract class AbstractScriptFileWatcher implements WatchService.WatchEve
         this.scheduler = getScheduler();
 
         currentStartLevel = startLevelService.getStartLevel();
-        if (currentStartLevel > StartLevelService.STARTLEVEL_MODEL) {
+        if (currentStartLevel >= StartLevelService.STARTLEVEL_RULEENGINE) {
             initialImport();
         }
     }
@@ -386,7 +386,7 @@ public abstract class AbstractScriptFileWatcher implements WatchService.WatchEve
             return;
         }
 
-        if (currentStartLevel == StartLevelService.STARTLEVEL_STATES) {
+        if (currentStartLevel == StartLevelService.STARTLEVEL_RULEENGINE) {
             initialImport();
         } else {
             scriptMap.values().stream().sorted()

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -613,7 +613,7 @@ class AbstractScriptFileWatcherTest extends JavaTest {
 
         assertThat(initialized.isDone(), is(false));
 
-        updateStartLevel(StartLevelService.STARTLEVEL_STATES);
+        updateStartLevel(StartLevelService.STARTLEVEL_RULEENGINE);
         waitForAssert(() -> assertThat(initialized.isDone(), is(true)));
     }
 


### PR DESCRIPTION
Some script file watcher implementations may need to access their rule engine's configurations. The rule engines need to be initialized before ScriptFileWatcher performs the initial import.

Specifically, this issue caused an NPE in jrubyscripting addon because AbstractScriptFileWatcher initialImport() calls getScriptType() down the line but still within AbstractScriptFileWatcher's constructor. The derived class hasn't finished initializing itself.  In jrubyscripting's implementation, to decide whether the given path should be watched, it needs access to its scriptengine, which at this point hasn't been initialized yet.