### PR TITLE
Upgrade XStream to 1.4.20

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -350,7 +350,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -538,7 +538,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -36,7 +36,7 @@
 		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.1</bundle>
 
 		<!-- TODO: Unbundled libraries -->
-		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.19</bundle>
+		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.20</bundle>
 	</feature>
 
 	<feature name="openhab.tp-coap" description="Californium CoAP library" version="${project.version}">

--- a/itests/org.openhab.core.addon.tests/itest.bndrun
+++ b/itests/org.openhab.core.addon.tests/itest.bndrun
@@ -37,7 +37,6 @@ Fragment-Host: org.openhab.core.addon
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
@@ -60,4 +59,5 @@ Fragment-Host: org.openhab.core.addon
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -65,7 +65,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.eclipse.jetty.websocket.common;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -49,8 +49,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -62,4 +60,5 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -49,8 +49,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -62,4 +60,5 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -51,8 +51,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.transform;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -64,4 +62,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -49,8 +49,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -62,4 +60,5 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -49,8 +49,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -62,4 +60,5 @@ Fragment-Host: org.openhab.core.automation
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -60,6 +60,5 @@ Fragment-Host: org.openhab.core.config.core
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	xstream;version='[1.4.19,1.4.20)'
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -65,5 +64,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -39,7 +39,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
@@ -65,4 +64,4 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -65,5 +64,5 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -61,7 +61,6 @@ Provide-Capability: \
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -73,5 +72,5 @@ Provide-Capability: \
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -54,5 +54,4 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -40,7 +40,6 @@ feature.openhab-config: \
 	junit-platform-launcher;version='[1.8.1,1.8.2)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
@@ -64,4 +63,4 @@ feature.openhab-config: \
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -81,7 +81,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.4.0,6.4.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.4,1.3.5)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -106,5 +105,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.15,8.0.16)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -86,7 +86,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
 	org.eclipse.jetty.client;version='[9.4.50,9.4.51)',\
@@ -108,10 +107,11 @@ Fragment-Host: org.openhab.core.model.item
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.15,8.0.16)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\
-	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)'
+	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)',\
+	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.0.0,4.0.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -90,7 +90,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -113,9 +112,10 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.15,8.0.16)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\
-	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)'
+	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)',\
+	org.openhab.core.model.persistence.runtime;version='[4.0.0,4.0.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -88,7 +88,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.voice;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -115,4 +114,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\
-	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)'
+	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)',\
+	org.openhab.core.model.persistence.runtime;version='[4.0.0,4.0.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -51,7 +51,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	com.google.inject;version='[5.0.1,5.0.2)',\
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
@@ -117,10 +116,11 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.15,8.0.16)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.apache.felix.http.servlet-api;version='[1.1.2,1.1.3)',\
 	org.eclipse.jetty.alpn.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.client;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.http2.common;version='[9.4.50,9.4.51)',\
-	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)'
+	org.eclipse.jetty.http2.hpack;version='[9.4.50,9.4.51)',\
+	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.0.0,4.0.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -46,8 +46,6 @@ Fragment-Host: org.openhab.core.storage.json
 	org.openhab.core.thing;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -59,4 +57,5 @@ Fragment-Host: org.openhab.core.storage.json
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -58,5 +58,4 @@ Fragment-Host: org.openhab.core
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -42,7 +42,6 @@ Fragment-Host: org.openhab.core.thing
 	org.objenesis;version='[3.2.0,3.2.1)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.2.0,1.2.1)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	ch.qos.logback.classic;version='[1.2.11,1.2.12)',\
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
@@ -66,4 +65,5 @@ Fragment-Host: org.openhab.core.thing
 	org.eclipse.jetty.util;version='[9.4.50,9.4.51)',\
 	org.eclipse.jetty.util.ajax;version='[9.4.50,9.4.51)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.0,2.2.1)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.voice
 	org.openhab.core.voice.tests;version='[4.0.0,4.0.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	xstream;version='[1.4.19,1.4.20)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -72,4 +71,5 @@ Fragment-Host: org.openhab.core.voice
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.15,8.0.16)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.15,8.0.16)',\
-	org.osgi.service.component;version='[1.5.0,1.5.1)'
+	org.osgi.service.component;version='[1.5.0,1.5.1)',\
+	xstream;version='[1.4.20,1.4.21)'

--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.19</version>
+      <version>1.4.20</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
@@ -105,15 +105,8 @@ public class GenerateDefaultTranslationsMojoTest {
     }
 
     @AfterEach
-    public void afterEach() {
-        try {
-            Files.walk(tempPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-        } catch (IOException e) {
-            // XStream does not close the HierarchicalStreamReader created in XStream.fromXML(URL)
-            // which causes issues when deleting the temporary path on Windows.
-            // See: https://github.com/x-stream/xstream/pull/287
-            tempPath.toFile().deleteOnExit();
-        }
+    public void afterEach() throws IOException {
+        Files.walk(tempPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     }
 
     private void assertSameProperties(Path expectedPath, Path actualPath) throws IOException {


### PR DESCRIPTION
This addresses CVE-2022-40151 and CVE-2022-41966, see:

https://x-stream.github.io/changes.html#1.4.20

This version also [fixes](https://github.com/x-stream/xstream/pull/287) an issue with closing streams so the workaround in GenerateDefaultTranslationsMojoTest is no longer needed.