### PR TITLE
Channels once more displayed in correct order in Main UI

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing.internal;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public class ThingImpl implements Thing {
 
     private @Nullable ThingUID bridgeUID;
 
-    private final Map<ChannelUID, Channel> channels = new HashMap<>();
+    private final Map<ChannelUID, Channel> channels = new LinkedHashMap<>();
 
     private Configuration configuration = new Configuration();
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
@@ -31,7 +31,8 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 @NonNullByDefault
 public class ThingChannelsTest extends JavaOSGiTest {
 
-    private static final List<String> CHANNEL_IDS = List.of("polarBear", "alligator", "hippopotamus", "aardvark");
+    private static final List<String> CHANNEL_IDS = List.of("polarBear", "alligator", "hippopotamus", "aardvark",
+            "whiteRabbit", "redHerring", "orangutan", "kangaroo", "rubberDuck", "timorousBeastie");
 
     @Test
     public void testThingChannelOrder() {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+
+/**
+ * Test for thing channel creation and display order.
+ *
+ * @author Andrew Fiddian-Green - Initial contribution
+ */
+@NonNullByDefault
+public class ThingChannelsTest extends JavaOSGiTest {
+
+    private static final List<String> CHANNEL_IDS = List.of("polarBear", "alligator", "hippopotamus", "aardvark");
+
+    @Test
+    public void testThingChannelOrder() {
+        ThingTypeUID thingTypeUID = new ThingTypeUID("bindingId", "thingTypeId");
+        ThingUID thingUID = new ThingUID(thingTypeUID, "thingLabel");
+
+        // create and fill the list of origin channels
+        List<Channel> originChannels = new ArrayList<>();
+        CHANNEL_IDS.forEach(channelId -> originChannels
+                .add(ChannelBuilder.create(new ChannelUID(thingUID, channelId), null).withLabel(channelId).build()));
+
+        // build a thing with the origin channels and get its result channels
+        Thing thing = ThingBuilder.create(thingTypeUID, thingUID).withChannels(originChannels).build();
+        List<Channel> resultChannels = thing.getChannels();
+
+        // run the tests
+        assertEquals(CHANNEL_IDS.size(), originChannels.size());
+        assertEquals(CHANNEL_IDS.size(), resultChannels.size());
+        for (int i = 0; i < CHANNEL_IDS.size(); i++) {
+            String expectId = CHANNEL_IDS.get(i);
+            Channel resultChannel = resultChannels.get(i);
+            assertTrue(expectId.equals(resultChannel.getUID().getId()));
+            assertTrue(expectId.equals(resultChannel.getLabel()));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3442

As described in #3442 _"we switched from a `List<Channel>` to a `Map<ChannelUID, Channel>` which does not necessarily preserve the order"_ -- with the consequence that in the Main UI, Thing Channels were no longer displayed in the order in which they were declared in the `thing.xml` file.

This PR uses `LinkedHashMap<ChannelUID, Channel>` instead of `HashMap<ChannelUID, Channel>` so that Thing Channels are once more displayed in the order in which they were declared in the `thing.xml` file.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>