### PR TITLE
Fix NPE caused by AbstractScriptFileWatcher initialization order

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -620,8 +620,10 @@ class AbstractScriptFileWatcherTest extends JavaTest {
     @Test
     public void testIfInitializedForLateInitialization() {
         scriptFileWatcher = createScriptFileWatcher(true);
-        when(startLevelServiceMock.getStartLevel()).thenReturn(StartLevelService.STARTLEVEL_RULEENGINE);
         AbstractScriptFileWatcher watcher = createScriptFileWatcher();
+        watcher.activate();
+        watcher.onReadyMarkerAdded(new ReadyMarker(StartLevelService.STARTLEVEL_MARKER_TYPE,
+                Integer.toString(StartLevelService.STARTLEVEL_STATES)));
 
         waitForAssert(() -> assertThat(watcher.ifInitialized().isDone(), is(true)));
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -622,6 +622,7 @@ class AbstractScriptFileWatcherTest extends JavaTest {
     @Test
     public void testIfInitializedForLateInitialization() {
         scriptFileWatcher = createScriptFileWatcher(true);
+        when(startLevelServiceMock.getStartLevel()).thenReturn(StartLevelService.STARTLEVEL_RULEENGINE);
         AbstractScriptFileWatcher watcher = createScriptFileWatcher();
         watcher.activate();
         watcher.onReadyMarkerAdded(new ReadyMarker(StartLevelService.STARTLEVEL_MARKER_TYPE,

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -554,7 +554,7 @@ class AbstractScriptFileWatcherTest extends JavaTest {
     }
 
     @Test
-    public void testDirectoryRemoved() {
+    public void testFileRemoved() {
         scriptFileWatcher = createScriptFileWatcher(true);
         when(scriptEngineManagerMock.isSupported("js")).thenReturn(true);
         ScriptEngineContainer scriptEngineContainer = mock(ScriptEngineContainer.class);
@@ -565,16 +565,18 @@ class AbstractScriptFileWatcherTest extends JavaTest {
 
         Path p1 = getFile("dir/script.js");
         Path p2 = getFile("dir/script2.js");
-        Path d = p1.getParent();
 
         scriptFileWatcher.processWatchEvent(CREATE, p1);
         scriptFileWatcher.processWatchEvent(CREATE, p2);
-        scriptFileWatcher.processWatchEvent(DELETE, d);
 
         awaitEmptyQueue();
 
         verify(scriptEngineManagerMock, timeout(DEFAULT_TEST_TIMEOUT_MS)).createScriptEngine("js", p1.toString());
         verify(scriptEngineManagerMock, timeout(DEFAULT_TEST_TIMEOUT_MS)).createScriptEngine("js", p2.toString());
+
+        scriptFileWatcher.processWatchEvent(DELETE, p1);
+        scriptFileWatcher.processWatchEvent(DELETE, p2);
+
         verify(scriptEngineManagerMock, timeout(DEFAULT_TEST_TIMEOUT_MS)).removeEngine(p1.toString());
         verify(scriptEngineManagerMock, timeout(DEFAULT_TEST_TIMEOUT_MS)).removeEngine(p2.toString());
     }


### PR DESCRIPTION
See the discussion in #3445

Another problem I encountered was the onReadyMarkerAdded got called out of order. It jumped from 80 -> 20 -> 100 -> 40 -> 50 -> 70 -> 30. Here's an example trace:
```
023-03-13 01:42:22.428 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=80) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.428 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=20) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.429 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=100) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.430 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=40) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.430 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=50) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.431 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=70) 100 => 100 for /openhab/conf/automation/ruby
2023-03-13 01:42:22.431 [TRACE] [ort.loader.AbstractScriptFileWatcher] - onReadyMarkerAdded(startlevel=30) 100 => 100 for /openhab/conf/automation/ruby
```

This caused AbstractScriptFileWatcher to stop loading the files because the last startLevel it received through onReadyMarkerAdded() was startLevel 30, so it never end up instructing importFileWhenReady to run.

