### PR TITLE
Fix ready marker ordering on late subscriptions

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/ReadyServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/ReadyServiceImpl.java
@@ -14,9 +14,9 @@ package org.openhab.core.internal.service;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
@@ -38,7 +38,7 @@ public class ReadyServiceImpl implements ReadyService {
     private final Logger logger = LoggerFactory.getLogger(ReadyServiceImpl.class);
     private static final ReadyMarkerFilter ANY = new ReadyMarkerFilter();
 
-    private final Set<ReadyMarker> markers = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<ReadyMarker> markers = Collections.synchronizedSet(new LinkedHashSet<>());
 
     private final Map<ReadyTracker, ReadyMarkerFilter> trackers = new HashMap<>();
     private final ReentrantReadWriteLock rwlTrackers = new ReentrantReadWriteLock(true);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/ReadyServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/ReadyServiceImplTest.java
@@ -12,12 +12,17 @@
  */
 package org.openhab.core.internal.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyMarkerFilter;
 import org.openhab.core.service.ReadyService.ReadyTracker;
@@ -83,5 +88,18 @@ public class ReadyServiceImplTest {
         rs.unregisterTracker(tracker);
         verify(tracker).onReadyMarkerRemoved(isA(ReadyMarker.class));
         verifyNoMoreInteractions(tracker);
+    }
+
+    @Test
+    public void testReadyMarkerOrderPreserved() {
+        ReadyTracker tracker = mock(ReadyTracker.class);
+        ReadyServiceImpl rs = new ReadyServiceImpl();
+        List<ReadyMarker> markers = List.of(new ReadyMarker("foo", "c"), new ReadyMarker("foo", "1"),
+                new ReadyMarker("foo", "a"), new ReadyMarker("foo", "3"));
+        markers.forEach(rs::markReady);
+        rs.registerTracker(tracker, new ReadyMarkerFilter().withType("foo"));
+        ArgumentCaptor<ReadyMarker> captor = ArgumentCaptor.forClass(ReadyMarker.class);
+        verify(tracker, times(4)).onReadyMarkerAdded(captor.capture());
+        assertThat(captor.getAllValues(), Matchers.contains(markers.toArray(ReadyMarker[]::new)));
     }
 }


### PR DESCRIPTION
In #3451 it was discovered that the `ReadyServiceImpl` sends ready markers in arbitrary order when the listener is registered after the ready marker was received. This PR changes the implementation so that the original order is preserved.