### PR TITLE
Add dependency on jetty-alpn-java-client

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -75,6 +75,7 @@
 		<feature dependency="true">pax-web-jetty-http2-jdk9</feature>
 		<bundle dependency="true">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-client/${jetty.version}</bundle>
+		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-java-client/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-client/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty.version}</bundle>
 		<bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty.version}</bundle>


### PR DESCRIPTION
The `jetty-alpn-java-client` dependency was missing in #3433

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>