### PR TITLE
Fix file processing in FileTransformationProvider

### DIFF
--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
@@ -14,6 +14,7 @@ package org.openhab.core.transform;
 
 import static org.openhab.core.service.WatchService.Kind.CREATE;
 import static org.openhab.core.service.WatchService.Kind.DELETE;
+import static org.openhab.core.service.WatchService.Kind.MODIFY;
 import static org.openhab.core.transform.Transformation.FUNCTION;
 
 import java.io.IOException;
@@ -101,7 +102,7 @@ public class FileTransformationProvider implements WatchService.WatchEventListen
                 logger.trace("Removed configuration from file '{}", path);
                 listeners.forEach(listener -> listener.removed(this, oldElement));
             }
-        } else if (Files.isRegularFile(finalPath) && ((kind == CREATE) || (kind == WatchService.Kind.MODIFY))) {
+        } else if (Files.isRegularFile(finalPath) && ((kind == CREATE) || (kind == MODIFY))) {
             try {
                 String fileName = path.getFileName().toString();
                 Matcher m = FILENAME_PATTERN.matcher(fileName);

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
@@ -12,22 +12,22 @@
  */
 package org.openhab.core.transform;
 
+import static org.openhab.core.service.WatchService.Kind.CREATE;
+import static org.openhab.core.service.WatchService.Kind.DELETE;
 import static org.openhab.core.transform.Transformation.FUNCTION;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.openhab.core.OpenHAB;
 import org.openhab.core.common.registry.ProviderChangeListener;
 import org.openhab.core.service.WatchService;
 import org.osgi.service.component.annotations.Activate;
@@ -46,13 +46,9 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(service = TransformationProvider.class, immediate = true)
 public class FileTransformationProvider implements WatchService.WatchEventListener, TransformationProvider {
-    private static final WatchEvent.Kind<?>[] WATCH_EVENTS = { StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY };
     private static final Set<String> IGNORED_EXTENSIONS = Set.of("txt", "swp");
     private static final Pattern FILENAME_PATTERN = Pattern
             .compile("(?<filename>.+?)(_(?<language>[a-z]{2}))?\\.(?<extension>[^.]*)$");
-    private static final Path TRANSFORMATION_PATH = Path.of(OpenHAB.getConfigFolder(),
-            TransformationService.TRANSFORM_FOLDER_NAME);
 
     private final Logger logger = LoggerFactory.getLogger(FileTransformationProvider.class);
 
@@ -64,19 +60,13 @@ public class FileTransformationProvider implements WatchService.WatchEventListen
     @Activate
     public FileTransformationProvider(
             @Reference(target = WatchService.CONFIG_WATCHER_FILTER) WatchService watchService) {
-        this(watchService, TRANSFORMATION_PATH);
-    }
-
-    // constructor package private used for testing
-    FileTransformationProvider(WatchService watchService, Path transformationPath) {
-        this.transformationPath = transformationPath;
         this.watchService = watchService;
+        this.transformationPath = watchService.getWatchPath().resolve(TransformationService.TRANSFORM_FOLDER_NAME);
 
         watchService.registerListener(this, transformationPath);
         // read initial contents
-        try {
-            Files.walk(transformationPath).filter(Files::isRegularFile).map(transformationPath::relativize)
-                    .forEach(f -> processPath(WatchService.Kind.CREATE, f));
+        try (Stream<Path> files = Files.walk(transformationPath)) {
+            files.filter(Files::isRegularFile).map(transformationPath::relativize).forEach(f -> processPath(CREATE, f));
         } catch (IOException e) {
             logger.warn("Could not list files in '{}', transformation configurations might be missing: {}",
                     transformationPath, e.getMessage());
@@ -105,14 +95,13 @@ public class FileTransformationProvider implements WatchService.WatchEventListen
 
     private void processPath(WatchService.Kind kind, Path path) {
         Path finalPath = transformationPath.resolve(path);
-        if (kind == WatchService.Kind.DELETE) {
+        if (kind == DELETE) {
             Transformation oldElement = transformationConfigurations.remove(path);
             if (oldElement != null) {
                 logger.trace("Removed configuration from file '{}", path);
                 listeners.forEach(listener -> listener.removed(this, oldElement));
             }
-        } else if (Files.isRegularFile(finalPath)
-                && (kind == WatchService.Kind.CREATE || kind == WatchService.Kind.MODIFY)) {
+        } else if (Files.isRegularFile(finalPath) && ((kind == CREATE) || (kind == WatchService.Kind.MODIFY))) {
             try {
                 String fileName = path.getFileName().toString();
                 Matcher m = FILENAME_PATTERN.matcher(fileName);

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/FileTransformationProviderTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/FileTransformationProviderTest.java
@@ -19,6 +19,9 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.openhab.core.service.WatchService.Kind.CREATE;
+import static org.openhab.core.service.WatchService.Kind.DELETE;
+import static org.openhab.core.service.WatchService.Kind.MODIFY;
 import static org.openhab.core.transform.Transformation.FUNCTION;
 
 import java.io.IOException;
@@ -89,7 +92,7 @@ public class FileTransformationProviderTest {
         Files.writeString(transformationPath.resolve(ADDED_FILENAME), ADDED_CONTENT);
         Transformation addedConfiguration = new Transformation(ADDED_FILENAME.toString(), ADDED_FILENAME.toString(),
                 FOO_TYPE, Map.of(FUNCTION, ADDED_CONTENT));
-        provider.processWatchEvent(WatchService.Kind.CREATE, ADDED_FILENAME);
+        provider.processWatchEvent(CREATE, ADDED_FILENAME);
 
         // assert registry is notified and internal cache updated
         Mockito.verify(listenerMock).added(provider, addedConfiguration);
@@ -101,7 +104,7 @@ public class FileTransformationProviderTest {
         Files.writeString(transformationPath.resolve(INITIAL_FILENAME), "updated");
         Transformation updatedConfiguration = new Transformation(INITIAL_FILENAME.toString(),
                 INITIAL_FILENAME.toString(), FOO_TYPE, Map.of(FUNCTION, "updated"));
-        provider.processWatchEvent(WatchService.Kind.MODIFY, INITIAL_FILENAME);
+        provider.processWatchEvent(MODIFY, INITIAL_FILENAME);
 
         Mockito.verify(listenerMock).updated(provider, INITIAL_CONFIGURATION, updatedConfiguration);
         assertThat(provider.getAll(), contains(updatedConfiguration));
@@ -110,7 +113,7 @@ public class FileTransformationProviderTest {
 
     @Test
     public void testDeletingConfigurationIsPropagated() {
-        provider.processWatchEvent(WatchService.Kind.DELETE, INITIAL_FILENAME);
+        provider.processWatchEvent(DELETE, INITIAL_FILENAME);
 
         Mockito.verify(listenerMock).removed(provider, INITIAL_CONFIGURATION);
         assertThat(provider.getAll(), not(contains(INITIAL_CONFIGURATION)));
@@ -125,7 +128,7 @@ public class FileTransformationProviderTest {
 
         Transformation expected = new Transformation(fileName, fileName, FOO_TYPE, Map.of(FUNCTION, INITIAL_CONTENT));
 
-        provider.processWatchEvent(WatchService.Kind.CREATE, Path.of(fileName));
+        provider.processWatchEvent(CREATE, Path.of(fileName));
         assertThat(provider.getAll(), hasItem(expected));
     }
 
@@ -134,8 +137,8 @@ public class FileTransformationProviderTest {
         Path extensionMissing = Path.of("extensionMissing");
         Path path = transformationPath.resolve(extensionMissing);
         Files.writeString(path, INITIAL_CONTENT);
-        provider.processWatchEvent(WatchService.Kind.CREATE, extensionMissing);
-        provider.processWatchEvent(WatchService.Kind.MODIFY, extensionMissing);
+        provider.processWatchEvent(CREATE, extensionMissing);
+        provider.processWatchEvent(MODIFY, extensionMissing);
 
         Mockito.verify(listenerMock, never()).added(any(), any());
         Mockito.verify(listenerMock, never()).updated(any(), any(), any());
@@ -146,8 +149,8 @@ public class FileTransformationProviderTest {
         Path extensionIgnored = Path.of("extensionIgnore.txt");
         Path path = transformationPath.resolve(extensionIgnored);
         Files.writeString(path, INITIAL_CONTENT);
-        provider.processWatchEvent(WatchService.Kind.CREATE, extensionIgnored);
-        provider.processWatchEvent(WatchService.Kind.MODIFY, extensionIgnored);
+        provider.processWatchEvent(CREATE, extensionIgnored);
+        provider.processWatchEvent(MODIFY, extensionIgnored);
 
         Mockito.verify(listenerMock, never()).added(any(), any());
         Mockito.verify(listenerMock, never()).updated(any(), any(), any());


### PR DESCRIPTION
Fixes #3456 

Relative and absolute path were not properly handled. The watch service provides relative paths to the root watch folder. The implementation expected absolute path (which were provided in the initial import).

This was not discovered by the tests because the tests wrongly modeled the watch service calls to `processWatchEvent`.