### PR TITLE
[voice] Fix default interpreter selection.

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -157,6 +157,13 @@ public class DialogContext {
             return this;
         }
 
+        public Builder withHLI(@Nullable HumanLanguageInterpreter service) {
+            if (service != null) {
+                this.hlis = List.of(service);
+            }
+            return this;
+        }
+
         public Builder withHLIs(Collection<HumanLanguageInterpreter> services) {
             return withHLIs(new ArrayList<>(services));
         }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -519,7 +519,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 .withKS(this.getKS()) //
                 .withSTT(this.getSTT()) //
                 .withTTS(this.getTTS()) //
-                .withHLIs(this.getHLIs()) //
+                .withHLI(this.getHLI()) //
                 .withVoice(this.getDefaultVoice()) //
                 .withMelody(listeningMelody) //
                 .withListeningItem(listeningItem);


### PR DESCRIPTION
This fixes the selection of the default human language interpreter.

By error it's loading the whole list of interpreters.

Should this be back-ported to the 3.4.x branch? I think the issue is also there.

Regards!

