### PR TITLE
[audio] More capabilities for AudioSink using the AudioServlet

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.audio;
 
+import java.io.IOException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.audio.internal.AudioServlet;
 
@@ -70,6 +72,7 @@ public interface AudioHTTPServer {
      * @param a Runnable callback for cleaning resources. The AudioHTTPServer will run the callback when the stream is
      *            not used anymore and timed-out.
      * @return the relative URL to access the stream starting with a '/'
+     * @throws IOException when the stream is not a {@link ClonableAudioStream} and we cannot get or store it on disk.
      */
-    String serve(AudioStream stream, int seconds, Runnable callBack);
+    String serve(AudioStream stream, int seconds, Runnable callBack) throws IOException;
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
@@ -40,13 +40,15 @@ public interface AudioHTTPServer {
     /**
      * Creates a relative url for a given {@link AudioStream} where it can be requested multiple times within the given
      * time frame.
-     * This method only accepts {@link FixedLengthAudioStream}s, since it needs to be able to create multiple concurrent
-     * streams from it, which isn't possible with a regular {@link AudioStream}.
+     * This method accepts all {@link AudioStream}s, but it is better to use {@link FixedLengthAudioStream}s since it
+     * needs to be able to create multiple concurrent streams from it.
+     * If generic {@link AudioStream} is used, we try to keep this capability by storing it in a small memory buffer,
+     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream is too long.
      * Streams are closed, once they expire.
      *
      * @param stream the stream to serve on HTTP
      * @param seconds number of seconds for which the stream is available through HTTP
      * @return the relative URL to access the stream starting with a '/'
      */
-    String serve(FixedLengthAudioStream stream, int seconds);
+    String serve(AudioStream stream, int seconds);
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
@@ -40,10 +40,12 @@ public interface AudioHTTPServer {
     /**
      * Creates a relative url for a given {@link AudioStream} where it can be requested multiple times within the given
      * time frame.
-     * This method accepts all {@link AudioStream}s, but it is better to use {@link FixedLengthAudioStream}s since it
+     * This method accepts all {@link AudioStream}s, but it is better to use {@link ClonableAudioStream}s since it
      * needs to be able to create multiple concurrent streams from it.
-     * If generic {@link AudioStream} is used, we try to keep this capability by storing it in a small memory buffer,
-     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream is too long.
+     * If generic {@link AudioStream} is used, the method tries to add the Clonable capability by storing it in a small
+     * memory buffer,
+     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream reached the buffer capacity, or fails if the
+     * stream is too long.
      * Streams are closed, once they expire.
      *
      * @param stream the stream to serve on HTTP
@@ -51,4 +53,23 @@ public interface AudioHTTPServer {
      * @return the relative URL to access the stream starting with a '/'
      */
     String serve(AudioStream stream, int seconds);
+
+    /**
+     * Creates a relative url for a given {@link AudioStream} where it can be requested multiple times within the given
+     * time frame.
+     * This method accepts all {@link AudioStream}s, but it is better to use {@link ClonableAudioStream}s since it
+     * needs to be able to create multiple concurrent streams from it.
+     * If generic {@link AudioStream} is used, method tries to add the Clonable capability by storing it in a small
+     * memory buffer,
+     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream reached the buffer capacity, or fails if the
+     * stream is too long.
+     * Streams are closed, once they expire.
+     *
+     * @param stream the stream to serve on HTTP
+     * @param seconds number of seconds for which the stream is available through HTTP
+     * @param a Runnable callback for cleaning resources. The AudioHTTPServer will run the callback when the stream is
+     *            not used anymore and timed-out.
+     * @return the relative URL to access the stream starting with a '/'
+     */
+    String serve(AudioStream stream, int seconds, Runnable callBack);
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
@@ -13,6 +13,7 @@
 package org.openhab.core.audio;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.audio.internal.AudioServlet;
@@ -36,43 +37,48 @@ public interface AudioHTTPServer {
      *
      * @param stream the stream to serve on HTTP
      * @return the relative URL to access the stream starting with a '/'
+     * @deprecated Use {@link AudioHTTPServer#serve(AudioStream, int, boolean, CompletableFuture)}
      */
+    @Deprecated
     String serve(AudioStream stream);
 
     /**
      * Creates a relative url for a given {@link AudioStream} where it can be requested multiple times within the given
      * time frame.
-     * This method accepts all {@link AudioStream}s, but it is better to use {@link ClonableAudioStream}s since it
-     * needs to be able to create multiple concurrent streams from it.
-     * If generic {@link AudioStream} is used, the method tries to add the Clonable capability by storing it in a small
-     * memory buffer,
-     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream reached the buffer capacity, or fails if the
-     * stream is too long.
+     * This method accepts all {@link AudioStream}s, but it is better to use {@link ClonableAudioStream}s. If generic
+     * {@link AudioStream} is used, the method tries to add the Clonable capability by storing it in a small memory
+     * buffer, e.g {@link ByteArrayAudioStream}, or in a cached file if the stream reached the buffer capacity,
+     * or fails if the stream is too long.
      * Streams are closed, once they expire.
      *
      * @param stream the stream to serve on HTTP
      * @param seconds number of seconds for which the stream is available through HTTP
      * @return the relative URL to access the stream starting with a '/'
+     * @deprecated Use {@link AudioHTTPServer#serve(AudioStream, int, boolean, CompletableFuture)}
      */
+    @Deprecated
     String serve(AudioStream stream, int seconds);
 
     /**
-     * Creates a relative url for a given {@link AudioStream} where it can be requested multiple times within the given
-     * time frame.
-     * This method accepts all {@link AudioStream}s, but it is better to use {@link ClonableAudioStream}s since it
-     * needs to be able to create multiple concurrent streams from it.
-     * If generic {@link AudioStream} is used, method tries to add the Clonable capability by storing it in a small
-     * memory buffer,
-     * e.g {@link ByteArrayAudioStream}, or in a cached file if the stream reached the buffer capacity, or fails if the
-     * stream is too long.
+     * Creates a relative url for a given {@link AudioStream} where it can be requested one or multiple times within the
+     * given time frame.
+     * This method accepts all {@link AudioStream}s, but if multiTimeStream is set to true it is better to use
+     * {@link ClonableAudioStream}s. Otherwise, if a generic {@link AudioStream} is used, the method will then try
+     * to add the Clonable capability by storing it in a small memory buffer, e.g {@link ByteArrayAudioStream}, or in a
+     * cached file if the stream reached the buffer capacity, or fails to render the sound completely if the stream is
+     * too long.
+     * A {@link CompletableFuture} is used to inform the caller that the playback ends in order to clean
+     * resources and run delayed task, such as restoring volume.
      * Streams are closed, once they expire.
      *
      * @param stream the stream to serve on HTTP
-     * @param seconds number of seconds for which the stream is available through HTTP
-     * @param a Runnable callback for cleaning resources. The AudioHTTPServer will run the callback when the stream is
-     *            not used anymore and timed-out.
-     * @return the relative URL to access the stream starting with a '/'
+     * @param seconds number of seconds for which the stream is available through HTTP. The stream will be deleted only
+     *            if not started, so you can set a duration shorter than the track's duration.
+     * @param multiTimeStream set to true if this stream should be played multiple time, and thus needs to be made
+     *            Cloneable if it is not already.
+     * @return information about the {@link StreamServed}, including the relative URL to access the stream starting with
+     *         a '/', and a CompletableFuture to know when the playback ends.
      * @throws IOException when the stream is not a {@link ClonableAudioStream} and we cannot get or store it on disk.
      */
-    String serve(AudioStream stream, int seconds, Runnable callBack) throws IOException;
+    StreamServed serve(AudioStream stream, int seconds, boolean multiTimeStream) throws IOException;
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -252,4 +252,15 @@ public interface AudioManager {
      * @return ids of matching sinks
      */
     Set<String> getSinkIds(String pattern);
+
+    /**
+     * Handles a volume command change and returns a Runnable to restore it.
+     * Returning a Runnable allows us to have a no-op Runnable if changing volume back is not needed, and conveniently
+     * keeping it as one liner usable in a chain for the caller.
+     *
+     * @param volume The volume to set
+     * @param sink The sink to set the volume to
+     * @return A runnable to restore the volume to its previous value, or no-operation if no change is required.
+     */
+    Runnable handleVolumeCommand(@Nullable PercentType volume, AudioSink sink);
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
@@ -87,12 +87,16 @@ public interface AudioSink {
      * interface, the sink should hereafter get rid of it by calling the dispose method.
      *
      * @param audioStream the audio stream to play or null to keep quiet
-     * @throws UnsupportedAudioFormatException If audioStream format is not supported
-     * @throws UnsupportedAudioStreamException If audioStream is not supported
+     * @return A future completed when the sound is fully played. The method can instead complete with
+     *         UnsupportedAudioFormatException if the audioStream format is not supported, or
+     *         UnsupportedAudioStreamException If audioStream is not supported
      */
-    default CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream)
-            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
-        process(audioStream);
+    default CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream) {
+        try {
+            process(audioStream);
+        } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
+            return CompletableFuture.failedFuture(e);
+        }
         return CompletableFuture.completedFuture(null);
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
@@ -58,6 +58,9 @@ public interface AudioSink {
      *
      * In case the audioStream is null, this should be interpreted as a request to end any currently playing stream.
      *
+     * If you call this method and if the sink is synchronous, you should thereafter get rid of a stream implementing
+     * the {@link org.openhab.core.common.Disposable} interface by calling the dispose method.
+     *
      * @param audioStream the audio stream to play or null to keep quiet
      * @throws UnsupportedAudioFormatException If audioStream format is not supported
      * @throws UnsupportedAudioStreamException If audioStream is not supported
@@ -94,4 +97,17 @@ public interface AudioSink {
      * @throws IOException if the volume can not be set
      */
     void setVolume(PercentType volume) throws IOException;
+
+    /**
+     * Tell if the sink is synchronous.
+     * If true, caller may dispose of the stream immediately after the process method.
+     * On the contrary, if in the process method, the sink returns before the input stream is entirely consumed,
+     * then the sink should override this method and return false.
+     * Please note that by doing so, the sink should then take care itself of the InputStream implementing the
+     * {@link org.openhab.core.common.Disposable} interface by calling the dispose method when finishing
+     * reading it.
+     */
+    default boolean isSynchronous() {
+        return true;
+    }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
@@ -88,12 +88,14 @@ public interface AudioSink {
      * @throws UnsupportedAudioFormatException If audioStream format is not supported
      * @throws UnsupportedAudioStreamException If audioStream is not supported
      */
-    default void process(@Nullable AudioStream audioStream, Runnable whenFinished)
+    default void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
         try {
             process(audioStream);
         } finally {
-            whenFinished.run();
+            if (whenFinished != null) {
+                whenFinished.run();
+            }
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.Disposable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Definition of an audio output like headphones, a speaker or for writing to
+ * a file / clip.
+ * This version is asynchronous: when the process() method returns, the {@link AudioStream}
+ * may or may not be played, and we don't know when the delayed task will be executed.
+ * CAUTION : It is the responsibility of the implementing AudioSink class to call the runDelayedTask
+ * method when playing is done.
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AudioSinkAsync implements AudioSink {
+
+    private final Logger logger = LoggerFactory.getLogger(AudioSinkAsync.class);
+
+    private final Map<AudioStream, Runnable> runnableByAudioStream = new HashMap<>();
+
+    @Override
+    public void process(@Nullable AudioStream audioStream, Runnable whenFinished)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+
+        try {
+            if (audioStream != null) {
+                runnableByAudioStream.put(audioStream, whenFinished);
+            }
+            process(audioStream);
+        } finally {
+            if (audioStream == null) {
+                // No need to delay the post process task
+                whenFinished.run();
+            }
+        }
+    }
+
+    /**
+     * Will run the delayed task stored previously.
+     *
+     * @param audioStream The AudioStream is the key to find the delayed Runnable task in the storage.
+     */
+    protected void runDelayed(AudioStream audioStream) {
+        Runnable delayedTask = runnableByAudioStream.remove(audioStream);
+
+        if (delayedTask != null) {
+            delayedTask.run();
+        }
+
+        // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
+        // to auto dispose:
+        if (audioStream instanceof Disposable disposableAudioStream) {
+            try {
+                disposableAudioStream.dispose();
+            } catch (IOException e) {
+                String fileName = audioStream instanceof FileAudioStream file ? file.toString() : "unknown";
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Cannot dispose of stream {}", fileName, e);
+                } else {
+                    logger.warn("Cannot dispose of stream {}, reason {}", fileName, e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
@@ -40,16 +40,16 @@ public abstract class AudioSinkAsync implements AudioSink {
     private final Map<AudioStream, Runnable> runnableByAudioStream = new HashMap<>();
 
     @Override
-    public void process(@Nullable AudioStream audioStream, Runnable whenFinished)
+    public void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
 
         try {
-            if (audioStream != null) {
+            if (audioStream != null && whenFinished != null) {
                 runnableByAudioStream.put(audioStream, whenFinished);
             }
             process(audioStream);
         } finally {
-            if (audioStream == null) {
+            if (audioStream == null && whenFinished != null) {
                 // No need to delay the post process task
                 whenFinished.run();
             }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
@@ -42,7 +42,6 @@ public abstract class AudioSinkAsync implements AudioSink {
     @Override
     public void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
-
         try {
             if (audioStream != null && whenFinished != null) {
                 runnableByAudioStream.put(audioStream, whenFinished);

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
@@ -15,6 +15,7 @@ package org.openhab.core.audio;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -25,10 +26,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Definition of an audio output like headphones, a speaker or for writing to
  * a file / clip.
- * This version is asynchronous: when the process() method returns, the {@link AudioStream}
- * may or may not be played, and we don't know when the delayed task will be executed.
- * CAUTION : It is the responsibility of the implementing AudioSink class to call the runDelayedTask
- * method when playing is done.
+ * Helper class for asynchronous sink : when the process() method returns, the {@link AudioStream}
+ * may or may not be played. It is the responsibility of the implementing AudioSink class to
+ * complete the CompletableFuture when playing is done. Any delayed tasks will then be performed, such as volume
+ * restoration.
  *
  * @author Gwendal Roulleau - Initial contribution
  */
@@ -37,38 +38,66 @@ public abstract class AudioSinkAsync implements AudioSink {
 
     private final Logger logger = LoggerFactory.getLogger(AudioSinkAsync.class);
 
-    private final Map<AudioStream, Runnable> runnableByAudioStream = new HashMap<>();
+    private final Map<AudioStream, CompletableFuture<@Nullable Void>> runnableByAudioStream = new HashMap<>();
 
     @Override
-    public void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
+    public CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+        CompletableFuture<@Nullable Void> completableFuture = new CompletableFuture<@Nullable Void>();
         try {
-            if (audioStream != null && whenFinished != null) {
-                runnableByAudioStream.put(audioStream, whenFinished);
+            if (audioStream != null) {
+                runnableByAudioStream.put(audioStream, completableFuture);
             }
-            process(audioStream);
+            processAsynchronously(audioStream);
+            return completableFuture;
         } finally {
-            if (audioStream == null && whenFinished != null) {
+            if (audioStream == null) {
                 // No need to delay the post process task
-                whenFinished.run();
+                runnableByAudioStream.remove(audioStream);
+                completableFuture.complete(null);
             }
         }
     }
 
-    /**
-     * Will run the delayed task stored previously.
-     *
-     * @param audioStream The AudioStream is the key to find the delayed Runnable task in the storage.
-     */
-    protected void runDelayed(AudioStream audioStream) {
-        Runnable delayedTask = runnableByAudioStream.remove(audioStream);
+    @Override
+    public void process(@Nullable AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+        processAsynchronously(audioStream);
+    }
 
-        if (delayedTask != null) {
-            delayedTask.run();
+    /**
+     * Processes the passed {@link AudioStream} asynchronously. This method is expected to return before the stream is
+     * fully played. This is the sink responsibility to call the {@link AudioSinkAsync#playbackFinished(AudioStream)}
+     * when it is.
+     *
+     * If the passed {@link AudioStream} is not supported by this instance, an {@link UnsupportedAudioStreamException}
+     * is thrown.
+     *
+     * If the passed {@link AudioStream} has an {@link AudioFormat} not supported by this instance,
+     * an {@link UnsupportedAudioFormatException} is thrown.
+     *
+     * In case the audioStream is null, this should be interpreted as a request to end any currently playing stream.
+     *
+     * @param audioStream the audio stream to play or null to keep quiet
+     * @throws UnsupportedAudioFormatException If audioStream format is not supported
+     * @throws UnsupportedAudioStreamException If audioStream is not supported
+     */
+    protected abstract void processAsynchronously(@Nullable AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException;
+
+    /**
+     * Will complete the future previously returned, allowing the core to run delayed task.
+     *
+     * @param audioStream The AudioStream is the key to find the delayed CompletableFuture in the storage.
+     */
+    protected void playbackFinished(AudioStream audioStream) {
+        CompletableFuture<@Nullable Void> completableFuture = runnableByAudioStream.remove(audioStream);
+        if (completableFuture != null) {
+            completableFuture.complete(null);
         }
 
         // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
-        // to auto dispose:
+        // to auto dispose.
         if (audioStream instanceof Disposable disposableAudioStream) {
             try {
                 disposableAudioStream.dispose();

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.Disposable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Definition of an audio output like headphones, a speaker or for writing to
+ * a file / clip.
+ * This version is synchronous: when the process() method returns,
+ * the source is considered played, and could be disposed.
+ * Any delayed tasks can then be performed, such as volume restoration
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AudioSinkSync implements AudioSink {
+
+    private final Logger logger = LoggerFactory.getLogger(AudioSinkSync.class);
+
+    @Override
+    public void process(@Nullable AudioStream audioStream, Runnable whenFinished)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+
+        try {
+            process(audioStream);
+        } finally {
+
+            whenFinished.run();
+
+            // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
+            // to auto dispose:
+            if (audioStream instanceof Disposable disposableAudioStream) {
+                try {
+                    disposableAudioStream.dispose();
+                } catch (IOException e) {
+                    String fileName = audioStream instanceof FileAudioStream file ? file.toString() : "unknown";
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot dispose of stream {}", fileName, e);
+                    } else {
+                        logger.warn("Cannot dispose of stream {}, reason {}", fileName, e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
@@ -35,14 +35,15 @@ public abstract class AudioSinkSync implements AudioSink {
     private final Logger logger = LoggerFactory.getLogger(AudioSinkSync.class);
 
     @Override
-    public void process(@Nullable AudioStream audioStream, Runnable whenFinished)
+    public void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
 
         try {
             process(audioStream);
         } finally {
-
-            whenFinished.run();
+            if (whenFinished != null) {
+                whenFinished.run();
+            }
 
             // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
             // to auto dispose:

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
@@ -37,7 +37,6 @@ public abstract class AudioSinkSync implements AudioSink {
     @Override
     public void process(@Nullable AudioStream audioStream, @Nullable Runnable whenFinished)
             throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
-
         try {
             process(audioStream);
         } finally {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
@@ -36,10 +36,12 @@ public abstract class AudioSinkSync implements AudioSink {
     private final Logger logger = LoggerFactory.getLogger(AudioSinkSync.class);
 
     @Override
-    public CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream)
-            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException {
+    public CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream) {
         try {
             processSynchronously(audioStream);
+            return CompletableFuture.completedFuture(null);
+        } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
+            return CompletableFuture.failedFuture(e);
         } finally {
             // as the stream is not needed anymore, we should dispose of it
             if (audioStream instanceof Disposable disposableAudioStream) {
@@ -55,7 +57,6 @@ public abstract class AudioSinkSync implements AudioSink {
                 }
             }
         }
-        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioStream.java
@@ -15,6 +15,7 @@ package org.openhab.core.audio;
 import java.io.InputStream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Wrapper for a source of audio data.
@@ -37,4 +38,14 @@ public abstract class AudioStream extends InputStream {
      * @return The supported audio format
      */
     public abstract AudioFormat getFormat();
+
+    /**
+     * Usefull for sinks playing the same stream multiple times,
+     * to avoid already done computation (like reencoding).
+     *
+     * @return A string uniquely identifying the stream.
+     */
+    public @Nullable String getId() {
+        return null;
+    }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.io.InputStream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This is an {@link AudioStream}, that can be cloned
+ *
+ * @author Gwendal Roulleau - Initial contribution, separation from FixedLengthAudioStream
+ */
+@NonNullByDefault
+public abstract class ClonableAudioStream extends AudioStream {
+
+    /**
+     * Returns a new, fully independent stream instance, which can be read and closed without impacting the original
+     * instance.
+     *
+     * @return a new input stream that can be consumed by the caller
+     * @throws AudioException if stream cannot be created
+     */
+    public abstract InputStream getClonedStream() throws AudioException;
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
@@ -18,10 +18,12 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.audio.utils.AudioStreamUtils;
 import org.openhab.core.audio.utils.AudioWaveUtils;
+import org.openhab.core.common.Disposable;
 
 /**
  * This is an AudioStream from an audio file
@@ -31,7 +33,7 @@ import org.openhab.core.audio.utils.AudioWaveUtils;
  * @author Christoph Weitkamp - Refactored use of filename extension
  */
 @NonNullByDefault
-public class FileAudioStream extends FixedLengthAudioStream {
+public class FileAudioStream extends FixedLengthAudioStream implements Disposable {
 
     public static final String WAV_EXTENSION = "wav";
     public static final String MP3_EXTENSION = "mp3";
@@ -42,16 +44,22 @@ public class FileAudioStream extends FixedLengthAudioStream {
     private final AudioFormat audioFormat;
     private InputStream inputStream;
     private final long length;
+    private final boolean isTemporaryFile;
 
     public FileAudioStream(File file) throws AudioException {
         this(file, getAudioFormat(file));
     }
 
     public FileAudioStream(File file, AudioFormat format) throws AudioException {
+        this(file, format, false);
+    }
+
+    public FileAudioStream(File file, AudioFormat format, boolean isTemporaryFile) throws AudioException {
         this.file = file;
         this.inputStream = getInputStream(file);
         this.audioFormat = format;
         this.length = file.length();
+        this.isTemporaryFile = isTemporaryFile;
     }
 
     private static AudioFormat getAudioFormat(File file) throws AudioException {
@@ -124,5 +132,12 @@ public class FileAudioStream extends FixedLengthAudioStream {
     @Override
     public InputStream getClonedStream() throws AudioException {
         return getInputStream(file);
+    }
+
+    @Override
+    public void dispose() throws IOException {
+        if (isTemporaryFile) {
+            Files.delete(file.toPath());
+        }
     }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FixedLengthAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FixedLengthAudioStream.java
@@ -12,18 +12,16 @@
  */
 package org.openhab.core.audio;
 
-import java.io.InputStream;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * This is an {@link AudioStream}, which can provide information about its absolute length and is able to provide
- * cloned streams.
+ * This is a {@link ClonableAudioStream}, which can also provide information about its absolute length.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Gwendal Roulleau - Separate getClonedStream into its own class
  */
 @NonNullByDefault
-public abstract class FixedLengthAudioStream extends AudioStream {
+public abstract class FixedLengthAudioStream extends ClonableAudioStream {
 
     /**
      * Provides the length of the stream in bytes.
@@ -31,13 +29,4 @@ public abstract class FixedLengthAudioStream extends AudioStream {
      * @return absolute length in bytes
      */
     public abstract long length();
-
-    /**
-     * Returns a new, fully independent stream instance, which can be read and closed without impacting the original
-     * instance.
-     *
-     * @return a new input stream that can be consumed by the caller
-     * @throws AudioException if stream cannot be created
-     */
-    public abstract InputStream getClonedStream() throws AudioException;
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/StreamServed.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/StreamServed.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Streams served by the AudioHTTPServer.
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+public record StreamServed(String url, AudioStream audioStream, AtomicInteger currentlyServedStream, AtomicLong timeout,
+        boolean multiTimeStream, CompletableFuture<@Nullable Void> playEnd) {
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Refactored use of filename extension
  */
 @NonNullByDefault
-public class URLAudioStream extends AudioStream {
+public class URLAudioStream extends ClonableAudioStream {
 
     private static final Pattern PLS_STREAM_PATTERN = Pattern.compile("^File[0-9]=(.+)$");
 
@@ -153,5 +153,10 @@ public class URLAudioStream extends AudioStream {
     @Override
     public String toString() {
         return url;
+    }
+
+    @Override
+    public InputStream getClonedStream() throws AudioException {
+        return new URLAudioStream(url);
     }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -41,6 +41,7 @@ import org.openhab.core.audio.URLAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
 import org.openhab.core.audio.utils.ToneSynthesizer;
+import org.openhab.core.common.Disposable;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.config.core.ParameterOption;
@@ -142,8 +143,16 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
             }
             try {
                 sink.process(audioStream);
+                // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
+                // to auto dispose:
+                if (sink.isSynchronous() && audioStream instanceof Disposable disposableAudioStream) {
+                    disposableAudioStream.dispose();
+                }
             } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
                 logger.warn("Error playing '{}': {}", audioStream, e.getMessage(), e);
+            } catch (IOException e) {
+                String fileName = audioStream instanceof FileAudioStream file ? file.toString() : "unknown";
+                logger.warn("Cannot dispose of audio stream {}", fileName, e);
             } finally {
                 if (volume != null && oldVolume != null) {
                     // restore volume only if it was set before

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -40,7 +40,6 @@ import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.URLAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
-import org.openhab.core.audio.utils.AudioSinkUtils;
 import org.openhab.core.audio.utils.ToneSynthesizer;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ConfigurableService;
@@ -123,10 +122,12 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     public void play(@Nullable AudioStream audioStream, @Nullable String sinkId, @Nullable PercentType volume) {
         AudioSink sink = getSink(sinkId);
         if (sink != null) {
-            Runnable volumeRestoration = AudioSinkUtils.handleVolumeCommand(volume, sink, logger);
+            Runnable volumeRestauration = null;
             try {
-                sink.process(audioStream, volumeRestoration);
+                volumeRestauration = handleVolumeCommand(volume, sink);
+                sink.processAndComplete(audioStream).thenRun(volumeRestauration);
             } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
+                volumeRestauration.run();
                 logger.warn("Error playing '{}': {}", audioStream, e.getMessage(), e);
             }
         } else {
@@ -323,6 +324,53 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
             }
         }
         return null;
+    }
+
+    @Override
+    public Runnable handleVolumeCommand(@Nullable PercentType volume, AudioSink sink) {
+        boolean volumeChanged = false;
+        PercentType oldVolume = null;
+
+        Runnable toRunWhenProcessFinished = () -> {
+        };
+
+        if (volume == null) {
+            return toRunWhenProcessFinished;
+        }
+
+        // set notification sound volume
+        try {
+            // get current volume
+            oldVolume = sink.getVolume();
+        } catch (IOException | UnsupportedOperationException e) {
+            logger.debug("An exception occurred while getting the volume of sink '{}' : {}", sink.getId(),
+                    e.getMessage(), e);
+        }
+
+        if (!volume.equals(oldVolume) || oldVolume == null) {
+            try {
+                sink.setVolume(volume);
+                volumeChanged = true;
+            } catch (IOException | UnsupportedOperationException e) {
+                logger.debug("An exception occurred while setting the volume of sink '{}' : {}", sink.getId(),
+                        e.getMessage(), e);
+            }
+        }
+
+        final PercentType oldVolumeFinal = oldVolume;
+        // restore volume only if it was set before
+        if (volumeChanged && oldVolumeFinal != null) {
+            toRunWhenProcessFinished = () -> {
+                try {
+                    sink.setVolume(oldVolumeFinal);
+                } catch (IOException | UnsupportedOperationException e) {
+                    logger.debug("An exception occurred while setting the volume of sink '{}' : {}", sink.getId(),
+                            e.getMessage(), e);
+                }
+            };
+        }
+
+        return toRunWhenProcessFinished;
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -17,7 +17,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +47,6 @@ import org.openhab.core.audio.ByteArrayAudioStream;
 import org.openhab.core.audio.ClonableAudioStream;
 import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.FixedLengthAudioStream;
-import org.openhab.core.common.Disposable;
 import org.openhab.core.common.ThreadPoolManager;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -301,7 +299,7 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
                     fileSize += length;
                 }
             }
-            clonableAudioStreamResult = new TemporaryFileAudioStream(tempFile, stream.getFormat());
+            clonableAudioStreamResult = new FileAudioStream(tempFile, stream.getFormat(), true);
         }
         tryClose(stream);
         return clonableAudioStreamResult;
@@ -313,22 +311,6 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     private String getRelativeURL(String streamId) {
         return SERVLET_PATH + "/" + streamId;
-    }
-
-    // Using a FileAudioStream implementing Disposable allows file deletion when it is not used anymore
-    private static class TemporaryFileAudioStream extends FileAudioStream implements Disposable {
-
-        private File file;
-
-        public TemporaryFileAudioStream(File file, AudioFormat format) throws AudioException {
-            super(file, format);
-            this.file = file;
-        }
-
-        @Override
-        public void dispose() throws IOException {
-            Files.delete(file.toPath());
-        }
     }
 
     protected static record StreamServed(String id, AudioStream audioStream, AtomicInteger currentlyServedStream,

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -204,6 +204,7 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
             if (numberOfStreamServed <= 0) {
                 final FixedLengthAudioStream stream = multiTimeStreams.remove(streamId);
                 streamTimeouts.remove(streamId);
+                currentlyServedResponseByStreamId.remove(streamId);
                 tryClose(stream);
                 if (stream instanceof Disposable disposableStream) {
                     try {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -105,7 +105,6 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     private InputStream prepareInputStream(final StreamServed servedStream, final HttpServletResponse resp,
             List<String> acceptedMimeTypes) throws AudioException {
-
         logger.debug("Stream to serve is {}", servedStream.id);
 
         // try to set the content-type, if possible
@@ -151,7 +150,6 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-
         String requestURI = req.getRequestURI();
         if (requestURI == null) {
             resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "requestURI is null");
@@ -267,7 +265,6 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     @Override
     public String serve(AudioStream stream, int seconds, @Nullable Runnable callBack) throws IOException {
-
         String streamId = UUID.randomUUID().toString();
         ClonableAudioStream clonableAudioStream = null;
         if (stream instanceof ClonableAudioStream clonableAudioStreamDetected) {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -305,14 +305,15 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
                 // but with a limit
                 int fileSize = ONETIME_STREAM_BUFFER_MAX_SIZE + 1;
                 while ((length = stream.read(buf)) != -1 && fileSize < ONETIME_STREAM_FILE_MAX_SIZE) {
-                    outputStream.write(buf, 0, length);
-                    fileSize += length;
+                    int lengthToWrite = Math.min(length, ONETIME_STREAM_FILE_MAX_SIZE - fileSize);
+                    outputStream.write(buf, 0, lengthToWrite);
+                    fileSize += lengthToWrite;
                 }
             }
             try {
                 clonableAudioStreamResult = new FileAudioStream(tempFile, stream.getFormat(), true);
             } catch (AudioException e) { // this is in fact a FileNotFoundException and should not happen
-                throw new IOException("Cannot found the cache file we just created.", e);
+                throw new IOException("Cannot find the cache file we just created.", e);
             }
         }
         tryClose(stream);

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
@@ -13,7 +13,6 @@
 package org.openhab.core.audio.internal.javasound;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Scanner;
@@ -87,6 +86,7 @@ public class JavaSoundAudioSink extends AudioSinkAsync {
             audioPlayer.start();
             try {
                 audioPlayer.join();
+                playbackFinished(audioStream);
             } catch (InterruptedException e) {
                 LOGGER.error("Playing audio has been interrupted.");
             }
@@ -177,7 +177,7 @@ public class JavaSoundAudioSink extends AudioSinkAsync {
                 return true;
             });
             if (volumes[0] != null) {
-                return new PercentType(new BigDecimal(volumes[0] * 100f));
+                return new PercentType(Math.round(volumes[0] * 100f));
             } else {
                 LOGGER.warn("Cannot determine master volume level - assuming 100%");
                 return PercentType.HUNDRED;

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioSink;
+import org.openhab.core.audio.AudioSinkSync;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.URLAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
@@ -55,7 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 @Component(service = AudioSink.class, immediate = true)
-public class JavaSoundAudioSink implements AudioSink {
+public class JavaSoundAudioSink extends AudioSinkSync {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaSoundAudioSink.class);
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioAudioSink.java
@@ -83,7 +83,11 @@ public class WebAudioAudioSink extends AudioSinkAsync {
             // we will let the HTTP servlet run the delayed task when finished with the stream
             Runnable delayedTask = () -> this.runDelayed(audioStream);
             // we need to serve it for a while and make it available to multiple clients
-            sendEvent(audioHTTPServer.serve(audioStream, 10, delayedTask).toString());
+            try {
+                sendEvent(audioHTTPServer.serve(audioStream, 10, delayedTask).toString());
+            } catch (IOException e) {
+                logger.warn("Cannot precache the audio stream to serve it", e);
+            }
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio.utils;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioSink;
+import org.openhab.core.library.types.PercentType;
+import org.slf4j.Logger;
+
+/**
+ * Some utility methods for sink
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class AudioSinkUtils {
+
+    /**
+     * Handle a volume command change and returns a Runnable to restore it.
+     *
+     * @param volume The volume to set
+     * @param sink The sink to set the volume to
+     * @param logger to log error to
+     * @return A runnable to restore the volume to its previous value, or null if no change is required
+     */
+    public static @Nullable Runnable handleVolumeCommand(@Nullable PercentType volume, AudioSink sink, Logger logger) {
+        boolean volumeChanged = false;
+        PercentType oldVolume = null;
+
+        if (volume == null) {
+            return null;
+        }
+
+        // set notification sound volume
+        try {
+            // get current volume
+            oldVolume = sink.getVolume();
+        } catch (IOException e) {
+            logger.debug("An exception occurred while getting the volume of sink '{}' : {}", sink.getId(),
+                    e.getMessage(), e);
+        }
+
+        if (!volume.equals(oldVolume) || oldVolume == null) {
+            try {
+                sink.setVolume(volume);
+                volumeChanged = true;
+            } catch (IOException e) {
+                logger.debug("An exception occurred while setting the volume of sink '{}' : {}", sink.getId(),
+                        e.getMessage(), e);
+            }
+        }
+
+        final PercentType oldVolumeFinal = oldVolume;
+        Runnable toRunWhenProcessFinished = null;
+        // restore volume only if it was set before
+        if (volumeChanged && oldVolumeFinal != null) {
+            toRunWhenProcessFinished = () -> {
+                try {
+                    sink.setVolume(oldVolumeFinal);
+                } catch (IOException | UnsupportedOperationException e) {
+                    logger.debug("An exception occurred while setting the volume of sink '{}' : {}", sink.getId(),
+                            e.getMessage(), e);
+                }
+            };
+        }
+
+        return toRunWhenProcessFinished;
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
@@ -49,7 +49,7 @@ public class AudioSinkUtils {
         try {
             // get current volume
             oldVolume = sink.getVolume();
-        } catch (IOException e) {
+        } catch (IOException | UnsupportedOperationException e) {
             logger.debug("An exception occurred while getting the volume of sink '{}' : {}", sink.getId(),
                     e.getMessage(), e);
         }
@@ -58,7 +58,7 @@ public class AudioSinkUtils {
             try {
                 sink.setVolume(volume);
                 volumeChanged = true;
-            } catch (IOException e) {
+            } catch (IOException | UnsupportedOperationException e) {
                 logger.debug("An exception occurred while setting the volume of sink '{}' : {}", sink.getId(),
                         e.getMessage(), e);
             }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javazoom.jl.decoder.Bitstream;
+import javazoom.jl.decoder.BitstreamException;
+import javazoom.jl.decoder.Header;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioFormat;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Some utility methods for sink
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ *
+ */
+@NonNullByDefault
+@Component
+public class AudioSinkUtilsImpl implements AudioSinkUtils {
+
+    private final Logger logger = LoggerFactory.getLogger(AudioSinkUtilsImpl.class);
+
+    @Override
+    public @Nullable Long transferAndAnalyzeLength(InputStream in, OutputStream out, AudioFormat audioFormat)
+            throws IOException {
+        // take some data from the stream beginning
+        byte[] dataBytes = in.readNBytes(8192);
+
+        // beginning sound timestamp :
+        long startTime = System.nanoTime();
+        // copy already read data to the output stream :
+        out.write(dataBytes);
+        // transfer everything else
+        Long dataTransferedLength = dataBytes.length + in.transferTo(out);
+
+        if (dataTransferedLength > 0) {
+            if (AudioFormat.CODEC_PCM_SIGNED.equals(audioFormat.getCodec())) {
+                try (AudioInputStream audioInputStream = AudioSystem
+                        .getAudioInputStream(new ByteArrayInputStream(dataBytes))) {
+                    int frameSize = audioInputStream.getFormat().getFrameSize();
+                    float frameRate = audioInputStream.getFormat().getFrameRate();
+                    long computedDuration = Float.valueOf((dataTransferedLength / (frameSize * frameRate)) * 1000000000)
+                            .longValue();
+                    return startTime + computedDuration;
+                } catch (IOException | UnsupportedAudioFileException e) {
+                    logger.debug("Cannot compute the duration of input stream", e);
+                    return null;
+                }
+            } else if (AudioFormat.CODEC_MP3.equals(audioFormat.getCodec())) {
+                // not precise, no VBR, but better than nothing
+                Bitstream bitstream = new Bitstream(new ByteArrayInputStream(dataBytes));
+                try {
+                    Header h = bitstream.readFrame();
+                    if (h != null) {
+                        long computedDuration = Float.valueOf(h.total_ms(dataTransferedLength.intValue()) * 1000000)
+                                .longValue();
+                        return startTime + computedDuration;
+                    }
+                } catch (BitstreamException ex) {
+                    logger.debug("Cannot compute the duration of input stream", ex);
+                    return null;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
@@ -12,21 +12,7 @@
  */
 package org.openhab.core.audio.utils;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import javazoom.jl.decoder.Bitstream;
-import javazoom.jl.decoder.BitstreamException;
-import javazoom.jl.decoder.Header;
-
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.UnsupportedAudioFileException;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.audio.AudioFormat;
 
 /**
  * Some general filename and extension utilities.
@@ -79,57 +65,5 @@ public class AudioStreamUtils {
      */
     public static boolean isExtension(String filename, String extension) {
         return !extension.isEmpty() && getExtension(filename).equals(extension);
-    }
-
-    /**
-     * Transfers data from an input stream to an output stream and computes on the fly its duration
-     *
-     * @param in the input stream giving audio data ta play
-     * @param out the output stream receiving data to play
-     * @return the timestamp (from System.nanoTime) when the sound should be fully played. Returns null if computing
-     *         time fails.
-     * @throws IOException if reading from the stream or writing to the stream failed
-     */
-    public static @Nullable Long transferAndAnalyzeLength(InputStream in, OutputStream out, AudioFormat audioFormat)
-            throws IOException {
-        // take some data from the stream beginning
-        byte[] dataBytes = in.readNBytes(8192);
-
-        // beginning sound timestamp :
-        long startTime = System.nanoTime();
-        // copy already read data to the output stream :
-        out.write(dataBytes);
-        // transfer everything else
-        Long dataTransferedLength = dataBytes.length + in.transferTo(out);
-
-        if (dataTransferedLength > 0) {
-            if (AudioFormat.CODEC_PCM_SIGNED.equals(audioFormat.getCodec())) {
-                try (AudioInputStream audioInputStream = AudioSystem
-                        .getAudioInputStream(new ByteArrayInputStream(dataBytes))) {
-                    int frameSize = audioInputStream.getFormat().getFrameSize();
-                    float frameRate = audioInputStream.getFormat().getFrameRate();
-                    long computedDuration = Float.valueOf((dataTransferedLength / (frameSize * frameRate)) * 1000000000)
-                            .longValue();
-                    return startTime + computedDuration;
-                } catch (IOException | UnsupportedAudioFileException e) {
-                    return null;
-                }
-            } else if (AudioFormat.CODEC_MP3.equals(audioFormat.getCodec())) {
-                // not precise, no VBR, but better than nothing
-                Bitstream bitstream = new Bitstream(new ByteArrayInputStream(dataBytes));
-                try {
-                    Header h = bitstream.readFrame();
-                    if (h != null) {
-                        long computedDuration = Float.valueOf(h.total_ms(dataTransferedLength.intValue()) * 1000000)
-                                .longValue();
-                        return startTime + computedDuration;
-                    }
-                } catch (BitstreamException ex) {
-                    return null;
-                }
-            }
-        }
-
-        return null;
     }
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
@@ -12,7 +12,21 @@
  */
 package org.openhab.core.audio.utils;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javazoom.jl.decoder.Bitstream;
+import javazoom.jl.decoder.BitstreamException;
+import javazoom.jl.decoder.Header;
+
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioFormat;
 
 /**
  * Some general filename and extension utilities.
@@ -65,5 +79,57 @@ public class AudioStreamUtils {
      */
     public static boolean isExtension(String filename, String extension) {
         return !extension.isEmpty() && getExtension(filename).equals(extension);
+    }
+
+    /**
+     * Transfers data from an input stream to an output stream and computes on the fly its duration
+     *
+     * @param in the input stream giving audio data ta play
+     * @param out the output stream receiving data to play
+     * @return the timestamp (from System.nanoTime) when the sound should be fully played. Returns null if computing
+     *         time fails.
+     * @throws IOException if reading from the stream or writing to the stream failed
+     */
+    public static @Nullable Long transferAndAnalyzeLength(InputStream in, OutputStream out, AudioFormat audioFormat)
+            throws IOException {
+        // take some data from the stream beginning
+        byte[] dataBytes = in.readNBytes(8192);
+
+        // beginning sound timestamp :
+        long startTime = System.nanoTime();
+        // copy already read data to the output stream :
+        out.write(dataBytes);
+        // transfer everything else
+        Long dataTransferedLength = dataBytes.length + in.transferTo(out);
+
+        if (dataTransferedLength > 0) {
+            if (AudioFormat.CODEC_PCM_SIGNED.equals(audioFormat.getCodec())) {
+                try (AudioInputStream audioInputStream = AudioSystem
+                        .getAudioInputStream(new ByteArrayInputStream(dataBytes))) {
+                    int frameSize = audioInputStream.getFormat().getFrameSize();
+                    float frameRate = audioInputStream.getFormat().getFrameRate();
+                    long computedDuration = Float.valueOf((dataTransferedLength / (frameSize * frameRate)) * 1000000000)
+                            .longValue();
+                    return startTime + computedDuration;
+                } catch (IOException | UnsupportedAudioFileException e) {
+                    return null;
+                }
+            } else if (AudioFormat.CODEC_MP3.equals(audioFormat.getCodec())) {
+                // not precise, no VBR, but better than nothing
+                Bitstream bitstream = new Bitstream(new ByteArrayInputStream(dataBytes));
+                try {
+                    Header h = bitstream.readFrame();
+                    if (h != null) {
+                        long computedDuration = Float.valueOf(h.total_ms(dataTransferedLength.intValue()) * 1000000)
+                                .longValue();
+                        return startTime + computedDuration;
+                    }
+                } catch (BitstreamException ex) {
+                    return null;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
@@ -33,7 +33,6 @@ import org.mockito.quality.Strictness;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.ByteArrayAudioStream;
-import org.openhab.core.audio.FixedLengthAudioStream;
 import org.openhab.core.test.TestPortUtil;
 import org.openhab.core.test.TestServer;
 import org.openhab.core.test.java.JavaTest;
@@ -126,7 +125,7 @@ public abstract class AbstractAudioServletTest extends JavaTest {
 
         String path;
         if (timeInterval != null) {
-            path = audioServlet.serve((FixedLengthAudioStream) stream, timeInterval);
+            path = audioServlet.serve(stream, timeInterval);
         } else {
             path = audioServlet.serve(stream);
         }

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
@@ -33,6 +33,8 @@ import org.mockito.quality.Strictness;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.ByteArrayAudioStream;
+import org.openhab.core.audio.utils.AudioSinkUtils;
+import org.openhab.core.audio.utils.AudioSinkUtilsImpl;
 import org.openhab.core.test.TestPortUtil;
 import org.openhab.core.test.TestServer;
 import org.openhab.core.test.java.JavaTest;
@@ -61,10 +63,11 @@ public abstract class AbstractAudioServletTest extends JavaTest {
 
     public @Mock @NonNullByDefault({}) HttpService httpServiceMock;
     public @Mock @NonNullByDefault({}) HttpContext httpContextMock;
+    public AudioSinkUtils audioSinkUtils = new AudioSinkUtilsImpl();
 
     @BeforeEach
     public void setupServerAndClient() {
-        audioServlet = new AudioServlet();
+        audioServlet = new AudioServlet(audioSinkUtils);
 
         ServletHolder servletHolder = new ServletHolder(audioServlet);
 

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -30,7 +30,7 @@ import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.ByteArrayAudioStream;
 import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.FixedLengthAudioStream;
-import org.openhab.core.audio.internal.AudioServlet.StreamServed;
+import org.openhab.core.audio.StreamServed;
 import org.openhab.core.audio.internal.utils.BundledSoundFileHandler;
 
 /**

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -198,6 +198,7 @@ public class AudioServletTest extends AbstractAudioServletTest {
         AudioFormat audioFormat = mock(AudioFormat.class);
         when(audioStream.getFormat()).thenReturn(audioFormat);
         when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
+        when(audioStream.readNBytes(anyInt())).thenReturn(new byte[] { 1, 2, 3 });
 
         String url = serveStream(audioStream);
         assertThat(audioServlet.getServedStreams().values().stream().map(StreamServed::audioStream).toList(),
@@ -221,6 +222,8 @@ public class AudioServletTest extends AbstractAudioServletTest {
             cloneCounter.getAndIncrement();
             return clonedStream;
         });
+        when(audioStream.readNBytes(anyInt())).thenReturn(new byte[] { 1, 2, 3 });
+        when(clonedStream.readNBytes(anyInt())).thenReturn(new byte[] { 1, 2, 3 });
         when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
 
         String url = serveStream(audioStream, 2);

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -14,10 +14,8 @@ package org.openhab.core.audio.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -29,8 +27,10 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
+import org.openhab.core.audio.ByteArrayAudioStream;
 import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.FixedLengthAudioStream;
+import org.openhab.core.audio.internal.AudioServlet.StreamServed;
 import org.openhab.core.audio.internal.utils.BundledSoundFileHandler;
 
 /**
@@ -128,7 +128,7 @@ public class AudioServletTest extends AbstractAudioServletTest {
     }
 
     @Test
-    public void requestToMultitimeStreamCannotBeDoneAfterTheTimeoutOfTheStreamHasExipred() throws Exception {
+    public void requestToMultitimeStreamCannotBeDoneAfterTheTimeoutOfTheStreamHasExpired() throws Exception {
         final int streamTimeout = 3;
 
         AudioStream audioStream = getByteArrayAudioStream(testByteArray, AudioFormat.CONTAINER_NONE,
@@ -151,8 +151,8 @@ public class AudioServletTest extends AbstractAudioServletTest {
             assertThat("The response media type was not as expected", response.getMediaType(),
                     is(MEDIA_TYPE_AUDIO_MPEG));
 
-            assertThat("The audio stream was not added to the multitime streams",
-                    audioServlet.getMultiTimeStreams().containsValue(audioStream), is(true));
+            assertThat("The audio stream was not added to the multitime streams", audioServlet.getServedStreams()
+                    .values().stream().map(StreamServed::audioStream).toList().contains(audioStream), is(true));
         }
 
         waitForAssert(() -> {
@@ -161,12 +161,35 @@ public class AudioServletTest extends AbstractAudioServletTest {
             } catch (Exception e) {
                 throw new IllegalStateException(e);
             }
-            assertThat("The audio stream was not removed from multitime streams",
-                    audioServlet.getMultiTimeStreams().containsValue(audioStream), is(false));
+            assertThat("The audio stream was not removed from multitime streams", audioServlet.getServedStreams()
+                    .values().stream().map(StreamServed::audioStream).toList().contains(audioStream), is(false));
         });
 
         response = getHttpRequest(url).send();
         assertThat("The response status was not as expected", response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+
+    @Test
+    public void oneTimeStreamIsRecreatedAsAClonable() throws Exception {
+        AudioStream audioStream = mock(AudioStream.class);
+        AudioFormat audioFormat = mock(AudioFormat.class);
+        when(audioStream.getFormat()).thenReturn(audioFormat);
+        when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
+        when(audioStream.readNBytes(anyInt())).thenReturn(testByteArray);
+
+        String url = serveStream(audioStream, 10);
+        String uuid = url.substring(url.lastIndexOf("/") + 1);
+        StreamServed servedStream = audioServlet.getServedStreams().get(uuid);
+
+        // does not contain directly the stream because it is now a new stream wrapper
+        assertThat(servedStream.audioStream(), not(audioStream));
+        // it is now a ByteArrayAudioStream wrapper :
+        assertThat(servedStream.audioStream(), instanceOf(ByteArrayAudioStream.class));
+
+        ContentResponse response = getHttpRequest(url).send();
+        assertThat("The response content was not as expected", response.getContent(), is(testByteArray));
+
+        verify(audioStream).close();
     }
 
     @Test
@@ -177,11 +200,14 @@ public class AudioServletTest extends AbstractAudioServletTest {
         when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
 
         String url = serveStream(audioStream);
+        assertThat(audioServlet.getServedStreams().values().stream().map(StreamServed::audioStream).toList(),
+                contains(audioStream));
 
         getHttpRequest(url).send();
 
         verify(audioStream).close();
-        assertThat(audioServlet.getOneTimeStreams().values(), not(contains(audioStream)));
+        assertThat(audioServlet.getServedStreams().values().stream().map(StreamServed::audioStream).toList(),
+                not(contains(audioStream)));
     }
 
     @Test
@@ -198,6 +224,8 @@ public class AudioServletTest extends AbstractAudioServletTest {
         when(audioFormat.getCodec()).thenReturn(AudioFormat.CODEC_MP3);
 
         String url = serveStream(audioStream, 2);
+        assertThat(audioServlet.getServedStreams().values().stream().map(StreamServed::audioStream).toList(),
+                contains(audioStream));
 
         waitForAssert(() -> {
             try {
@@ -210,7 +238,8 @@ public class AudioServletTest extends AbstractAudioServletTest {
         });
 
         verify(audioStream).close();
-        assertThat(audioServlet.getMultiTimeStreams().values(), not(contains(audioStream)));
+        assertThat(audioServlet.getServedStreams().values().stream().map(StreamServed::audioStream).toList(),
+                not(contains(audioStream)));
 
         verify(clonedStream, times(cloneCounter.get())).close();
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -25,11 +25,9 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioException;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
-import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
 import org.openhab.core.audio.utils.ToneSynthesizer;
-import org.openhab.core.common.Disposable;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.items.ItemUtil;
@@ -149,7 +147,7 @@ public class DialogProcessor implements KSListener, STTListener {
 
     /**
      * Starts a persistent dialog
-     *
+     * 
      * @throws IllegalStateException if keyword spot service is misconfigured
      */
     public void start() throws IllegalStateException {
@@ -382,24 +380,11 @@ public class DialogProcessor implements KSListener, STTListener {
             if (dialogContext.sink().getSupportedStreams().stream().anyMatch(clazz -> clazz.isInstance(audioStream))) {
                 try {
                     dialogContext.sink().process(audioStream);
-                    // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
-                    // to auto dispose:
-                    if (dialogContext.sink().isSynchronous()
-                            && audioStream instanceof Disposable disposableAudioStream) {
-                        disposableAudioStream.dispose();
-                    }
                 } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Error saying '{}': {}", text, e.getMessage(), e);
                     } else {
                         logger.warn("Error saying '{}': {}", text, e.getMessage());
-                    }
-                } catch (IOException e) {
-                    String fileName = audioStream instanceof FileAudioStream file ? file.toString() : "unknown";
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Cannot dispose of stream {}", fileName, e);
-                    } else {
-                        logger.warn("Cannot dispose of stream {}", fileName);
                     }
                 }
             } else {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -25,9 +25,11 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioException;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioStream;
+import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
 import org.openhab.core.audio.utils.ToneSynthesizer;
+import org.openhab.core.common.Disposable;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.items.ItemUtil;
@@ -147,7 +149,7 @@ public class DialogProcessor implements KSListener, STTListener {
 
     /**
      * Starts a persistent dialog
-     * 
+     *
      * @throws IllegalStateException if keyword spot service is misconfigured
      */
     public void start() throws IllegalStateException {
@@ -380,11 +382,24 @@ public class DialogProcessor implements KSListener, STTListener {
             if (dialogContext.sink().getSupportedStreams().stream().anyMatch(clazz -> clazz.isInstance(audioStream))) {
                 try {
                     dialogContext.sink().process(audioStream);
+                    // if the stream is not needed anymore, then we should call back the AudioStream to let it a chance
+                    // to auto dispose:
+                    if (dialogContext.sink().isSynchronous()
+                            && audioStream instanceof Disposable disposableAudioStream) {
+                        disposableAudioStream.dispose();
+                    }
                 } catch (UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Error saying '{}': {}", text, e.getMessage(), e);
                     } else {
                         logger.warn("Error saying '{}': {}", text, e.getMessage());
+                    }
+                } catch (IOException e) {
+                    String fileName = audioStream instanceof FileAudioStream file ? file.toString() : "unknown";
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Cannot dispose of stream {}", fileName, e);
+                    } else {
+                        logger.warn("Cannot dispose of stream {}", fileName);
                     }
                 }
             } else {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -42,7 +42,6 @@ import org.openhab.core.audio.AudioSource;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.UnsupportedAudioFormatException;
 import org.openhab.core.audio.UnsupportedAudioStreamException;
-import org.openhab.core.audio.utils.AudioSinkUtils;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ConfigurableService;
@@ -229,6 +228,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     public void say(String text, @Nullable String voiceId, @Nullable String sinkId, @Nullable PercentType volume) {
         Objects.requireNonNull(text, "Text cannot be said as it is null.");
 
+        Runnable volumeRestauration = null;
         try {
             TTSService tts = null;
             Voice voice = null;
@@ -272,15 +272,16 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 throw new TTSException(
                         "Failed playing audio stream '" + audioStream + "' as audio sink doesn't support it");
             }
-
-            Runnable volumeRestoration = AudioSinkUtils.handleVolumeCommand(volume, sink, logger);
-
-            sink.process(audioStream, volumeRestoration);
+            volumeRestauration = audioManager.handleVolumeCommand(volume, sink);
+            sink.processAndComplete(audioStream).thenRun(volumeRestauration);
         } catch (TTSException | UnsupportedAudioFormatException | UnsupportedAudioStreamException e) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Error saying '{}': {}", text, e.getMessage(), e);
             } else {
                 logger.warn("Error saying '{}': {}", text, e.getMessage());
+            }
+            if (volumeRestauration != null) {
+                volumeRestauration.run();
             }
         }
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioStreamFromCache.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioStreamFromCache.java
@@ -32,10 +32,12 @@ public class AudioStreamFromCache extends FixedLengthAudioStream {
 
     private InputStreamCacheWrapper inputStream;
     private AudioFormat audioFormat;
+    private String key;
 
-    public AudioStreamFromCache(InputStreamCacheWrapper inputStream, AudioFormatInfo audioFormat) {
+    public AudioStreamFromCache(InputStreamCacheWrapper inputStream, AudioFormatInfo audioFormat, String key) {
         this.inputStream = inputStream;
         this.audioFormat = audioFormat.toAudioFormat();
+        this.key = key;
     }
 
     @Override
@@ -100,5 +102,10 @@ public class AudioStreamFromCache extends FixedLengthAudioStream {
     @Override
     public boolean markSupported() {
         return inputStream.markSupported();
+    }
+
+    @Override
+    public @Nullable String getId() {
+        return key;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
@@ -135,7 +135,7 @@ public class TTSLRUCacheImpl implements TTSCache {
                 // we are sure that the cache is used, and so we can use an AudioStream
                 // implementation that use convenient methods for some client, like getClonedStream()
                 // or mark /reset
-                return new AudioStreamFromCache(inputStreamCacheWrapper, metadata);
+                return new AudioStreamFromCache(inputStreamCacheWrapper, metadata, key);
             } else {
                 // the cache is not used, we can use the original response AudioStream
                 return (AudioStream) fileAndMetadata.getInputStream();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
@@ -25,6 +25,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.Disposable;
 import org.openhab.core.storage.Storage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,6 +233,9 @@ public class LRUMediaCacheEntry<V> {
                     InputStream inputStreamLocal = inputStream;
                     if (inputStreamLocal != null) {
                         inputStreamLocal.close();
+                    }
+                    if (inputStreamLocal instanceof Disposable disposableStream) {
+                        disposableStream.dispose();
                     }
                 }
             }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/Disposable.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/Disposable.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.common;
+
+import java.io.IOException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * For resource needing a callback when they are not needed anymore.
+ *
+ * @author Gwendal Roulleau - Initial contribution
+ */
+@NonNullByDefault
+@FunctionalInterface
+public interface Disposable {
+    void dispose() throws IOException;
+}


### PR DESCRIPTION
Hello,

Following discussions with @lolodomo, I try here to enhance some aspect of the audio framework

- This proposal extracts `ClonableAudioStream` from `FixedLengthAudioStream`. We can have clonable Stream but without the fixed length property (example : `URLAudioStream`).

- Some (`AudioServlets` ?) sink can only work with `FixedLengthAudioStream `(at least squeezebox and webaudio sinks). Because they need to clone a stream to serve several client, or a client several times. To lift this limitation, this proposal make the `AudioServlet` able to cache the whole stream in memory (if < 1MB)  or in file (if <5 MB) to serve the sink a fitting stream by wrapping it with an implementation of `FixedLenghtAudioStream` (either `ByteArrayAudioStream` or `FileAudioStream`)

- Some AudioSink services can work asynchronously. It means that the process method returns before the sound is played entirely. It is an issue because of the volume restoration functionality that doesn't wait. For example, if we play a sound in the `ChromecastAudioSink` with a specific volume :  the volume is fixed at the desired level, the sound is served on the `AudioServlet`, the request is sent to the Chromecast device, and the volume level is immediately restored to the previous value **without waiting the stream consumption**.
~~This proposal adds a `Runnable` argument to the process method. This `Runnable` has the volume restoration code inside. It should be the sink's responsibility to execute this code when it has done playing.~~ This proposal adds a return value to the process method : a CompletableFuture which should be completed when the sound is fully played. It is the responsibility of the sink to complete this Future.
To not break compatibility or change behaviour, there is now a default process method in the `AudioSink` interface : it plays the sound in the sink and ~~launches the `Runnable`~~ complete the `CompletableFuture` immediately after the process method returns (exactly as before).
To change this behaviour, the `AudioSinks` has to override the new process method to handle the ~~`Runnable`~~ `CompletableFuture` at the proper time.
To ease further developement, I added two abstract classes : `AudioSinkSync` and `AudioSinkAsync`. I also provided two examples with the openHAB included sinks. ~~The `JavaSoundAudioSink` now extends the synced one~~, the `JavaSoundAudioSink` and the `WebAudioSink` (with the help of a now aware `AudioServlet`) extends the asynchronous one. 
~~The `AudioServlet` implementation is not very good, as it considers that a stream is ended when all bytes have been transfered and it is timed out, but it is still better than before. To further enhance this, we could maybe add some kind of calculation to compute the sound duration (as it is actually done by the `PulseAudioSink`, for this purpose). But it should be another PR.~~
An utility method to compute sound duration is included, with no guarantee of success (better than nothing). The AudioServlet makes use of it to know when to expire a stream and complete the `CompletableFuture`

- Some TTS services (at least pico tts, probably others), create temporary files to store TTS result before sending it to the framework. Some even makes temporary file to work around the issue with `AudioServlet` and `FixedLengthAudioStream`, mainly MimicTTS (This should not be necessary and could be deleted if this PR is merged) It also puts a need to delete file after use. We can use the java temporary file method, as some already do, but it delays the deletion to the end of the JVM, and it is not fool proof. This proposal adds a callback method for deleting file when they are not needed, with a Disposable interface.
Deleting the temporary file is the sink's responsibility.
To ease the development and mutualize code, the `AudioSinkSync` and `AudioSynkAsync` classes has, for one, this capability (Sync), and, for the other, an utility method (Async).

- Adding an identifyier to audio stream for further development. This will allow, for example, audio sink to cache data related to a stream, and not compute it everytime. I have a use case in mind with some sinks (`PulseAudio` and `Doorbird`) that do some encoding.