### PR TITLE
Adding "category" property to things

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
@@ -46,7 +46,7 @@ public class EnrichedThingDTO extends AbstractThingDTO {
     EnrichedThingDTO(ThingDTO thingDTO, List<EnrichedChannelDTO> channels, ThingStatusInfo statusInfo,
             FirmwareStatusDTO firmwareStatus, boolean editable) {
         super(thingDTO.thingTypeUID, thingDTO.UID, thingDTO.label, thingDTO.bridgeUID, thingDTO.configuration,
-                thingDTO.properties, thingDTO.location);
+                thingDTO.properties, thingDTO.location, thingDTO.category);
         this.channels = channels;
         this.statusInfo = statusInfo;
         this.firmwareStatus = firmwareStatus;

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/Thing.xtext
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/Thing.xtext
@@ -22,6 +22,7 @@ ModelBridge returns ModelThing:
 	bridge?='Bridge' (id=UID | thingTypeId=UID_SEGMENT thingId=UID_SEGMENT)
     (label=STRING)?
     ('@' location=STRING)?
+    ('<' icon=(ID|STRING) '>')?    
 	('['
 		properties+=ModelProperty? (',' properties+=ModelProperty)*
 	']')?
@@ -39,6 +40,7 @@ ModelThing:
 	(label=STRING)?
 	('(' bridgeUID = UID ')')?
 	('@' location=STRING)?
+    ('<' icon=(ID|STRING) '>')?
 	('['
 		properties+=ModelProperty? (',' properties+=ModelProperty)*
 	']')?

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -235,6 +235,8 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         val label = if(modelThing.label !== null) modelThing.label else thingType?.label
 
         val location = modelThing.location
+        
+        val category = modelThing.icon
 
         val ThingUID bridgeUID = if(modelThing.bridgeUID !== null) new ThingUID(modelThing.bridgeUID)
         val thingFromHandler = getThingFromThingHandlerFactories(thingTypeUID, label, configuration, thingUID,
@@ -250,6 +252,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         thingBuilder.withBridge(bridgeUID)
         thingBuilder.withLabel(label)
         thingBuilder.withLocation(location)
+        thingBuilder.withCategory(category)
 
         val channels = createChannels(thingTypeUID, thingUID, modelThing.channels,
             thingType?.channelDefinitions ?: newArrayList)
@@ -321,6 +324,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         targetThing.configuration.merge(sourceThing.configuration)
         targetThing.merge(sourceThing.channels)
         targetThing.location = sourceThing.location
+        targetThing.category = sourceThing.category
         targetThing.label = sourceThing.label
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
@@ -225,6 +225,20 @@ public interface Thing extends Identifiable<ThingUID> {
     void setLocation(@Nullable String location);
 
     /**
+     * Returns the category of the {@link Thing} or null if no category is set.
+     *
+     * @return category or null
+     */
+    public @Nullable String getCategory();
+
+    /**
+     * Set the category of the {@link Thing}.
+     *
+     * @param category or null
+     */
+    void setCategory(@Nullable String category);
+
+    /**
      * Returns information whether the {@link Thing} is enabled or not.
      *
      * @return Returns {@code true} if the thing is enabled. Return {@code false} otherwise.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseBridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseBridgeHandler.java
@@ -52,7 +52,8 @@ public abstract class BaseBridgeHandler extends BaseThingHandler implements Brid
     protected BridgeBuilder editThing() {
         return BridgeBuilder.create(thing.getThingTypeUID(), thing.getUID()).withBridge(thing.getBridgeUID())
                 .withChannels(thing.getChannels()).withConfiguration(thing.getConfiguration())
-                .withLabel(thing.getLabel()).withLocation(thing.getLocation()).withProperties(thing.getProperties());
+                .withLabel(thing.getLabel()).withLocation(thing.getLocation()).withCategory(thing.getCategory())
+                .withProperties(thing.getProperties());
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -414,7 +414,8 @@ public abstract class BaseThingHandler implements ThingHandler {
         return ThingBuilder.create(this.thing.getThingTypeUID(), this.thing.getUID())
                 .withBridge(this.thing.getBridgeUID()).withChannels(this.thing.getChannels())
                 .withConfiguration(this.thing.getConfiguration()).withLabel(this.thing.getLabel())
-                .withLocation(this.thing.getLocation()).withProperties(this.thing.getProperties());
+                .withLocation(this.thing.getLocation()).withCategory(this.thing.getCategory())
+                .withProperties(this.thing.getProperties());
     }
 
     /**
@@ -426,7 +427,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * {@link ThingHandlerCallback#validateConfigurationParameters(Thing, Map)}. It is also necessary to ensure that all
      * channel configurations are valid by calling
      * {@link ThingHandlerCallback#validateConfigurationParameters(Channel, Map)}.
-     * 
+     *
      * @param thing thing, that was updated and should be persisted
      */
     @SuppressWarnings("PMD.CompareObjectsWithEquals")

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
@@ -90,7 +90,8 @@ public class ThingFactory {
         List<Channel> channels = ThingFactoryHelper.createChannels(thingType, thingUID, configDescriptionRegistry);
 
         return createThingBuilder(thingType, thingUID).withConfiguration(configuration).withChannels(channels)
-                .withProperties(thingType.getProperties()).withBridge(bridgeUID).build();
+                .withCategory(thingType.getCategory()).withProperties(thingType.getProperties()).withBridge(bridgeUID)
+                .build();
     }
 
     public static @Nullable Thing createThing(ThingUID thingUID, Configuration configuration,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/BridgeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/BridgeBuilder.java
@@ -108,4 +108,9 @@ public class BridgeBuilder extends ThingBuilder {
     public BridgeBuilder withLocation(@Nullable String location) {
         return (BridgeBuilder) super.withLocation(location);
     }
+
+    @Override
+    public BridgeBuilder withCategory(@Nullable String category) {
+        return (BridgeBuilder) super.withCategory(category);
+    }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
@@ -48,6 +48,7 @@ public class ThingBuilder {
     private @Nullable ThingUID bridgeUID;
     private @Nullable Map<String, String> properties;
     private @Nullable String location;
+    private @Nullable String category;
 
     protected ThingBuilder(ThingTypeUID thingTypeUID, ThingUID thingUID) {
         this.thingUID = thingUID;
@@ -86,7 +87,8 @@ public class ThingBuilder {
     public static ThingBuilder create(Thing thing) {
         return ThingBuilder.create(thing.getThingTypeUID(), thing.getUID()).withBridge(thing.getBridgeUID())
                 .withChannels(thing.getChannels()).withConfiguration(thing.getConfiguration())
-                .withLabel(thing.getLabel()).withLocation(thing.getLocation()).withProperties(thing.getProperties());
+                .withLabel(thing.getLabel()).withLocation(thing.getLocation()).withCategory(thing.getCategory())
+                .withProperties(thing.getProperties());
     }
 
     /**
@@ -251,6 +253,17 @@ public class ThingBuilder {
         return this;
     }
 
+    /**
+     * Set the category for this thing
+     *
+     * @param category a string wih the category of the thing
+     * @return the {@link ThingBuilder} itself
+     */
+    public ThingBuilder withCategory(@Nullable String category) {
+        this.category = category;
+        return this;
+    }
+
     protected Thing populate(ThingImpl thing) {
         thing.setLabel(label);
         thing.setChannels(channels);
@@ -262,6 +275,7 @@ public class ThingBuilder {
             }
         }
         thing.setLocation(location);
+        thing.setCategory(category);
         return thing;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
@@ -32,12 +32,13 @@ public abstract class AbstractThingDTO {
     public String UID;
     public String thingTypeUID;
     public String location;
+    public String category;
 
     public AbstractThingDTO() {
     }
 
     protected AbstractThingDTO(String thingTypeUID, String UID, String label, String bridgeUID,
-            Map<String, Object> configuration, Map<String, String> properties, String location) {
+            Map<String, Object> configuration, Map<String, String> properties, String location, String category) {
         this.thingTypeUID = thingTypeUID;
         this.UID = UID;
         this.label = label;
@@ -45,5 +46,6 @@ public abstract class AbstractThingDTO {
         this.configuration = configuration;
         this.properties = properties;
         this.location = location;
+        this.category = category;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
@@ -32,8 +32,8 @@ public class ThingDTO extends AbstractThingDTO {
     }
 
     protected ThingDTO(String thingTypeUID, String UID, String label, String bridgeUID, List<ChannelDTO> channels,
-            Map<String, Object> configuration, Map<String, String> properties, String location) {
-        super(thingTypeUID, UID, label, bridgeUID, configuration, properties, location);
+            Map<String, Object> configuration, Map<String, String> properties, String location, String category) {
+        super(thingTypeUID, UID, label, bridgeUID, configuration, properties, location, category);
         this.channels = channels;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
@@ -54,7 +54,8 @@ public class ThingDTOMapper {
         final ThingUID bridgeUID = thing.getBridgeUID();
 
         return new ThingDTO(thingTypeUID, thingUID, thing.getLabel(), bridgeUID != null ? bridgeUID.toString() : null,
-                channelDTOs, toMap(thing.getConfiguration()), thing.getProperties(), thing.getLocation());
+                channelDTOs, toMap(thing.getConfiguration()), thing.getProperties(), thing.getLocation(),
+                thing.getCategory());
     }
 
     /**

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -64,6 +64,8 @@ public class ThingImpl implements Thing {
 
     private @Nullable String location;
 
+    private @Nullable String category;
+
     private transient volatile ThingStatusInfo status = ThingStatusInfoBuilder
             .create(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE).build();
 
@@ -206,7 +208,7 @@ public class ThingImpl implements Thing {
 
     @Override
     public @Nullable String setProperty(String name, @Nullable String value) {
-        if (name == null || name.isEmpty()) {
+        if (name.isEmpty()) {
             throw new IllegalArgumentException("Property name must not be null or empty");
         }
         synchronized (this) {
@@ -230,6 +232,16 @@ public class ThingImpl implements Thing {
     @Override
     public void setLocation(@Nullable String location) {
         this.location = location;
+    }
+
+    @Override
+    public @Nullable String getCategory() {
+        return category;
+    }
+
+    @Override
+    public void setCategory(@Nullable String category) {
+        this.category = category;
     }
 
     @Override

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
@@ -28,7 +28,7 @@ public class ThingStorageEntity extends ThingDTO {
 
     public ThingStorageEntity(ThingDTO thingDTO, boolean isBridge) {
         super(thingDTO.thingTypeUID, thingDTO.UID, thingDTO.label, thingDTO.bridgeUID, thingDTO.channels,
-                thingDTO.configuration, thingDTO.properties, thingDTO.location);
+                thingDTO.configuration, thingDTO.properties, thingDTO.location, thingDTO.category);
         this.isBridge = isBridge;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
@@ -188,6 +188,13 @@ public class ThingHelper {
             builder.withLocation(thing.getLocation());
         }
 
+        // Update the category
+        if (updatedContents.category != null) {
+            builder.withCategory(updatedContents.category);
+        } else {
+            builder.withCategory(thing.getCategory());
+        }
+
         // update bridge UID
         if (updatedContents.bridgeUID != null) {
             builder.withBridge(new ThingUID(updatedContents.bridgeUID));


### PR DESCRIPTION
Following the suggestion I made [here](https://community.openhab.org/t/openhab-4-0-wishlist/142388/403?u=glhopital).

Thing-Type and Thing XML schemas where already holding a category field.
This adds the ability to add it in `.things` files, with the same syntax than `.items` file (eg:

`magic:color-light:magicColor @"theplace" <lightbulb>
`

I'm missing the ability to inherit thing category from thing-type category (did not find where it happens).

Using the API explorer, I get visibility on category as a field of the thing. If this gets approved (and probably enhanced), it could then be added in web-ui.