### PR TITLE
[de] Fix article of "token"

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_de.properties
+++ b/bundles/org.openhab.core.io.http.auth/src/main/resources/messages_de.properties
@@ -8,7 +8,7 @@ auth.createapitoken.prompt = Erstelle einen neuen Token, um externe Dienste zu a
 auth.createapitoken.name.unique.fail = Ein Token mit dem selben Namen existiert bereits. Bitte erneut versuchen.
 auth.createapitoken.name.format.fail = Ungültiger Token Name. Bitte nutzen Sie nur alphanumerische Zeichen.
 auth.createapitoken.success = Neuer Token erstellt\:
-auth.createapitoken.success.footer = Bitte kopieren Sie es jetzt. Es wird anschließend nicht mehr angezeigt.
+auth.createapitoken.success.footer = Bitte kopieren Sie ihn jetzt, da er anschließend nicht mehr angezeigt wird.
 
 auth.password.confirm.fail = Passwörter stimmen nicht überein. Bitte erneut versuchen.
 


### PR DESCRIPTION
The word `token` is male in German. In `auth.createapitoken.success.footer` the word was gender neutral