### PR TITLE
Fix ConfigValidationMessage in ThingManagerImpl

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -677,7 +677,7 @@ public class ThingManagerImpl implements ReadyTracker, ThingManager, ThingTracke
         if (prototype == null) {
             ConfigValidationMessage message = new ConfigValidationMessage("thing/channel",
                     "Type description for '{0}' not found although we checked the presence before.",
-                    "type_description_missing", targetUID);
+                    "type_description_missing", targetUID.toString());
             throw new ConfigValidationException(bundleContext.getBundle(), translationProvider, List.of(message));
         }
 


### PR DESCRIPTION
Seen in the message in #3473: The placeholder was not properly replaced.