### PR TITLE
Support a cleaner syntax for SCRIPT transformation

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.module.script;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -84,6 +85,7 @@ public class ScriptTransformationService
 
     private final TransformationRegistry transformationRegistry;
     private final Map<String, String> supportedScriptTypes = new ConcurrentHashMap<>();
+    private final List<String> supportedTransformationTypes = new ArrayList<>(List.of(SUPPORTED_CONFIGURATION_TYPE));
 
     private final ScriptEngineManager scriptEngineManager;
 
@@ -275,7 +277,7 @@ public class ScriptTransformationService
         if (PROFILE_CONFIG_URI.equals(uri.toString())) {
             if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param)
                     || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)) {
-                return transformationRegistry.getTransformations(List.of(SUPPORTED_CONFIGURATION_TYPE)).stream()
+                return transformationRegistry.getTransformations(supportedTransformationTypes).stream()
                         .map(c -> new ParameterOption(c.getUID(), c.getLabel())).collect(Collectors.toList());
             }
             if (ScriptProfile.CONFIG_SCRIPT_LANGUAGE.equals(param)) {
@@ -295,10 +297,12 @@ public class ScriptTransformationService
         if (parameterOption != null) {
             supportedScriptTypes.put(parameterOption.getKey(), parameterOption.getValue());
         }
+        supportedTransformationTypes.addAll(engineFactory.getScriptTypes());
     }
 
     public void unsetScriptEngineFactory(ScriptEngineFactory engineFactory) {
         supportedScriptTypes.remove(ScriptEngineFactoryHelper.getPreferredMimeType(engineFactory));
+        supportedTransformationTypes.removeAll(engineFactory.getScriptTypes());
     }
 
     private static class ScriptRecord {


### PR DESCRIPTION
Support `SCRIPT(file.rb)` syntax as an alternative, not a replacement, to `SCRIPT(rb:file.script)`
Also `SCRIPT(file.rb?param1=x)` works like `SCRIPT(rb:file.script?param1=x)`

The original syntax is still fully supported, so this is not a breaking change.

This makes changing from JS transformation to SCRIPT transformation as easy as changing `JS(myscript.js)` to `SCRIPT(myscript.js)`

Discussed in #3465

I understand that @J-N-K disagreed with this proposal. However, I feel very strongly about making the script transformation syntax more elegant and intuitive for file-based scripts and I have created this PR as a PoC to demonstrate what I wish to achieve. 

Unrelated to the matter, some extra error checks were added to the regex pattern to avoid errors, e.g. when an inline transformation script had a `?` character as part of the code, it would've been extracted as  parameters, which shouldn't be the case.

If this doesn't negatively affect anything else, I'd appreciate further considerations for this PR. If there are any potential issues that I'm not aware of, I'll try to address them also.
