### PR TITLE
Bump commons-fileupload

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -392,7 +392,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
It is not needed in openhab-core or openhab-addons.