### PR TITLE
Add dynamic scripting-language transformation service

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(factory = "org.openhab.core.automation.module.script.transformation.factory")
 public class ScriptTransformationService implements TransformationService, RegistryChangeListener<Transformation> {
+    public static final String SCRIPT_TYPE_PROPERTY_NAME = "openhab.transform.script.scriptType";
     public static final String OPENHAB_TRANSFORMATION_SCRIPT = "openhab-transformation-script-";
 
     private static final Pattern INLINE_SCRIPT_CONFIG_PATTERN = Pattern.compile("\\|(?<inlineScript>.+)");
@@ -75,16 +76,15 @@ public class ScriptTransformationService implements TransformationService, Regis
     @Activate
     public ScriptTransformationService(@Reference TransformationRegistry transformationRegistry,
             @Reference ScriptEngineManager scriptEngineManager, Map<String, Object> config) {
-        String servicePropertyName = ConfigParser.valueAs(config.get(TransformationService.SERVICE_PROPERTY_NAME),
-                String.class);
-        if (servicePropertyName == null) {
+        String scriptType = ConfigParser.valueAs(config.get(SCRIPT_TYPE_PROPERTY_NAME), String.class);
+        if (scriptType == null) {
             throw new IllegalStateException(
-                    "'" + TransformationService.SERVICE_PROPERTY_NAME + "' must not be null in service configuration");
+                    "'" + SCRIPT_TYPE_PROPERTY_NAME + "' must not be null in service configuration");
         }
 
         this.transformationRegistry = transformationRegistry;
         this.scriptEngineManager = scriptEngineManager;
-        this.scriptType = servicePropertyName.toLowerCase();
+        this.scriptType = scriptType;
         transformationRegistry.addRegistryChangeListener(this);
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -253,7 +253,7 @@ public class ScriptTransformationService implements TransformationService, Confi
 
     @Override
     public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
-        var configDescription = getConfigDescription(profileConfigUri, locale);
+        ConfigDescription configDescription = getConfigDescription(profileConfigUri, locale);
         if (configDescription != null) {
             return List.of(configDescription);
         }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -87,6 +87,7 @@ public class ScriptTransformationService implements TransformationService, Confi
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
     private final String scriptType;
+    private final URI profileConfigUri;
 
     private final Map<String, ScriptRecord> scriptCache = new ConcurrentHashMap<>();
 
@@ -108,6 +109,7 @@ public class ScriptTransformationService implements TransformationService, Confi
         this.configDescRegistry = configDescRegistry;
         this.scriptEngineManager = scriptEngineManager;
         this.scriptType = scriptType;
+        this.profileConfigUri = URI.create(PROFILE_CONFIG_URI_PREFIX + scriptType.toUpperCase());
         transformationRegistry.addRegistryChangeListener(this);
     }
 
@@ -238,13 +240,7 @@ public class ScriptTransformationService implements TransformationService, Confi
     @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
-        String uriString = uri.toString();
-        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX)) {
-            return null;
-        }
-
-        String scriptType = uriString.substring(PROFILE_CONFIG_URI_PREFIX.length()).toLowerCase();
-        if (!this.scriptType.equals(scriptType)) {
+        if (!uri.equals(profileConfigUri)) {
             return null;
         }
 
@@ -257,8 +253,7 @@ public class ScriptTransformationService implements TransformationService, Confi
 
     @Override
     public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
-        URI uri = URI.create(PROFILE_CONFIG_URI_PREFIX + scriptType.toUpperCase());
-        var configDescription = getConfigDescription(uri, locale);
+        var configDescription = getConfigDescription(profileConfigUri, locale);
         if (configDescription != null) {
             return List.of(configDescription);
         }
@@ -268,12 +263,7 @@ public class ScriptTransformationService implements TransformationService, Confi
 
     @Override
     public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
-        String uriString = uri.toString();
-        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX)) {
-            return null;
-        }
-        String transformationId = uriString.substring(PROFILE_CONFIG_URI_PREFIX.length());
-        if (!transformationId.equals(scriptType.toUpperCase())) {
+        if (!uri.equals(profileConfigUri)) {
             return null;
         }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -55,7 +55,8 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jimmy Tanagra - Initial contribution
  */
-@Component(immediate = true, service = { ConfigDescriptionProvider.class, ConfigOptionProvider.class })
+@Component(immediate = true, service = { ScriptTransformationServiceFactory.class, ConfigDescriptionProvider.class,
+        ConfigOptionProvider.class })
 @NonNullByDefault
 public class ScriptTransformationServiceFactory implements ConfigDescriptionProvider, ConfigOptionProvider {
     private final Logger logger = LoggerFactory.getLogger(ScriptTransformationServiceFactory.class);
@@ -98,6 +99,7 @@ public class ScriptTransformationServiceFactory implements ConfigDescriptionProv
 
             Dictionary<String, Object> properties = new Hashtable<>();
             properties.put(TransformationService.SERVICE_PROPERTY_NAME, type.toUpperCase());
+            properties.put(ScriptTransformationService.SCRIPT_TYPE_PROPERTY_NAME, type);
             ComponentInstance<ScriptTransformationService> instance = scriptTransformationFactory
                     .newInstance(properties);
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -12,20 +12,34 @@
  */
 package org.openhab.core.automation.module.script;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.internal.ScriptEngineFactoryHelper;
+import org.openhab.core.automation.module.script.profile.ScriptProfile;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+import org.openhab.core.config.core.ConfigDescriptionProvider;
+import org.openhab.core.config.core.ConfigDescriptionRegistry;
+import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.transform.TransformationRegistry;
 import org.openhab.core.transform.TransformationService;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentFactory;
+import org.osgi.service.component.ComponentInstance;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -41,28 +55,32 @@ import org.slf4j.LoggerFactory;
  *
  * @author Jimmy Tanagra - Initial contribution
  */
-@Component(immediate = true, service = ScriptTransformationServiceFactory.class)
+@Component(immediate = true, service = { ConfigDescriptionProvider.class, ConfigOptionProvider.class })
 @NonNullByDefault
-public class ScriptTransformationServiceFactory {
+public class ScriptTransformationServiceFactory implements ConfigDescriptionProvider, ConfigOptionProvider {
     private final Logger logger = LoggerFactory.getLogger(ScriptTransformationServiceFactory.class);
 
-    private final TransformationRegistry transformationRegistry;
-    private final ScriptEngineManager scriptEngineManager;
-    private final BundleContext bundleContext;
+    public static final String PROFILE_CONFIG_URI_PREFIX = "profile:transform:";
+    private static final URI CONFIG_DESCRIPTION_TEMPLATE_URI = URI.create(PROFILE_CONFIG_URI_PREFIX + "SCRIPT");
 
-    private final Map<String, ServiceRegistration> scriptTransformations = new ConcurrentHashMap<>();
+    private final ConfigDescriptionRegistry configDescRegistry;
+    private final ComponentFactory<ScriptTransformationService> scriptTransformationFactory;
+    private final TransformationRegistry transformationRegistry;
+
+    private final Map<String, TransformationRecord> scriptTransformations = new ConcurrentHashMap<>();
 
     @Activate
-    public ScriptTransformationServiceFactory(@Reference TransformationRegistry transformationRegistry,
-            @Reference ScriptEngineManager scriptEngineManager, BundleContext bundleContext) {
-        this.bundleContext = bundleContext;
+    public ScriptTransformationServiceFactory(@Reference ConfigDescriptionRegistry configDescRegistry,
+            @Reference TransformationRegistry transformationRegistry,
+            @Reference(target = "(component.factory=org.openhab.core.automation.module.script.transformation.factory)") ComponentFactory<ScriptTransformationService> factory) {
+        this.configDescRegistry = configDescRegistry;
+        this.scriptTransformationFactory = factory;
         this.transformationRegistry = transformationRegistry;
-        this.scriptEngineManager = scriptEngineManager;
     }
 
     @Deactivate
     public void deactivate() {
-        scriptTransformations.values().forEach(this::unregisterService);
+        scriptTransformations.values().stream().map(tr -> tr.instance()).forEach(this::unregisterService);
     }
 
     /**
@@ -77,39 +95,119 @@ public class ScriptTransformationServiceFactory {
         }
 
         scriptTransformations.computeIfAbsent(scriptType.get(), type -> {
-            ScriptTransformationService scriptTransformation = new ScriptTransformationService(type,
-                    transformationRegistry, scriptEngineManager);
 
             Dictionary<String, Object> properties = new Hashtable<>();
             properties.put(TransformationService.SERVICE_PROPERTY_NAME, type.toUpperCase());
-            return bundleContext.registerService(TransformationService.class, scriptTransformation, properties);
+            ComponentInstance<ScriptTransformationService> instance = scriptTransformationFactory
+                    .newInstance(properties);
+
+            return new TransformationRecord(instance, getLanguageName(type, engineFactory));
         });
     }
 
     public void unsetScriptEngineFactory(ScriptEngineFactory engineFactory) {
         Optional<String> scriptType = ScriptEngineFactoryHelper.getPreferredExtension(engineFactory);
         if (scriptType.isPresent()) {
-            Optional.ofNullable(scriptTransformations.remove(scriptType.get())).ifPresent(this::unregisterService);
+            Optional.ofNullable(scriptTransformations.remove(scriptType.get()))
+                    .ifPresent(tr -> unregisterService(tr.instance()));
         }
     }
 
-    public Set<String> getScriptTypes() {
-        return scriptTransformations.keySet();
+    public Stream<String> getScriptTypes() {
+        return scriptTransformations.keySet().stream();
+    }
+
+    private String getLanguageName(final String scriptType, ScriptEngineFactory engineFactory) {
+        var scriptEngine = engineFactory.createScriptEngine(scriptType);
+        String languageName = ScriptEngineFactoryHelper.getLanguageName(scriptEngine.getFactory());
+        return languageName;
     }
 
     @Nullable
-    public ScriptTransformationService getTransformationService(final String scriptType) {
-        ServiceRegistration reg = scriptTransformations.get(scriptType);
-        if (reg != null) {
-            return (ScriptTransformationService) bundleContext.getService(reg.getReference());
+    public String getLanguageName(final String scriptType) {
+        TransformationRecord tr = scriptTransformations.get(scriptType);
+        if (tr != null) {
+            return tr.languageName();
         }
         return null;
     }
 
-    private void unregisterService(ServiceRegistration reg) {
-        ScriptTransformationService scriptTransformation = (ScriptTransformationService) bundleContext
-                .getService(reg.getReference());
-        scriptTransformation.deactivate();
-        reg.unregister();
+    private void unregisterService(ComponentInstance<ScriptTransformationService> instance) {
+        instance.getInstance().deactivate();
+        instance.dispose();
+    }
+
+    @Nullable
+    public ScriptTransformationService getTransformationService(String scriptType) {
+        TransformationRecord rec = scriptTransformations.get(scriptType);
+        if (rec == null) {
+            return null;
+        }
+        return rec.instance().getInstance();
+    }
+
+    @Override
+    public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
+        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
+        if (template == null) {
+            return Collections.emptyList();
+        }
+
+        return getScriptTypes().map(type -> ConfigDescriptionBuilder
+                .create(URI.create(PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()))
+                .withParameters(template.getParameters()).withParameterGroups(template.getParameterGroups()).build())
+                .toList();
+    }
+
+    /**
+     * Provides a {@link ConfigDescription} for the given URI.
+     *
+     * @param uri uri of the config description
+     * @param locale locale
+     * @return config description or null if no config description could be found
+     */
+    @Override
+    public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
+        String uriString = uri.toString();
+        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX) || !getProfileConfigURIs().contains(uriString)) {
+            return null;
+        }
+
+        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
+        if (template == null) {
+            return null;
+        }
+        return ConfigDescriptionBuilder.create(uri).withParameters(template.getParameters())
+                .withParameterGroups(template.getParameterGroups()).build();
+    }
+
+    private Set<String> getProfileConfigURIs() {
+        return getScriptTypes().map(type -> PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()).collect(Collectors.toSet());
+    }
+
+    @Override
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
+        String uriString = uri.toString();
+        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX) || !getProfileConfigURIs().contains(uriString)) {
+            return null;
+        }
+
+        String[] uri_parts = uri.toString().split(":");
+        if (uri_parts.length == 0) {
+            return null;
+        }
+
+        String scriptType = uri_parts[uri_parts.length - 1].toLowerCase();
+
+        if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param) || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)) {
+            var scriptTypes = scriptType.equals("dsl") ? List.of(scriptType, "rules") : List.of(scriptType);
+            return transformationRegistry.getTransformations(scriptTypes).stream()
+                    .map(c -> new ParameterOption(c.getUID(), c.getLabel())).collect(Collectors.toList());
+        }
+        return null;
+    }
+
+    private record TransformationRecord(ComponentInstance<ScriptTransformationService> instance, String languageName) {
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.internal.ScriptEngineFactoryHelper;
+import org.openhab.core.transform.TransformationRegistry;
+import org.openhab.core.transform.TransformationService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link ScriptTransformationServiceFactory} registers a {@link ScriptTransformationService}
+ * for each newly added script engine.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@Component(immediate = true, service = ScriptTransformationServiceFactory.class)
+@NonNullByDefault
+public class ScriptTransformationServiceFactory {
+    private final Logger logger = LoggerFactory.getLogger(ScriptTransformationServiceFactory.class);
+
+    private final TransformationRegistry transformationRegistry;
+    private final ScriptEngineManager scriptEngineManager;
+    private final BundleContext bundleContext;
+
+    private final Map<String, ServiceRegistration> scriptTransformations = new ConcurrentHashMap<>();
+
+    @Activate
+    public ScriptTransformationServiceFactory(@Reference TransformationRegistry transformationRegistry,
+            @Reference ScriptEngineManager scriptEngineManager, BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
+        this.transformationRegistry = transformationRegistry;
+        this.scriptEngineManager = scriptEngineManager;
+    }
+
+    @Deactivate
+    public void deactivate() {
+        scriptTransformations.values().forEach(this::unregisterService);
+    }
+
+    /**
+     * As {@link ScriptEngineFactory}s are added/removed, this method will cache all available script types
+     * and registers a transformation service for the script engine.
+     */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    public void setScriptEngineFactory(ScriptEngineFactory engineFactory) {
+        Optional<String> scriptType = ScriptEngineFactoryHelper.getPreferredExtension(engineFactory);
+        if (!scriptType.isPresent()) {
+            return;
+        }
+
+        scriptTransformations.computeIfAbsent(scriptType.get(), type -> {
+            ScriptTransformationService scriptTransformation = new ScriptTransformationService(type,
+                    transformationRegistry, scriptEngineManager);
+
+            Dictionary<String, Object> properties = new Hashtable<>();
+            properties.put(TransformationService.SERVICE_PROPERTY_NAME, type.toUpperCase());
+            return bundleContext.registerService(TransformationService.class, scriptTransformation, properties);
+        });
+    }
+
+    public void unsetScriptEngineFactory(ScriptEngineFactory engineFactory) {
+        Optional<String> scriptType = ScriptEngineFactoryHelper.getPreferredExtension(engineFactory);
+        if (scriptType.isPresent()) {
+            Optional.ofNullable(scriptTransformations.remove(scriptType.get())).ifPresent(this::unregisterService);
+        }
+    }
+
+    public Set<String> getScriptTypes() {
+        return scriptTransformations.keySet();
+    }
+
+    @Nullable
+    public ScriptTransformationService getTransformationService(final String scriptType) {
+        ServiceRegistration reg = scriptTransformations.get(scriptType);
+        if (reg != null) {
+            return (ScriptTransformationService) bundleContext.getService(reg.getReference());
+        }
+        return null;
+    }
+
+    private void unregisterService(ServiceRegistration reg) {
+        ScriptTransformationService scriptTransformation = (ScriptTransformationService) bundleContext
+                .getService(reg.getReference());
+        scriptTransformation.deactivate();
+        reg.unregister();
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -12,14 +12,8 @@
  */
 package org.openhab.core.automation.module.script;
 
-import static org.openhab.core.automation.module.script.profile.ScriptProfileFactory.PROFILE_CONFIG_URI_PREFIX;
-
-import java.net.URI;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,12 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.script.ScriptEngine;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.internal.ScriptEngineFactoryHelper;
-import org.openhab.core.config.core.ConfigDescription;
-import org.openhab.core.config.core.ConfigDescriptionBuilder;
-import org.openhab.core.config.core.ConfigDescriptionProvider;
-import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.ComponentFactory;
 import org.osgi.service.component.ComponentInstance;
@@ -49,20 +38,17 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Jimmy Tanagra - Initial contribution
  */
-@Component(immediate = true, service = { ScriptTransformationServiceFactory.class, ConfigDescriptionProvider.class })
+@Component(immediate = true, service = { ScriptTransformationServiceFactory.class })
 @NonNullByDefault
-public class ScriptTransformationServiceFactory implements ConfigDescriptionProvider {
-    private static final URI CONFIG_DESCRIPTION_TEMPLATE_URI = URI.create(PROFILE_CONFIG_URI_PREFIX + "SCRIPT");
+public class ScriptTransformationServiceFactory {
 
-    private final ConfigDescriptionRegistry configDescRegistry;
     private final ComponentFactory<ScriptTransformationService> scriptTransformationFactory;
 
     private final Map<String, ComponentInstance<ScriptTransformationService>> scriptTransformations = new ConcurrentHashMap<>();
 
     @Activate
-    public ScriptTransformationServiceFactory(@Reference ConfigDescriptionRegistry configDescRegistry,
+    public ScriptTransformationServiceFactory(
             @Reference(target = "(component.factory=org.openhab.core.automation.module.script.transformation.factory)") ComponentFactory<ScriptTransformationService> factory) {
-        this.configDescRegistry = configDescRegistry;
         this.scriptTransformationFactory = factory;
     }
 
@@ -113,38 +99,5 @@ public class ScriptTransformationServiceFactory implements ConfigDescriptionProv
     private void unregisterService(ComponentInstance<ScriptTransformationService> instance) {
         instance.getInstance().deactivate();
         instance.dispose();
-    }
-
-    @Override
-    public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
-        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
-        if (template == null) {
-            return Collections.emptyList();
-        }
-
-        return scriptTransformations.keySet().stream()
-                .map(type -> ConfigDescriptionBuilder.create(URI.create(PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()))
-                        .withParameters(template.getParameters()).withParameterGroups(template.getParameterGroups())
-                        .build())
-                .toList();
-    }
-
-    @Override
-    public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
-        String uriString = uri.toString();
-        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX)) {
-            return null;
-        }
-        String scriptType = uriString.substring(PROFILE_CONFIG_URI_PREFIX.length());
-        if (!scriptTransformations.containsKey(scriptType.toLowerCase())) {
-            return null;
-        }
-
-        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
-        if (template == null) {
-            return null;
-        }
-        return ConfigDescriptionBuilder.create(uri).withParameters(template.getParameters())
-                .withParameterGroups(template.getParameterGroups()).build();
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -76,8 +76,9 @@ public class ScriptTransformationServiceFactory {
             }
             String languageName = ScriptEngineFactoryHelper.getLanguageName(scriptEngine.getFactory());
             Dictionary<String, Object> properties = new Hashtable<>();
-            properties.put(TransformationService.SERVICE_PROPERTY_NAME, type.toUpperCase());
-            properties.put(TransformationService.SERVICE_PROPERTY_LABEL, languageName);
+            String name = type.toUpperCase();
+            properties.put(TransformationService.SERVICE_PROPERTY_NAME, name);
+            properties.put(TransformationService.SERVICE_PROPERTY_LABEL, name + " - " + languageName);
             properties.put(ScriptTransformationService.SCRIPT_TYPE_PROPERTY_NAME, type);
             return scriptTransformationFactory.newInstance(properties);
         });

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -76,9 +76,8 @@ public class ScriptTransformationServiceFactory {
             }
             String languageName = ScriptEngineFactoryHelper.getLanguageName(scriptEngine.getFactory());
             Dictionary<String, Object> properties = new Hashtable<>();
-            String name = type.toUpperCase();
-            properties.put(TransformationService.SERVICE_PROPERTY_NAME, name);
-            properties.put(TransformationService.SERVICE_PROPERTY_LABEL, name + " - " + languageName);
+            properties.put(TransformationService.SERVICE_PROPERTY_NAME, type.toUpperCase());
+            properties.put(TransformationService.SERVICE_PROPERTY_LABEL, "SCRIPT " + languageName);
             properties.put(ScriptTransformationService.SCRIPT_TYPE_PROPERTY_NAME, type);
             return scriptTransformationFactory.newInstance(properties);
         });

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
@@ -13,8 +13,10 @@
 package org.openhab.core.automation.module.script.internal;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.script.ScriptEngine;
 
@@ -66,5 +68,11 @@ public class ScriptEngineFactoryHelper {
         return String.format("%s (%s)",
                 factory.getLanguageName().substring(0, 1).toUpperCase() + factory.getLanguageName().substring(1),
                 factory.getLanguageVersion());
+    }
+
+    public static Optional<String> getPreferredExtension(ScriptEngineFactory factory) {
+        // return an Optional because GenericScriptEngineFactory has no scriptTypes
+        return factory.getScriptTypes().stream().filter(type -> !type.contains("/"))
+                .min(Comparator.comparing(String::length));
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class ScriptProfile implements StateProfile {
 
-    public static final String CONFIG_SCRIPT_LANGUAGE = "scriptLanguage";
     public static final String CONFIG_TO_ITEM_SCRIPT = "toItemScript";
     public static final String CONFIG_TO_HANDLER_SCRIPT = "toHandlerScript";
 
@@ -54,14 +53,15 @@ public class ScriptProfile implements StateProfile {
     private final List<Class<? extends Command>> acceptedCommandTypes;
     private final List<Class<? extends Command>> handlerAcceptedCommandTypes;
 
-    private final String scriptLanguage;
     private final String toItemScript;
     private final String toHandlerScript;
+    private final ProfileTypeUID profileTypeUID;
 
     private final boolean isConfigured;
 
-    public ScriptProfile(ProfileCallback callback, ProfileContext profileContext,
+    public ScriptProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext profileContext,
             TransformationService transformationService) {
+        this.profileTypeUID = profileTypeUID;
         this.callback = callback;
         this.transformationService = transformationService;
 
@@ -69,18 +69,10 @@ public class ScriptProfile implements StateProfile {
         this.acceptedDataTypes = profileContext.getAcceptedDataTypes();
         this.handlerAcceptedCommandTypes = profileContext.getHandlerAcceptedCommandTypes();
 
-        this.scriptLanguage = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_SCRIPT_LANGUAGE),
-                String.class, "");
         this.toItemScript = ConfigParser.valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_ITEM_SCRIPT),
                 String.class, "");
         this.toHandlerScript = ConfigParser
                 .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_HANDLER_SCRIPT), String.class, "");
-
-        if (scriptLanguage.isBlank()) {
-            logger.error("Script language is not defined. Profile will discard all states and commands.");
-            isConfigured = false;
-            return;
-        }
 
         if (toItemScript.isBlank() && toHandlerScript.isBlank()) {
             logger.error(
@@ -94,7 +86,7 @@ public class ScriptProfile implements StateProfile {
 
     @Override
     public ProfileTypeUID getProfileTypeUID() {
-        return ScriptProfileFactory.SCRIPT_PROFILE_UID;
+        return profileTypeUID;
     }
 
     @Override
@@ -149,7 +141,7 @@ public class ScriptProfile implements StateProfile {
     private @Nullable String executeScript(String script, Type input) {
         if (!script.isBlank()) {
             try {
-                return transformationService.transform(scriptLanguage + ":" + script, input.toFullString());
+                return transformationService.transform(script, input.toFullString());
             } catch (TransformationException e) {
                 if (e.getCause() instanceof ScriptException) {
                     logger.error("Failed to process script '{}': {}", script, e.getCause().getMessage());

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -14,14 +14,13 @@ package org.openhab.core.automation.module.script.profile;
 
 import java.util.Collection;
 import java.util.Locale;
-import java.util.Optional;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.ScriptTransformationService;
-import org.openhab.core.automation.module.script.ScriptTransformationServiceFactory;
 import org.openhab.core.thing.profiles.Profile;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
@@ -31,11 +30,10 @@ import org.openhab.core.thing.profiles.ProfileTypeBuilder;
 import org.openhab.core.thing.profiles.ProfileTypeProvider;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
 import org.openhab.core.transform.TransformationService;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * The {@link ScriptProfileFactory} creates {@link ScriptProfile} instances
@@ -45,27 +43,21 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(service = { ProfileFactory.class, ProfileTypeProvider.class })
 public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
-    private final Logger logger = LoggerFactory.getLogger(ScriptProfileFactory.class);
+    public static final String PROFILE_CONFIG_URI_PREFIX = "profile:transform:";
 
-    private final ScriptTransformationServiceFactory scriptTransformationFactory;
-
-    @Activate
-    public ScriptProfileFactory(final @Reference ScriptTransformationServiceFactory scriptTransformationFactory) {
-        this.scriptTransformationFactory = scriptTransformationFactory;
-    }
+    private final Map<String, ServiceRecord> services = new ConcurrentHashMap<>();
 
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
         String scriptType = profileTypeUID.getId().toLowerCase();
-        ScriptTransformationService transformationService = scriptTransformationFactory
-                .getTransformationService(scriptType);
+        ScriptTransformationService transformationService = services.get(scriptType).service();
         return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
     }
 
     @Override
     public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
-        return getScriptTypes()
+        return services.keySet().stream()
                 .map(type -> new ProfileTypeUID(TransformationService.TRANSFORM_PROFILE_SCOPE, type.toUpperCase()))
                 .toList();
     }
@@ -74,13 +66,23 @@ public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider
     public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
         return getSupportedProfileTypeUIDs().stream().map(uid -> {
             String id = uid.getId();
-            String label = Optional.ofNullable(scriptTransformationFactory.getLanguageName(id.toLowerCase()))
-                    .map(name -> id + " - " + name).orElse(id);
+            String label = services.get(id).serviceLabel();
             return ProfileTypeBuilder.newState(uid, label).build();
         }).collect(Collectors.toList());
     }
 
-    private Stream<String> getScriptTypes() {
-        return scriptTransformationFactory.getScriptTypes();
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    public void bindScriptTransformationService(ScriptTransformationService service, Map<String, Object> properties) {
+        String serviceId = (String) properties.get(TransformationService.SERVICE_PROPERTY_NAME);
+        String serviceName = (String) properties.get(TransformationService.SERVICE_PROPERTY_LABEL);
+        services.put(serviceId, new ServiceRecord(service, serviceName));
+    }
+
+    public void unbindScriptTransformationService(ScriptTransformationService service, Map<String, Object> properties) {
+        String serviceId = (String) properties.get(TransformationService.SERVICE_PROPERTY_NAME);
+        services.remove(serviceId);
+    }
+
+    private record ServiceRecord(ScriptTransformationService service, String serviceLabel) {
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -12,13 +12,24 @@
  */
 package org.openhab.core.automation.module.script.profile;
 
+import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.ScriptTransformationService;
+import org.openhab.core.automation.module.script.ScriptTransformationServiceFactory;
+import org.openhab.core.config.core.ConfigDescription;
+import org.openhab.core.config.core.ConfigDescriptionBuilder;
+import org.openhab.core.config.core.ConfigDescriptionProvider;
+import org.openhab.core.config.core.ConfigDescriptionRegistry;
+import org.openhab.core.config.core.ConfigOptionProvider;
+import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.thing.profiles.Profile;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
@@ -27,6 +38,7 @@ import org.openhab.core.thing.profiles.ProfileType;
 import org.openhab.core.thing.profiles.ProfileTypeBuilder;
 import org.openhab.core.thing.profiles.ProfileTypeProvider;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.transform.TransformationRegistry;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -37,39 +49,116 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Jan N. Klug - Initial contribution
  */
-@Component(service = { ScriptProfileFactory.class, ProfileFactory.class, ProfileTypeProvider.class })
+@Component(service = { ScriptProfileFactory.class, ProfileFactory.class, ProfileTypeProvider.class,
+        ConfigDescriptionProvider.class, ConfigOptionProvider.class })
 @NonNullByDefault
-public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
+public class ScriptProfileFactory
+        implements ProfileFactory, ProfileTypeProvider, ConfigOptionProvider, ConfigDescriptionProvider {
+    public static final String PROFILE_CONFIG_URI_PREFIX = "profile:transform:";
+    private static final URI CONFIG_DESCRIPTION_TEMPLATE_URI = URI.create(PROFILE_CONFIG_URI_PREFIX + "SCRIPT");
 
-    public static final ProfileTypeUID SCRIPT_PROFILE_UID = new ProfileTypeUID(
-            TransformationService.TRANSFORM_PROFILE_SCOPE, "SCRIPT");
-
-    private static final ProfileType PROFILE_TYPE_SCRIPT = ProfileTypeBuilder.newState(SCRIPT_PROFILE_UID, "Script")
-            .build();
-
-    private final ScriptTransformationService transformationService;
+    private final TransformationRegistry transformationRegistry;
+    private final ScriptTransformationServiceFactory scriptTransformationFactory;
+    private final ConfigDescriptionRegistry configDescRegistry;
 
     @Activate
-    public ScriptProfileFactory(final @Reference ScriptTransformationService transformationService) {
-        this.transformationService = transformationService;
+    public ScriptProfileFactory(final @Reference ScriptTransformationServiceFactory scriptTransformationFactory,
+            final @Reference ConfigDescriptionRegistry configDescRegistry,
+            final @Reference TransformationRegistry transformationRegistry) {
+        this.transformationRegistry = transformationRegistry;
+        this.scriptTransformationFactory = scriptTransformationFactory;
+        this.configDescRegistry = configDescRegistry;
     }
 
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
-        if (SCRIPT_PROFILE_UID.equals(profileTypeUID)) {
-            return new ScriptProfile(callback, profileContext, transformationService);
+
+        if (getSupportedProfileTypeUIDs().contains(profileTypeUID)) {
+            String scriptType = profileTypeUID.getId().toLowerCase();
+            ScriptTransformationService transformationService = scriptTransformationFactory
+                    .getTransformationService(scriptType);
+            return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
         }
         return null;
     }
 
     @Override
     public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
-        return Set.of(SCRIPT_PROFILE_UID);
+        return scriptTransformationFactory.getScriptTypes().stream()
+                .map(type -> new ProfileTypeUID(TransformationService.TRANSFORM_PROFILE_SCOPE, type.toUpperCase()))
+                .toList();
     }
 
     @Override
     public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
-        return Set.of(PROFILE_TYPE_SCRIPT);
+        return getSupportedProfileTypeUIDs().stream().map(uid -> ProfileTypeBuilder.newState(uid, uid.getId()).build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
+        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
+        if (template == null) {
+            return Collections.emptyList();
+        }
+
+        return scriptTransformationFactory.getScriptTypes().stream()
+                .map(type -> ConfigDescriptionBuilder.create(URI.create(PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()))
+                        .withParameters(template.getParameters()).withParameterGroups(template.getParameterGroups())
+                        .build())
+                .toList();
+    }
+
+    private Stream<String> getProfileConfigURIs() {
+        return scriptTransformationFactory.getScriptTypes().stream()
+                .map(type -> PROFILE_CONFIG_URI_PREFIX + type.toUpperCase());
+    }
+
+    /**
+     * Provides a {@link ConfigDescription} for the given URI.
+     *
+     * @param uri uri of the config description
+     * @param locale locale
+     * @return config description or null if no config description could be found
+     */
+    @Override
+    public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
+
+        if (getProfileConfigURIs()
+                .noneMatch(script_transformation_uri -> script_transformation_uri.equals(uri.toString()))) {
+            return null;
+        }
+
+        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
+        if (template == null) {
+            return null;
+        }
+        return ConfigDescriptionBuilder.create(uri).withParameters(template.getParameters())
+                .withParameterGroups(template.getParameterGroups()).build();
+    }
+
+    @Override
+    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
+            @Nullable Locale locale) {
+        if (getProfileConfigURIs()
+                .noneMatch(script_transformation_uri -> script_transformation_uri.equals(uri.toString()))) {
+            return null;
+        }
+
+        String[] uri_parts = uri.toString().split(":");
+        if (uri_parts.length == 0) {
+            return null;
+        }
+
+        String scriptType = uri_parts[uri_parts.length - 1].toLowerCase();
+
+        if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param) || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)) {
+            Collection<String> scriptTypes = scriptType.equals("dsl") ? List.of(scriptType, "rules")
+                    : List.of(scriptType);
+            return transformationRegistry.getTransformations(scriptTypes).stream()
+                    .map(c -> new ParameterOption(c.getUID(), c.getLabel())).collect(Collectors.toList());
+        }
+        return null;
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -12,12 +12,9 @@
  */
 package org.openhab.core.automation.module.script.profile;
 
-import java.net.URI;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,12 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.ScriptTransformationService;
 import org.openhab.core.automation.module.script.ScriptTransformationServiceFactory;
-import org.openhab.core.config.core.ConfigDescription;
-import org.openhab.core.config.core.ConfigDescriptionBuilder;
-import org.openhab.core.config.core.ConfigDescriptionProvider;
-import org.openhab.core.config.core.ConfigDescriptionRegistry;
-import org.openhab.core.config.core.ConfigOptionProvider;
-import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.thing.profiles.Profile;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
@@ -39,52 +30,37 @@ import org.openhab.core.thing.profiles.ProfileType;
 import org.openhab.core.thing.profiles.ProfileTypeBuilder;
 import org.openhab.core.thing.profiles.ProfileTypeProvider;
 import org.openhab.core.thing.profiles.ProfileTypeUID;
-import org.openhab.core.transform.TransformationRegistry;
 import org.openhab.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link ScriptProfileFactory} creates {@link ScriptProfile} instances
  *
  * @author Jan N. Klug - Initial contribution
  */
-@Component(service = { ScriptProfileFactory.class, ProfileFactory.class, ProfileTypeProvider.class,
-        ConfigDescriptionProvider.class, ConfigOptionProvider.class })
 @NonNullByDefault
-public class ScriptProfileFactory
-        implements ProfileFactory, ProfileTypeProvider, ConfigOptionProvider, ConfigDescriptionProvider {
-    public static final String PROFILE_CONFIG_URI_PREFIX = "profile:transform:";
-    private static final URI CONFIG_DESCRIPTION_TEMPLATE_URI = URI.create(PROFILE_CONFIG_URI_PREFIX + "SCRIPT");
+@Component(service = { ProfileFactory.class, ProfileTypeProvider.class })
+public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider {
+    private final Logger logger = LoggerFactory.getLogger(ScriptProfileFactory.class);
 
-    private final TransformationRegistry transformationRegistry;
     private final ScriptTransformationServiceFactory scriptTransformationFactory;
-    private final ConfigDescriptionRegistry configDescRegistry;
 
     @Activate
-    public ScriptProfileFactory(final @Reference ScriptTransformationServiceFactory scriptTransformationFactory,
-            final @Reference ConfigDescriptionRegistry configDescRegistry,
-            final @Reference TransformationRegistry transformationRegistry) {
-        this.transformationRegistry = transformationRegistry;
+    public ScriptProfileFactory(final @Reference ScriptTransformationServiceFactory scriptTransformationFactory) {
         this.scriptTransformationFactory = scriptTransformationFactory;
-        this.configDescRegistry = configDescRegistry;
     }
 
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
-        if (!profileTypeUID.getScope().equals(TransformationService.TRANSFORM_PROFILE_SCOPE)) {
-            return null;
-        }
-
-        if (getSupportedProfileTypeUIDs().contains(profileTypeUID)) {
-            String scriptType = profileTypeUID.getId().toLowerCase();
-            ScriptTransformationService transformationService = scriptTransformationFactory
-                    .getTransformationService(scriptType);
-            return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
-        }
-        return null;
+        String scriptType = profileTypeUID.getId().toLowerCase();
+        ScriptTransformationService transformationService = scriptTransformationFactory
+                .getTransformationService(scriptType);
+        return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
     }
 
     @Override
@@ -96,73 +72,15 @@ public class ScriptProfileFactory
 
     @Override
     public Collection<ProfileType> getProfileTypes(@Nullable Locale locale) {
-        return getSupportedProfileTypeUIDs().stream().map(uid -> ProfileTypeBuilder.newState(uid, uid.getId()).build())
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public Collection<ConfigDescription> getConfigDescriptions(@Nullable Locale locale) {
-        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
-        if (template == null) {
-            return Collections.emptyList();
-        }
-
-        return getScriptTypes().map(type -> ConfigDescriptionBuilder
-                .create(URI.create(PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()))
-                .withParameters(template.getParameters()).withParameterGroups(template.getParameterGroups()).build())
-                .toList();
+        return getSupportedProfileTypeUIDs().stream().map(uid -> {
+            String id = uid.getId();
+            String label = Optional.ofNullable(scriptTransformationFactory.getLanguageName(id.toLowerCase()))
+                    .map(name -> id + " - " + name).orElse(id);
+            return ProfileTypeBuilder.newState(uid, label).build();
+        }).collect(Collectors.toList());
     }
 
     private Stream<String> getScriptTypes() {
-        return scriptTransformationFactory.getScriptTypes().stream();
-    }
-
-    private Set<String> getProfileConfigURIs() {
-        return getScriptTypes().map(type -> PROFILE_CONFIG_URI_PREFIX + type.toUpperCase()).collect(Collectors.toSet());
-    }
-
-    /**
-     * Provides a {@link ConfigDescription} for the given URI.
-     *
-     * @param uri uri of the config description
-     * @param locale locale
-     * @return config description or null if no config description could be found
-     */
-    @Override
-    public @Nullable ConfigDescription getConfigDescription(URI uri, @Nullable Locale locale) {
-        String uriString = uri.toString();
-        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX) || !getProfileConfigURIs().contains(uriString)) {
-            return null;
-        }
-
-        ConfigDescription template = configDescRegistry.getConfigDescription(CONFIG_DESCRIPTION_TEMPLATE_URI, locale);
-        if (template == null) {
-            return null;
-        }
-        return ConfigDescriptionBuilder.create(uri).withParameters(template.getParameters())
-                .withParameterGroups(template.getParameterGroups()).build();
-    }
-
-    @Override
-    public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
-            @Nullable Locale locale) {
-        String uriString = uri.toString();
-        if (!uriString.startsWith(PROFILE_CONFIG_URI_PREFIX) || !getProfileConfigURIs().contains(uriString)) {
-            return null;
-        }
-
-        String[] uri_parts = uri.toString().split(":");
-        if (uri_parts.length == 0) {
-            return null;
-        }
-
-        String scriptType = uri_parts[uri_parts.length - 1].toLowerCase();
-
-        if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param) || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)) {
-            var scriptTypes = scriptType.equals("dsl") ? List.of(scriptType, "rules") : List.of(scriptType);
-            return transformationRegistry.getTransformations(scriptTypes).stream()
-                    .map(c -> new ParameterOption(c.getUID(), c.getLabel())).collect(Collectors.toList());
-        }
-        return null;
+        return scriptTransformationFactory.getScriptTypes();
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -50,16 +50,15 @@ public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider
     @Override
     public @Nullable Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback,
             ProfileContext profileContext) {
-        String scriptType = profileTypeUID.getId().toLowerCase();
-        ScriptTransformationService transformationService = services.get(scriptType).service();
+        String serviceId = profileTypeUID.getId();
+        ScriptTransformationService transformationService = services.get(serviceId).service();
         return new ScriptProfile(profileTypeUID, callback, profileContext, transformationService);
     }
 
     @Override
     public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
         return services.keySet().stream()
-                .map(type -> new ProfileTypeUID(TransformationService.TRANSFORM_PROFILE_SCOPE, type.toUpperCase()))
-                .toList();
+                .map(id -> new ProfileTypeUID(TransformationService.TRANSFORM_PROFILE_SCOPE, id)).toList();
     }
 
     @Override

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -73,8 +73,8 @@ public class ScriptProfileFactory implements ProfileFactory, ProfileTypeProvider
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     public void bindScriptTransformationService(ScriptTransformationService service, Map<String, Object> properties) {
         String serviceId = (String) properties.get(TransformationService.SERVICE_PROPERTY_NAME);
-        String serviceName = (String) properties.get(TransformationService.SERVICE_PROPERTY_LABEL);
-        services.put(serviceId, new ServiceRecord(service, serviceName));
+        String serviceLabel = (String) properties.get(TransformationService.SERVICE_PROPERTY_LABEL);
+        services.put(serviceId, new ServiceRecord(service, serviceLabel));
     }
 
     public void unbindScriptTransformationService(ScriptTransformationService service, Map<String, Object> properties) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -5,10 +5,6 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="profile:transform:SCRIPT">
-		<parameter name="scriptLanguage" type="text" required="true">
-			<label>Script Language</label>
-			<description>MIME-type ("application/vnd.openhab.dsl.rule") of the scripting language</description>
-		</parameter>
 		<parameter name="toItemScript" type="text">
 			<label>Thing To Item Transformation</label>
 			<description>The Script for transforming state updates and commands from the Thing handler to the item. The script

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,4 +1,4 @@
-profile.system.script.toItemScript.label = To Item Script
-profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
-profile.system.script.toHandlerScript.label = To Handler Script
-profile.system.script.toHandlerScript.description = The Script for transforming states and commands from item to handler.
+profile.system.script.toItemScript.label = Thing To Item Transformation
+profile.system.script.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.
+profile.system.script.toHandlerScript.label = Item To Thing Transformation
+profile.system.script.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,6 +1,4 @@
-profile.system.script.scriptLanguage.label = Script Language
-profile.system.script.scriptLanguage.description = MIME-type ("application/vnd.openhab.dsl.rule") of the scripting language
-profile.system.script.toItemScript.label = Thing To Item Transformation
-profile.system.script.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.
-profile.system.script.toHandlerScript.label = Item To Thing Transformation
-profile.system.script.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.system.script.toItemScript.label = To Item Script
+profile.system.script.toItemScript.description = The Script for transforming states and commands from handler to item.
+profile.system.script.toHandlerScript.label = To Handler Script
+profile.system.script.toHandlerScript.description = The Script for transforming states and commands from item to handler.

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_da.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_da.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = Script-sprog
-profile.system.script.scriptLanguage.description = MIME-type ("application/vnd.openhab.dsl.rule") for script-sproget
 profile.system.script.toItemScript.label = Til item-script
 profile.system.script.toItemScript.description = Scriptet til at transformere tilstande og kommandoer fra handler til item.
 profile.system.script.toHandlerScript.label = Til handler-script

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_de.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_de.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = Skriptsprache
-profile.system.script.scriptLanguage.description = MIME-Typ ("application/vnd.openhab.dsl.rule") der Skriptsprache.
 profile.system.script.toItemScript.label = Transformation Thing -> Item
 profile.system.script.toItemScript.description = Das Skript für die Transformtion von States und Commands vom Thing zum Item.
 profile.system.script.toHandlerScript.label = Transformation Item -> Thing

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_fi.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_fi.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = Skriptin kieli
-profile.system.script.scriptLanguage.description = Skriptin kielen MIME-tyyppi ("application/vnd.openhab.dsl.rule")
 profile.system.script.toItemScript.label = Item-skriptiksi
 profile.system.script.toItemScript.description = Skripti, jota käytetään tilojen ja komentojen muuntoon käsittelijästä itemiksi.
 profile.system.script.toHandlerScript.label = Käsittelijäskriptiksi

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_he.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_he.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = שפת תסריט
-profile.system.script.scriptLanguage.description = סוג MIME ("application/vnd.openhab.dsl.rule") של שפת הסקריפט
 profile.system.script.toItemScript.label = המרת Thing לפריט
 profile.system.script.toItemScript.description = הסקריפט להפיכת עדכוני מצב ופקודות מהמטפל ב-Thing לפריט. הסקריפט עשוי לחזור null כדי למחוק את העדכונים/פקודות ולא להעביר אותם.
 profile.system.script.toHandlerScript.label = שינוי פריט ל-thing

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_it.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_it.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = Linguaggio Script
-profile.system.script.scriptLanguage.description = Tipo MIME ("application/vnd.openhab.dsl.rule") del linguaggio di scripting
 profile.system.script.toItemScript.label = Trasformazione da Thing a Item
 profile.system.script.toItemScript.description = Lo script per trasformare gli aggiornamenti dello stato e i comandi dal gestore Thing all'Item. Lo script può restituire null per scartare gli aggiornamenti/comandi e non passarli.
 profile.system.script.toHandlerScript.label = Trasformazione da Item a Thing

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_pl.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile_pl.properties
@@ -1,5 +1,3 @@
-profile.system.script.scriptLanguage.label = Język Skryptu
-profile.system.script.scriptLanguage.description = MIME-Typ języka skryptu ("application/vnd.openhab.dsl.rule")
 profile.system.script.toItemScript.label = Skrypt transformacji z kanału do elementu
 profile.system.script.toItemScript.description = Skrypt do transformacji stanu lub wartości z kanału do elementu. Skrypt może zwrócić stan lub wartość *null* aby pominąć transformację i nie przekazać jej do elementu.
 profile.system.script.toHandlerScript.label = Skrypt transformacji z elementu do kanału

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -40,7 +40,6 @@ import org.mockito.quality.Strictness;
 import org.openhab.core.transform.Transformation;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationRegistry;
-import org.openhab.core.transform.TransformationService;
 
 /**
  * The {@link ScriptTransformationServiceTest} holds tests for the {@link ScriptTransformationService}
@@ -51,7 +50,7 @@ import org.openhab.core.transform.TransformationService;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ScriptTransformationServiceTest {
-    private static final String SCRIPT_LANGUAGE = "customdsl";
+    private static final String SCRIPT_LANGUAGE = "customDsl";
     private static final String SCRIPT_UID = "scriptUid." + SCRIPT_LANGUAGE;
     private static final String INVALID_SCRIPT_UID = "invalidScriptUid";
 
@@ -76,7 +75,7 @@ public class ScriptTransformationServiceTest {
     @BeforeEach
     public void setUp() throws ScriptException {
         Map<String, Object> properties = new HashMap<>();
-        properties.put(TransformationService.SERVICE_PROPERTY_NAME, SCRIPT_LANGUAGE);
+        properties.put(ScriptTransformationService.SCRIPT_TYPE_PROPERTY_NAME, SCRIPT_LANGUAGE);
         service = new ScriptTransformationService(transformationRegistry, scriptEngineManager, properties);
 
         when(scriptEngineManager.createScriptEngine(eq(SCRIPT_LANGUAGE), any())).thenReturn(scriptEngineContainer);

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -39,6 +40,7 @@ import org.mockito.quality.Strictness;
 import org.openhab.core.transform.Transformation;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationRegistry;
+import org.openhab.core.transform.TransformationService;
 
 /**
  * The {@link ScriptTransformationServiceTest} holds tests for the {@link ScriptTransformationService}
@@ -49,7 +51,7 @@ import org.openhab.core.transform.TransformationRegistry;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ScriptTransformationServiceTest {
-    private static final String SCRIPT_LANGUAGE = "customDsl";
+    private static final String SCRIPT_LANGUAGE = "customdsl";
     private static final String SCRIPT_UID = "scriptUid." + SCRIPT_LANGUAGE;
     private static final String INVALID_SCRIPT_UID = "invalidScriptUid";
 
@@ -73,7 +75,9 @@ public class ScriptTransformationServiceTest {
 
     @BeforeEach
     public void setUp() throws ScriptException {
-        service = new ScriptTransformationService(SCRIPT_LANGUAGE, transformationRegistry, scriptEngineManager);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(TransformationService.SERVICE_PROPERTY_NAME, SCRIPT_LANGUAGE);
+        service = new ScriptTransformationService(transformationRegistry, scriptEngineManager, properties);
 
         when(scriptEngineManager.createScriptEngine(eq(SCRIPT_LANGUAGE), any())).thenReturn(scriptEngineContainer);
         when(scriptEngineManager.isSupported(anyString()))

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.transform.Transformation;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationRegistry;
@@ -76,7 +77,8 @@ public class ScriptTransformationServiceTest {
     public void setUp() throws ScriptException {
         Map<String, Object> properties = new HashMap<>();
         properties.put(ScriptTransformationService.SCRIPT_TYPE_PROPERTY_NAME, SCRIPT_LANGUAGE);
-        service = new ScriptTransformationService(transformationRegistry, scriptEngineManager, properties);
+        service = new ScriptTransformationService(transformationRegistry, mock(ConfigDescriptionRegistry.class),
+                scriptEngineManager, properties);
 
         when(scriptEngineManager.createScriptEngine(eq(SCRIPT_LANGUAGE), any())).thenReturn(scriptEngineContainer);
         when(scriptEngineManager.isSupported(anyString()))

--- a/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
+++ b/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
@@ -117,8 +117,9 @@ public class TransformationResource implements RESTResource {
         try {
             Collection<ServiceReference<TransformationService>> refs = bundleContext
                     .getServiceReferences(TransformationService.class, null);
-            Stream<String> services = refs.stream().map(ref -> (String) ref.getProperty("openhab.transform"))
-                    .filter(Objects::nonNull).map(Objects::requireNonNull);
+            Stream<String> services = refs.stream()
+                    .map(ref -> (String) ref.getProperty(TransformationService.SERVICE_PROPERTY_NAME))
+                    .filter(Objects::nonNull).map(Objects::requireNonNull).sorted();
             return Response.ok(new Stream2JSONInputStream(services)).build();
         } catch (InvalidSyntaxException e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
@@ -61,7 +61,7 @@ public class TransformationHelper {
     public static @Nullable TransformationService getTransformationService(@Nullable BundleContext context,
             String transformationType) {
         if (context != null) {
-            String filter = "(openhab.transform=" + transformationType + ")";
+            String filter = "(" + TransformationService.SERVICE_PROPERTY_NAME + "=" + transformationType + ")";
             try {
                 Collection<ServiceReference<TransformationService>> refs = context
                         .getServiceReferences(TransformationService.class, filter);

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface TransformationService {
 
+    public static final String SERVICE_PROPERTY_NAME = "openhab.transform";
     public static final String TRANSFORM_FOLDER_NAME = "transform";
     public static final String TRANSFORM_PROFILE_SCOPE = "transform";
 

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
@@ -32,9 +32,10 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface TransformationService {
 
-    public static final String SERVICE_PROPERTY_NAME = "openhab.transform";
-    public static final String TRANSFORM_FOLDER_NAME = "transform";
-    public static final String TRANSFORM_PROFILE_SCOPE = "transform";
+    String SERVICE_PROPERTY_NAME = "openhab.transform";
+    String SERVICE_PROPERTY_LABEL = "openhab.transform.label";
+    String TRANSFORM_FOLDER_NAME = "transform";
+    String TRANSFORM_PROFILE_SCOPE = "transform";
 
     /**
      * Transforms the input <code>source</code> by means of the given <code>function</code> and returns the transformed

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
@@ -32,10 +32,10 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface TransformationService {
 
-    String SERVICE_PROPERTY_NAME = "openhab.transform";
-    String SERVICE_PROPERTY_LABEL = "openhab.transform.label";
-    String TRANSFORM_FOLDER_NAME = "transform";
-    String TRANSFORM_PROFILE_SCOPE = "transform";
+    public static final String SERVICE_PROPERTY_NAME = "openhab.transform";
+    public static final String SERVICE_PROPERTY_LABEL = "openhab.transform.label";
+    public static final String TRANSFORM_FOLDER_NAME = "transform";
+    public static final String TRANSFORM_PROFILE_SCOPE = "transform";
 
     /**
      * Transforms the input <code>source</code> by means of the given <code>function</code> and returns the transformed

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
@@ -32,10 +32,10 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface TransformationService {
 
-    public static final String SERVICE_PROPERTY_NAME = "openhab.transform";
-    public static final String SERVICE_PROPERTY_LABEL = "openhab.transform.label";
-    public static final String TRANSFORM_FOLDER_NAME = "transform";
-    public static final String TRANSFORM_PROFILE_SCOPE = "transform";
+    String SERVICE_PROPERTY_NAME = "openhab.transform";
+    String SERVICE_PROPERTY_LABEL = "openhab.transform.label";
+    String TRANSFORM_FOLDER_NAME = "transform";
+    String TRANSFORM_PROFILE_SCOPE = "transform";
 
     /**
      * Transforms the input <code>source</code> by means of the given <code>function</code> and returns the transformed


### PR DESCRIPTION
See previous discussions in #3465 and #3476
Resolve #3465
Potentially fix #3521

Documentation: https://github.com/openhab/openhab-docs/pull/2042
Breaking change notice: https://github.com/openhab/openhab-distro/pull/1514

Why? 
- A simpler syntax for file-based transformations, reduces potential errors
- Transformation script files will have their own proper extension that corresponds to its actual language, e.g. .js, .rb, .py, etc. This is a much more elegant way than using .script which is very confusing especially when utilising multiple languages.
- Simplified UI when choosing script based profile transformations. Users only need to select the language when _creating_ the transformation, and not having to choose the language again each and every time they need to _use_ the transformation. This saves a tremendous amount of effort when dealing with many item-to-channel links.
- Removes the potential language mismatch that was previously possible especially through the UI
- The UI will only show the transformations in the relevant language chosen, unlike previously where there was no way to identify the actual language of a .script transformation file.
- Continued support / backwards compatibility, JS() transformation will continue to work in openHAB 4.0

`SCRIPT` transformation itself is removed completely.
Instead, it creates the transformation for whatever language is registered in the system: 
- DSL
- JS
- RB
- GROOVY
- PY

It will only show the ones that are actually installed. Here, I have Ruby, Jython and JS Scripting installed and Groovy not installed, so GROOVY is not showing up on the list

<img width="436" alt="image" src="https://user-images.githubusercontent.com/2554958/227766413-2100a2e2-2dd5-4d9a-b447-8969a4ce57eb.png">

Also note that it only shows the scripts for the selected language. Above shows only Ruby scripts, and below, only JS scripts:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/2554958/227766449-6a7b77b0-9c30-416c-8e07-2d8d80f6c1ca.png">

The profile URI for Ruby transformation is `profile:transform:RB` which corresponds to the .rb extension
The profile URI for JS transformation is `profile:transform:JS` which corresponds to the .js extension
... and so on.

Furthermore, the configuration options can also be localised, although I can't seem to get anything (including MAP, REGEX, etc) to show any language other than English on my system, even after changing my language regional setting in openhab.

It should be compatible with the old JS transformation too. Here's my sitemap:
```
		Switch item=Black_Alert label="Black Alert [JS(bro.js):%s]"
```
bro.js:
```
(function (i) {
  return i + " Bro!";
})(input)
```

<img width="516" alt="image" src="https://user-images.githubusercontent.com/2554958/227766740-85fb5b48-5c18-4cee-80a4-9e2ed003ef78.png">

Even inline JS transformation works like it used to:

```
		Switch item=Black_Alert label="Black Alert [JS(| input + \" - Inline Bro!\"):%s]"
```


And now Ruby inline transformation works too:

```
		Switch item=Black_Alert label="Black Alert [RB(| \" #{input} - Ruby Inline Bro!\"):%s]"
```

And here's the result of the REST `rest/transformation/services`

```
[
  "JSONPATH",
  "REGEX",
  "MAP",
  "DSL",
  "RB",
  "JS",
  "PY"
]
```

And the result of `rest/profile-types` (with other profile entries removed for brevity)

```
[
  {
    "uid": "transform:RB",
    "label": "RB",
    "kind": "STATE",
    "supportedItemTypes": []
  },
  {
    "uid": "transform:JS",
    "label": "JS",
    "kind": "STATE",
    "supportedItemTypes": []
  },
  {
    "uid": "transform:PY",
    "label": "PY",
    "kind": "STATE",
    "supportedItemTypes": []
  },
  {
    "uid": "transform:DSL",
    "label": "DSL",
    "kind": "STATE",
    "supportedItemTypes": []
  }
]
```


