### PR TITLE
[modbus] Fix error handling with DNS resolution / Unknown host errors

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusConnectionPool.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusConnectionPool.java
@@ -30,14 +30,15 @@ import net.wimpi.modbus.net.ModbusSlaveConnection;
  *
  */
 @NonNullByDefault
-public class ModbusConnectionPool extends GenericKeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> {
+public class ModbusConnectionPool extends GenericKeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> {
 
-    public ModbusConnectionPool(KeyedPooledObjectFactory<ModbusSlaveEndpoint, ModbusSlaveConnection> factory) {
+    public ModbusConnectionPool(
+            KeyedPooledObjectFactory<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> factory) {
         super(factory, new ModbusPoolConfig());
     }
 
     @Override
-    public void setConfig(@Nullable GenericKeyedObjectPoolConfig<ModbusSlaveConnection> conf) {
+    public void setConfig(@Nullable GenericKeyedObjectPoolConfig<@Nullable ModbusSlaveConnection> conf) {
         if (conf == null) {
             return;
         } else if (!(conf instanceof ModbusPoolConfig)) {

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -347,7 +347,7 @@ public class ModbusManagerImpl implements ModbusManager {
      * - https://community.openhab.org/t/connection-pooling-in-modbus-binding/5246/
      */
 
-    private volatile @Nullable KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> connectionPool;
+    private volatile @Nullable KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> connectionPool;
     private volatile @Nullable ModbusSlaveConnectionFactoryImpl connectionFactory;
     private volatile Map<PollTask, ScheduledFuture<?>> scheduledPollTasks = new ConcurrentHashMap<>();
     /**
@@ -360,7 +360,7 @@ public class ModbusManagerImpl implements ModbusManager {
     private void constructConnectionPool() {
         ModbusSlaveConnectionFactoryImpl connectionFactory = new ModbusSlaveConnectionFactoryImpl(
                 DEFAULT_POOL_CONFIGURATION);
-        GenericKeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> genericKeyedObjectPool = new ModbusConnectionPool(
+        GenericKeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> genericKeyedObjectPool = new ModbusConnectionPool(
                 connectionFactory);
         genericKeyedObjectPool.setSwallowedExceptionListener(new SwallowedExceptionListener() {
 
@@ -379,7 +379,7 @@ public class ModbusManagerImpl implements ModbusManager {
 
     private Optional<ModbusSlaveConnection> borrowConnection(ModbusSlaveEndpoint endpoint) {
         Optional<ModbusSlaveConnection> connection = Optional.empty();
-        KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> pool = connectionPool;
+        KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> pool = connectionPool;
         if (pool == null) {
             return connection;
         }
@@ -405,7 +405,7 @@ public class ModbusManagerImpl implements ModbusManager {
     }
 
     private void invalidate(ModbusSlaveEndpoint endpoint, Optional<ModbusSlaveConnection> connection) {
-        KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> pool = connectionPool;
+        KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> pool = connectionPool;
         if (pool == null) {
             return;
         }
@@ -423,7 +423,7 @@ public class ModbusManagerImpl implements ModbusManager {
     }
 
     private void returnConnection(ModbusSlaveEndpoint endpoint, Optional<ModbusSlaveConnection> connection) {
-        KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> pool = connectionPool;
+        KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> pool = connectionPool;
         if (pool == null) {
             return;
         }
@@ -454,7 +454,7 @@ public class ModbusManagerImpl implements ModbusManager {
      */
     private <R, C extends ModbusResultCallback, F extends ModbusFailureCallback<R>, T extends TaskWithEndpoint<R, C, F>> Optional<ModbusSlaveConnection> getConnection(
             AggregateStopWatch timer, boolean oneOffTask, @NonNull T task) throws PollTaskUnregistered {
-        KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> connectionPool = this.connectionPool;
+        KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> connectionPool = this.connectionPool;
         if (connectionPool == null) {
             return Optional.empty();
         }
@@ -983,7 +983,7 @@ public class ModbusManagerImpl implements ModbusManager {
     @Deactivate
     protected void deactivate() {
         synchronized (this) {
-            KeyedObjectPool<ModbusSlaveEndpoint, ModbusSlaveConnection> connectionPool = this.connectionPool;
+            KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> connectionPool = this.connectionPool;
             if (connectionPool != null) {
                 for (ModbusCommunicationInterface commInterface : this.communicationInterfaces) {
                     try {

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusPoolConfig.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusPoolConfig.java
@@ -32,7 +32,7 @@ import net.wimpi.modbus.net.ModbusSlaveConnection;
  *
  */
 @NonNullByDefault
-public class ModbusPoolConfig extends GenericKeyedObjectPoolConfig<ModbusSlaveConnection> {
+public class ModbusPoolConfig extends GenericKeyedObjectPoolConfig<@Nullable ModbusSlaveConnection> {
 
     @SuppressWarnings("unused")
     private EvictionPolicy<ModbusSlaveConnection> evictionPolicy = new DefaultEvictionPolicy<>();


### PR DESCRIPTION
Potential fix for unhandled exception, leading to "unrecoverable" error state (openHAB restart needed). See the community post below.

I cannot verify whether this actually fixes the issue as the error is very rare

This would be good candidate for 3.x maintenance branch as well

- Corrected null typing -- apparently IDE was not strict enough to complain
- handle case of ModbusSlaveConnectionFactoryImpl::create returning null ModbusSlaveConnection, leading to activateObject called with PooledObject(null) [NPE was handled], and then leading to validateObject called with PooledObject(null) [was not handled, p.getObject().isConnected() crashes -- probably bad things happened!]

From https://community.openhab.org/t/modbus-binding-problems-with-silently-disconnected-items/139363/28?u=ssalonen

logs from user showing error in `ModbusSlaveConnectionFactoryImpl:create` calling `getInetAddress`. `getInetAddress` fails which leads to `null` connection being `create`d.
```
2023-03-20 21:46:35.356 [WARN ] [ing.ModbusSlaveConnectionFactoryImpl] - KeyedPooledModbusSlaveConnectionFactory: Unknown host: REDACTED.fritz.box: Temporary failure in name resolution. Connection creation failed.
2023-03-20 21:46:35.359 [WARN ] [ing.ModbusSlaveConnectionFactoryImpl] - Error connecting connection null for endpoint ModbusIPSlaveEndpoint [address=REDACTED.fritz.box, port=502]: null
```

followed then by

```
2023-03-21 10:00:02.536 [WARN ] [rt.modbus.internal.ModbusManagerImpl] - Error getting a new connection for endpoint ModbusIPSlaveEndpoint [address=REDACTED.fritz.box, port=502]. Error was: java.lang.InterruptedException null 
2023-03-21 10:00:02.538 [WARN ] [rt.modbus.internal.ModbusManagerImpl] - Could not connect to endpoint ModbusIPSlaveEndpoint [address=REDACTED.fritz.box, port=502] -- aborting request ModbusReadRequestBlueprint [slaveId=1, functionCode=READ_INPUT_REGISTERS, start=8197, length=59, maxTries=3] [operation ID 14e6d99f-c13e-4b7b-8e86-3615c813ca1f]
```