### PR TITLE
Sort profile-type resources by their label

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -13,6 +13,7 @@
 package org.openhab.core.io.rest.core.internal.profile;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -114,7 +115,8 @@ public class ProfileTypeResource implements RESTResource {
     protected Stream<ProfileTypeDTO> getProfileTypes(@Nullable Locale locale, @Nullable String channelTypeUID,
             @Nullable String itemType) {
         return profileTypeRegistry.getProfileTypes(locale).stream().filter(matchesChannelUID(channelTypeUID, locale))
-                .filter(matchesItemType(itemType)).map(profileType -> ProfileTypeDTOMapper.map(profileType));
+                .filter(matchesItemType(itemType)).sorted(Comparator.comparing(ProfileType::getLabel))
+                .map(profileType -> ProfileTypeDTOMapper.map(profileType));
     }
 
     private Predicate<ProfileType> matchesChannelUID(@Nullable String channelTypeUID, @Nullable Locale locale) {


### PR DESCRIPTION
Sort the profile type json result from the REST service. This makes the UI a bit more predictable. Helpful for repetitive operations so your eyes don't go around hunting for the wanted item.

Current:
<img width="477" alt="image" src="https://user-images.githubusercontent.com/2554958/228105043-afe1f77d-c820-45ca-a4f7-f7030f5f7787.png">


Sorted:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/2554958/228105806-34946fe2-9d2e-416d-a641-71a894ccd000.png">
