### PR TITLE
Use try-with-resources on Files.walk/Files.list

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -78,8 +78,12 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     }
 
     private Stream<Path> karFilesStream(Path addonDirectory) throws IOException {
-        return Files.isDirectory(addonDirectory) ? Files.list(addonDirectory).map(Path::getFileName)
-                .filter(path -> path.toString().endsWith(KAR_EXTENSION)) : Stream.empty();
+        if (Files.isDirectory(addonDirectory)) {
+            try (Stream<Path> files = Files.list(addonDirectory)) {
+                return files.map(Path::getFileName).filter(path -> path.toString().endsWith(KAR_EXTENSION));
+            }
+        }
+        return Stream.empty();
     }
 
     private String pathToKarRepoName(Path path) {
@@ -153,8 +157,8 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     private void installFromCache(String addonId) throws MarketplaceHandlerException {
         Path addonPath = getAddonCacheDirectory(addonId);
         if (Files.isDirectory(addonPath)) {
-            try {
-                List<Path> karFiles = Files.list(addonPath).collect(Collectors.toList());
+            try (Stream<Path> files = Files.list(addonPath)) {
+                List<Path> karFiles = files.toList();
                 if (karFiles.size() != 1) {
                     throw new MarketplaceHandlerException(
                             "The local cache folder doesn't contain a single file: " + addonPath, null);
@@ -172,10 +176,10 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     }
 
     private void ensureCachedKarsAreInstalled() {
-        try {
-            if (Files.isDirectory(KAR_CACHE_PATH)) {
-                Files.list(KAR_CACHE_PATH).filter(Files::isDirectory).map(this::addonIdFromPath)
-                        .filter(addonId -> !isInstalled(addonId)).forEach(addonId -> {
+        if (Files.isDirectory(KAR_CACHE_PATH)) {
+            try (Stream<Path> files = Files.list(KAR_CACHE_PATH)) {
+                files.filter(Files::isDirectory).map(this::addonIdFromPath).filter(addonId -> !isInstalled(addonId))
+                        .forEach(addonId -> {
                             logger.info("Reinstalling missing marketplace KAR: {}", addonId);
                             try {
                                 installFromCache(addonId);
@@ -183,9 +187,9 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
                                 logger.warn("Failed reinstalling add-on from cache", e);
                             }
                         });
+            } catch (IOException e) {
+                logger.warn("Failed to re-install KARs: {}", e.getMessage());
             }
-        } catch (IOException e) {
-            logger.warn("Failed to re-install KARs: {}", e.getMessage());
         }
         isReady = true;
     }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
@@ -22,7 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.OpenHAB;
@@ -79,8 +79,8 @@ public abstract class MarketplaceBundleInstaller {
     protected void installFromCache(BundleContext bundleContext, String addonId) throws MarketplaceHandlerException {
         Path addonPath = getAddonCacheDirectory(addonId);
         if (Files.isDirectory(addonPath)) {
-            try {
-                List<Path> bundleFiles = Files.list(addonPath).collect(Collectors.toList());
+            try (Stream<Path> files = Files.list(addonPath)) {
+                List<Path> bundleFiles = files.toList();
                 if (bundleFiles.size() != 1) {
                     throw new MarketplaceHandlerException(
                             "The local cache folder doesn't contain a single file: " + addonPath, null);
@@ -122,8 +122,10 @@ public abstract class MarketplaceBundleInstaller {
         try {
             Path addonPath = getAddonCacheDirectory(addonId);
             if (Files.isDirectory(addonPath)) {
-                for (Path bundleFile : Files.list(addonPath).collect(Collectors.toList())) {
-                    Files.delete(bundleFile);
+                try (Stream<Path> files = Files.list(addonPath)) {
+                    for (Path path : files.toList()) {
+                        Files.delete(path);
+                    }
                 }
             }
             Files.delete(addonPath);
@@ -147,9 +149,9 @@ public abstract class MarketplaceBundleInstaller {
      * @param bundleContext the {@link BundleContext} to use to look up the bundles
      */
     protected void ensureCachedBundlesAreInstalled(BundleContext bundleContext) {
-        try {
-            if (Files.isDirectory(BUNDLE_CACHE_PATH)) {
-                Files.list(BUNDLE_CACHE_PATH).filter(Files::isDirectory).map(this::addonIdFromPath)
+        if (Files.isDirectory(BUNDLE_CACHE_PATH)) {
+            try (Stream<Path> files = Files.list(BUNDLE_CACHE_PATH)) {
+                files.filter(Files::isDirectory).map(this::addonIdFromPath)
                         .filter(addonId -> !isBundleInstalled(bundleContext, addonId)).forEach(addonId -> {
                             logger.info("Reinstalling missing marketplace bundle: {}", addonId);
                             try {
@@ -158,9 +160,10 @@ public abstract class MarketplaceBundleInstaller {
                                 logger.warn("Failed reinstalling add-on from cache", e);
                             }
                         });
+
+            } catch (IOException e) {
+                logger.warn("Failed to re-install bundles: {}", e.getMessage());
             }
-        } catch (IOException e) {
-            logger.warn("Failed to re-install bundles: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/utils/BundledSoundFileHandler.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/utils/BundledSoundFileHandler.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.OpenHAB;
@@ -71,12 +72,10 @@ public class BundledSoundFileHandler implements Closeable {
     public void close() {
         System.setProperty(OpenHAB.CONFIG_DIR_PROG_ARGUMENT, OpenHAB.DEFAULT_CONFIG_FOLDER);
 
-        if (tmpdir != null) {
-            try {
-                Files.walk(tmpdir).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-            } catch (IOException ex) {
-                logger.error("Exception while deleting files", ex);
-            }
+        try (Stream<Path> files = Files.walk(tmpdir)) {
+            files.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        } catch (IOException ex) {
+            logger.error("Exception while deleting files", ex);
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCache.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCache.java
@@ -20,6 +20,7 @@ import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -30,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -112,21 +113,19 @@ public class LRUMediaCache<V> {
     }
 
     private void cleanCacheDirectory() throws IOException {
-        try {
-            List<@Nullable Path> filesInCacheFolder = Files.list(cacheFolder).collect(Collectors.toList());
+        try (Stream<Path> files = Files.list(cacheFolder)) {
+            List<Path> filesInCacheFolder = new ArrayList<>(files.toList());
 
             // 1 delete empty files
-            Iterator<@Nullable Path> fileDeleterIterator = filesInCacheFolder.iterator();
+            Iterator<Path> fileDeleterIterator = filesInCacheFolder.iterator();
             while (fileDeleterIterator.hasNext()) {
                 Path path = fileDeleterIterator.next();
-                if (path != null) {
-                    File file = path.toFile();
-                    if (file.length() == 0) {
-                        file.delete();
-                        String fileName = path.getFileName().toString();
-                        storage.remove(fileName);
-                        fileDeleterIterator.remove();
-                    }
+                File file = path.toFile();
+                if (file.length() == 0) {
+                    file.delete();
+                    String fileName = path.getFileName().toString();
+                    storage.remove(fileName);
+                    fileDeleterIterator.remove();
                 }
             }
 


### PR DESCRIPTION
It is recommended to use try-with-resources when using `File.list` or `Files.walk` to ensure streams are properly closed.