### PR TITLE
Fix AbstractDependencyTracker

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
@@ -79,9 +79,9 @@ public abstract class AbstractScriptDependencyTracker
 
     @Override
     public void processWatchEvent(WatchService.Kind kind, Path path) {
-        File file = path.toFile();
+        File file = libraryPath.resolve(path).toFile();
         if (!file.isHidden() && (kind == DELETE || (file.canRead() && (kind == CREATE || kind == MODIFY)))) {
-            dependencyChanged(file.getPath());
+            dependencyChanged(path.toString());
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
@@ -81,7 +81,7 @@ public abstract class AbstractScriptDependencyTracker
     public void processWatchEvent(WatchService.Kind kind, Path path) {
         File file = libraryPath.resolve(path).toFile();
         if (!file.isHidden() && (kind == DELETE || (file.canRead() && (kind == CREATE || kind == MODIFY)))) {
-            dependencyChanged(path.toString());
+            dependencyChanged(file.toString());
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
@@ -15,6 +15,8 @@ package org.openhab.core.automation.module.script.rulesupport.loader;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -40,15 +43,21 @@ import org.openhab.core.service.WatchService;
 public class AbstractScriptDependencyTrackerTest {
 
     private static final String WATCH_DIR = "test";
+    private static final Path DEPENDENCY = Path.of("depFile");
+    private static final Path DEPENDENCY2 = Path.of("depFile2");
 
     private @NonNullByDefault({}) AbstractScriptDependencyTracker scriptDependencyTracker;
     private @Mock @NonNullByDefault({}) WatchService watchServiceMock;
+    private @NonNullByDefault({}) @TempDir Path rootWatchPath;
 
     @BeforeEach
-    public void setup() {
-        when(watchServiceMock.getWatchPath()).thenReturn(Path.of(""));
+    public void setup() throws IOException {
+        when(watchServiceMock.getWatchPath()).thenReturn(rootWatchPath);
         scriptDependencyTracker = new AbstractScriptDependencyTracker(watchServiceMock, WATCH_DIR) {
         };
+
+        Files.createFile(rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY));
+        Files.createFile(rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY2));
     }
 
     @AfterEach
@@ -58,7 +67,7 @@ public class AbstractScriptDependencyTrackerTest {
 
     @Test
     public void testScriptLibraryWatcherIsCreatedAndActivated() {
-        verify(watchServiceMock).registerListener(eq(scriptDependencyTracker), eq(Path.of(WATCH_DIR)));
+        verify(watchServiceMock).registerListener(eq(scriptDependencyTracker), eq(rootWatchPath.resolve(WATCH_DIR)));
     }
 
     @Test
@@ -69,15 +78,15 @@ public class AbstractScriptDependencyTrackerTest {
     }
 
     @Test
-    public void testDependencyChangeIsForwardedToMultipleListeners() {
+    public void testDependencyChangeIsForwardedToMultipleListeners() throws IOException {
         ScriptDependencyTracker.Listener listener1 = mock(ScriptDependencyTracker.Listener.class);
         ScriptDependencyTracker.Listener listener2 = mock(ScriptDependencyTracker.Listener.class);
 
         scriptDependencyTracker.addChangeTracker(listener1);
         scriptDependencyTracker.addChangeTracker(listener2);
 
-        scriptDependencyTracker.startTracking("scriptId", "depPath");
-        scriptDependencyTracker.dependencyChanged("depPath");
+        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY.toString());
+        scriptDependencyTracker.processWatchEvent(WatchService.Kind.CREATE, DEPENDENCY);
 
         verify(listener1).onDependencyChange(eq("scriptId"));
         verify(listener2).onDependencyChange(eq("scriptId"));
@@ -91,10 +100,9 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId1", "depPath");
-        scriptDependencyTracker.startTracking("scriptId2", "depPath");
-
-        scriptDependencyTracker.dependencyChanged("depPath");
+        scriptDependencyTracker.startTracking("scriptId1", DEPENDENCY.toString());
+        scriptDependencyTracker.startTracking("scriptId2", DEPENDENCY.toString());
+        scriptDependencyTracker.processWatchEvent(WatchService.Kind.MODIFY, DEPENDENCY);
 
         verify(listener).onDependencyChange(eq("scriptId1"));
         verify(listener).onDependencyChange(eq("scriptId2"));
@@ -107,11 +115,10 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId", "depPath1");
-        scriptDependencyTracker.startTracking("scriptId", "depPath2");
-
-        scriptDependencyTracker.dependencyChanged("depPath1");
-        scriptDependencyTracker.dependencyChanged("depPath2");
+        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY.toString());
+        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY2.toString());
+        scriptDependencyTracker.processWatchEvent(WatchService.Kind.MODIFY, DEPENDENCY);
+        scriptDependencyTracker.processWatchEvent(WatchService.Kind.DELETE, DEPENDENCY2);
 
         verify(listener, times(2)).onDependencyChange(eq("scriptId"));
         verifyNoMoreInteractions(listener);
@@ -123,10 +130,10 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId1", "depPath1");
-        scriptDependencyTracker.startTracking("scriptId2", "depPath2");
+        scriptDependencyTracker.startTracking("scriptId1", DEPENDENCY.toString());
+        scriptDependencyTracker.startTracking("scriptId2", DEPENDENCY2.toString());
 
-        scriptDependencyTracker.dependencyChanged("depPath1");
+        scriptDependencyTracker.processWatchEvent(WatchService.Kind.CREATE, DEPENDENCY);
 
         verify(listener).onDependencyChange(eq("scriptId1"));
         verifyNoMoreInteractions(listener);

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
@@ -58,8 +58,8 @@ public class AbstractScriptDependencyTrackerTest {
         scriptDependencyTracker = new AbstractScriptDependencyTracker(watchServiceMock, WATCH_DIR) {
         };
 
-        depPath =rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY);
-        depPath2 =rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY2);
+        depPath = rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY);
+        depPath2 = rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY2);
 
         Files.createFile(depPath);
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
@@ -49,6 +49,8 @@ public class AbstractScriptDependencyTrackerTest {
     private @NonNullByDefault({}) AbstractScriptDependencyTracker scriptDependencyTracker;
     private @Mock @NonNullByDefault({}) WatchService watchServiceMock;
     private @NonNullByDefault({}) @TempDir Path rootWatchPath;
+    private @NonNullByDefault({}) Path depPath;
+    private @NonNullByDefault({}) Path depPath2;
 
     @BeforeEach
     public void setup() throws IOException {
@@ -56,8 +58,12 @@ public class AbstractScriptDependencyTrackerTest {
         scriptDependencyTracker = new AbstractScriptDependencyTracker(watchServiceMock, WATCH_DIR) {
         };
 
-        Files.createFile(rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY));
-        Files.createFile(rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY2));
+        depPath =rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY);
+        depPath2 =rootWatchPath.resolve(WATCH_DIR).resolve(DEPENDENCY2);
+
+        Files.createFile(depPath);
+
+        Files.createFile(depPath2);
     }
 
     @AfterEach
@@ -85,7 +91,7 @@ public class AbstractScriptDependencyTrackerTest {
         scriptDependencyTracker.addChangeTracker(listener1);
         scriptDependencyTracker.addChangeTracker(listener2);
 
-        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY.toString());
+        scriptDependencyTracker.startTracking("scriptId", depPath.toString());
         scriptDependencyTracker.processWatchEvent(WatchService.Kind.CREATE, DEPENDENCY);
 
         verify(listener1).onDependencyChange(eq("scriptId"));
@@ -100,8 +106,8 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId1", DEPENDENCY.toString());
-        scriptDependencyTracker.startTracking("scriptId2", DEPENDENCY.toString());
+        scriptDependencyTracker.startTracking("scriptId1", depPath.toString());
+        scriptDependencyTracker.startTracking("scriptId2", depPath.toString());
         scriptDependencyTracker.processWatchEvent(WatchService.Kind.MODIFY, DEPENDENCY);
 
         verify(listener).onDependencyChange(eq("scriptId1"));
@@ -115,8 +121,8 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY.toString());
-        scriptDependencyTracker.startTracking("scriptId", DEPENDENCY2.toString());
+        scriptDependencyTracker.startTracking("scriptId", depPath.toString());
+        scriptDependencyTracker.startTracking("scriptId", depPath2.toString());
         scriptDependencyTracker.processWatchEvent(WatchService.Kind.MODIFY, DEPENDENCY);
         scriptDependencyTracker.processWatchEvent(WatchService.Kind.DELETE, DEPENDENCY2);
 
@@ -130,8 +136,8 @@ public class AbstractScriptDependencyTrackerTest {
 
         scriptDependencyTracker.addChangeTracker(listener);
 
-        scriptDependencyTracker.startTracking("scriptId1", DEPENDENCY.toString());
-        scriptDependencyTracker.startTracking("scriptId2", DEPENDENCY2.toString());
+        scriptDependencyTracker.startTracking("scriptId1", depPath.toString());
+        scriptDependencyTracker.startTracking("scriptId2", depPath2.toString());
 
         scriptDependencyTracker.processWatchEvent(WatchService.Kind.CREATE, DEPENDENCY);
 


### PR DESCRIPTION
Reported in private communication. This is the same issue that was already fixed in #3457. The `.canRead` check failed because it was done on a relative path instead of an absolute one.