### PR TITLE
Prevent unnecessary MODIFY events in WatchServiceImpl

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -210,6 +210,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
 
     @Override
     public void onEvent(@Nullable DirectoryChangeEvent directoryChangeEvent) throws IOException {
+        logger.error("{} - {}", System.currentTimeMillis(), directoryChangeEvent);
         if (directoryChangeEvent == null || directoryChangeEvent.isDirectory()
                 || directoryChangeEvent.eventType() == DirectoryChangeEvent.EventType.OVERFLOW) {
             // exit early, we are neither interested in directory events nor in OVERFLOW events
@@ -238,6 +239,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
 
     private void notifyListeners(Path path) {
         List<Kind> kinds = scheduledEventKinds.remove(path);
+        logger.error("Events in queue: {}", kinds);
         if (kinds == null || kinds.isEmpty()) {
             logger.debug("Tried to notify listeners of change events for '{}', but the event list is empty.", path);
             return;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import io.methvin.watcher.DirectoryChangeEvent;
 import io.methvin.watcher.DirectoryChangeListener;
 import io.methvin.watcher.DirectoryWatcher;
+import io.methvin.watcher.hashing.FileHash;
 
 /**
  * The {@link WatchServiceImpl} is the implementation of the {@link WatchService}
@@ -70,6 +72,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
 
     private final List<Listener> dirPathListeners = new CopyOnWriteArrayList<>();
     private final List<Listener> subDirPathListeners = new CopyOnWriteArrayList<>();
+    private final Map<Path, FileHash> hashCache = new ConcurrentHashMap<>();
     private final ExecutorService executor;
     private final ScheduledExecutorService scheduler;
 
@@ -81,7 +84,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
     private @Nullable ServiceRegistration<WatchService> reg;
 
     private final Map<Path, ScheduledFuture<?>> scheduledEvents = new HashMap<>();
-    private final Map<Path, List<Kind>> scheduledEventKinds = new ConcurrentHashMap<>();
+    private final Map<Path, List<DirectoryChangeEvent>> scheduledEventKinds = new ConcurrentHashMap<>();
 
     @Activate
     public WatchServiceImpl(WatchServiceConfiguration config, BundleContext bundleContext) throws IOException {
@@ -170,6 +173,8 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
             }
             this.reg = null;
         }
+
+        hashCache.clear();
     }
 
     @Override
@@ -210,7 +215,6 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
 
     @Override
     public void onEvent(@Nullable DirectoryChangeEvent directoryChangeEvent) throws IOException {
-        logger.error("{} - {}", System.currentTimeMillis(), directoryChangeEvent);
         if (directoryChangeEvent == null || directoryChangeEvent.isDirectory()
                 || directoryChangeEvent.eventType() == DirectoryChangeEvent.EventType.OVERFLOW) {
             // exit early, we are neither interested in directory events nor in OVERFLOW events
@@ -218,12 +222,6 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
         }
 
         Path path = directoryChangeEvent.path();
-        Kind kind = switch (directoryChangeEvent.eventType()) {
-            case CREATE -> Kind.CREATE;
-            case MODIFY -> Kind.MODIFY;
-            case DELETE -> Kind.DELETE;
-            case OVERFLOW -> Kind.OVERFLOW;
-        };
 
         synchronized (scheduledEvents) {
             ScheduledFuture<?> future = scheduledEvents.remove(path);
@@ -231,40 +229,39 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
                 future.cancel(true);
             }
             future = scheduler.schedule(() -> notifyListeners(path), PROCESSING_TIME, TimeUnit.MILLISECONDS);
-            scheduledEventKinds.computeIfAbsent(path, k -> new CopyOnWriteArrayList<>()).add(kind);
+            scheduledEventKinds.computeIfAbsent(path, k -> new CopyOnWriteArrayList<>()).add(directoryChangeEvent);
             scheduledEvents.put(path, future);
 
         }
     }
 
     private void notifyListeners(Path path) {
-        List<Kind> kinds = scheduledEventKinds.remove(path);
-        logger.error("Events in queue: {}", kinds);
-        if (kinds == null || kinds.isEmpty()) {
+        List<DirectoryChangeEvent> events = scheduledEventKinds.remove(path);
+        if (events == null || events.isEmpty()) {
             logger.debug("Tried to notify listeners of change events for '{}', but the event list is empty.", path);
             return;
         }
 
-        if (kinds.size() == 1) {
-            // we have only one event
-            doNotify(path, kinds.get(0));
-            return;
-        }
-
-        Kind firstElement = kinds.get(0);
-        Kind lastElement = kinds.get(kinds.size() - 1);
+        DirectoryChangeEvent firstElement = events.get(0);
+        DirectoryChangeEvent lastElement = events.get(events.size() - 1);
 
         // determine final event
-        if (lastElement == Kind.DELETE) {
-            if (firstElement == Kind.CREATE) {
-                logger.debug("Discarding events for '{}' because file was immediately deleted bafter creation", path);
+        if (lastElement.eventType() == DirectoryChangeEvent.EventType.DELETE) {
+            if (firstElement.eventType() == DirectoryChangeEvent.EventType.CREATE) {
+                logger.debug("Discarding events for '{}' because file was immediately deleted after creation", path);
                 return;
             }
+            hashCache.remove(lastElement.path());
             doNotify(path, Kind.DELETE);
-        } else if (firstElement == Kind.CREATE) {
+        } else if (firstElement.eventType() == DirectoryChangeEvent.EventType.CREATE) {
+            hashCache.put(lastElement.path(), lastElement.hash());
             doNotify(path, Kind.CREATE);
         } else {
-            doNotify(path, Kind.MODIFY);
+            FileHash oldHash = hashCache.put(lastElement.path(), lastElement.hash());
+            if (!Objects.equals(oldHash, lastElement.hash())) {
+                // only notify if hashes are different, otherwise the file content did not chnge
+                doNotify(path, Kind.MODIFY);
+            }
         }
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
@@ -77,8 +77,8 @@ public class WatchServiceImplTest extends JavaTest {
     public void testFileInWatchedDir() throws IOException, InterruptedException {
         watchService.registerListener(listener, rootPath, false);
 
-        Path testFile = rootPath.resolve(TEST_FILE_NAME + "1");
-        Path relativeTestFilePath = Path.of(TEST_FILE_NAME + "1");
+        Path testFile = rootPath.resolve(TEST_FILE_NAME);
+        Path relativeTestFilePath = Path.of(TEST_FILE_NAME);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -100,8 +100,8 @@ public class WatchServiceImplTest extends JavaTest {
         // listener is listening to root and sub-dir
         watchService.registerListener(listener, rootPath, true);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "2");
-        Path relativeTestFilePath = Path.of(SUB_DIR_PATH_NAME, TEST_FILE_NAME + "2");
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
+        Path relativeTestFilePath = Path.of(SUB_DIR_PATH_NAME, TEST_FILE_NAME);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -123,8 +123,8 @@ public class WatchServiceImplTest extends JavaTest {
         // listener is only listening to sub-dir of root
         watchService.registerListener(listener, Path.of(SUB_DIR_PATH_NAME), false);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "3");
-        Path relativeTestFilePath = Path.of(TEST_FILE_NAME + "3");
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
+        Path relativeTestFilePath = Path.of(TEST_FILE_NAME);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -145,7 +145,7 @@ public class WatchServiceImplTest extends JavaTest {
 
         watchService.registerListener(listener, rootPath, false);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "4");
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertNoEvent();
@@ -167,7 +167,7 @@ public class WatchServiceImplTest extends JavaTest {
         Path subDirSubDir = Files.createDirectories(rootPath.resolve(SUB_DIR_PATH_NAME).resolve(SUB_DIR_PATH_NAME));
         assertNoEvent();
 
-        Path testFile = subDirSubDir.resolve(TEST_FILE_NAME + "5");
+        Path testFile = subDirSubDir.resolve(TEST_FILE_NAME);
         Path relativeTestFilePath = rootPath.relativize(testFile);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
@@ -77,8 +77,8 @@ public class WatchServiceImplTest extends JavaTest {
     public void testFileInWatchedDir() throws IOException, InterruptedException {
         watchService.registerListener(listener, rootPath, false);
 
-        Path testFile = rootPath.resolve(TEST_FILE_NAME);
-        Path relativeTestFilePath = Path.of(TEST_FILE_NAME);
+        Path testFile = rootPath.resolve(TEST_FILE_NAME + "1");
+        Path relativeTestFilePath = Path.of(TEST_FILE_NAME + "1");
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -100,8 +100,8 @@ public class WatchServiceImplTest extends JavaTest {
         // listener is listening to root and sub-dir
         watchService.registerListener(listener, rootPath, true);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
-        Path relativeTestFilePath = Path.of(SUB_DIR_PATH_NAME, TEST_FILE_NAME);
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "2");
+        Path relativeTestFilePath = Path.of(SUB_DIR_PATH_NAME, TEST_FILE_NAME + "2");
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -123,8 +123,8 @@ public class WatchServiceImplTest extends JavaTest {
         // listener is only listening to sub-dir of root
         watchService.registerListener(listener, Path.of(SUB_DIR_PATH_NAME), false);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
-        Path relativeTestFilePath = Path.of(TEST_FILE_NAME);
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "3");
+        Path relativeTestFilePath = Path.of(TEST_FILE_NAME + "3");
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertEvent(relativeTestFilePath, Kind.CREATE);
@@ -145,7 +145,7 @@ public class WatchServiceImplTest extends JavaTest {
 
         watchService.registerListener(listener, rootPath, false);
 
-        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME);
+        Path testFile = rootPath.resolve(SUB_DIR_PATH_NAME).resolve(TEST_FILE_NAME + "4");
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);
         assertNoEvent();
@@ -167,7 +167,7 @@ public class WatchServiceImplTest extends JavaTest {
         Path subDirSubDir = Files.createDirectories(rootPath.resolve(SUB_DIR_PATH_NAME).resolve(SUB_DIR_PATH_NAME));
         assertNoEvent();
 
-        Path testFile = subDirSubDir.resolve(TEST_FILE_NAME);
+        Path testFile = subDirSubDir.resolve(TEST_FILE_NAME + "5");
         Path relativeTestFilePath = rootPath.relativize(testFile);
 
         Files.writeString(testFile, "initial content", StandardCharsets.UTF_8);


### PR DESCRIPTION
Related to #3518 

In some cases writing the same content to a file results in a MODIFY event because in an intermediate state the file is truncated to zero length. With this PR prior to emitting a MODIFY event the `WatchServiceImpl` checks whether the hash of the file content at the end of the wait time is the same as before and suppresses the event.

Found in CI tests.