### PR TITLE
Fix IllegalStateException in CommunityKarafAddonHandler

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -80,7 +80,8 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
     private Stream<Path> karFilesStream(Path addonDirectory) throws IOException {
         if (Files.isDirectory(addonDirectory)) {
             try (Stream<Path> files = Files.list(addonDirectory)) {
-                return files.map(Path::getFileName).filter(path -> path.toString().endsWith(KAR_EXTENSION));
+                return files.map(Path::getFileName).filter(path -> path.toString().endsWith(KAR_EXTENSION)).toList()
+                        .stream();
             }
         }
         return Stream.empty();


### PR DESCRIPTION
This is a regression from #3504: the stream is used as return value in a method but is closed because the try-with-resources was contained in the method itself. The stream is now collected to a list and then returned as a stream.

This results in continuous re-installs for kars from the community market place or JSON 3rd party addon services