### PR TITLE
Fix wrong event subscription in `CommunicationManager`

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -43,7 +43,6 @@ import org.openhab.core.items.ItemUtil;
 import org.openhab.core.items.events.AbstractItemRegistryEvent;
 import org.openhab.core.items.events.GroupStateUpdatedEvent;
 import org.openhab.core.items.events.ItemCommandEvent;
-import org.openhab.core.items.events.ItemStateEvent;
 import org.openhab.core.items.events.ItemStateUpdatedEvent;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DecimalType;
@@ -116,7 +115,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     // the timeout to use for any item event processing
     public static final long THINGHANDLER_EVENT_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
 
-    private static final Set<String> SUBSCRIBED_EVENT_TYPES = Set.of(ItemStateEvent.TYPE, ItemCommandEvent.TYPE,
+    private static final Set<String> SUBSCRIBED_EVENT_TYPES = Set.of(ItemStateUpdatedEvent.TYPE, ItemCommandEvent.TYPE,
             GroupStateUpdatedEvent.TYPE, ChannelTriggeredEvent.TYPE);
 
     private final Logger logger = LoggerFactory.getLogger(CommunicationManager.class);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -416,7 +416,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     private void sendGroupStateUpdatedEvent(String memberName, State state) {
         EventPublisher eventPublisher1 = this.eventPublisher;
         if (eventPublisher1 != null) {
-            eventPublisher1.post(ItemEventFactory.createGroupStateEvent(getName(), memberName, state, null));
+            eventPublisher1.post(ItemEventFactory.createGroupStateUpdatedEvent(getName(), memberName, state, null));
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
@@ -95,14 +95,14 @@ public class ItemEventFactory extends AbstractEventFactory {
         } else if (ItemRemovedEvent.TYPE.equals(eventType)) {
             return createRemovedEvent(topic, payload);
         } else if (GroupStateUpdatedEvent.TYPE.equals(eventType)) {
-            return createGroupStateEvent(topic, payload);
+            return createGroupStateUpdatedEvent(topic, payload);
         } else if (GroupItemStateChangedEvent.TYPE.equals(eventType)) {
             return createGroupStateChangedEvent(topic, payload);
         }
         throw new IllegalArgumentException("The event type '" + eventType + "' is not supported by this factory.");
     }
 
-    private Event createGroupStateEvent(String topic, String payload) {
+    private Event createGroupStateUpdatedEvent(String topic, String payload) {
         String itemName = getItemName(topic);
         String memberName = getMemberName(topic);
         ItemEventPayloadBean bean = deserializePayload(payload, ItemEventPayloadBean.class);
@@ -321,7 +321,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     }
 
     /**
-     * Creates an group item state updated event.
+     * Creates a group item state updated event.
      *
      * @param groupName the name of the group to report the state update for
      * @param member the name of the item that updated the group state
@@ -330,7 +330,7 @@ public class ItemEventFactory extends AbstractEventFactory {
      * @return the created group item state update event
      * @throws IllegalArgumentException if groupName or state is null
      */
-    public static GroupStateUpdatedEvent createGroupStateEvent(String groupName, String member, State state,
+    public static GroupStateUpdatedEvent createGroupStateUpdatedEvent(String groupName, String member, State state,
             @Nullable String source) {
         assertValidArguments(groupName, member, state, "state");
         String topic = buildGroupTopic(GROUP_STATE_EVENT_TOPIC, groupName, member);


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/3141 introduced an `ItemStateUpdatedEvent` and updated `CommunicationManager` to only receive updates on this event.
However, it was forgotten to update the subscribed event types, so no updated were received at all.

The `CommuncationManagerOSGiTest` was not able to detect this regression, because in the test the event is `received` via a method call, but not an event subscription/the event bus.

This also renames the method for creating a `GroupStateUpdatedEvent` for more clarity.