### PR TITLE
Add a Range Filter profile

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
@@ -67,7 +67,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     private final ChannelTypeRegistry channelTypeRegistry;
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Set.of(DEFAULT_TYPE, FOLLOW_TYPE, HYSTERESIS_TYPE,
-            OFFSET_TYPE, RANGE_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
+            OFFSET_TYPE, RANGE_TYPE, RANGE_FILTER_TYPE, RAWBUTTON_ON_OFF_SWITCH_TYPE, RAWBUTTON_TOGGLE_PLAYER_TYPE,
             RAWBUTTON_TOGGLE_ROLLERSHUTTER_TYPE, RAWBUTTON_TOGGLE_SWITCH_TYPE, RAWROCKER_DIMMER_TYPE,
             RAWROCKER_NEXT_PREVIOUS_TYPE, RAWROCKER_ON_OFF_TYPE, RAWROCKER_PLAY_PAUSE_TYPE,
             RAWROCKER_REWIND_FASTFORWARD_TYPE, RAWROCKER_STOP_MOVE_TYPE, RAWROCKER_UP_DOWN_TYPE,
@@ -75,7 +75,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             TIMESTAMP_UPDATE_TYPE);
 
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Set.of(DEFAULT, FOLLOW, HYSTERESIS, OFFSET,
-            RANGE, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
+            RANGE, RANGE_FILTER, RAWBUTTON_ON_OFF_SWITCH, RAWBUTTON_TOGGLE_PLAYER, RAWBUTTON_TOGGLE_ROLLERSHUTTER,
             RAWBUTTON_TOGGLE_SWITCH, RAWROCKER_DIMMER, RAWROCKER_NEXT_PREVIOUS, RAWROCKER_ON_OFF, RAWROCKER_PLAY_PAUSE,
             RAWROCKER_REWIND_FASTFORWARD, RAWROCKER_STOP_MOVE, RAWROCKER_UP_DOWN, TRIGGER_EVENT_STRING,
             TIMESTAMP_CHANGE, TIMESTAMP_OFFSET, TIMESTAMP_TRIGGER, TIMESTAMP_UPDATE);
@@ -107,6 +107,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemOffsetProfile(callback, context);
         } else if (RANGE.equals(profileTypeUID)) {
             return new SystemRangeStateProfile(callback, context);
+        } else if (RANGE_FILTER.equals(profileTypeUID)) {
+            return new SystemRangeFilterProfile(callback, context);
         } else if (BUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
             return new ToggleProfile<OnOffType>(callback, context, BUTTON_TOGGLE_SWITCH,
                     DefaultSystemChannelTypeProvider.SYSTEM_BUTTON, OnOffType.ON, OnOffType.OFF,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeFilterProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeFilterProfile.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.config.core.ConfigParser;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.Units;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.ProfileTypeUID;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.thing.profiles.SystemProfiles;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * This is the default implementation for a {@link SystemRangeFilterProfile}.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@NonNullByDefault
+public class SystemRangeFilterProfile implements StateProfile {
+
+    static final String RANGE_PARAM = "range";
+    static final String RANGE_ACTION_PARAM = "action";
+    static final String RANGE_ACTION_ALLOW = "allow";
+    static final String RANGE_ACTION_DISCARD = "discard";
+
+    private static final Pattern RANGE_PATTERN = Pattern.compile(
+            "^(?<beginType>\\[|\\()\\s*(?<begin>[^\\]\\)]*?)\\s*\\.\\.\\s*(?<end>[^\\]\\)]*?)\\s*(?<endType>\\]|\\))$");
+
+    private final Logger logger = LoggerFactory.getLogger(SystemRangeFilterProfile.class);
+
+    private final ProfileCallback callback;
+
+    private final List<Range> ranges;
+    private final boolean inverted;
+
+    public SystemRangeFilterProfile(ProfileCallback callback, ProfileContext context) {
+        this.callback = callback;
+
+        String rangeAction = ConfigParser.valueAsOrElse(context.getConfiguration().get(RANGE_ACTION_PARAM),
+                String.class, RANGE_ACTION_ALLOW);
+
+        this.inverted = switch (rangeAction) {
+            case RANGE_ACTION_ALLOW -> false;
+            case RANGE_ACTION_DISCARD -> true;
+            default -> throw new IllegalArgumentException(
+                    String.format("Invalid %s option: '%s'. Valid options are: '%s' or '%s'", linkUID(),
+                            RANGE_ACTION_PARAM, rangeAction, RANGE_ACTION_ALLOW, RANGE_ACTION_DISCARD));
+        };
+
+        Object rangeConfig = context.getConfiguration().get(RANGE_PARAM);
+        if (!(rangeConfig instanceof String rangeStr)) {
+            throw new IllegalArgumentException(
+                    String.format("%s: Invalid range parameter: '%s'", linkUID(), rangeConfig));
+        }
+
+        List<Range> ranges = new ArrayList<>();
+        Arrays.stream(rangeStr.split(",")).map(String::trim).filter(s -> !s.isBlank()).forEach(rangeElement -> {
+            Matcher rangeMatcher = RANGE_PATTERN.matcher(rangeElement);
+            if (rangeMatcher.matches()) {
+                Optional<Range> range = createRange(rangeElement, rangeMatcher.group("beginType"),
+                        rangeMatcher.group("begin"), rangeMatcher.group("end"), rangeMatcher.group("endType"));
+                range.ifPresent(r -> ranges.add(r));
+            } else {
+                throw new IllegalArgumentException(
+                        String.format("%s: Invalid range syntax '%s'.", linkUID(), rangeElement));
+            }
+        });
+
+        if (ranges.isEmpty()) {
+            throw new IllegalArgumentException(
+                    linkUID() + ": No valid range specifications found. Everything will be discarded.");
+        }
+        this.ranges = Collections.unmodifiableList(ranges);
+    }
+
+    private Optional<Range> createRange(String range, String beginType, String rangeBegin, String rangeEnd,
+            String endType) {
+        Optional<Comparator> beginComparator = Optional.empty();
+        Optional<Comparator> endComparator = Optional.empty();
+        Unit unit = Units.ONE;
+        Optional<BigDecimal> beginValueCheck = Optional.empty();
+
+        if (!rangeBegin.isBlank()) {
+            try {
+                QuantityType<?> value = QuantityType.valueOf(rangeBegin);
+                final BigDecimal beginValue = value.toBigDecimal();
+                beginComparator = Optional.of(switch (beginType) {
+                    case "[" -> (input) -> input.compareTo(beginValue) >= 0;
+                    case "(" -> (input) -> input.compareTo(beginValue) > 0;
+                    default -> throw new IllegalStateException(String.format(
+                            "Invalid begin type '%s' of the filter range '%s'. This is a bug.", beginType, range));
+                });
+                unit = value.getUnit();
+                beginValueCheck = Optional.of(beginValue);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        String.format("%s: Invalid filter range begin: '%s'. %s", linkUID(), range, e.getMessage()));
+            }
+        }
+
+        if (!rangeEnd.isBlank()) {
+            try {
+                @Nullable
+                QuantityType<?> value = QuantityType.valueOf(rangeEnd);
+                if (beginComparator.isPresent()) {
+                    value = value.toInvertibleUnit(unit);
+                }
+                if (value != null) {
+                    final BigDecimal endValue = value.toBigDecimal();
+                    endComparator = Optional.of(switch (endType) {
+                        case "]" -> (input) -> input.compareTo(endValue) <= 0;
+                        case ")" -> (input) -> input.compareTo(endValue) < 0;
+                        default -> throw new IllegalStateException(String.format(
+                                "Invalid end type '%s' of the filter range '%s'. This is a bug.", endType, range));
+                    });
+                    if (beginComparator.map(begin -> !begin.check(endValue)).orElse(false)) {
+                        throw new IllegalArgumentException("The end value is smaller than the begin limit.");
+                    }
+                    if (beginValueCheck.isPresent() && !endComparator.get().check(beginValueCheck.get())) {
+                        throw new IllegalArgumentException("The begin value is bigger than the end limit.");
+                    }
+                } else {
+                    throw new IllegalArgumentException("Begin and end have incompatible units.");
+                }
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        String.format("%s: Invalid filter range end: '%s'. %s", linkUID(), range, e.getMessage()));
+            }
+        }
+
+        if (beginComparator.isEmpty() && endComparator.isEmpty()) {
+            throw new IllegalArgumentException(String.format("%s: The range '%s' is empty.", linkUID(), range));
+        }
+
+        return Optional.of(new Range(range, beginComparator, endComparator, unit));
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.RANGE;
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand(command);
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        // do nothing
+    }
+
+    private @Nullable QuantityType<?> toQuantity(final Type value) {
+        if (value instanceof QuantityType quantity) {
+            return quantity;
+        } else if (value instanceof DecimalType decimal) {
+            return new QuantityType(decimal, Units.ONE);
+        }
+        return null;
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        if (isAllowed(command)) {
+            callback.sendCommand(command);
+        } else {
+            logger.debug("{}: Command '{}' discarded by filter profile.", linkUID(), command);
+        }
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        if (isAllowed(state)) {
+            callback.sendUpdate(state);
+        } else {
+            logger.debug("{}: State update '{}' discarded by filter profile.", linkUID(), state);
+        }
+    }
+
+    private boolean isAllowed(Type value) {
+        @Nullable
+        QuantityType<?> quantityValue = toQuantity(value);
+        if (quantityValue == null) {
+            return false;
+        }
+
+        boolean withinRange = isWithinAnyRange(quantityValue);
+        return inverted ? !withinRange : withinRange;
+    }
+
+    private boolean isWithinAnyRange(QuantityType<?> value) {
+        return ranges.stream().anyMatch(range -> {
+            @Nullable
+            QuantityType<?> checkValue = value;
+            if (!range.unit().equals(Units.ONE)) {
+                checkValue = value.toInvertibleUnit(range.unit());
+                if (checkValue == null) {
+                    logger.warn("{}: Incompatible units between the incoming value '{}' and the range '{}'.", linkUID(),
+                            value, range.range());
+                    return false;
+                }
+            }
+            return range.covers(checkValue.toBigDecimal());
+        });
+    }
+
+    private String linkUID() {
+        return callback.getItemChannelLink().getUID();
+    }
+
+    private interface Comparator {
+        boolean check(BigDecimal value);
+    }
+
+    private record Range(String range, Optional<Comparator> begin, Optional<Comparator> end, Unit unit) {
+        boolean covers(BigDecimal value) {
+            return begin.map(c -> c.check(value)).orElse(true) && end.map(c -> c.check(value)).orElse(true);
+        }
+    }
+}

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
@@ -31,6 +31,7 @@ public interface SystemProfiles {
     ProfileTypeUID OFFSET = new ProfileTypeUID(SYSTEM_SCOPE, "offset");
     ProfileTypeUID HYSTERESIS = new ProfileTypeUID(SYSTEM_SCOPE, "hysteresis");
     ProfileTypeUID RANGE = new ProfileTypeUID(SYSTEM_SCOPE, "range");
+    ProfileTypeUID RANGE_FILTER = new ProfileTypeUID(SYSTEM_SCOPE, "range-filter");
     ProfileTypeUID BUTTON_TOGGLE_SWITCH = new ProfileTypeUID(SYSTEM_SCOPE, "button-toggle-switch");
     ProfileTypeUID BUTTON_TOGGLE_PLAYER = new ProfileTypeUID(SYSTEM_SCOPE, "button-toggle-player");
     ProfileTypeUID BUTTON_TOGGLE_ROLLERSHUTTER = new ProfileTypeUID(SYSTEM_SCOPE, "button-toggle-rollershutter");
@@ -62,6 +63,11 @@ public interface SystemProfiles {
     ProfileType HYSTERESIS_TYPE = ProfileTypeBuilder.newState(HYSTERESIS, "Hysteresis") //
             .withSupportedItemTypesOfChannel(CoreItemFactory.DIMMER, CoreItemFactory.NUMBER) //
             .withSupportedItemTypes(CoreItemFactory.SWITCH) //
+            .build();
+
+    ProfileType RANGE_FILTER_TYPE = ProfileTypeBuilder.newState(RANGE_FILTER, "Range Filter") //
+            .withSupportedItemTypesOfChannel(CoreItemFactory.DIMMER, CoreItemFactory.NUMBER) //
+            .withSupportedItemTypes(CoreItemFactory.NUMBER) //
             .build();
 
     ProfileType RANGE_TYPE = ProfileTypeBuilder.newState(RANGE, "Range") //

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/rangeFilterProfile.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/rangeFilterProfile.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0 https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:system:range-filter">
+		<parameter name="range" type="text" required="true">
+			<label>Range</label>
+			<description><![CDATA[
+				The range to allow (or reject when inverted) using interval notation.
+				<ul>
+					<li><tt>[1..2]</tt> means to allow <tt>1 <= value <= 2</tt>.</li>
+					<li><tt>[1..2)</tt> means to allow <tt>1 <= value < 2</tt>.</li>
+				</ul>
+				Unit of Measurement can be specified against a dimensioned channel, e.g. <tt>( -18 °C .. -2 °C )</tt>.
+
+				Begin-less and end-less ranges can be defined by omitting the corresponding value.
+				For example: <tt>[..10]</tt> for <= 10 and <tt>[10..]<tt> for >= 10.
+
+				Multiple ranges can be specified, e.g. <tt>[1..2], [5..8], [9..]</tt>
+			]]></description>
+		</parameter>
+		<parameter name="action" type="text">
+			<label>Range Action</label>
+			<description>Whether to allow or discard values within the given range.</description>
+			<options>
+				<option value="allow">Only allow values within the range</option>
+				<option value="discard">Only allow values outside the range</option>
+			</options>
+			<default>allow</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
@@ -10,6 +10,13 @@ profile.config.system.hysteresis.upper.label = Upper Bound
 profile.config.system.hysteresis.upper.description = Maps to ON if value is above upper bound (plain number or number with unit).
 profile.config.system.hysteresis.inverted.label = Inverted
 profile.config.system.hysteresis.inverted.description = Inverts resulting mapping of ON / OFF, if true.
+profile-type.system.filter.label = Filter
+profile.config.system.filter.range.label = Range
+profile.config.system.filter.range.description = The range to allow (or reject when inverted) using interval notation. <ul> <li><tt>[1..2]</tt> means to allow <tt>1 <= value <= 2</tt>.</li> <li><tt>[1..2)</tt> means to allow <tt>1 <= value < 2</tt>.</li> </ul> Unit of Measurement can be specified against a dimensioned channel, e.g. <tt>( -18 °C .. -2 °C )</tt>. Begin-less and end-less ranges can be defined by omitting the corresponding value. For example: <tt>[..10]</tt> for <= 10 and <tt>[10..]<tt> for >= 10. Multiple ranges can be specified, e.g. <tt>[1..2], [5..8], [9..]</tt>
+profile.config.system.filter.rangeAction.label = Range Action
+profile.config.system.filter.rangeAction.description = Whether to allow or discard values within the given range.
+profile.config.system.filter.rangeAction.option.allow = Only allow values within the range
+profile.config.system.filter.rangeAction.option.discard = Only allow values outside the range
 profile-type.system.range.label = Range
 profile.config.system.range.lower.label = Lower Bound
 profile.config.system.range.lower.description = Maps to ON if value is between lower and upper bound (plain number or number with unit).

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeFilterProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeFilterProfileTest.java
@@ -1,0 +1,432 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal.profiles;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.profiles.ProfileCallback;
+import org.openhab.core.thing.profiles.ProfileContext;
+import org.openhab.core.thing.profiles.StateProfile;
+import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
+
+/**
+ * Basic unit tests for {@link SystemRangeFilterProfile}.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@ExtendWith(MockitoExtension.class)
+@NonNullByDefault
+public class SystemRangeFilterProfileTest {
+
+    private record TestParameter(@Nullable String range, boolean inverted, Map<? extends Type, Boolean> tests) {
+    };
+
+    private record RangeTestParameter(@Nullable String range, boolean isValid) {
+    };
+
+    public static List<TestParameter> singleRangeParameters() {
+        return List.of( //
+                // inclusive begin and end
+                new TestParameter("[1..2]", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), true, // included
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), true, // included
+                        new DecimalType(2.1), false, //
+                        new DecimalType(3), false, //
+                        new DecimalType(-1), false //
+                )), //
+                new TestParameter("[30..70]", false, Map.of( //
+                        new PercentType(0), false, //
+                        new PercentType(29), false, //
+                        new PercentType(30), true, //
+                        new PercentType(50), true, //
+                        new PercentType(70), true, //
+                        new PercentType(71), false, //
+                        new PercentType(100), false //
+                )), //
+                // exclusive begin, inclusive end
+                new TestParameter("(1..2]", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), false, // excluded
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), true, // included
+                        new DecimalType(2.1), false //
+                )), //
+                // inclusive begin, exclusive end
+                new TestParameter("[1..2)", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), true, // included
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), false, // excluded
+                        new DecimalType(2.1), false //
+                )), //
+                // exclusive begin and end
+                new TestParameter("(1..2)", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), false, // excluded
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), false, // excluded
+                        new DecimalType(2.1), false //
+                )), //
+                // beginless
+                new TestParameter("(..2)", false, Map.of( //
+                        new DecimalType(-100), true, //
+                        new DecimalType(0), true, //
+                        new DecimalType(1), true, //
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), false, // excluded
+                        new DecimalType(2.1), false //
+                )), //
+                // endless
+                new TestParameter("(10..)", false, Map.of( //
+                        new DecimalType(-100), false, //
+                        new DecimalType(0), false, //
+                        new DecimalType(10), false, //
+                        new DecimalType(15), true, //
+                        new DecimalType(100), true //
+                )), //
+                // unitless range will compare the input values regardless of their unit
+                new TestParameter("[1..2]", false, Map.of( //
+                        new QuantityType<>("0.9 °C"), false, //
+                        new QuantityType<>("1 °C"), true, //
+                        new QuantityType<>("1.5 °C"), true, //
+                        new QuantityType<>("2 °C"), true, //
+                        new QuantityType<>("3 °C"), false, //
+                        new QuantityType<>("0.9 W"), false, //
+                        new QuantityType<>("1 W"), true, //
+                        new QuantityType<>("1.5 W"), true, //
+                        new QuantityType<>("2 W"), true, //
+                        new QuantityType<>("3 W"), false //
+                )), // Test values in different unit
+                new TestParameter("[1 °C..2 °C]", false, Map.of( //
+                        new QuantityType<>("0.9 °C"), false, //
+                        new QuantityType<>("1 °C"), true, //
+                        new QuantityType<>("1.5 °C"), true, //
+                        new QuantityType<>("2 °C"), true, //
+                        new QuantityType<>("3 °C"), false, //
+                        new QuantityType<>("1 °F"), false, //
+                        new QuantityType<>("2 °F"), false, //
+                        new QuantityType<>("34 °F"), true, //
+                        new QuantityType<>("36 °F"), false //
+                )), // Test mixing units in the range limits
+                new TestParameter("[1 °C..35.6 °F]", false, Map.of( //
+                        new QuantityType<>("0.9 °C"), false, //
+                        new QuantityType<>("1 °C"), true, //
+                        new QuantityType<>("1.5 °C"), true, //
+                        new QuantityType<>("2 °C"), true, //
+                        new QuantityType<>("3 °C"), false, //
+                        new QuantityType<>("1 °F"), false, //
+                        new QuantityType<>("2 °F"), false, //
+                        new QuantityType<>("34 °F"), true, //
+                        new QuantityType<>("35 °F"), true, //
+                        new QuantityType<>("36 °F"), false //
+                )), // Test values with incompatible unit
+                new TestParameter("[1 °C..10 °C]", false, Map.of( //
+                        new DecimalType(1), false, //
+                        new QuantityType<>("5 W"), false //
+                ))//
+        );
+    }
+
+    public static List<TestParameter> multipleRangeParameters() {
+        return List.of( //
+                new TestParameter("[1..2],[10..20]", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), true, //
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), true, //
+                        new DecimalType(3), false, //
+                        new DecimalType(10), true, //
+                        new DecimalType(15), true, //
+                        new DecimalType(20), true, //
+                        new DecimalType(21), false //
+                )), //
+                new TestParameter("(1..2],[10..20]", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), false, //
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), true, //
+                        new DecimalType(3), false, //
+                        new DecimalType(10), true, //
+                        new DecimalType(15), true, //
+                        new DecimalType(20), true, //
+                        new DecimalType(21), false //
+                )), //
+                new TestParameter("[1..2),[10..20)", false, Map.of( //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), true, //
+                        new DecimalType(1.5), true, //
+                        new DecimalType(2), false, //
+                        new DecimalType(3), false, //
+                        new DecimalType(10), true, //
+                        new DecimalType(15), true, //
+                        new DecimalType(20), false, //
+                        new DecimalType(21), false //
+                )), //
+                new TestParameter("[1..2),[10..20],[50..60]", false, Map.ofEntries( //
+                        entry(new DecimalType(0), false), //
+                        entry(new DecimalType(1), true), //
+                        entry(new DecimalType(1.5), true), //
+                        entry(new DecimalType(2), false), //
+                        entry(new DecimalType(3), false), //
+                        entry(new DecimalType(10), true), //
+                        entry(new DecimalType(15), true), //
+                        entry(new DecimalType(20), true), //
+                        entry(new DecimalType(30), false), //
+                        entry(new DecimalType(50), true), //
+                        entry(new DecimalType(51), true), //
+                        entry(new DecimalType(60), true), //
+                        entry(new DecimalType(61), false) //
+                )) //
+        );
+    }
+
+    public static List<TestParameter> invertedRangeParameters() {
+        return List.of( //
+                new TestParameter("[1..2]", true, Map.of( //
+                        new DecimalType(0), true, //
+                        new DecimalType(1), false, //
+                        new DecimalType(1.5), false, //
+                        new DecimalType(2), false, //
+                        new DecimalType(2.1), true, //
+                        new DecimalType(3), true, //
+                        new DecimalType(-1), true //
+                )), //
+                new TestParameter("(1..2]", true, Map.of( //
+                        new DecimalType(0), true, //
+                        new DecimalType(1), true, //
+                        new DecimalType(1.5), false, //
+                        new DecimalType(2), false, //
+                        new DecimalType(2.1), true //
+                )), //
+                new TestParameter("[1..2)", true, Map.of( //
+                        new DecimalType(0), true, //
+                        new DecimalType(1), false, //
+                        new DecimalType(1.5), false, //
+                        new DecimalType(2), true, //
+                        new DecimalType(2.1), true //
+                )), //
+                // exclusive begin and end
+                new TestParameter("(1..2)", true, Map.of( //
+                        new DecimalType(0), true, //
+                        new DecimalType(1), true, //
+                        new DecimalType(1.5), false, //
+                        new DecimalType(2), true, //
+                        new DecimalType(2.1), true //
+                )), //
+                // beginless
+                new TestParameter("(..2)", true, Map.of( //
+                        new DecimalType(-100), false, //
+                        new DecimalType(0), false, //
+                        new DecimalType(1), false, //
+                        new DecimalType(1.5), false, //
+                        new DecimalType(2), true, //
+                        new DecimalType(2.1), true //
+                )), //
+                // endless
+                new TestParameter("(10..)", true, Map.of( //
+                        new DecimalType(-100), true, //
+                        new DecimalType(0), true, //
+                        new DecimalType(10), true, //
+                        new DecimalType(15), false, //
+                        new DecimalType(100), false //
+                )), //
+                new TestParameter("[1..2),[10..20],[50..60]", true, Map.ofEntries( //
+                        entry(new DecimalType(0), true), //
+                        entry(new DecimalType(1), false), //
+                        entry(new DecimalType(1.5), false), //
+                        entry(new DecimalType(2), true), //
+                        entry(new DecimalType(3), true), //
+                        entry(new DecimalType(10), false), //
+                        entry(new DecimalType(15), false), //
+                        entry(new DecimalType(20), false), //
+                        entry(new DecimalType(30), true), //
+                        entry(new DecimalType(50), false), //
+                        entry(new DecimalType(51), false), //
+                        entry(new DecimalType(60), false), //
+                        entry(new DecimalType(61), true) //
+                )) //
+        );
+    }
+
+    public static List<RangeTestParameter> syntaxTestParameters() {
+        return List.of( //
+                new RangeTestParameter(" [1..2]", true), //
+                new RangeTestParameter("[1..2] ", true), //
+                new RangeTestParameter(" [1..2] ", true), //
+                new RangeTestParameter("[ 1..2]", true), //
+                new RangeTestParameter("[1 ..2]", true), //
+                new RangeTestParameter("[1.. 2]", true), //
+                new RangeTestParameter("[1..2 ]", true), //
+                new RangeTestParameter(" [ 1 .. 2 ] ", true), //
+                new RangeTestParameter("[1..2][3..4]", false), //
+                new RangeTestParameter("[1..2] [3..4]", false), //
+                new RangeTestParameter("[1..2],[3..4]", true), //
+                new RangeTestParameter("[1..2], [3..4]", true), //
+                new RangeTestParameter("[1..2] ,[3..4]", true), //
+                new RangeTestParameter("[1..2] , [3..4]", true), //
+                new RangeTestParameter(" [1..2] , [3..4 ] ", true), //
+                new RangeTestParameter("[1..2], [3..4], [5..6],[7..8]", true), //
+                new RangeTestParameter("[1..2], [3..4], [5..6]|7...8]", false), //
+                new RangeTestParameter("", false), //
+                new RangeTestParameter("asdfafd", false), //
+                new RangeTestParameter("[foo..3]", false), //
+                new RangeTestParameter("[1..foo]", false), //
+                new RangeTestParameter("[foo..bar]", false), //
+                new RangeTestParameter("[1 kW..2 kW]", true) //
+        );
+    }
+
+    public static List<RangeTestParameter> unitCompatibilityTestParameters() {
+        return List.of( //
+                new RangeTestParameter("[1 °C..200 °F]", true), //
+                new RangeTestParameter("[10 psi..300 kPa]", true), //
+                new RangeTestParameter("[1 kW..2 kW]", true), //
+                new RangeTestParameter("[1 kW..2000 W]", true), //
+                new RangeTestParameter("[1 kW..2]", false), //
+                new RangeTestParameter("[1..2 kW]", false), //
+                new RangeTestParameter("[1 kW..2 °C]", false) //
+        );
+    }
+
+    public static List<RangeTestParameter> boundaryTestParameters() {
+        return List.of( //
+                new RangeTestParameter("[1 °C..2 °F]", false), // 2 °F is smaller than 1 °C
+                new RangeTestParameter("[1..1]", true), //
+                new RangeTestParameter("(1..1]", false), //
+                new RangeTestParameter("[1..1)", false), //
+                new RangeTestParameter("(1..1)", false) //
+        );
+    }
+
+    private @Mock(answer = Answers.RETURNS_DEEP_STUBS) @NonNullByDefault({}) ProfileCallback callbackMock;
+    private @Mock @NonNullByDefault({}) ProfileContext contextMock;
+    private ItemChannelLink itemChannelLink = new ItemChannelLink("Item", new ChannelUID("thing:test:channel:uid"));
+
+    @ParameterizedTest
+    @MethodSource("singleRangeParameters")
+    public void testOnStateUpdateFromHandlerWithSingleRange(TestParameter testParameter) {
+        final StateProfile profile = initProfile(testParameter.range(), testParameter.inverted());
+        testParameter.tests().forEach((input, passedThrough) -> {
+            verifySendUpdate(profile, (State) input, passedThrough);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("singleRangeParameters")
+    public void testOnCommandFromHandlerWithSingleRange(TestParameter testParameter) {
+        final StateProfile profile = initProfile(testParameter.range(), testParameter.inverted());
+        testParameter.tests().forEach((input, passedThrough) -> {
+            verifySendCommand(profile, (Command) input, passedThrough);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("multipleRangeParameters")
+    public void testOnCommandFromHandlerWithMultipleRanges(TestParameter testParameter) {
+        final StateProfile profile = initProfile(testParameter.range(), testParameter.inverted());
+        testParameter.tests().forEach((input, passedThrough) -> {
+            verifySendCommand(profile, (Command) input, passedThrough);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("invertedRangeParameters")
+    public void testOnCommandFromHandlerWithInvertedRanges(TestParameter testParameter) {
+        final StateProfile profile = initProfile(testParameter.range(), testParameter.inverted());
+        testParameter.tests().forEach((input, passedThrough) -> {
+            verifySendCommand(profile, (Command) input, passedThrough);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("syntaxTestParameters")
+    public void testRangeSyntax(RangeTestParameter testParameter) {
+        performRangeTest(testParameter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("unitCompatibilityTestParameters")
+    public void testRangeUnitCompatibilityCheck(RangeTestParameter testParameter) {
+        performRangeTest(testParameter);
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundaryTestParameters")
+    public void testRangeBoundaryCheck(RangeTestParameter testParameter) {
+        performRangeTest(testParameter);
+    }
+
+    private void performRangeTest(RangeTestParameter testParameter) {
+        if (testParameter.isValid()) {
+            assertDoesNotThrow(() -> initProfile(testParameter.range(), false));
+        } else {
+            assertThrows(IllegalArgumentException.class, () -> initProfile(testParameter.range(), false));
+        }
+    }
+
+    private StateProfile initProfile(@Nullable String range, boolean inverted) {
+        final Map<String, @Nullable Object> properties = new HashMap<>(2);
+        properties.put(SystemRangeFilterProfile.RANGE_PARAM, range);
+        properties.put(SystemRangeFilterProfile.RANGE_ACTION_PARAM,
+                inverted ? SystemRangeFilterProfile.RANGE_ACTION_DISCARD : SystemRangeFilterProfile.RANGE_ACTION_ALLOW);
+        when(contextMock.getConfiguration()).thenReturn(new Configuration(properties));
+        lenient().when(callbackMock.getItemChannelLink()).thenReturn(itemChannelLink);
+        return new SystemRangeFilterProfile(callbackMock, contextMock);
+    }
+
+    private void verifySendCommand(StateProfile profile, Command command, boolean passedThrough) {
+        reset(callbackMock);
+        profile.onCommandFromHandler(command);
+        if (passedThrough) {
+            verify(callbackMock, times(1)).sendCommand(eq(command));
+        } else {
+            verify(callbackMock, never()).sendCommand(eq(command));
+        }
+    }
+
+    private void verifySendUpdate(StateProfile profile, State state, boolean passedThrough) {
+        reset(callbackMock);
+        profile.onStateUpdateFromHandler(state);
+        if (passedThrough) {
+            verify(callbackMock, times(1)).sendUpdate(eq(state));
+        } else {
+            verify(callbackMock, never()).sendUpdate(eq(state));
+        }
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -53,9 +53,12 @@ import org.openhab.core.thing.type.ChannelType;
 @NonNullByDefault
 public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
 
-    private final Map<String, Object> properties = Map.of(SystemOffsetProfile.OFFSET_PARAM, BigDecimal.ZERO,
-            SystemHysteresisStateProfile.LOWER_PARAM, BigDecimal.TEN, SystemRangeStateProfile.UPPER_PARAM,
-            BigDecimal.valueOf(40));
+    private final Map<String, Object> properties = Map.of( //
+            SystemOffsetProfile.OFFSET_PARAM, BigDecimal.ZERO, //
+            SystemHysteresisStateProfile.LOWER_PARAM, BigDecimal.TEN, //
+            SystemRangeStateProfile.UPPER_PARAM, BigDecimal.valueOf(40), //
+            SystemRangeFilterProfile.RANGE_PARAM, "[1..2]" //
+    );
 
     private @NonNullByDefault({}) SystemProfileFactory profileFactory;
 
@@ -73,7 +76,7 @@ public class SystemProfileFactoryOSGiTest extends JavaOSGiTest {
     @Test
     public void systemProfileTypesAndUidsShouldBeAvailable() {
         Collection<ProfileTypeUID> systemProfileTypeUIDs = profileFactory.getSupportedProfileTypeUIDs();
-        assertThat(systemProfileTypeUIDs, hasSize(21));
+        assertThat(systemProfileTypeUIDs, hasSize(22));
 
         Collection<ProfileType> systemProfileTypes = profileFactory.getProfileTypes(null);
         assertThat(systemProfileTypes, hasSize(systemProfileTypeUIDs.size()));


### PR DESCRIPTION
Add a `range-filter` profile to allow/discard values inside a given range.

Example .items file:
```java
// Simple range - allows 0 - 30
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[0 .. 30]" }
// exclusive boundaries with ( and ) discards 0 and 30
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="(0 .. 30)" }
// exclusive boundaries only on beginning/end: accepts 0, discards 30
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[0 .. 30)" }

// Supports "inverted" range: discards what's in the given range
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[0 .. 30]", action="discard" }

// Supports begin-less and end-less range, i.e. for a simple "greater than / less than" filter
//   allow anything up to and including 30
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[ .. 30]" }
//   allow anything 30 or above
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[30..]" }

// multiple ranges
Number MyNumber { channel="xxxx" [profile="system:range-filter", range="[0 .. 30], [60..80]" }

// Dimensioned item/channel
Number:Temperature MyTemp { channel="xxxx" [profile="system:range-filter", range="[-50 °C..60 °C]" ] }
// mix units in the range
Number:Temperature MyTemp { channel="xxxx" [profile="system:range-filter", range="[-50 °C..140 °F]" ] }
```

Config in the Main UI:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/2554958/230762804-96668959-8e14-46e3-b7ac-dec565272a75.png">





