### PR TITLE
[oauth] Add support for custom deserialization of AccessTokenResponse

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -35,7 +35,7 @@ import org.openhab.core.io.net.http.HttpClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.gson.JsonDeserializer;
+import com.google.gson.GsonBuilder;
 
 /**
  * Implementation of OAuthClientService.
@@ -68,16 +68,19 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     private final String handle;
     private final int tokenExpiresInSeconds;
     private final HttpClientFactory httpClientFactory;
+    private final @Nullable GsonBuilder gsonBuilder;
     private final List<AccessTokenRefreshListener> accessTokenRefreshListeners = new ArrayList<>();
 
     private PersistedParams persistedParams = new PersistedParams();
 
     private volatile boolean closed = false;
 
-    private OAuthClientServiceImpl(String handle, int tokenExpiresInSeconds, HttpClientFactory httpClientFactory) {
+    private OAuthClientServiceImpl(String handle, int tokenExpiresInSeconds, HttpClientFactory httpClientFactory,
+            @Nullable GsonBuilder gsonBuilder) {
         this.handle = handle;
         this.tokenExpiresInSeconds = tokenExpiresInSeconds;
         this.httpClientFactory = httpClientFactory;
+        this.gsonBuilder = gsonBuilder;
     }
 
     /**
@@ -103,7 +106,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             return null;
         }
         OAuthClientServiceImpl clientService = new OAuthClientServiceImpl(handle, tokenExpiresInSeconds,
-                httpClientFactory);
+                httpClientFactory, null);
         clientService.storeHandler = storeHandler;
         clientService.persistedParams = persistedParamsFromStore;
 
@@ -124,7 +127,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     static OAuthClientServiceImpl createInstance(String handle, OAuthStoreHandler storeHandler,
             HttpClientFactory httpClientFactory, PersistedParams params) {
         OAuthClientServiceImpl clientService = new OAuthClientServiceImpl(handle, params.tokenExpiresInSeconds,
-                httpClientFactory);
+                httpClientFactory, null);
 
         clientService.storeHandler = storeHandler;
         clientService.persistedParams = params;
@@ -153,7 +156,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             throw new OAuthException("Missing client ID");
         }
 
-        OAuthConnector connector = new OAuthConnector(httpClientFactory, persistedParams.deserializerClassName);
+        GsonBuilder gsonBuilder = this.gsonBuilder;
+        OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory)
+                : new OAuthConnector(httpClientFactory, gsonBuilder);
         return connector.getAuthorizationUrl(authorizationUrl, clientId, redirectURI, persistedParams.state,
                 scopeToUse);
     }
@@ -207,7 +212,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             throw new OAuthException("Missing client ID");
         }
 
-        OAuthConnector connector = new OAuthConnector(httpClientFactory, persistedParams.deserializerClassName);
+        GsonBuilder gsonBuilder = this.gsonBuilder;
+        OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory)
+                : new OAuthConnector(httpClientFactory, gsonBuilder);
         AccessTokenResponse accessTokenResponse = connector.grantTypeAuthorizationCode(tokenUrl, authorizationCode,
                 clientId, persistedParams.clientSecret, redirectURI,
                 Boolean.TRUE.equals(persistedParams.supportsBasicAuth));
@@ -239,7 +246,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             throw new OAuthException("Missing token url");
         }
 
-        OAuthConnector connector = new OAuthConnector(httpClientFactory, persistedParams.deserializerClassName);
+        GsonBuilder gsonBuilder = this.gsonBuilder;
+        OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory)
+                : new OAuthConnector(httpClientFactory, gsonBuilder);
         AccessTokenResponse accessTokenResponse = connector.grantTypePassword(tokenUrl, username, password,
                 persistedParams.clientId, persistedParams.clientSecret, scope,
                 Boolean.TRUE.equals(persistedParams.supportsBasicAuth));
@@ -264,7 +273,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             throw new OAuthException("Missing client ID");
         }
 
-        OAuthConnector connector = new OAuthConnector(httpClientFactory, persistedParams.deserializerClassName);
+        GsonBuilder gsonBuilder = this.gsonBuilder;
+        OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory)
+                : new OAuthConnector(httpClientFactory, gsonBuilder);
         // depending on usage, cannot guarantee every parameter is not null at the beginning
         AccessTokenResponse accessTokenResponse = connector.grantTypeClientCredentials(tokenUrl, clientId,
                 persistedParams.clientSecret, scope, Boolean.TRUE.equals(persistedParams.supportsBasicAuth));
@@ -298,7 +309,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
             throw new OAuthException("tokenUrl is required but null");
         }
 
-        OAuthConnector connector = new OAuthConnector(httpClientFactory, persistedParams.deserializerClassName);
+        GsonBuilder gsonBuilder = this.gsonBuilder;
+        OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory)
+                : new OAuthConnector(httpClientFactory, gsonBuilder);
         AccessTokenResponse accessTokenResponse = connector.grantTypeRefreshToken(tokenUrl,
                 lastAccessToken.getRefreshToken(), persistedParams.clientId, persistedParams.clientSecret,
                 persistedParams.scope, Boolean.TRUE.equals(persistedParams.supportsBasicAuth));
@@ -400,10 +413,9 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     }
 
     @Override
-    public <T extends JsonDeserializer<?>> OAuthClientService withDeserializer(Class<T> deserializerClass) {
+    public OAuthClientService withGsonBuilder(GsonBuilder gsonBuilder) {
         OAuthClientServiceImpl clientService = new OAuthClientServiceImpl(handle, persistedParams.tokenExpiresInSeconds,
-                httpClientFactory);
-        persistedParams.deserializerClassName = deserializerClass.getName();
+                httpClientFactory, gsonBuilder);
         clientService.persistedParams = persistedParams;
         clientService.storeHandler = storeHandler;
 

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -121,7 +121,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
      *            {@link org.openhab.core.auth.client.oauth2.OAuthFactory#createOAuthClientService}*
      * @param storeHandler Storage handler
      * @param httpClientFactory Http client factory
-     * @param persistedParams These parameters are static with respect to the oauth provider and thus can be persisted.
+     * @param persistedParams These parameters are static with respect to the OAuth provider and thus can be persisted.
      * @return OAuthClientServiceImpl an instance
      */
     static OAuthClientServiceImpl createInstance(String handle, OAuthStoreHandler storeHandler,

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
@@ -33,8 +33,6 @@ class PersistedParams {
     String state;
     String redirectUri;
     int tokenExpiresInSeconds = 60;
-    @Nullable
-    String deserializerClassName;
 
     /**
      * Default constructor needed for json serialization.
@@ -59,7 +57,6 @@ class PersistedParams {
      *            of the access tokens. This allows the access token to expire earlier than the
      *            official stated expiry time; thus prevents the caller obtaining a valid token at the time of invoke,
      *            only to find the token immediately expired.
-     * @param deserializerClass (optional) if a specific deserializer is needed
      */
     public PersistedParams(String handle, String tokenUrl, String authorizationUrl, String clientId,
             String clientSecret, String scope, Boolean supportsBasicAuth, int tokenExpiresInSeconds,
@@ -72,7 +69,6 @@ class PersistedParams {
         this.scope = scope;
         this.supportsBasicAuth = supportsBasicAuth;
         this.tokenExpiresInSeconds = tokenExpiresInSeconds;
-        this.deserializerClassName = deserializerClassName;
     }
 
     @Override
@@ -89,7 +85,6 @@ class PersistedParams {
         result = prime * result + ((supportsBasicAuth == null) ? 0 : supportsBasicAuth.hashCode());
         result = prime * result + tokenExpiresInSeconds;
         result = prime * result + ((tokenUrl == null) ? 0 : tokenUrl.hashCode());
-        result = prime * result + ((deserializerClassName != null) ? deserializerClassName.hashCode() : 0);
         return result;
     }
 
@@ -166,13 +161,6 @@ class PersistedParams {
                 return false;
             }
         } else if (!tokenUrl.equals(other.tokenUrl)) {
-            return false;
-        }
-        if (deserializerClassName == null) {
-            if (other.deserializerClassName != null) {
-                return false;
-            }
-        } else if (deserializerClassName != null && !deserializerClassName.equals(other.deserializerClassName)) {
             return false;
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
-import com.google.gson.JsonDeserializer;
+import com.google.gson.GsonBuilder;
 
 /**
  * This is the service factory to produce an OAuth2 service client that authenticates using OAUTH2.
@@ -291,10 +291,10 @@ public interface OAuthClientService extends AutoCloseable {
     boolean removeAccessTokenRefreshListener(AccessTokenRefreshListener listener);
 
     /**
-     * Adds a personalized deserializer to a given oauth service.
+     * Adds a custom GsonBuilder to be used with a given OAuth service.
      *
-     * @param deserializeClass the deserializer class that should be used to deserialize AccessTokenResponse
-     * @return the oauth service
+     * @param gsonBuilder the custom GsonBuilder instance
+     * @return the OAuth service
      */
-    <T extends JsonDeserializer<?>> OAuthClientService withDeserializer(Class<T> deserializerClass);
+    OAuthClientService withGsonBuilder(GsonBuilder gsonBuilder);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
@@ -21,7 +21,7 @@ import com.google.gson.GsonBuilder;
 
 /**
  * This is the service factory to produce an OAuth2 service client that authenticates using OAUTH2.
- * This is a service factory pattern; the OAuthe2 service client is not shared between bundles.
+ * This is a service factory pattern; the OAuth2 service client is not shared between bundles.
  *
  * <p>
  * The basic uses of this OAuthClient are as follows:
@@ -291,7 +291,7 @@ public interface OAuthClientService extends AutoCloseable {
     boolean removeAccessTokenRefreshListener(AccessTokenRefreshListener listener);
 
     /**
-     * Adds a custom GsonBuilder to be used with a given OAuth service.
+     * Adds a custom GsonBuilder to be used with the OAuth service instance.
      *
      * @param gsonBuilder the custom GsonBuilder instance
      * @return the OAuth service

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthFactory.java
@@ -26,12 +26,12 @@ import org.eclipse.jdt.annotation.Nullable;
 public interface OAuthFactory {
 
     /**
-     * Creates a new oauth service. Use this method only once to obtain a handle and store
+     * Creates a new OAuth service. Use this method only once to obtain a handle and store
      * this handle for further in a persistent storage container.
      *
-     * @param handle the handle to the oauth service
-     * @param tokenUrl the token url of the oauth provider. This is used for getting access token.
-     * @param authorizationUrl the authorization url of the oauth provider. This is used purely for generating
+     * @param handle the handle to the OAuth service
+     * @param tokenUrl the token url of the OAuth provider. This is used for getting access token.
+     * @param authorizationUrl the authorization url of the OAuth provider. This is used purely for generating
      *            authorization code/ url.
      * @param clientId the client id
      * @param clientSecret the client secret (optional)
@@ -39,23 +39,23 @@ public interface OAuthFactory {
      * @param supportsBasicAuth whether the OAuth provider supports basic authorization or the client id and client
      *            secret should be passed as form params. true - use http basic authentication, false - do not use http
      *            basic authentication, null - unknown (default to do not use)
-     * @return the oauth service
+     * @return the OAuth service
      */
     OAuthClientService createOAuthClientService(String handle, String tokenUrl, @Nullable String authorizationUrl,
             String clientId, @Nullable String clientSecret, @Nullable String scope,
             @Nullable Boolean supportsBasicAuth);
 
     /**
-     * Gets the oauth service for a given handle
+     * Gets the OAuth service for a given handle
      *
-     * @param handle the handle to the oauth service
-     * @return the oauth service or null if it doesn't exist
+     * @param handle the handle to the OAuth service
+     * @return the OAuth service or null if it doesn't exist
      */
     @Nullable
     OAuthClientService getOAuthClientService(String handle);
 
     /**
-     * Unget an oauth service, this unget/unregister the service, and frees the resources.
+     * Unget an OAuth service, this unget/unregister the service, and frees the resources.
      * The existing tokens/ configurations (persisted parameters) are still saved
      * in the store. It will internally call {@code OAuthClientService#close()}.
      *
@@ -64,7 +64,7 @@ public interface OAuthFactory {
      * If OAuth service is closed directly, without using {@code #ungetOAuthService(String)},
      * then a small residual footprint is left in the cache.
      *
-     * @param handle the handle to the oauth service
+     * @param handle the handle to the OAuth service
      */
     void ungetOAuthService(String handle);
 
@@ -72,7 +72,7 @@ public interface OAuthFactory {
      * This method is for unget/unregister the service,
      * then <strong>DELETE</strong> access token, configuration data from the store
      *
-     * @param handle
+     * @param handle the handle to the OAuth service
      */
     void deleteServiceAndAccessToken(String handle);
 }


### PR DESCRIPTION
This reverts #1891 and fixes #1888 by providing a new way to customize deserialization of `AccessTokenResponse` which has been tested with the Netatmo binding. See openhab/openhab-addons#14755 for a description of the concrete Netatmo problem that so far prevented Netatmo from using the core OAuth implementation.

In this new approach a custom `GsonBuilder` can be provided which can be preconfigured with custom type adapters etc.

This fixes the issue with #1891:
```
[oauth2client.internal.OAuthConnector] - Unable to construct custom deserializer 'org.openhab.binding.netatmo.internal.deserialization.AccessTokenResponseDeserializer'
java.lang.ClassNotFoundException: org.openhab.binding.netatmo.internal.deserialization.AccessTokenResponseDeserializer cannot be found by org.openhab.core.auth.oauth2client_4.0.0.202304080304
```

but also adds more flexibility, for example by allowing multiple type adapters, not only a single fixed deserialization class.