### PR TITLE
Extend item syntax for category/icon

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
@@ -16,7 +16,7 @@ ItemModel:
 ModelItem:
 	(ModelNormalItem | ModelGroupItem) name=ID
 	(label=STRING)?
-	('<' icon=(ID|STRING) '>')?
+	('<' icon=Icon '>')?
 	('(' groups+=ID (',' groups+=ID)* ')')? 
 	('[' tags+=(ID|STRING) (',' tags+=(ID|STRING))* ']')?
 	('{' bindings+=ModelBinding (',' bindings+=ModelBinding)* '}')? 
@@ -62,6 +62,10 @@ BOOLEAN returns ecore::EBoolean:
 
 NUMBER returns ecore::EBigDecimal:
     ('-')? ID ('.' ID )?
+;
+
+Icon:
+	(ID ':' (ID ':')?)? ID
 ;
 
 terminal ID: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;


### PR DESCRIPTION
The icon value can now contain until 3 segments separated by a semi-column.
First segment is the icon source. Example: oh, if, iconify, material, f7, ...
Second segment is the icon set. Example: classic
Third segment is the icon name (and can contain hyphen). Example: temperature

In case only two segments are provided, the first segment is the icon source and the second the icon name. "classic" icon set is assumed if icon source is "oh".
In case only one segment is provided, the icon source is assumed to be the openHAB server and its classic icon set and the value is then the icon name.

Ability to use a string containing anything has been removed.

Related to #3052

Signed-off-by: Laurent Garnier <lg.hc@free.fr>