### PR TITLE
[ephemeris] Upgrade/replace Jollyday

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -362,9 +362,9 @@
 
     <!-- jollyday -->
     <dependency>
-      <groupId>de.jollyday</groupId>
-      <artifactId>jollyday</artifactId>
-      <version>0.5.10</version>
+      <groupId>de.focus-shift</groupId>
+      <artifactId>jollyday-jaxb</artifactId>
+      <version>0.14.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -953,9 +953,9 @@
 
     <!-- jollyday -->
     <dependency>
-      <groupId>de.jollyday</groupId>
-      <artifactId>jollyday</artifactId>
-      <version>0.5.10</version>
+      <groupId>de.focus-shift</groupId>
+      <artifactId>jollyday-jaxb</artifactId>
+      <version>0.14.0</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -55,11 +55,11 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.jollyday.Holiday;
-import de.jollyday.HolidayManager;
-import de.jollyday.ManagerParameter;
-import de.jollyday.ManagerParameters;
-import de.jollyday.util.ResourceUtil;
+import de.focus_shift.Holiday;
+import de.focus_shift.HolidayManager;
+import de.focus_shift.ManagerParameter;
+import de.focus_shift.ManagerParameters;
+import de.focus_shift.util.ResourceUtil;
 
 /**
  * This service provides functionality around ephemeris services and is the central service to be used directly by

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -191,9 +191,9 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.5.10</capability>
-		<bundle>mvn:org.threeten/threeten-extra/1.5.0</bundle>
-		<bundle>mvn:de.jollyday/jollyday/0.5.10</bundle>
+		<capability>openhab.tp;feature=jollyday;version=0.14.0</capability>
+		<bundle>mvn:org.threeten/threeten-extra/1.7.2</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jaxb/0.14.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -17,8 +17,8 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -17,8 +17,8 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -17,8 +17,8 @@ Fragment-Host: org.openhab.core.automation.module.script
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -17,8 +17,8 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -17,8 +17,8 @@ Fragment-Host: org.openhab.core.automation
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -22,8 +22,8 @@ feature.openhab-config: \
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	jakarta.annotation-api;version='[2.0.0,2.0.1)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -23,8 +23,8 @@ Fragment-Host: org.openhab.core.model.item
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.eclipse.emf.common;version='[2.17.0,2.17.1)',\
 	org.eclipse.emf.ecore;version='[2.20.0,2.20.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.16.0,2.16.1)',\

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -27,8 +27,8 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.eclipse.emf.common;version='[2.17.0,2.17.1)',\
 	org.eclipse.emf.ecore;version='[2.20.0,2.20.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.16.0,2.16.1)',\

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -26,8 +26,8 @@ Fragment-Host: org.openhab.core.model.script
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.eclipse.emf.common;version='[2.17.0,2.17.1)',\
 	org.eclipse.emf.ecore;version='[2.20.0,2.20.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.16.0,2.16.1)',\

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -24,8 +24,8 @@ Fragment-Host: org.openhab.core.model.thing
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
-	jollyday;version='[0.5.10,0.5.11)',\
-	org.threeten.extra;version='[1.5.0,1.5.1)',\
+	jollyday;version='[0.14.0,0.14.1)',\
+	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	org.eclipse.emf.common;version='[2.17.0,2.17.1)',\
 	org.eclipse.emf.ecore;version='[2.20.0,2.20.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.16.0,2.16.1)',\


### PR DESCRIPTION
This is my initial attempt to replace https://github.com/svendiedrichsen/jollyday by https://github.com/focus-shift/jollyday

However, I don't know what I'm doing, and how to test it, so creating this draft in case anyone would be able to share hints.

I was able to compile **org.openhab.core.ephemeris-4.0.0-SNAPSHOT.jar** and replace this in a development installation:

```shell
openhab> bundle:uninstall org.openhab.core.ephemeris
```

and then dropping the JAR. This results in:

```
2023-04-12 22:43:58.661 [WARN ] [org.apache.felix.fileinstall        ] - Error while starting bundle: file:/openHAB/addons/org.openhab.core.ephemeris-4.0.0-SNAPSHOT.jar
org.osgi.framework.BundleException: Could not resolve module: org.openhab.core.ephemeris [257]
  Unresolved requirement: Import-Package: de.focus_shift

	at org.eclipse.osgi.container.Module.start(Module.java:463) ~[org.eclipse.osgi-3.18.0.jar:?]
	at org.eclipse.osgi.internal.framework.EquinoxBundle.start(EquinoxBundle.java:445) ~[org.eclipse.osgi-3.18.0.jar:?]
	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundle(DirectoryWatcher.java:1260) ~[?:?]
	at org.apache.felix.fileinstall.internal.DirectoryWatcher.startBundles(DirectoryWatcher.java:1233) ~[?:?]
	at org.apache.felix.fileinstall.internal.DirectoryWatcher.doProcess(DirectoryWatcher.java:520) ~[?:?]
	at org.apache.felix.fileinstall.internal.DirectoryWatcher.process(DirectoryWatcher.java:365) ~[?:?]
	at org.apache.felix.fileinstall.internal.DirectoryWatcher.run(DirectoryWatcher.java:316) ~[?:?]
```

which I then tried to solve by also dropping jollyday-jaxb-0.14.0.jar as jollyday-jaxb.jar, but without success.

Resolves #3544 (well, that would be the plan)