### PR TITLE
Add multiplier option to offset profile

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/offsetProfile.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/offsetProfile.xml
@@ -6,10 +6,19 @@
 	https://openhab.org/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="profile:system:offset">
+		<parameter name="multiplier" type="decimal">
+			<label>Multiplier</label>
+			<description>Multiplier to be applied on the state towards the item. The inverse will be applied on the commands from
+				the item to the channel.</description>
+			<default>1</default>
+		</parameter>
 		<parameter name="offset" type="text" required="true">
 			<label>Offset</label>
-			<description>Offset (plain number or number with unit) to be applied on the state towards the item. The negative
-				offset will be applied in the reverse direction.</description>
+			<description><![CDATA[
+				Offset (plain number or number with unit) to be applied on the state towards the item. The negative
+				offset will be applied in the reverse direction. The offset is added after the multiplier is applied.
+				The resulting value is <tt>mX + b</tt> where m is the multiplier and b is the offset.]]></description>
+			<default>0</default>
 		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
@@ -1,8 +1,10 @@
 profile-type.system.default.label = Default
 profile-type.system.follow.label = Follow
 profile-type.system.offset.label = Offset
+profile.config.system.offset.multiplier.label = Multiplier
+profile.config.system.offset.multiplier.description = Multiplier to be applied on the state towards the item. The inverse will be applied on the commands from the item to the channel.
 profile.config.system.offset.offset.label = Offset
-profile.config.system.offset.offset.description = Offset (plain number or number with unit) to be applied on the state towards the item. The negative offset will be applied in the reverse direction.
+profile.config.system.offset.offset.description = Offset (plain number or number with unit) to be applied on the state towards the item. The negative offset will be applied in the reverse direction. The offset is added after the multiplier is applied. The resulting value is <tt>mX + b</tt> where m is the multiplier and b is the offset.
 profile-type.system.hysteresis.label = Hysteresis
 profile.config.system.hysteresis.lower.label = Lower Bound
 profile.config.system.hysteresis.lower.description = Maps to OFF if value is below lower bound (plain number or number with unit).

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
@@ -12,201 +12,228 @@
  */
 package org.openhab.core.thing.internal.profiles;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.number.IsCloseTo.closeTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import javax.measure.Unit;
-import javax.measure.quantity.Temperature;
+import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
-import org.openhab.core.library.unit.ImperialUnits;
-import org.openhab.core.library.unit.SIUnits;
-import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.Type;
 
 /**
  * Tests for the system:offset profile
  *
  * @author Stefan Triller - Initial contribution
+ * @author Jimmy Tanagra - Refactor and add tests for multiplier
  */
 @NonNullByDefault
 public class SystemOffsetProfileTest {
 
-    @BeforeEach
-    public void setup() {
-        // initialize parser with ImperialUnits, otherwise units like °F are unknown
-        @SuppressWarnings("unused")
-        Unit<Temperature> fahrenheit = ImperialUnits.FAHRENHEIT;
+    record TestParameters(@Nullable Object multiplier, @Nullable Object offset, boolean towardsItem, Type input,
+            @Nullable Type expectedResult) {
     }
 
-    @Test
-    public void testDecimalTypeOnCommandFromItem() {
+    public static DecimalType ONE = new DecimalType(1);
+
+    public static Collection<TestParameters> identityParameters() {
+        return List.of( //
+                // basic identity checks that convert ONE to ONE
+                new TestParameters(null, null, true, ONE, ONE), //
+                new TestParameters(null, null, true, new DecimalType(10), new DecimalType(10)), //
+                new TestParameters(null, null, true, new QuantityType<>("0 °C"), new QuantityType<>("0 °C")), //
+                new TestParameters(null, null, false, ONE, ONE), //
+                new TestParameters(1, null, false, ONE, ONE), //
+                new TestParameters(1, null, true, ONE, ONE), //
+                new TestParameters(1, DecimalType.ZERO, false, ONE, ONE), //
+                new TestParameters(1, DecimalType.ZERO, true, ONE, ONE), //
+                new TestParameters(null, DecimalType.ZERO, false, ONE, ONE), //
+                new TestParameters(null, DecimalType.ZERO, true, ONE, ONE), //
+                new TestParameters("1", "0", false, ONE, ONE), //
+                new TestParameters("1", "0", true, ONE, ONE), //
+                new TestParameters(1, 0, true, ONE, ONE), //
+
+                new TestParameters(null, "", true, ONE, ONE), //
+
+                new TestParameters(null, null, false, ONE, ONE) // dummy entry so I don't have to keep editing the comma
+        );
+    }
+
+    public static Collection<TestParameters> decimalTypeParameters() {
+        return List.of( //
+                new TestParameters(5, 0, true, new DecimalType(7), new DecimalType(35)), //
+                new TestParameters(5, 0, false, new DecimalType(35), new DecimalType(7)), //
+
+                new TestParameters(0.1, 0, true, new DecimalType(100), new DecimalType(10)), //
+                new TestParameters(0.1, 0, false, new DecimalType(10), new DecimalType(100)), //
+
+                new TestParameters(-1, 0, true, new DecimalType(100), new DecimalType(-100)), //
+                new TestParameters(-1, 0, false, new DecimalType(-100), new DecimalType(100)), //
+
+                new TestParameters(1, 3, true, new DecimalType(23), new DecimalType(26)), //
+                new TestParameters(1, 3, false, new DecimalType(26), new DecimalType(23)), //
+
+                new TestParameters(1, -3, true, new DecimalType(23), new DecimalType(20)), //
+                new TestParameters(1, -3, false, new DecimalType(20), new DecimalType(23)), //
+
+                new TestParameters(5, 3, true, new DecimalType(23), new DecimalType(118)), //
+                new TestParameters(5, 3, false, new DecimalType(118), new DecimalType(23)), //
+
+                new TestParameters(null, null, false, ONE, ONE) // dummy entry so I don't have to keep editing the comma
+        );
+    }
+
+    public static Collection<TestParameters> quantityTypeParameters() {
+        return List.of( //
+                new TestParameters(2, null, true, new QuantityType<>("23 °C"), new QuantityType<>("46 °C")), //
+                new TestParameters(2, null, false, new QuantityType<>("46 °C"), new QuantityType<>("23 °C")), //
+
+                new TestParameters(-2, null, true, new QuantityType<>("23 °C"), new QuantityType<>("-46 °C")), //
+                new TestParameters(-2, null, false, new QuantityType<>("-46 °C"), new QuantityType<>("23 °C")), //
+
+                new TestParameters(null, "3°C", true, new QuantityType<>("23°C"), new QuantityType<>("26°C")), //
+                new TestParameters(null, "3°C", false, new QuantityType<>("26°C"), new QuantityType<>("23°C")), //
+
+                new TestParameters(null, "-3°C", true, new QuantityType<>("23°C"), new QuantityType<>("20°C")), //
+                new TestParameters(null, "-3°C", false, new QuantityType<>("20°C"), new QuantityType<>("23°C")), //
+
+                new TestParameters("5", "3°C", true, new QuantityType<>("23 °C"), new QuantityType<>("118 °C")), //
+                new TestParameters("5", "3°C", false, new QuantityType<>("118 °C"), new QuantityType<>("23 °C")), //
+
+                // Offset in a different unit to the value
+                new TestParameters(null, "9 °F", true, new QuantityType<>("23°C"), new QuantityType<>("28°C")), //
+                new TestParameters(null, "9 °F", false, new QuantityType<>("28°C"), new QuantityType<>("23°C")), //
+                new TestParameters(null, "1 kW", true, new QuantityType<>("120 W"), new QuantityType<>("1120 W")), //
+                new TestParameters(null, "1 kW", false, new QuantityType<>("1120 W"), new QuantityType<>("120 W")), //
+
+                // Non unit offset + value with unit
+                new TestParameters(null, 3, true, new QuantityType<>("23°C"), new QuantityType<>("26°C")), //
+
+                // Decimal offset, input is QuantityType with unit ONE
+                new TestParameters(null, 3, true, new QuantityType<>(), new QuantityType<>("3")), //
+
+                new TestParameters(null, null, false, ONE, ONE) // dummy entry so I don't have to keep editing the comma
+        );
+    }
+
+    public static Collection<TestParameters> invalidParameters() {
+        return List.of( //
+                // Incompatible units
+                new TestParameters(1, "1 °C", true, new QuantityType<>("5 W"), null), //
+                new TestParameters(1, "1 °C", false, new QuantityType<>("5 W"), null), //
+
+                // Incoming values are passed through when the parameters were invalid
+                new TestParameters(1, "bar", true, ONE, ONE), //
+                new TestParameters(1, "bar", true, new QuantityType<>("5 °F"), new QuantityType<>("5 °F")), //
+
+                new TestParameters(null, null, false, ONE, ONE) // dummy entry so I don't have to keep editing the comma
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("identityParameters")
+    public void testIdentity(TestParameters parameters) {
+        performTest(parameters);
+    }
+
+    @ParameterizedTest
+    @MethodSource("decimalTypeParameters")
+    public void testDecimalType(TestParameters parameters) {
+        performTest(parameters);
+    }
+
+    @ParameterizedTest
+    @MethodSource("quantityTypeParameters")
+    public void testQuantityType(TestParameters parameters) {
+        performTest(parameters);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidParameters")
+    public void testInvalidParameters(TestParameters parameters) {
+        performTest(parameters);
+    }
+
+    private void performTest(TestParameters parameters) {
         ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
+        SystemOffsetProfile offsetProfile = createProfile(callback, parameters.multiplier(), parameters.offset());
 
-        Command cmd = new DecimalType(23);
-        offsetProfile.onCommandFromItem(cmd);
-
-        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
-        verify(callback, times(1)).handleCommand(capture.capture());
-
-        Command result = capture.getValue();
-        DecimalType decResult = (DecimalType) result;
-        assertEquals(20, decResult.intValue());
+        if (parameters.towardsItem()) {
+            performTestTowardsItem(callback, offsetProfile, parameters);
+        } else {
+            performTestFromItem(callback, offsetProfile, parameters);
+        }
     }
 
-    @Test
-    public void testQuantityTypeOnCommandFromItem() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3°C");
+    private void performTestTowardsItem(ProfileCallback callback, SystemOffsetProfile offsetProfile,
+            TestParameters parameters) {
+        offsetProfile.onCommandFromHandler((Command) parameters.input());
+        if (parameters.expectedResult() == null) {
+            verify(callback, never()).sendCommand(any());
+        } else {
+            ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+            verify(callback, times(1)).sendCommand(capture.capture());
+            assertEqualValuesAndUnits(parameters.expectedResult(), capture.getValue());
+        }
 
-        Command cmd = new QuantityType<>("23°C");
-        offsetProfile.onCommandFromItem(cmd);
-
-        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
-        verify(callback, times(1)).handleCommand(capture.capture());
-
-        Command result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertEquals(20, decResult.intValue());
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
+        offsetProfile.onStateUpdateFromHandler((State) parameters.input());
+        if (parameters.expectedResult() == null) {
+            verify(callback, never()).sendUpdate(any());
+        } else {
+            ArgumentCaptor<State> capturedState = ArgumentCaptor.forClass(State.class);
+            verify(callback, times(1)).sendUpdate(capturedState.capture());
+            assertEqualValuesAndUnits(parameters.expectedResult(), capturedState.getValue());
+        }
     }
 
-    @Test
-    public void testDecimalTypeOnCommandFromHandler() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
-
-        Command cmd = new DecimalType(23);
-        offsetProfile.onCommandFromHandler(cmd);
-
-        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
-        verify(callback, times(1)).sendCommand(capture.capture());
-
-        Command result = capture.getValue();
-        DecimalType decResult = (DecimalType) result;
-        assertEquals(26, decResult.intValue());
+    private void performTestFromItem(ProfileCallback callback, SystemOffsetProfile offsetProfile,
+            TestParameters parameters) {
+        offsetProfile.onCommandFromItem((Command) parameters.input());
+        if (parameters.expectedResult() == null) {
+            verify(callback, never()).handleCommand(any());
+        } else {
+            ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
+            verify(callback, times(1)).handleCommand(capture.capture());
+            assertEqualValuesAndUnits(parameters.expectedResult(), capture.getValue());
+        }
     }
 
-    @Test
-    public void testDecimalTypeOnStateUpdateFromHandler() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
-
-        State state = new DecimalType(23);
-        offsetProfile.onStateUpdateFromHandler(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        DecimalType decResult = (DecimalType) result;
-        assertEquals(26, decResult.intValue());
-    }
-
-    @Test
-    public void testQuantityTypeOnCommandFromHandler() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3°C");
-
-        Command cmd = new QuantityType<>("23°C");
-        offsetProfile.onCommandFromHandler(cmd);
-
-        ArgumentCaptor<Command> capture = ArgumentCaptor.forClass(Command.class);
-        verify(callback, times(1)).sendCommand(capture.capture());
-
-        Command result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertEquals(26, decResult.intValue());
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
-    }
-
-    @Test
-    public void testQuantityTypeOnStateUpdateFromHandler() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3°C");
-
-        State state = new QuantityType<>("23°C");
-        offsetProfile.onStateUpdateFromHandler(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertEquals(26, decResult.intValue());
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
-    }
-
-    @Test
-    public void testQuantityTypeOnStateUpdateFromHandlerFahrenheitOffset() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3 °F");
-
-        State state = new QuantityType<>("23 °C");
-        offsetProfile.onStateUpdateFromHandler(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertThat(decResult.doubleValue(), is(closeTo(24.6666666666666666666666666666667d, 0.0000000000000001d)));
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
-    }
-
-    @Test
-    public void testQuantityTypeWithUnitCelsiusOnStateUpdateFromHandlerDecimalOffset() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
-
-        State state = new QuantityType<>("23 °C");
-        offsetProfile.onStateUpdateFromHandler(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertEquals(26, decResult.intValue());
-        assertEquals(SIUnits.CELSIUS, decResult.getUnit());
-    }
-
-    @Test
-    public void testQuantityTypeWithUnitOneOnStateUpdateFromHandlerDecimalOffset() {
-        ProfileCallback callback = mock(ProfileCallback.class);
-        SystemOffsetProfile offsetProfile = createProfile(callback, "3");
-
-        State state = new QuantityType<>();
-        offsetProfile.onStateUpdateFromHandler(state);
-
-        ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
-        verify(callback, times(1)).sendUpdate(capture.capture());
-
-        State result = capture.getValue();
-        QuantityType<?> decResult = (QuantityType<?>) result;
-        assertEquals(3, decResult.intValue());
-        assertEquals(Units.ONE, decResult.getUnit());
-    }
-
-    private SystemOffsetProfile createProfile(ProfileCallback callback, String offset) {
+    private SystemOffsetProfile createProfile(ProfileCallback callback, @Nullable Object multiplier,
+            @Nullable Object offset) {
         ProfileContext context = mock(ProfileContext.class);
         Configuration config = new Configuration();
-        config.put(SystemOffsetProfile.OFFSET_PARAM, offset);
+        if (offset != null) {
+            config.put(SystemOffsetProfile.OFFSET_PARAM, offset);
+        }
+        if (multiplier != null) {
+            config.put(SystemOffsetProfile.MULTIPLIER_PARAM, multiplier);
+        }
         when(context.getConfiguration()).thenReturn(config);
 
         return new SystemOffsetProfile(callback, context);
+    }
+
+    private void assertEqualValuesAndUnits(Object expected, Object captured) {
+        if (expected instanceof QuantityType qtyExpected) {
+            assertThat(captured, instanceOf(QuantityType.class));
+            QuantityType<?> qtyCaptured = (QuantityType<?>) captured;
+            assertEquals(qtyExpected.toBigDecimal(), qtyCaptured.toBigDecimal());
+            assertEquals(qtyExpected.getUnit(), qtyCaptured.getUnit());
+        } else {
+            assertEquals(expected, captured);
+        }
     }
 }


### PR DESCRIPTION
Resolve #3538

Add multiplier option to offset profile so people don't need to install the modbus addon just to get such a profile.

There are some differences compared to the modbus `gain-offset` profile, primarily:
- modbus gain-offset profile applies its offset parameter before calculating the gain (pre-gain offset), i.e. output = (input + offset) * gain
- This PR calculates it in the convention of a linear equation y = mx + b, so the offset is added after applying the gain (post-gain offset).
- The multiplier is a simple decimal type. No unit injection is done by this profile.

This PR should maintain backwards compatibility against existing users who only configured the `offset` parameter. In such circumstances, the multiplier defaults to `1` (no gain/attenuation). However:
- Incompatible units between the offset and the incoming value, previously resulted in an `UNDEF` being passed on. This is changed so nothing gets passed on.

