### PR TITLE
Icon server: remove old style request with the state in the URL

### DIFF
--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
@@ -106,7 +106,7 @@ public class IconServlet extends HttpServlet {
             return;
         }
 
-        String state = getState(req);
+        String state = req.getParameter(PARAM_STATE);
         String iconSetId = getIconSetId(req);
 
         Format format = getFormat(req);
@@ -173,8 +173,7 @@ public class IconServlet extends HttpServlet {
 
     private String getCategory(HttpServletRequest req) {
         String category = substringAfterLast(req.getRequestURI(), "/");
-        category = substringBeforeLast(category, ".");
-        return substringBeforeLast(category, "-");
+        return substringBeforeLast(category, ".");
     }
 
     private Format getFormat(HttpServletRequest req) {
@@ -203,22 +202,6 @@ public class IconServlet extends HttpServlet {
             return defaultIconSetId;
         } else {
             return iconSetId;
-        }
-    }
-
-    private @Nullable String getState(HttpServletRequest req) {
-        String state = req.getParameter(PARAM_STATE);
-        if (state != null) {
-            return state;
-        } else {
-            String filename = substringAfterLast(req.getRequestURI(), "/");
-            state = substringAfterLast(filename, "-");
-            state = substringBeforeLast(state, ".");
-            if (!state.isEmpty()) {
-                return state;
-            } else {
-                return null;
-            }
         }
     }
 

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
@@ -57,6 +57,10 @@ public class AbstractResourceIconProviderTest {
                         return new ByteArrayInputStream("x-30.png".getBytes());
                     case "x-y z.png":
                         return new ByteArrayInputStream("x-y z.png".getBytes());
+                    case "a-bb-ccc-30.png":
+                        return new ByteArrayInputStream("a-bb-ccc-30.png".getBytes());
+                    case "a-bb-ccc-y z.png":
+                        return new ByteArrayInputStream("a-bb-ccc-y z.png".getBytes());
                     default:
                         return null;
                 }
@@ -96,9 +100,22 @@ public class AbstractResourceIconProviderTest {
     public void testScanningForState() throws IOException {
         try (InputStream is = provider.getIcon("x", "classic", "34", Format.PNG)) {
             assertNotNull(is);
+            assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8), is("x-30.png"));
         }
 
         try (InputStream is = provider.getIcon("x", "classic", "25", Format.PNG)) {
+            assertNull(is);
+        }
+    }
+
+    @Test
+    public void testScanningIconWithHyphensForState() throws IOException {
+        try (InputStream is = provider.getIcon("a-bb-ccc", "classic", "34", Format.PNG)) {
+            assertNotNull(is);
+            assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8), is("a-bb-ccc-30.png"));
+        }
+
+        try (InputStream is = provider.getIcon("a-bb-ccc", "classic", "25", Format.PNG)) {
             assertNull(is);
         }
     }
@@ -111,9 +128,23 @@ public class AbstractResourceIconProviderTest {
     }
 
     @Test
+    public void testIconWithHyphensWithQuantityTypeState() throws IOException {
+        try (InputStream is = provider.getIcon("a-bb-ccc", "classic", "34 °C", Format.PNG)) {
+            assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8), is("a-bb-ccc-30.png"));
+        }
+    }
+
+    @Test
     public void testWithStringTypeState() throws IOException {
         try (InputStream is = provider.getIcon("x", "classic", "y z", Format.PNG)) {
             assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8), is("x-y z.png"));
+        }
+    }
+
+    @Test
+    public void testIconWithHyphensWithStringTypeState() throws IOException {
+        try (InputStream is = provider.getIcon("a-bb-ccc", "classic", "y z", Format.PNG)) {
+            assertThat(new String(is.readAllBytes(), StandardCharsets.UTF_8), is("a-bb-ccc-y z.png"));
         }
     }
 }

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
@@ -90,23 +90,6 @@ public class IconServletTest {
     }
 
     @Test
-    public void testOldUrlStyle() throws ServletException, IOException {
-        when(requestMock.getRequestURI()).thenReturn("/icon/y-34.png");
-
-        when(responseMock.getOutputStream()).thenReturn(responseOutputStream);
-
-        when(provider1Mock.hasIcon("y", "classic", Format.PNG)).thenReturn(0);
-        when(provider1Mock.getIcon("y", "classic", "34", Format.PNG))
-                .thenReturn(new ByteArrayInputStream("provider 1 icon: y classic 34 png".getBytes()));
-
-        servlet.addIconProvider(provider1Mock);
-        servlet.doGet(requestMock, responseMock);
-
-        assertEquals("provider 1 icon: y classic 34 png", responseOutputStream.getOutput());
-        verify(responseMock, never()).sendError(anyInt());
-    }
-
-    @Test
     public void testPriority() throws ServletException, IOException {
         when(requestMock.getRequestURI()).thenReturn("/icon/x");
         when(requestMock.getParameter(PARAM_FORMAT)).thenReturn("svg");


### PR DESCRIPTION
The state is now expected to be passed only in the "state" parameter of the request.

As a result, the icon name can now contain hyphen(s).

Closes #3543

Signed-off-by: Laurent Garnier <lg.hc@free.fr>