### PR TITLE
Add methods to get Semantic tag synonyms and description

### DIFF
--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
@@ -90,13 +90,13 @@ public class SemanticTags {
     public static List<String> getLabelAndSynonyms(Class<? extends Tag> tag, Locale locale) {
         ResourceBundle rb = ResourceBundle.getBundle(TAGS_BUNDLE_NAME, locale,
                 Control.getNoFallbackControl(Control.FORMAT_PROPERTIES));
+        TagInfo tagInfo = tag.getAnnotation(TagInfo.class);
         try {
-            String entry = rb.getString(tag.getAnnotation(TagInfo.class).id());
+            String entry = rb.getString(tagInfo.id());
             return List.of(entry.toLowerCase(locale).split(","));
         } catch (MissingResourceException e) {
-            TagInfo tagInfo = tag.getAnnotation(TagInfo.class);
             Stream<String> label = Stream.of(tagInfo.label());
-            Stream<String> synonyms = Stream.of(tagInfo.synonyms().split(","));
+            Stream<String> synonyms = Stream.of(tagInfo.synonyms().split(",")).map(String::trim);
             return Stream.concat(label, synonyms).map(s -> s.toLowerCase(locale)).distinct().toList();
         }
     }
@@ -104,16 +104,38 @@ public class SemanticTags {
     public static String getLabel(Class<? extends Tag> tag, Locale locale) {
         ResourceBundle rb = ResourceBundle.getBundle(TAGS_BUNDLE_NAME, locale,
                 Control.getNoFallbackControl(Control.FORMAT_PROPERTIES));
+        TagInfo tagInfo = tag.getAnnotation(TagInfo.class);
         try {
-            String entry = rb.getString(tag.getAnnotation(TagInfo.class).id());
+            String entry = rb.getString(tagInfo.id());
             if (entry.contains(",")) {
                 return entry.substring(0, entry.indexOf(","));
             } else {
                 return entry;
             }
         } catch (MissingResourceException e) {
-            return tag.getAnnotation(TagInfo.class).label();
+            return tagInfo.label();
         }
+    }
+
+    public static List<String> getSynonyms(Class<? extends Tag> tag, Locale locale) {
+        ResourceBundle rb = ResourceBundle.getBundle(TAGS_BUNDLE_NAME, locale,
+                Control.getNoFallbackControl(Control.FORMAT_PROPERTIES));
+        String synonyms = "";
+        TagInfo tagInfo = tag.getAnnotation(TagInfo.class);
+        try {
+            String entry = rb.getString(tagInfo.id());
+            int start = entry.indexOf(",") + 1;
+            if (start > 0 && entry.length() > start) {
+                synonyms = entry.substring(start);
+            }
+        } catch (MissingResourceException e) {
+            synonyms = tagInfo.synonyms();
+        }
+        return Stream.of(synonyms.split(",")).map(String::trim).toList();
+    }
+
+    public static String getDescription(Class<? extends Tag> tag, Locale locale) {
+        return tag.getAnnotation(TagInfo.class).description();
     }
 
     /**

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.semantics;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Locale;
@@ -30,7 +32,9 @@ import org.openhab.core.semantics.model.location.Locations;
 import org.openhab.core.semantics.model.location.Room;
 import org.openhab.core.semantics.model.point.Measurement;
 import org.openhab.core.semantics.model.point.Points;
+import org.openhab.core.semantics.model.property.Light;
 import org.openhab.core.semantics.model.property.Properties;
+import org.openhab.core.semantics.model.property.SoundVolume;
 import org.openhab.core.semantics.model.property.Temperature;
 
 /**
@@ -81,6 +85,23 @@ public class SemanticTagsTest {
         assertEquals(Kitchen.class, SemanticTags.getByLabelOrSynonym("Kitchen", Locale.ENGLISH).iterator().next());
         assertEquals(Kitchen.class, SemanticTags.getByLabelOrSynonym("Küche", Locale.GERMAN).iterator().next());
         assertEquals(Bathroom.class, SemanticTags.getByLabelOrSynonym("Badezimmer", Locale.GERMAN).iterator().next());
+    }
+
+    @Test
+    public void testGetLabel() {
+        assertEquals("Kitchen", SemanticTags.getLabel(Kitchen.class, Locale.ENGLISH));
+        assertEquals("Sound Volume", SemanticTags.getLabel(SoundVolume.class, Locale.ENGLISH));
+    }
+
+    @Test
+    public void testGetSynonyms() {
+        assertThat(SemanticTags.getSynonyms(Light.class, Locale.ENGLISH), hasItems("Lights", "Lighting"));
+    }
+
+    @Test
+    public void testGetDescription() {
+        Class<? extends Tag> tag = SemanticTags.add("TestDesc", Light.class, null, null, "Test Description");
+        assertEquals("Test Description", SemanticTags.getDescription(tag, Locale.ENGLISH));
     }
 
     @Test


### PR DESCRIPTION
Add methods for getting the label and description of a semantic tag.

In addition to enriching the ability to work with semantic tags, this should also help in building a rest endpoint that provides the semantic tags to mainui, as discussed here: https://github.com/openhab/openhab-webui/issues/1822

Although at this point I'm not yet sure exactly what's needed for the rest endpoint. More methods would probably be needed when we tackle the implementation of that feature.