### PR TITLE
Remove redundant public and abstract modifiers from interfaces

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedActionHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedActionHandlerFactory.java
@@ -24,5 +24,6 @@ import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedHand
  */
 @NonNullByDefault
 public interface ScriptedActionHandlerFactory extends ScriptedHandler {
-    public @Nullable ActionHandler get(Action action);
+    @Nullable
+    ActionHandler get(Action action);
 }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedConditionHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedConditionHandlerFactory.java
@@ -24,5 +24,6 @@ import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedHand
  */
 @NonNullByDefault
 public interface ScriptedConditionHandlerFactory extends ScriptedHandler {
-    public @Nullable ConditionHandler get(Condition module);
+    @Nullable
+    ConditionHandler get(Condition module);
 }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedTriggerHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedTriggerHandlerFactory.java
@@ -24,5 +24,6 @@ import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedHand
  */
 @NonNullByDefault
 public interface ScriptedTriggerHandlerFactory extends ScriptedHandler {
-    public @Nullable TriggerHandler get(Trigger module);
+    @Nullable
+    TriggerHandler get(Trigger module);
 }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandlerCallback.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandlerCallback.java
@@ -23,5 +23,5 @@ import org.openhab.core.automation.handler.TriggerHandlerCallback;
  */
 @NonNullByDefault
 public interface SimpleTriggerHandlerCallback extends TriggerHandlerCallback {
-    public void triggered(Map<String, ?> context);
+    void triggered(Map<String, ?> context);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
@@ -68,7 +68,7 @@ public interface RuleRegistry extends Registry<Rule, String> {
      * @throws IllegalStateException when the RuleManagedProvider is unavailable.
      */
     @Override
-    public Rule add(Rule rule);
+    Rule add(Rule rule);
 
     /**
      * Gets a collection of {@link Rule}s which shares same tag.
@@ -76,7 +76,7 @@ public interface RuleRegistry extends Registry<Rule, String> {
      * @param tag specifies a tag that will filter the rules.
      * @return collection of {@link Rule}s having specified tag.
      */
-    public Collection<Rule> getByTag(@Nullable String tag);
+    Collection<Rule> getByTag(@Nullable String tag);
 
     /**
      * Gets a collection of {@link Rule}s which has specified tags.
@@ -84,5 +84,5 @@ public interface RuleRegistry extends Registry<Rule, String> {
      * @param tags specifies tags that will filter the rules.
      * @return collection of {@link Rule}s having specified tags.
      */
-    public Collection<Rule> getByTags(String... tags);
+    Collection<Rule> getByTags(String... tags);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
@@ -37,5 +37,5 @@ public interface ConditionHandler extends ModuleHandler {
      *            and the inputs of the {@link Condition}.
      * @return {@code true} if {@link Condition} is satisfied, {@code false} otherwise.
      */
-    public boolean isSatisfied(Map<String, Object> context);
+    boolean isSatisfied(Map<String, Object> context);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
@@ -28,7 +28,7 @@ public interface ModuleHandler {
     /**
      * The method is called by RuleManager to free resources when {@link ModuleHandler} is released.
      */
-    public void dispose();
+    void dispose();
 
     /**
      * The callback is injected to the handler through this method.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandlerFactory.java
@@ -44,7 +44,7 @@ public interface ModuleHandlerFactory {
      *
      * @return collection of module type UIDs supported by this factory.
      */
-    public Collection<String> getTypes();
+    Collection<String> getTypes();
 
     /**
      * Creates a {@link ModuleHandler} instance needed for the operation of the {@link Module}s
@@ -55,7 +55,8 @@ public interface ModuleHandlerFactory {
      * @return a new {@link ModuleHandler} instance, or {@code null} if the type of the
      *         {@code module} parameter is not supported by this factory.
      */
-    public @Nullable ModuleHandler getHandler(Module module, String ruleUID);
+    @Nullable
+    ModuleHandler getHandler(Module module, String ruleUID);
 
     /**
      * Releases the {@link ModuleHandler} instance when it is not needed anymore
@@ -66,5 +67,5 @@ public interface ModuleHandlerFactory {
      * @param ruleUID the identifier of the {@link Rule} that the given module belongs to.
      * @param handler the {@link ModuleHandler} instance that is no longer needed.
      */
-    public void ungetHandler(Module module, String ruleUID, ModuleHandler handler);
+    void ungetHandler(Module module, String ruleUID, ModuleHandler handler);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
@@ -30,5 +30,5 @@ public interface TimeBasedConditionHandler extends ConditionHandler {
      * @param time The time to check.
      * @return <code>true</code> if and only if the given time satisfies this condition.
      */
-    public abstract boolean isSatisfiedAt(ZonedDateTime time);
+    abstract boolean isSatisfiedAt(ZonedDateTime time);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
@@ -30,5 +30,5 @@ public interface TimeBasedConditionHandler extends ConditionHandler {
      * @param time The time to check.
      * @return <code>true</code> if and only if the given time satisfies this condition.
      */
-    abstract boolean isSatisfiedAt(ZonedDateTime time);
+    boolean isSatisfiedAt(ZonedDateTime time);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
@@ -32,22 +32,22 @@ public interface Parser<T> {
      * Example : "parser.type" = "parser.module.type";
      * It is used as registration property of the corresponding service.
      */
-    public static String PARSER_TYPE = "parser.type";
+    static String PARSER_TYPE = "parser.type";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    public static String PARSER_MODULE_TYPE = "parser.module.type";
+    static String PARSER_MODULE_TYPE = "parser.module.type";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    public static String PARSER_TEMPLATE = "parser.template";
+    static String PARSER_TEMPLATE = "parser.template";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    public static String PARSER_RULE = "parser.rule";
+    static String PARSER_RULE = "parser.rule";
 
     /**
      * Defines a service registration property used for recognition of which file format is supported by the parser.
@@ -55,12 +55,12 @@ public interface Parser<T> {
      * Example : "format" = "json";
      * It is used as registration property of the corresponding service.
      */
-    public static String FORMAT = "format";
+    static String FORMAT = "format";
 
     /**
      * Defines the possible value of property {@link #FORMAT}. It means that the parser supports json format.
      */
-    public static String FORMAT_JSON = "json";
+    static String FORMAT_JSON = "json";
 
     /**
      * Loads a file with some particular format and parse it to the corresponding automation objects.
@@ -70,7 +70,7 @@ public interface Parser<T> {
      * @throws ParsingException is thrown when json format is wrong or there is a semantic error in description of
      *             the automation objects.
      */
-    public Set<T> parse(InputStreamReader reader) throws ParsingException;
+    Set<T> parse(InputStreamReader reader) throws ParsingException;
 
     /**
      * Records the automation objects in a file with some particular format.
@@ -80,5 +80,5 @@ public interface Parser<T> {
      * @throws Exception is thrown when I/O operation has failed or has been interrupted or generating of the text fails
      *             for some reasons.
      */
-    public void serialize(Set<T> dataObjects, OutputStreamWriter writer) throws Exception;
+    void serialize(Set<T> dataObjects, OutputStreamWriter writer) throws Exception;
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/Template.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/Template.java
@@ -40,7 +40,7 @@ public interface Template extends Identifiable<String> {
      * @return the identifier of the Template.
      */
     @Override
-    public String getUID();
+    String getUID();
 
     /**
      * Gets the assigned tags to a Template. The templates can have {@code tags} - non-hierarchical keywords or terms
@@ -48,7 +48,7 @@ public interface Template extends Identifiable<String> {
      *
      * @return the tags assigned to the template.
      */
-    public Set<String> getTags();
+    Set<String> getTags();
 
     /**
      * Gets the label of a Template. The label is a short, human-readable description of the Template defined by its
@@ -56,7 +56,8 @@ public interface Template extends Identifiable<String> {
      *
      * @return the label of the Template.
      */
-    public @Nullable String getLabel();
+    @Nullable
+    String getLabel();
 
     /**
      * Gets the description of a Template. The description is a detailed, human-understandable description of the
@@ -64,12 +65,13 @@ public interface Template extends Identifiable<String> {
      *
      * @return the description of the Template.
      */
-    public @Nullable String getDescription();
+    @Nullable
+    String getDescription();
 
     /**
      * Shows the visibility of a Template.
      *
      * @return the visibility of the Template.
      */
-    public Visibility getVisibility();
+    Visibility getVisibility();
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
@@ -41,7 +41,8 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      * @return the desired template instance or {@code null} if a template with such UID does not exist or the passed
      *         UID is {@code null}.
      */
-    public @Nullable E get(String uid, @Nullable Locale locale);
+    @Nullable
+    E get(String uid, @Nullable Locale locale);
 
     /**
      * Gets the templates filtered by tag.
@@ -50,7 +51,7 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            {@code null} then the result will contain all available templates.
      * @return a collection of templates, which correspond to the specified tag.
      */
-    public Collection<E> getByTag(@Nullable String tag);
+    Collection<E> getByTag(@Nullable String tag);
 
     /**
      * Gets the templates filtered by tag.
@@ -62,7 +63,7 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            elements are returned with the default localization.
      * @return a collection of localized templates, which correspond to the specified tag.
      */
-    public Collection<E> getByTag(@Nullable String tag, @Nullable Locale locale);
+    Collection<E> getByTag(@Nullable String tag, @Nullable Locale locale);
 
     /**
      * Gets the templates filtered by tags.
@@ -71,7 +72,7 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            is {@code null} then the result will contain all templates.
      * @return a collection of templates, which correspond to the specified set of tags.
      */
-    public Collection<E> getByTags(String... tags);
+    Collection<E> getByTags(String... tags);
 
     /**
      * Gets the templates filtered by tags.
@@ -83,7 +84,7 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            it is {@code null} then the result will contain all templates.
      * @return the templates, which correspond to the specified set of tags.
      */
-    public Collection<E> getByTags(@Nullable Locale locale, String... tags);
+    Collection<E> getByTags(@Nullable Locale locale, String... tags);
 
     /**
      * Gets all available templates, localized by specified locale.
@@ -93,5 +94,5 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *            elements are returned with the default localization.
      * @return a collection of localized templates, corresponding to the parameterized type.
      */
-    public Collection<E> getAll(@Nullable Locale locale);
+    Collection<E> getAll(@Nullable Locale locale);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
@@ -40,7 +40,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @return the desired {@link ModuleType} instance or {@code null} if a module type with such UID does not exist or
      *         the passed UID is {@code null}.
      */
-    public <T extends ModuleType> @Nullable T get(String moduleTypeUID, @Nullable Locale locale);
+    <T extends ModuleType> @Nullable T get(String moduleTypeUID, @Nullable Locale locale);
 
     /**
      * Gets the {@link ModuleType}s filtered by tag.
@@ -50,7 +50,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the specified filter.
      */
-    public <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag);
+    <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag);
 
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tag.
@@ -61,7 +61,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the specified filter.
      */
-    public <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag, @Nullable Locale locale);
+    <T extends ModuleType> Collection<T> getByTag(@Nullable String moduleTypeTag, @Nullable Locale locale);
 
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tags.
@@ -71,7 +71,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the filter.
      */
-    public <T extends ModuleType> Collection<T> getByTags(String... tags);
+    <T extends ModuleType> Collection<T> getByTags(String... tags);
 
     /**
      * This method is used for getting the {@link ModuleType}s filtered by tags.
@@ -82,7 +82,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param <T> the type of the required object.
      * @return the {@link ModuleType}s, which correspond to the filter.
      */
-    public <T extends ModuleType> Collection<T> getByTags(@Nullable Locale locale, String... tags);
+    <T extends ModuleType> Collection<T> getByTags(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link TriggerType}s. The returned {@link TriggerType}s are
@@ -92,7 +92,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *            {@link TriggerType}s.
      * @return collection of all available {@link TriggerType}s, localized by default locale.
      */
-    public Collection<TriggerType> getTriggers(String... tags);
+    Collection<TriggerType> getTriggers(String... tags);
 
     /**
      * This method is used for getting the {@link TriggerType}s, localized depending on passed locale parameter.
@@ -105,7 +105,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @return a collection of all available {@link TriggerType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<TriggerType> getTriggers(@Nullable Locale locale, String... tags);
+    Collection<TriggerType> getTriggers(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link ConditionType}s. The returned {@link ConditionType}s are
@@ -115,7 +115,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *            {@link ConditionType}s.
      * @return collection of all available {@link ConditionType}s, localized by default locale.
      */
-    public Collection<ConditionType> getConditions(String... tags);
+    Collection<ConditionType> getConditions(String... tags);
 
     /**
      * This method is used for getting the {@link ConditionType}s, localized depending on passed locale parameter.
@@ -128,7 +128,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @return a collection of all available {@link ConditionType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<ConditionType> getConditions(@Nullable Locale locale, String... tags);
+    Collection<ConditionType> getConditions(@Nullable Locale locale, String... tags);
 
     /**
      * This method is used for getting the {@link ActionType}s. The returned {@link ActionType}s are
@@ -138,7 +138,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *            {@link ActionType}s.
      * @return collection of all available {@link ActionType}s, localized by default locale.
      */
-    public Collection<ActionType> getActions(String... tags);
+    Collection<ActionType> getActions(String... tags);
 
     /**
      * This method is used for getting the {@link ActionType}s, localized depending on passed locale parameter.
@@ -151,5 +151,5 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @return a collection of all available {@link ActionType}s, localized by default locale or the passed locale
      *         parameter.
      */
-    public Collection<ActionType> getActions(@Nullable Locale locale, String... tags);
+    Collection<ActionType> getActions(@Nullable Locale locale, String... tags);
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/Normalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/Normalizer.java
@@ -31,5 +31,5 @@ public interface Normalizer {
      * @param value the object to be normalized
      * @return the well-defined type or the given object, if it was not possible to convert it
      */
-    public Object normalize(Object value);
+    Object normalize(Object value);
 }

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryParticipant.java
@@ -36,7 +36,7 @@ public interface UsbSerialDiscoveryParticipant {
      *
      * @return a set of thing type UIDs for which results can be created
      */
-    public Set<ThingTypeUID> getSupportedThingTypeUIDs();
+    Set<ThingTypeUID> getSupportedThingTypeUIDs();
 
     /**
      * Creates a discovery result for a USB device with corresponding serial port.
@@ -45,7 +45,8 @@ public interface UsbSerialDiscoveryParticipant {
      * @return the according discovery result or <code>null</code> if the device is not
      *         supported by this participant
      */
-    public @Nullable DiscoveryResult createResult(UsbSerialDeviceInformation deviceInformation);
+    @Nullable
+    DiscoveryResult createResult(UsbSerialDeviceInformation deviceInformation);
 
     /**
      * Returns the thing UID for a USB device with corresponding serial port.
@@ -54,5 +55,6 @@ public interface UsbSerialDiscoveryParticipant {
      * @return a thing UID or <code>null</code> if the device is not supported
      *         by this participant
      */
-    public @Nullable ThingUID getThingUID(UsbSerialDeviceInformation deviceInformation);
+    @Nullable
+    ThingUID getThingUID(UsbSerialDeviceInformation deviceInformation);
 }

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleCommandsContainer.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleCommandsContainer.java
@@ -24,5 +24,5 @@ import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
 @NonNullByDefault
 public interface ConsoleCommandsContainer {
 
-    public Collection<ConsoleCommandExtension> getConsoleCommandExtensions();
+    Collection<ConsoleCommandExtension> getConsoleCommandExtensions();
 }

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
@@ -27,5 +27,5 @@ public interface AuthenticationSecurityContext extends SecurityContext {
      *
      * @return the authentication instance
      */
-    public Authentication getAuthentication();
+    Authentication getAuthentication();
 }

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
@@ -33,7 +33,7 @@ public interface MDNSClient {
      *
      * @return a set of JmDNS instances
      */
-    public Set<JmDNS> getClientInstances();
+    Set<JmDNS> getClientInstances();
 
     /**
      * Listen for services of a given type
@@ -41,7 +41,7 @@ public interface MDNSClient {
      * @param type full qualified service type
      * @param listener listener for service updates
      */
-    public void addServiceListener(String type, ServiceListener listener);
+    void addServiceListener(String type, ServiceListener listener);
 
     /**
      * Remove listener for services of a given type
@@ -49,27 +49,27 @@ public interface MDNSClient {
      * @param type full qualified service type
      * @param listener listener for service updates
      */
-    public void removeServiceListener(String type, ServiceListener listener);
+    void removeServiceListener(String type, ServiceListener listener);
 
     /**
      * Register a service
      *
      * @param description service to register, described by (@link ServiceDescription)
      */
-    public void registerService(ServiceDescription description) throws IOException;
+    void registerService(ServiceDescription description) throws IOException;
 
     /**
      * Unregister a service. The service should have been registered.
      *
      * @param description service to remove, described by (@link ServiceDescription)
      */
-    public void unregisterService(ServiceDescription description);
+    void unregisterService(ServiceDescription description);
 
     /**
      * Unregister all services
      *
      */
-    public void unregisterAllServices();
+    void unregisterAllServices();
 
     /**
      * Returns a list of service infos of the specified type
@@ -77,7 +77,7 @@ public interface MDNSClient {
      * @param type service type name
      * @return an array of service instances
      */
-    public ServiceInfo[] list(String type);
+    ServiceInfo[] list(String type);
 
     /**
      * Returns a list of service infos of the specified type within timeout
@@ -86,11 +86,11 @@ public interface MDNSClient {
      * @param timeout the amount of time it should wait if no service info is found.
      * @return an array of service instances
      */
-    public ServiceInfo[] list(String type, Duration timeout);
+    ServiceInfo[] list(String type, Duration timeout);
 
     /**
      * Close properly JmDNS instances
      *
      */
-    public void close();
+    void close();
 }

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
@@ -26,12 +26,12 @@ public interface MDNSService {
      *
      * @param serviceDescription the {@link ServiceDescription} instance with all details to identify the service
      */
-    public void registerService(ServiceDescription description);
+    void registerService(ServiceDescription description);
 
     /**
      * This method unregisters a service not to be announced through Bonjour/MDNS
      *
      * @param serviceDescription the {@link ServiceDescription} instance with all details to identify the service
      */
-    public void unregisterService(ServiceDescription description);
+    void unregisterService(ServiceDescription description);
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusCommunicationInterface.java
@@ -38,7 +38,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      *
      * @return modbus slave endpoint
      */
-    public ModbusSlaveEndpoint getEndpoint();
+    ModbusSlaveEndpoint getEndpoint();
 
     /**
      * Submit one-time poll task. The method returns immediately, and the execution of the poll task will happen in
@@ -50,7 +50,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return future representing the polled task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public Future<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
+    Future<?> submitOneTimePoll(ModbusReadRequestBlueprint request, ModbusReadCallback resultCallback,
             ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
@@ -67,9 +67,8 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return poll task representing the regular poll
      * @throws IllegalStateException when this communication has been closed already
      */
-    public PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis,
-            long initialDelayMillis, ModbusReadCallback resultCallback,
-            ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
+    PollTask registerRegularPoll(ModbusReadRequestBlueprint request, long pollPeriodMillis, long initialDelayMillis,
+            ModbusReadCallback resultCallback, ModbusFailureCallback<ModbusReadRequestBlueprint> failureCallback);
 
     /**
      * Unregister regularly polled task
@@ -80,7 +79,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return whether poll task was unregistered. Poll task is not unregistered in case of unexpected errors or
      *         in the case where the poll task is not registered in the first place
      */
-    public boolean unregisterRegularPoll(PollTask task);
+    boolean unregisterRegularPoll(PollTask task);
 
     /**
      * Submit one-time write task. The method returns immediately, and the execution of the task will happen in
@@ -92,7 +91,7 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      * @return future representing the task
      * @throws IllegalStateException when this communication has been closed already
      */
-    public Future<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request, ModbusWriteCallback resultCallback,
+    Future<?> submitOneTimeWrite(ModbusWriteRequestBlueprint request, ModbusWriteCallback resultCallback,
             ModbusFailureCallback<ModbusWriteRequestBlueprint> failureCallback);
 
     /**
@@ -105,5 +104,5 @@ public interface ModbusCommunicationInterface extends AutoCloseable {
      *
      */
     @Override
-    public void close() throws Exception;
+    void close() throws Exception;
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
@@ -34,7 +34,7 @@ public interface ModbusManager {
      * @throws IllegalArgumentException if there is already open communication interface with same endpoint but
      *             differing configuration
      */
-    public ModbusCommunicationInterface newModbusCommunicationInterface(ModbusSlaveEndpoint endpoint,
+    ModbusCommunicationInterface newModbusCommunicationInterface(ModbusSlaveEndpoint endpoint,
             @Nullable EndpointPoolConfiguration configuration) throws IllegalArgumentException;
 
     /**
@@ -45,5 +45,5 @@ public interface ModbusManager {
      * @param endpoint endpoint to query
      * @return general connection settings of the given endpoint
      */
-    public EndpointPoolConfiguration getEndpointPoolConfiguration(ModbusSlaveEndpoint endpoint);
+    EndpointPoolConfiguration getEndpointPoolConfiguration(ModbusSlaveEndpoint endpoint);
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResponse.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResponse.java
@@ -32,5 +32,5 @@ public interface ModbusResponse {
      *
      * @return function code of the response
      */
-    public int getFunctionCode();
+    int getFunctionCode();
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprintVisitor.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprintVisitor.java
@@ -29,12 +29,12 @@ public interface ModbusWriteRequestBlueprintVisitor {
      *
      * @param blueprint
      */
-    public void visit(ModbusWriteCoilRequestBlueprint blueprint);
+    void visit(ModbusWriteCoilRequestBlueprint blueprint);
 
     /**
      * Visit request writing register data
      *
      * @param blueprint
      */
-    public void visit(ModbusWriteRegisterRequestBlueprint blueprint);
+    void visit(ModbusWriteRegisterRequestBlueprint blueprint);
 }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpoint.java
@@ -27,5 +27,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public interface ModbusSlaveEndpoint {
-    public <R> R accept(ModbusSlaveEndpointVisitor<R> visitor);
+    <R> R accept(ModbusSlaveEndpointVisitor<R> visitor);
 }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttActionCallback.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttActionCallback.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public interface MqttActionCallback {
-    public void onSuccess(String topic);
+    void onSuccess(String topic);
 
-    public void onFailure(String topic, Throwable error);
+    void onFailure(String topic, Throwable error);
 }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionObserver.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionObserver.java
@@ -33,5 +33,5 @@ public interface MqttConnectionObserver {
      * @param error An exception object (might be a MqttException) with the reason why
      *            a connection failed.
      */
-    public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error);
+    void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error);
 }

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttMessageSubscriber.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttMessageSubscriber.java
@@ -28,5 +28,5 @@ public interface MqttMessageSubscriber {
      * @param topic The mqtt topic on which the message was received.
      * @param payload content of the message.
      */
-    public void processMessage(String topic, byte[] payload);
+    void processMessage(String topic, byte[] payload);
 }

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortProvider.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortProvider.java
@@ -35,14 +35,15 @@ public interface SerialPortProvider {
      * @throws UnsupportedCommOperationException
      * @throws PortInUseException
      */
-    public @Nullable SerialPortIdentifier getPortIdentifier(URI portName);
+    @Nullable
+    SerialPortIdentifier getPortIdentifier(URI portName);
 
     /**
      * Gets all protocol types which this provider is able to create.
      *
      * @return The protocol type.
      */
-    public Stream<ProtocolType> getAcceptedProtocols();
+    Stream<ProtocolType> getAcceptedProtocols();
 
     /**
      * Gets all the available {@link SerialPortIdentifier}s for this {@link SerialPortProvider}.
@@ -51,5 +52,5 @@ public interface SerialPortProvider {
      *
      * @return The available ports
      */
-    public Stream<SerialPortIdentifier> getSerialPortIdentifiers();
+    Stream<SerialPortIdentifier> getSerialPortIdentifiers();
 }

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
@@ -22,10 +22,10 @@ package org.openhab.core.io.transport.upnp;
 public interface UpnpIOParticipant {
 
     /** Get the UDN of the participant **/
-    public String getUDN();
+    String getUDN();
 
     /** Called when the UPNP IO service receives a {variable,value} tuple for the given UPNP service **/
-    public void onValueReceived(String variable, String value, String service);
+    void onValueReceived(String variable, String value, String service);
 
     /**
      * Called to notify if a GENA subscription succeeded or failed.
@@ -33,7 +33,7 @@ public interface UpnpIOParticipant {
      * @param service the UPnP service subscribed
      * @param succeeded true if the subscription succeeded; false if failed
      */
-    public void onServiceSubscribed(String service, boolean succeeded);
+    void onServiceSubscribed(String service, boolean succeeded);
 
     /**
      * Called when the UPNP IO service is unable to poll the UDN of the participant, given that
@@ -42,5 +42,5 @@ public interface UpnpIOParticipant {
      * @param status false, if the poll fails when the polling was previously successful; true if the poll succeeds
      *            when the polling was previously failing
      */
-    public void onStatusChanged(boolean status);
+    void onStatusChanged(boolean status);
 }

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
@@ -32,7 +32,7 @@ public interface UpnpIOService {
      * @param actionID the Action to invoke
      * @param inputs a map of {variable,values} to parameterize the Action that will be invoked
      */
-    public Map<String, String> invokeAction(UpnpIOParticipant participant, String serviceID, String actionID,
+    Map<String, String> invokeAction(UpnpIOParticipant participant, String serviceID, String actionID,
             Map<String, String> inputs);
 
     /**
@@ -42,7 +42,7 @@ public interface UpnpIOService {
      * @param serviceID the UPNP service we want to subscribe to
      * @param duration the duration of the subscription
      */
-    public void addSubscription(UpnpIOParticipant participant, String serviceID, int duration);
+    void addSubscription(UpnpIOParticipant participant, String serviceID, int duration);
 
     /**
      * Unsubscribe from a GENA subscription
@@ -50,7 +50,7 @@ public interface UpnpIOService {
      * @param participant the participant of the subscription
      * @param serviceID the UPNP service we want to unsubscribe from
      */
-    public void removeSubscription(UpnpIOParticipant participant, String serviceID);
+    void removeSubscription(UpnpIOParticipant participant, String serviceID);
 
     /**
      * Verify if the a participant is registered
@@ -58,21 +58,21 @@ public interface UpnpIOService {
      * @param participant the participant whom's participation we want to verify
      * @return true of the participant is registered with the UpnpIOService
      */
-    public boolean isRegistered(UpnpIOParticipant participant);
+    boolean isRegistered(UpnpIOParticipant participant);
 
     /**
      * Register a participant with the UPNP IO Service
      * 
      * @param participant the participant whose participation we want to register
      */
-    public void registerParticipant(UpnpIOParticipant participant);
+    void registerParticipant(UpnpIOParticipant participant);
 
     /**
      * Unregister a participant with the UPNP IO Service
      * 
      * @param participant the participant whose participation we want to unregister
      */
-    public void unregisterParticipant(UpnpIOParticipant participant);
+    void unregisterParticipant(UpnpIOParticipant participant);
 
     /**
      * Retrieves the descriptor url for the participant
@@ -80,7 +80,7 @@ public interface UpnpIOService {
      * @param participant the participant whom's descriptor url is requested
      * @return the url of the descriptor as provided by the upnp device
      */
-    public URL getDescriptorURL(UpnpIOParticipant participant);
+    URL getDescriptorURL(UpnpIOParticipant participant);
 
     /**
      * Establish a polling mechanism to check the status of a specific UDN device. The polling mechanism
@@ -92,12 +92,12 @@ public interface UpnpIOService {
      * @param actionID the action to call
      * @param interval the interval in seconds
      */
-    public void addStatusListener(UpnpIOParticipant participant, String serviceID, String actionID, int interval);
+    void addStatusListener(UpnpIOParticipant participant, String serviceID, String actionID, int interval);
 
     /**
      * Stops the polling mechanism to check the status of a specific UDN device.
      * 
      * @param participant the participant for whom we want to remove the polling
      */
-    public void removeStatusListener(UpnpIOParticipant participant);
+    void removeStatusListener(UpnpIOParticipant participant);
 }

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepositoryChangeListener.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepositoryChangeListener.java
@@ -25,5 +25,5 @@ public interface ModelRepositoryChangeListener {
      * Performs dispatch of all binding configs and
      * fires all {@link ItemsChangeListener}s if {@code modelName} ends with "items".
      */
-    public void modelChanged(String modelName, EventType type);
+    void modelChanged(String modelName, EventType type);
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
@@ -22,7 +22,7 @@ import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 @SuppressWarnings("restriction")
 public interface Script {
 
-    public static final String SCRIPT_FILEEXT = "script";
+    static final String SCRIPT_FILEEXT = "script";
 
     /**
      * Executes the script instance and returns the execution result
@@ -30,7 +30,7 @@ public interface Script {
      * @return the execution result or <code>null</code>, if the script does not have a return value
      * @throws ScriptExecutionException if an error occurs during the execution
      */
-    public Object execute() throws ScriptExecutionException;
+    Object execute() throws ScriptExecutionException;
 
     /**
      * Executes the script instance with a given evaluation context and returns the execution result
@@ -40,5 +40,5 @@ public interface Script {
      * @return the execution result or <code>null</code>, if the script does not have a return value
      * @throws ScriptExecutionException if an error occurs during the execution
      */
-    public Object execute(IEvaluationContext evaluationContext) throws ScriptExecutionException;
+    Object execute(IEvaluationContext evaluationContext) throws ScriptExecutionException;
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptEngine.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptEngine.java
@@ -29,7 +29,7 @@ public interface ScriptEngine {
      * @return Script object, which can be executed
      * @throws ScriptParsingException
      */
-    public Script newScriptFromString(final String scriptAsString) throws ScriptParsingException;
+    Script newScriptFromString(final String scriptAsString) throws ScriptParsingException;
 
     /**
      * Executes a script that is passed as a string
@@ -39,7 +39,7 @@ public interface ScriptEngine {
      * @throws ScriptParsingException
      * @throws ScriptExecutionException
      */
-    public Object executeScript(final String scriptAsString) throws ScriptParsingException, ScriptExecutionException;
+    Object executeScript(final String scriptAsString) throws ScriptParsingException, ScriptExecutionException;
 
     /**
      * Wraps an Xbase XExpression in a Script instance
@@ -47,5 +47,5 @@ public interface ScriptEngine {
      * @param expression the XExpression
      * @return the Script instance containing the expression
      */
-    public Script newScriptFromXExpression(final XExpression expression);
+    Script newScriptFromXExpression(final XExpression expression);
 }

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Location.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Location.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @TagInfo(id = "Location")
 public interface Location extends Tag {
 
-    public static String name() {
+    static String name() {
         return "Location";
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingManager.java
@@ -31,7 +31,7 @@ public interface ThingManager {
      * @return {@code false} when the {@link Thing} has {@link ThingStatus} with {@link ThingStatusDetail#DISABLED}.
      *         Returns {@code true} in all other cases.
      */
-    public boolean isEnabled(ThingUID thingUID);
+    boolean isEnabled(ThingUID thingUID);
 
     /**
      * This method is used for changing <b>enabled</b> state of the {@link Thing}
@@ -41,5 +41,5 @@ public interface ThingManager {
      * @param thingUID UID of the {@link Thing}.
      * @param isEnabled a new <b>enabled / disabled</b> state of the {@link Thing}.
      */
-    public void setEnabled(ThingUID thingUID, boolean isEnabled);
+    void setEnabled(ThingUID thingUID, boolean isEnabled);
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
@@ -65,7 +65,7 @@ import org.openhab.core.thing.firmware.FirmwareUpdateService;
 public interface Firmware extends Comparable<Firmware> {
 
     /** The key for the requires a factory reset property. */
-    public static final String PROPERTY_REQUIRES_FACTORY_RESET = "requiresFactoryReset";
+    static final String PROPERTY_REQUIRES_FACTORY_RESET = "requiresFactoryReset";
 
     /**
      * Returns the thing type UID, that this firmware is associated with.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingTracker.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingTracker.java
@@ -29,7 +29,7 @@ import org.openhab.core.thing.ThingRegistryChangeListener;
 @NonNullByDefault
 public interface ThingTracker {
 
-    public enum ThingTrackerEvent {
+    enum ThingTrackerEvent {
         THING_ADDED,
         THING_REMOVING,
         THING_REMOVED,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeRegistry.java
@@ -32,7 +32,7 @@ public interface ProfileTypeRegistry {
      *
      * @return all profile types
      */
-    public List<ProfileType> getProfileTypes();
+    List<ProfileType> getProfileTypes();
 
     /**
      * Get the available {@link ProfileType}s from all providers.
@@ -40,5 +40,5 @@ public interface ProfileTypeRegistry {
      * @param locale the language to use (may be null)
      * @return all profile types
      */
-    public List<ProfileType> getProfileTypes(@Nullable Locale locale);
+    List<ProfileType> getProfileTypes(@Nullable Locale locale);
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
@@ -106,7 +106,7 @@ public interface ChartProvider {
      * Provides a list of image types
      *
      */
-    public enum ImageType {
+    enum ImageType {
         png,
         jpg,
         gif

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartTheme.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartTheme.java
@@ -30,21 +30,21 @@ public interface ChartTheme {
      *
      * @return theme name
      */
-    public String getThemeName();
+    String getThemeName();
 
     /**
      * Background color, plot area.
      *
      * @return background color, plot area
      */
-    public Color getPlotBackgroundColor();
+    Color getPlotBackgroundColor();
 
     /**
      * Color for the grid lines.
      *
      * @return color for the grid lines
      */
-    public Color getPlotGridLinesColor();
+    Color getPlotGridLinesColor();
 
     /**
      * Return the width of the grid lines.
@@ -52,7 +52,7 @@ public interface ChartTheme {
      * @param dpi DPI dots per inch to calculate the width
      * @return width of the grid lines
      */
-    public double getPlotGridLinesWidth(int dpi);
+    double getPlotGridLinesWidth(int dpi);
 
     /**
      * Return the dash spacing for the grid lines.
@@ -60,28 +60,28 @@ public interface ChartTheme {
      * @param dpi DPI dots per inch to calculate the width
      * @return dash spacing for the grid lines
      */
-    public double getPlotGridLinesDash(int dpi);
+    double getPlotGridLinesDash(int dpi);
 
     /**
      * Background color, legend area.
      *
      * @return background color, legend area
      */
-    public Color getLegendBackgroundColor();
+    Color getLegendBackgroundColor();
 
     /**
      * Background color, whole chart
      *
      * @return background color, whole chart
      */
-    public Color getChartBackgroundColor();
+    Color getChartBackgroundColor();
 
     /**
      * Font color, legend and general use.
      *
      * @return
      */
-    public Color getChartFontColor();
+    Color getChartFontColor();
 
     /**
      * Return a color for the given series number.
@@ -89,7 +89,7 @@ public interface ChartTheme {
      * @param series series number
      * @return color for the given series numer
      */
-    public Color getLineColor(int series);
+    Color getLineColor(int series);
 
     /**
      * Return the width of the series lines.
@@ -97,14 +97,14 @@ public interface ChartTheme {
      * @param dpi DPI dots per inch to calculate the width
      * @return width of the series lines
      */
-    public double getLineWidth(int dpi);
+    double getLineWidth(int dpi);
 
     /**
      * Color for the axis labels.
      *
      * @return
      */
-    public Color getAxisTickLabelsColor();
+    Color getAxisTickLabelsColor();
 
     /**
      * Font for the axis labels.
@@ -113,7 +113,7 @@ public interface ChartTheme {
      * @param dpi the DPI to calculate the font size
      * @return {@link Font} for the axis labels.
      */
-    public Font getAxisTickLabelsFont(int dpi);
+    Font getAxisTickLabelsFont(int dpi);
 
     /**
      * Font for the legend text.
@@ -122,7 +122,7 @@ public interface ChartTheme {
      * @param dpi the DPI to calculate the font size
      * @return {@link Font} for the legend text
      */
-    public Font getLegendFont(int dpi);
+    Font getLegendFont(int dpi);
 
     /**
      * Padding of the chart.
@@ -130,7 +130,7 @@ public interface ChartTheme {
      * @param dpi the DPI to calculate the padding
      * @return padding of the chart
      */
-    public int getChartPadding(int dpi);
+    int getChartPadding(int dpi);
 
     /**
      * Length of the line markers in the legend, in px.
@@ -138,5 +138,5 @@ public interface ChartTheme {
      * @param dpi the DPI to calculate the line length
      * @return length of the line markers in the legend, in px
      */
-    public int getLegendSeriesLineLength(int dpi);
+    int getLegendSeriesLineLength(int dpi);
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIProvider.java
@@ -32,7 +32,8 @@ public interface ItemUIProvider {
      * @param itemName the name of the item to return the icon for
      * @return the name of the category to use or null if undefined.
      */
-    public @Nullable String getCategory(String itemName);
+    @Nullable
+    String getCategory(String itemName);
 
     /**
      * Returns the label text to be used for an item in the UI.
@@ -40,7 +41,8 @@ public interface ItemUIProvider {
      * @param item the name of the item to return the label text for
      * @return the label text to be used in the UI or null if undefined.
      */
-    public @Nullable String getLabel(String itemName);
+    @Nullable
+    String getLabel(String itemName);
 
     /**
      * Provides a default widget for a given item (class). This is used whenever
@@ -52,7 +54,8 @@ public interface ItemUIProvider {
      * @return a widget implementation that can be used for the given item or null, if no default is available for the
      *         type
      */
-    public @Nullable Widget getDefaultWidget(@Nullable Class<? extends Item> itemType, String itemName);
+    @Nullable
+    Widget getDefaultWidget(@Nullable Class<? extends Item> itemType, String itemName);
 
     /**
      * <p>
@@ -66,5 +69,6 @@ public interface ItemUIProvider {
      * @param itemName the item name to get the widget for
      * @return a widget to use for the given item or <code>null</code> if sitemap should not be overridden.
      */
-    public @Nullable Widget getWidget(String itemName);
+    @Nullable
+    Widget getWidget(String itemName);
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/TileProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/TileProvider.java
@@ -23,5 +23,5 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public interface TileProvider {
-    public Stream<Tile> getTiles();
+    Stream<Tile> getTiles();
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSListener.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSListener.java
@@ -31,5 +31,5 @@ public interface KSListener {
      *
      * @param ksEvent The {@link KSEvent} fired by the {@link KSService}
      */
-    public void ksEventReceived(KSEvent ksEvent);
+    void ksEventReceived(KSEvent ksEvent);
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSService.java
@@ -34,7 +34,7 @@ public interface KSService {
      *
      * @return an id that identifies this service
      */
-    public String getId();
+    String getId();
 
     /**
      * Returns a localized human readable label that can be used within UIs.
@@ -42,21 +42,21 @@ public interface KSService {
      * @param locale the locale to provide the label for
      * @return a localized string to be used in UIs
      */
-    public String getLabel(@Nullable Locale locale);
+    String getLabel(@Nullable Locale locale);
 
     /**
      * Obtain the Locales available from this KSService
      *
      * @return The Locales available from this service
      */
-    public Set<Locale> getSupportedLocales();
+    Set<Locale> getSupportedLocales();
 
     /**
      * Obtain the audio formats supported by this KSService
      *
      * @return The audio formats supported by this service
      */
-    public Set<AudioFormat> getSupportedFormats();
+    Set<AudioFormat> getSupportedFormats();
 
     /**
      * This method starts the process of keyword spotting
@@ -84,6 +84,6 @@ public interface KSService {
      * @return A {@link KSServiceHandle} used to abort keyword spotting
      * @throws A {@link KSException} if any parameter is invalid or a problem occurs
      */
-    public KSServiceHandle spot(KSListener ksListener, AudioStream audioStream, Locale locale, String keyword)
+    KSServiceHandle spot(KSListener ksListener, AudioStream audioStream, Locale locale, String keyword)
             throws KSException;
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSServiceHandle.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSServiceHandle.java
@@ -24,5 +24,5 @@ public interface KSServiceHandle {
     /**
      * Aborts keyword spotting in the associated {@link KSService}
      */
-    public void abort();
+    void abort();
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTListener.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTListener.java
@@ -32,5 +32,5 @@ public interface STTListener {
      *
      * @param sttEvent The {@link STTEvent} fired by the {@link STTService}
      */
-    public void sttEventReceived(STTEvent sttEvent);
+    void sttEventReceived(STTEvent sttEvent);
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTService.java
@@ -33,7 +33,7 @@ public interface STTService {
      *
      * @return an id that identifies this service
      */
-    public String getId();
+    String getId();
 
     /**
      * Returns a localized human readable label that can be used within UIs.
@@ -41,21 +41,21 @@ public interface STTService {
      * @param locale the locale to provide the label for
      * @return a localized string to be used in UIs
      */
-    public String getLabel(@Nullable Locale locale);
+    String getLabel(@Nullable Locale locale);
 
     /**
      * Obtain the Locales available from this STTService
      *
      * @return The Locales available from this service
      */
-    public Set<Locale> getSupportedLocales();
+    Set<Locale> getSupportedLocales();
 
     /**
      * Obtain the audio formats supported by this STTService
      *
      * @return The audio formats supported by this service
      */
-    public Set<AudioFormat> getSupportedFormats();
+    Set<AudioFormat> getSupportedFormats();
 
     /**
      * This method starts the process of speech recognition.
@@ -85,6 +85,6 @@ public interface STTService {
      * @return A {@link STTServiceHandle} used to abort recognition
      * @throws A {@link SSTException} if any parameter is invalid or a STT problem occurs
      */
-    public STTServiceHandle recognize(STTListener sttListener, AudioStream audioStream, Locale locale,
-            Set<String> grammars) throws STTException;
+    STTServiceHandle recognize(STTListener sttListener, AudioStream audioStream, Locale locale, Set<String> grammars)
+            throws STTException;
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTServiceHandle.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTServiceHandle.java
@@ -24,5 +24,5 @@ public interface STTServiceHandle {
     /**
      * Aborts recognition in the associated {@link STTService}
      */
-    public void abort();
+    void abort();
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/Voice.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/Voice.java
@@ -30,19 +30,19 @@ public interface Voice {
      *
      * @return A String uniquely identifying the voice.
      */
-    public String getUID();
+    String getUID();
 
     /**
      * The voice label, usually used for GUIs
      *
      * @return The voice label, may not be globally unique
      */
-    public String getLabel();
+    String getLabel();
 
     /**
      * Locale of the voice
      *
      * @return Locale of the voice
      */
-    public Locale getLocale();
+    Locale getLocale();
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
@@ -31,7 +31,7 @@ public interface HumanLanguageInterpreter {
      *
      * @return an id that identifies this service
      */
-    public String getId();
+    String getId();
 
     /**
      * Returns a localized human readable label that can be used within UIs.
@@ -39,7 +39,7 @@ public interface HumanLanguageInterpreter {
      * @param locale the locale to provide the label for
      * @return a localized string to be used in UIs
      */
-    public String getLabel(@Nullable Locale locale);
+    String getLabel(@Nullable Locale locale);
 
     /**
      * Interprets a human language text fragment of a given {@link Locale}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/User.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/User.java
@@ -32,5 +32,5 @@ public interface User extends Principal, Identifiable<String> {
      * @see Role
      * @return role attributed to the user
      */
-    public Set<String> getRoles();
+    Set<String> getRoles();
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserRegistry.java
@@ -37,7 +37,7 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param roles the roles attributed to the new user
      * @return the new registered {@link User} instance
      */
-    public User register(String username, String password, Set<String> roles);
+    User register(String username, String password, Set<String> roles);
 
     /**
      * Change the password for a {@link User} in this registry. The implementation receives the new password and is
@@ -46,7 +46,7 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param username the username of the existing user
      * @param newPassword the new password
      */
-    public void changePassword(User user, String newPassword);
+    void changePassword(User user, String newPassword);
 
     /**
      * Adds a new session to the user profile
@@ -54,7 +54,7 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param user the user
      * @param session the session to add
      */
-    public void addUserSession(User user, UserSession session);
+    void addUserSession(User user, UserSession session);
 
     /**
      * Removes the specified session from the user profile
@@ -62,14 +62,14 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param user the user
      * @param session the session to remove
      */
-    public void removeUserSession(User user, UserSession session);
+    void removeUserSession(User user, UserSession session);
 
     /**
      * Clears all sessions from the user profile
      *
      * @param user the user
      */
-    public void clearSessions(User user);
+    void clearSessions(User user);
 
     /**
      * Adds a new API token to the user profile. The implementation is responsible for storing the token in a secure way
@@ -80,7 +80,7 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param scope the scope this API token will be valid for
      * @return the string that can be used as a Bearer token to match the new API token
      */
-    public String addUserApiToken(User user, String name, String scope);
+    String addUserApiToken(User user, String name, String scope);
 
     /**
      * Removes the specified API token from the user profile
@@ -88,5 +88,5 @@ public interface UserRegistry extends Registry<User, String>, AuthenticationProv
      * @param user the user
      * @param apiToken the API token
      */
-    public void removeUserApiToken(User user, UserApiToken apiToken);
+    void removeUserApiToken(User user, UserApiToken apiToken);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Registry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Registry.java
@@ -59,7 +59,8 @@ public interface Registry<@NonNull E extends Identifiable<K>, @NonNull K> {
      * @param key key of the element
      * @return element or null if no element was found
      */
-    public @Nullable E get(K key);
+    @Nullable
+    E get(K key);
 
     /**
      * Removes a {@link RegistryChangeListener} from the registry.
@@ -75,7 +76,7 @@ public interface Registry<@NonNull E extends Identifiable<K>, @NonNull K> {
      * @return the added element or newly created object of the same type
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public E add(E element);
+    E add(E element);
 
     /**
      * Updates the given element at the according {@link ManagedProvider}.
@@ -85,7 +86,8 @@ public interface Registry<@NonNull E extends Identifiable<K>, @NonNull K> {
      *         exists
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public @Nullable E update(E element);
+    @Nullable
+    E update(E element);
 
     /**
      * Removes the given element from the according {@link ManagedProvider}.
@@ -95,5 +97,6 @@ public interface Registry<@NonNull E extends Identifiable<K>, @NonNull K> {
      *         key exists
      * @throws IllegalStateException if no ManagedProvider is available
      */
-    public @Nullable E remove(K key);
+    @Nullable
+    E remove(K key);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
@@ -30,7 +30,7 @@ public interface EventSubscriber {
      * The constant {@link #ALL_EVENT_TYPES} must be returned by the {@link #getSubscribedEventTypes()} method, if the
      * event subscriber should subscribe to all event types.
      */
-    public static String ALL_EVENT_TYPES = "ALL";
+    static String ALL_EVENT_TYPES = "ALL";
 
     /**
      * Gets the event types to which the event subscriber is subscribed to.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
@@ -83,26 +83,26 @@ public interface ActiveItem extends Item {
      *
      * @param groupItemName name of the group (must not be null)
      */
-    abstract void removeGroupName(String groupItemName);
+    void removeGroupName(String groupItemName);
 
     /**
      * Assigns the according item to a group.
      *
      * @param groupItemName name of the group (must not be null)
      */
-    abstract void addGroupName(String groupItemName);
+    void addGroupName(String groupItemName);
 
     /**
      * Assigns the according item to the given groups.
      *
      * @param groupItemNames names of the groups (must not be null)
      */
-    abstract void addGroupNames(String... groupItemNames);
+    void addGroupNames(String... groupItemNames);
 
     /**
      * Assigns the according item to the given groups.
      *
      * @param groupItemNames names of the groups (must not be null)
      */
-    abstract void addGroupNames(List<String> groupItemNames);
+    void addGroupNames(List<String> groupItemNames);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
@@ -50,59 +50,59 @@ public interface ActiveItem extends Item {
      *
      * @param tag a tag that is to be added to item's tags.
      */
-    public void addTag(String tag);
+    void addTag(String tag);
 
     /**
      * Adds tags to the item.
      *
      * @param tags tags that are to be added to item's tags.
      */
-    public void addTags(String... tags);
+    void addTags(String... tags);
 
     /**
      * Adds tags to the item.
      *
      * @param tags tags that are to be added to item's tags.
      */
-    public void addTags(Collection<String> tags);
+    void addTags(Collection<String> tags);
 
     /**
      * Removes a tag from the item.
      *
      * @param tag a tag that is to be removed from item's tags.
      */
-    public void removeTag(String tag);
+    void removeTag(String tag);
 
     /**
      * Clears all tags of this item.
      */
-    public void removeAllTags();
+    void removeAllTags();
 
     /**
      * Removes the according item from a group.
      *
      * @param groupItemName name of the group (must not be null)
      */
-    public abstract void removeGroupName(String groupItemName);
+    abstract void removeGroupName(String groupItemName);
 
     /**
      * Assigns the according item to a group.
      *
      * @param groupItemName name of the group (must not be null)
      */
-    public abstract void addGroupName(String groupItemName);
+    abstract void addGroupName(String groupItemName);
 
     /**
      * Assigns the according item to the given groups.
      *
      * @param groupItemNames names of the groups (must not be null)
      */
-    public abstract void addGroupNames(String... groupItemNames);
+    abstract void addGroupNames(String... groupItemNames);
 
     /**
      * Assigns the according item to the given groups.
      *
      * @param groupItemNames names of the groups (must not be null)
      */
-    public abstract void addGroupNames(List<String> groupItemNames);
+    abstract void addGroupNames(List<String> groupItemNames);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -46,7 +46,7 @@ public interface Item extends Identifiable<String> {
      *
      * @return the current state
      */
-    public State getState();
+    State getState();
 
     /**
      * returns the current state of the item as a specific type
@@ -54,21 +54,21 @@ public interface Item extends Identifiable<String> {
      * @return the current state in the requested type or
      *         null, if state cannot be provided as the requested type
      */
-    public <T extends State> @Nullable T getStateAs(Class<T> typeClass);
+    <T extends State> @Nullable T getStateAs(Class<T> typeClass);
 
     /**
      * returns the name of the item
      *
      * @return the name of the item
      */
-    public String getName();
+    String getName();
 
     /**
      * returns the item type as defined by {@link ItemFactory}s
      *
      * @return the item type
      */
-    public String getType();
+    String getType();
 
     /**
      * <p>
@@ -86,7 +86,7 @@ public interface Item extends Identifiable<String> {
      *
      * @return a list of data types that can be used to update the item state
      */
-    public List<Class<? extends State>> getAcceptedDataTypes();
+    List<Class<? extends State>> getAcceptedDataTypes();
 
     /**
      * <p>
@@ -99,28 +99,29 @@ public interface Item extends Identifiable<String> {
      *
      * @return a list of all command types that can be used for this item
      */
-    public List<Class<? extends Command>> getAcceptedCommandTypes();
+    List<Class<? extends Command>> getAcceptedCommandTypes();
 
     /**
      * Returns a list of the names of the groups this item belongs to.
      *
      * @return list of item group names
      */
-    public List<String> getGroupNames();
+    List<String> getGroupNames();
 
     /**
      * Returns a set of tags. If the item is not tagged, an empty set is returned.
      *
      * @return set of tags.
      */
-    public Set<String> getTags();
+    Set<String> getTags();
 
     /**
      * Returns the label of the item or null if no label is set.
      *
      * @return item label or null
      */
-    public @Nullable String getLabel();
+    @Nullable
+    String getLabel();
 
     /**
      * Returns true if the item's tags contains the specific tag, otherwise false.
@@ -128,14 +129,15 @@ public interface Item extends Identifiable<String> {
      * @param tag a tag whose presence in the item's tags is to be tested.
      * @return true if the item's tags contains the specific tag, otherwise false.
      */
-    public boolean hasTag(String tag);
+    boolean hasTag(String tag);
 
     /**
      * Returns the category of the item or null if no category is set.
      *
      * @return category or null
      */
-    public @Nullable String getCategory();
+    @Nullable
+    String getCategory();
 
     /**
      * Returns the first provided state description (uses the default locale).
@@ -143,7 +145,8 @@ public interface Item extends Identifiable<String> {
      *
      * @return state description (can be null)
      */
-    public @Nullable StateDescription getStateDescription();
+    @Nullable
+    StateDescription getStateDescription();
 
     /**
      * Returns the first provided state description for a given locale.
@@ -152,7 +155,8 @@ public interface Item extends Identifiable<String> {
      * @param locale locale (can be null)
      * @return state description (can be null)
      */
-    public @Nullable StateDescription getStateDescription(@Nullable Locale locale);
+    @Nullable
+    StateDescription getStateDescription(@Nullable Locale locale);
 
     /**
      * Returns the {@link CommandDescription} for this item. In case no dedicated {@link CommandDescription} is
@@ -161,7 +165,7 @@ public interface Item extends Identifiable<String> {
      *
      * @return the {@link CommandDescription} for the default locale (can be null).
      */
-    public default @Nullable CommandDescription getCommandDescription() {
+    default @Nullable CommandDescription getCommandDescription() {
         return getCommandDescription(null);
     }
 
@@ -173,5 +177,6 @@ public interface Item extends Identifiable<String> {
      * @param locale locale (can be null)
      * @return command description (can be null)
      */
-    public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale);
+    @Nullable
+    CommandDescription getCommandDescription(@Nullable Locale locale);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
@@ -38,7 +38,7 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @return the uniquely identified item
      * @throws ItemNotFoundException if no item matches the input
      */
-    public Item getItem(String name) throws ItemNotFoundException;
+    Item getItem(String name) throws ItemNotFoundException;
 
     /**
      * This method retrieves a single item from the registry.
@@ -49,14 +49,14 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @throws ItemNotFoundException if no item matches the input
      * @throws ItemNotUniqueException if multiply items match the input
      */
-    public Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException;
+    Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException;
 
     /**
      * This method retrieves all items that are currently available in the registry
      *
      * @return a collection of all available items
      */
-    public Collection<Item> getItems();
+    Collection<Item> getItems();
 
     /**
      * This method retrieves all items with the given type
@@ -64,14 +64,14 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @param type item type as defined by {@link ItemFactory}s
      * @return a collection of all items of the given type
      */
-    public Collection<Item> getItemsOfType(String type);
+    Collection<Item> getItemsOfType(String type);
 
     /**
      * This method retrieves all items that match a given search pattern
      *
      * @return a collection of all items matching the search pattern
      */
-    public Collection<Item> getItems(String pattern);
+    Collection<Item> getItems(String pattern);
 
     /**
      * Returns list of items which contains all of the given tags.
@@ -79,7 +79,7 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @param tags array of tags to be present on the returned items.
      * @return list of items which contains all of the given tags.
      */
-    public Collection<Item> getItemsByTag(String... tags);
+    Collection<Item> getItemsByTag(String... tags);
 
     /**
      * Returns list of items with a certain type containing all of the given tags.
@@ -88,7 +88,7 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @param tags array of tags to be present on the returned items.
      * @return list of items which contains all of the given tags.
      */
-    public Collection<Item> getItemsByTagAndType(String type, String... tags);
+    Collection<Item> getItemsByTagAndType(String type, String... tags);
 
     /**
      * Returns list of items which contains all of the given tags.
@@ -98,12 +98,13 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @return list of items which contains all of the given tags, which is
      *         filtered by the given type filter.
      */
-    public <T extends Item> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags);
+    <T extends Item> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags);
 
     /**
      * @see ManagedItemProvider#remove(String, boolean)
      */
-    public @Nullable Item remove(String itemName, boolean recursive);
+    @Nullable
+    Item remove(String itemName, boolean recursive);
 
     /**
      * Add a hook to be informed before adding/after removing items.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
@@ -28,7 +28,7 @@ import org.openhab.core.common.registry.Registry;
 @NonNullByDefault
 public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
 
-    public static final String INTERNAL_NAMESPACE_PREFIX = "_";
+    static final String INTERNAL_NAMESPACE_PREFIX = "_";
 
     /**
      * Determines whether the given namespace is internal.
@@ -43,7 +43,7 @@ public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
      *
      * @param itemname the name of the item for which the namespaces should be searched.
      */
-    public Collection<String> getAllNamespaces(String itemname);
+    Collection<String> getAllNamespaces(String itemname);
 
     /**
      * Remove all metadata of a given item

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/StateChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/StateChangeListener.java
@@ -34,7 +34,7 @@ public interface StateChangeListener {
      * @param oldState the previous state
      * @param newState the new state
      */
-    public void stateChanged(Item item, State oldState, State newState);
+    void stateChanged(Item item, State oldState, State newState);
 
     /**
      * This method is called, if a state was updated, but has not changed
@@ -42,5 +42,5 @@ public interface StateChangeListener {
      * @param item the item whose state was updated
      * @param state the current state, same before and after the update
      */
-    public void stateUpdated(Item item, State state);
+    void stateUpdated(Item item, State state);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressService.java
@@ -62,12 +62,12 @@ public interface NetworkAddressService {
      *
      * @param listener The listener
      */
-    public void addNetworkAddressChangeListener(NetworkAddressChangeListener listener);
+    void addNetworkAddressChangeListener(NetworkAddressChangeListener listener);
 
     /**
      * Removes a {@link NetworkAddressChangeListener} so that it is no longer notified about changes.
      *
      * @param listener The listener
      */
-    public void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener);
+    void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener);
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronJob.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronJob.java
@@ -34,5 +34,5 @@ public interface CronJob {
      * @param data The data for the job
      * @throws Exception Exception thrown
      */
-    public void run(Map<String, Object> data) throws Exception;
+    void run(Map<String, Object> data) throws Exception;
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/ComplexType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/ComplexType.java
@@ -30,5 +30,5 @@ public interface ComplexType extends Type {
      *
      * @return all constituents with their names
      */
-    public SortedMap<String, PrimitiveType> getConstituents();
+    SortedMap<String, PrimitiveType> getConstituents();
 }


### PR DESCRIPTION
I wrote a small script to remove redundant public modifiers from the interfaces (https://github.com/openhab/openhab-core/pull/3522#discussion_r1167791483). WDYT?