### PR TITLE
Redefine connection in addon.xsd

### DIFF
--- a/bundles/org.openhab.core.addon/schema/addon-1.0.0.xsd
+++ b/bundles/org.openhab.core.addon/schema/addon-1.0.0.xsd
@@ -51,9 +51,26 @@
 
     <xs:simpleType name="connectionType">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="local"/>
-            <xs:enumeration value="cloud"/>
-            <xs:enumeration value="cloudDiscovery"/>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation>No interaction with external systems at all</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="local">
+                <xs:annotation>
+                    <xs:documentation>Interaction with external systems, without internet access</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="hybrid">
+                <xs:annotation>
+                    <xs:documentation>Interaction with external systems, internet access required only for extended functionality (such as discovery)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="cloud">
+                <xs:annotation>
+                    <xs:documentation>Interaction with external systems, internet access required for normal operation</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
         </xs:restriction>
     </xs:simpleType>
 

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -46,9 +46,9 @@ public class AddonInfo implements Identifiable<String> {
     private final String serviceId;
     private @Nullable String sourceBundle;
 
-    private AddonInfo(String id, String type, String name, String description, @Nullable String author,
-            @Nullable String connection, List<String> countries, @Nullable String configDescriptionURI,
-            @Nullable String serviceId, @Nullable String sourceBundle) throws IllegalArgumentException {
+    private AddonInfo(String id, String type, String name, String description, @Nullable String connection,
+            List<String> countries, @Nullable String configDescriptionURI, @Nullable String serviceId,
+            @Nullable String sourceBundle) throws IllegalArgumentException {
         // mandatory fields
         if (id.isBlank()) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
@@ -153,7 +153,6 @@ public class AddonInfo implements Identifiable<String> {
         private final String type;
         private String name = "";
         private String description = "";
-        private @Nullable String author;
         private @Nullable String connection;
         private List<String> countries = List.of();
         private @Nullable String configDescriptionURI = "";
@@ -184,11 +183,6 @@ public class AddonInfo implements Identifiable<String> {
 
         public Builder withDescription(String description) {
             this.description = description;
-            return this;
-        }
-
-        public Builder withAuthor(@Nullable String author) {
-            this.author = author;
             return this;
         }
 
@@ -229,8 +223,8 @@ public class AddonInfo implements Identifiable<String> {
          * @throws IllegalArgumentException if any of the information in this builder is invalid
          */
         public AddonInfo build() throws IllegalArgumentException {
-            return new AddonInfo(id, type, name, description, author, connection, countries, configDescriptionURI,
-                    serviceId, sourceBundle);
+            return new AddonInfo(id, type, name, description, connection, countries, configDescriptionURI, serviceId,
+                    sourceBundle);
         }
     }
 }

--- a/itests/org.openhab.core.addon.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/addon/addon.xml
+++ b/itests/org.openhab.core.addon.tests/src/main/resources/test-bundle-pool/BundleInfoTest.bundle/OH-INF/addon/addon.xml
@@ -7,6 +7,7 @@
 	<name>hue Binding</name>
 	<description>The hue Binding integrates the Philips hue system. It
 		allows to control hue lights.</description>
+	<connection>local</connection>
 
 	<!-- Dummy config -->
 	<config-description>

--- a/itests/org.openhab.core.addon.tests/src/main/resources/test-bundle-pool/acmeweather.bundle/OH-INF/addon/addon.xml
+++ b/itests/org.openhab.core.addon.tests/src/main/resources/test-bundle-pool/acmeweather.bundle/OH-INF/addon/addon.xml
@@ -7,5 +7,6 @@
 	<name>ACME Weather Binding</name>
 	<description>The ACME Weather Binding requests the ACME Weather Service to show the current temperature, humidity and
 		pressure.</description>
+	<connection>cloud</connection>
 
 </addon:addon>


### PR DESCRIPTION
Redefines `connection` in addon.xsd by:
- Adding new member `none` for no interactions with external systems at all (e.g. astro)
- Replacing member `cloudDiscovery` by `hybrid` which is more generic and can be used when internet access is not required, but can provide optional extended functionality (for example discovery).

Also includes a commit a very small cleanup after #3362.

Resolves #3555