### PR TITLE
[voice] Remove deprecated dialog methods

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -14,12 +14,10 @@ package org.openhab.core.voice;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.audio.AudioSink;
 import org.openhab.core.audio.AudioSource;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
@@ -138,73 +136,6 @@ public interface VoiceManager {
     DialogContext getLastDialogContext();
 
     /**
-     * Starts an infinite dialog sequence using all default services: keyword spotting on the default audio source,
-     * audio source listening to retrieve a question or a command (default Speech to Text service), interpretation and
-     * handling of the command, and finally playback of the answer on the default audio sink (default Text to Speech
-     * service).
-     *
-     * Only one dialog can be started for the default audio source.
-     *
-     * @throws IllegalStateException if required services are not all available or the default locale is not supported
-     *             by all these services or a dialog is already started for the default audio source
-     */
-    @Deprecated
-    void startDialog() throws IllegalStateException;
-
-    /**
-     * Starts an infinite dialog sequence: keyword spotting on the audio source, audio source listening to retrieve
-     * a question or a command (Speech to Text service), interpretation and handling of the command, and finally
-     * playback of the answer on the audio sink (Text to Speech service).
-     *
-     * Only one dialog can be started for an audio source.
-     *
-     * @param ks the keyword spotting service to use or null to use the default service
-     * @param stt the speech-to-text service to use or null to use the default service
-     * @param tts the text-to-speech service to use or null to use the default service
-     * @param hli the human language text interpreter to use or null to use the default service
-     * @param source the audio source to use or null to use the default source
-     * @param sink the audio sink to use or null to use the default sink
-     * @param locale the locale to use or null to use the default locale
-     * @param keyword the keyword to use during keyword spotting or null to use the default keyword
-     * @param listeningItem the item to switch ON while listening to a question
-     * @throws IllegalStateException if required services are not all available or the provided locale is not supported
-     *             by all these services or a dialog is already started for this audio source
-     */
-    @Deprecated
-    void startDialog(@Nullable KSService ks, @Nullable STTService stt, @Nullable TTSService tts,
-            @Nullable HumanLanguageInterpreter hli, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem)
-            throws IllegalStateException;
-
-    /**
-     * Starts an infinite dialog sequence: keyword spotting on the audio source, audio source listening to retrieve
-     * a question or a command (Speech to Text service), interpretation and handling of the command, and finally
-     * playback of the answer on the audio sink (Text to Speech service).
-     *
-     * Only one dialog can be started for an audio source.
-     *
-     * @param ks the keyword spotting service to use or null to use the default service
-     * @param stt the speech-to-text service to use or null to use the default service
-     * @param tts the text-to-speech service to use or null to use the default service
-     * @param voice the voice to use or null to use the default voice or any voice provided by the text-to-speech
-     *            service matching the locale
-     * @param hlis list of human language text interpreters to use, they are executed in order until the first
-     *            successful response, or empty to use the default service
-     * @param source the audio source to use or null to use the default source
-     * @param sink the audio sink to use or null to use the default sink
-     * @param locale the locale to use or null to use the default locale
-     * @param keyword the keyword to use during keyword spotting or null to use the default keyword
-     * @param listeningItem the item to switch ON while listening to a question
-     * @throws IllegalStateException if required services are not all available or the provided locale is not supported
-     *             by all these services or a dialog is already started for this audio source
-     */
-    @Deprecated
-    void startDialog(@Nullable KSService ks, @Nullable STTService stt, @Nullable TTSService tts, @Nullable Voice voice,
-            List<HumanLanguageInterpreter> hlis, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem)
-            throws IllegalStateException;
-
-    /**
      * Starts an infinite dialog sequence: keyword spotting on the audio source, audio source listening to retrieve
      * a question or a command (Speech to Text service), interpretation and handling of the command, and finally
      * playback of the answer on the audio sink (Text to Speech service).
@@ -232,44 +163,6 @@ public interface VoiceManager {
      * @throws IllegalStateException if no dialog is started for the audio source
      */
     void stopDialog(DialogContext context) throws IllegalStateException;
-
-    /**
-     * Executes a simple dialog sequence without keyword spotting using all default services: default audio source
-     * listening to retrieve a question or a command (default Speech to Text service), interpretation and handling of
-     * the command, and finally playback of the answer on the default audio sink (default Text to Speech service).
-     *
-     * Only possible if no dialog processor is already started for the default audio source.
-     *
-     * @throws IllegalStateException if required services are not all available or the provided default locale is not
-     *             supported by all these services or a dialog is already started for the default audio source
-     */
-    @Deprecated
-    void listenAndAnswer() throws IllegalStateException;
-
-    /**
-     * Executes a simple dialog sequence without keyword spotting: audio source listening to retrieve a question or a
-     * command (Speech to Text service), interpretation and handling of the command, and finally playback of the
-     * answer on the audio sink (Text to Speech service).
-     *
-     * Only possible if no dialog processor is already started for the audio source.
-     *
-     * @param stt the speech-to-text service to use or null to use the default service
-     * @param tts the text-to-speech service to use or null to use the default service
-     * @param voice the voice to use or null to use the default voice or any voice provided by the text-to-speech
-     *            service matching the locale
-     * @param hlis list of human language text interpreters to use, they are executed in order until the first
-     *            successful response, or empty to use the default service
-     * @param source the audio source to use or null to use the default source
-     * @param sink the audio sink to use or null to use the default sink
-     * @param locale the locale to use or null to use the default locale
-     * @param listeningItem the item to switch ON while listening to a question
-     * @throws IllegalStateException if required services are not all available or the provided locale is not supported
-     *             by all these services or a dialog is already started for this audio source
-     */
-    @Deprecated
-    void listenAndAnswer(@Nullable STTService stt, @Nullable TTSService tts, @Nullable Voice voice,
-            List<HumanLanguageInterpreter> hlis, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String listeningItem) throws IllegalStateException;
 
     /**
      * Executes a simple dialog sequence without keyword spotting: audio source listening to retrieve a question or a

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -531,62 +531,6 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     @Override
-    @Deprecated
-    public void startDialog() throws IllegalStateException {
-        startDialog(null, null, null, null, List.of(), null, null, null, this.keyword, this.listeningItem);
-    }
-
-    @Override
-    @Deprecated
-    public void startDialog(@Nullable KSService ks, @Nullable STTService stt, @Nullable TTSService tts,
-            @Nullable HumanLanguageInterpreter hli, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem)
-            throws IllegalStateException {
-        startDialog(ks, stt, tts, null, hli == null ? List.of() : List.of(hli), source, sink, locale, keyword,
-                listeningItem);
-    }
-
-    @Override
-    @Deprecated
-    public void startDialog(@Nullable KSService ks, @Nullable STTService stt, @Nullable TTSService tts,
-            @Nullable Voice voice, List<HumanLanguageInterpreter> hlis, @Nullable AudioSource source,
-            @Nullable AudioSink sink, @Nullable Locale locale, @Nullable String keyword, @Nullable String listeningItem)
-            throws IllegalStateException {
-        var builder = getDialogContextBuilder();
-        if (ks != null) {
-            builder.withKS(ks);
-        }
-        if (keyword != null) {
-            builder.withKeyword(keyword);
-        }
-        if (stt != null) {
-            builder.withSTT(stt);
-        }
-        if (tts != null) {
-            builder.withTTS(tts);
-        }
-        if (voice != null) {
-            builder.withVoice(voice);
-        }
-        if (!hlis.isEmpty()) {
-            builder.withHLIs(hlis);
-        }
-        if (source != null) {
-            builder.withSource(source);
-        }
-        if (sink != null) {
-            builder.withSink(sink);
-        }
-        if (locale != null) {
-            builder.withLocale(locale);
-        }
-        if (listeningItem != null) {
-            builder.withListeningItem(listeningItem);
-        }
-        startDialog(builder.build());
-    }
-
-    @Override
     public void startDialog(DialogContext context) throws IllegalStateException {
         var ksService = context.ks();
         var ksKeyword = context.keyword();
@@ -643,42 +587,6 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     @Override
     public void stopDialog(DialogContext context) throws IllegalStateException {
         stopDialog(context.source());
-    }
-
-    @Override
-    @Deprecated
-    public void listenAndAnswer() throws IllegalStateException {
-        listenAndAnswer(null, null, null, List.of(), null, null, null, null);
-    }
-
-    @Override
-    @Deprecated
-    public void listenAndAnswer(@Nullable STTService stt, @Nullable TTSService tts, @Nullable Voice voice,
-            List<HumanLanguageInterpreter> hlis, @Nullable AudioSource source, @Nullable AudioSink sink,
-            @Nullable Locale locale, @Nullable String listeningItem) throws IllegalStateException {
-        var builder = getDialogContextBuilder();
-        if (stt != null) {
-            builder.withSTT(stt);
-        }
-        if (tts != null) {
-            builder.withTTS(tts);
-        }
-        if (!hlis.isEmpty()) {
-            builder.withHLIs(hlis);
-        }
-        if (source != null) {
-            builder.withSource(source);
-        }
-        if (sink != null) {
-            builder.withSink(sink);
-        }
-        if (locale != null) {
-            builder.withLocale(locale);
-        }
-        if (listeningItem != null) {
-            builder.withListeningItem(listeningItem);
-        }
-        listenAndAnswer(builder.build());
     }
 
     @Override

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -38,6 +38,7 @@ import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.voice.DialogContext;
 import org.openhab.core.voice.DialogRegistration;
 import org.openhab.core.voice.Voice;
 import org.openhab.core.voice.VoiceManager;
@@ -200,8 +201,10 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         ksService = new KSServiceStub();
         hliStub = new HumanLanguageInterpreterStub();
 
-        assertThrows(IllegalStateException.class, () -> voiceManager.startDialog(ksService, sttService, null, null,
-                List.of(hliStub), source, sink, Locale.ENGLISH, "word", null));
+        assertThrows(IllegalStateException.class,
+                () -> voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                        .withKS(ksService).withSTT(sttService).withTTS(null).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                        .withKeyword("word").build()));
 
         assertFalse(ksService.isWordSpotted());
         assertFalse(sink.getIsStreamProcessed());
@@ -218,8 +221,10 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         registerService(ttsService);
         registerService(hliStub);
 
-        assertThrows(IllegalStateException.class, () -> voiceManager.startDialog(ksService, sttService, ttsService,
-                null, List.of(hliStub), source, sink, Locale.FRENCH, "mot", null));
+        assertThrows(IllegalStateException.class,
+                () -> voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                        .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub)
+                        .withLocale(Locale.FRENCH).withKeyword("mot").build()));
 
         assertFalse(ksService.isWordSpotted());
         assertFalse(sink.getIsStreamProcessed());
@@ -236,8 +241,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         registerService(ttsService);
         registerService(hliStub);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertTrue(ksService.isWordSpotted());
         assertTrue(sttService.isRecognized());
@@ -264,8 +270,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         ksService.setExceptionExpected(true);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertFalse(ksService.isWordSpotted());
         assertFalse(sttService.isRecognized());
@@ -290,8 +297,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         ksService.setErrorExpected(true);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertFalse(ksService.isWordSpotted());
         assertFalse(sttService.isRecognized());
@@ -317,8 +325,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         sttService.setExceptionExpected(true);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertTrue(ksService.isWordSpotted());
         assertFalse(sttService.isRecognized());
@@ -343,8 +352,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         sttService.setErrorExpected(true);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertTrue(ksService.isWordSpotted());
         assertFalse(sttService.isRecognized());
@@ -369,8 +379,9 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
 
         hliStub.setExceptionExpected(true);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertTrue(ksService.isWordSpotted());
         assertTrue(sttService.isRecognized());
@@ -407,8 +418,10 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         // Wait some time to be sure that the configuration will be updated
         Thread.sleep(2000);
 
-        voiceManager.startDialog();
+        DialogContext context = voiceManager.getDialogContextBuilder().build();
+        voiceManager.startDialog(context);
 
+        assertThat(voiceManager.getLastDialogContext(), is(context));
         assertTrue(ksService.isWordSpotted());
         assertTrue(sttService.isRecognized());
         assertThat(hliStub.getQuestion(), is("Recognized text"));
@@ -432,13 +445,16 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         registerService(ttsService);
         registerService(hliStub);
 
-        voiceManager.startDialog(ksService, sttService, ttsService, null, List.of(hliStub), source, sink,
-                Locale.ENGLISH, "word", null);
+        voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub).withLocale(Locale.ENGLISH)
+                .withKeyword("word").build());
 
         assertTrue(ksService.isWordSpotted());
 
-        assertThrows(IllegalStateException.class, () -> voiceManager.startDialog(ksService, sttService, ttsService,
-                null, List.of(hliStub), source, sink, Locale.ENGLISH, "word", null));
+        assertThrows(IllegalStateException.class,
+                () -> voiceManager.startDialog(voiceManager.getDialogContextBuilder().withSource(source).withSink(sink)
+                        .withKS(ksService).withSTT(sttService).withTTS(ttsService).withHLI(hliStub)
+                        .withLocale(Locale.ENGLISH).withKeyword("word").build()));
 
         voiceManager.stopDialog(source);
 


### PR DESCRIPTION
Remove VoiceManager deprecated method overloads for 'startDialog' and 'listenAndAnswer'.

Closes #3262