### PR TITLE
[ephemeris] Add support for overriding holiday definitions

### DIFF
--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -46,8 +46,8 @@ import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.ephemeris.EphemerisManager;
 import org.openhab.core.i18n.LocaleProvider;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
-import org.osgi.framework.FrameworkUtil;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -102,14 +102,15 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     private final ResourceUtil resourceUtil = new ResourceUtil();
 
     private final LocaleProvider localeProvider;
-    private final Bundle bundle = FrameworkUtil.getBundle(getClass());
+    private final Bundle bundle;
 
     private @NonNullByDefault({}) String country;
     private @Nullable String region;
 
     @Activate
-    public EphemerisManagerImpl(final @Reference LocaleProvider localeProvider) {
+    public EphemerisManagerImpl(final @Reference LocaleProvider localeProvider, final BundleContext bundleContext) {
         this.localeProvider = localeProvider;
+        bundle = bundleContext.getBundle();
 
         try (InputStream stream = bundle.getResource(JOLLYDAY_COUNTRY_DESCRIPTIONS).openStream()) {
             final Properties properties = new Properties();

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -235,11 +235,12 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
         HolidayManager holidayManager = holidayManagers.get(managerKey);
         if (holidayManager == null) {
             final ManagerParameter parameters;
-            if (managerKey.getClass() == String.class) {
-                URL urlOverride = bundle.getResource(
-                        RESOURCES_ROOT + CalendarPartManagerParameter.getConfigurationFileName((String) managerKey));
-                parameters = urlOverride != null ? ManagerParameters.create(urlOverride)
-                        : ManagerParameters.create((String) managerKey);
+            if (managerKey instanceof String stringKey) {
+                URL urlOverride = bundle
+                        .getResource(RESOURCES_ROOT + CalendarPartManagerParameter.getConfigurationFileName(stringKey));
+                parameters = urlOverride != null //
+                        ? ManagerParameters.create(urlOverride)
+                        : ManagerParameters.create(stringKey);
             } else {
                 parameters = ManagerParameters.create((URL) managerKey);
             }

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -167,23 +167,26 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
             }
         });
 
-        if (config.containsKey(CONFIG_COUNTRY)) {
-            country = config.get(CONFIG_COUNTRY).toString().toLowerCase();
+        Object configValue = config.get(CONFIG_COUNTRY);
+        if (configValue != null) {
+            country = configValue.toString().toLowerCase();
         } else {
             country = localeProvider.getLocale().getCountry().toLowerCase();
             logger.debug("Using system default country '{}' ", country);
         }
 
-        if (config.containsKey(CONFIG_REGION)) {
-            String region = config.get(CONFIG_REGION).toString().toLowerCase();
+        configValue = config.get(CONFIG_REGION);
+        if (configValue != null) {
+            String region = configValue.toString().toLowerCase();
             countryParameters.add(region);
             this.region = region;
         } else {
             this.region = null;
         }
 
-        if (config.containsKey(CONFIG_CITY)) {
-            countryParameters.add(config.get(CONFIG_CITY).toString());
+        configValue = config.get(CONFIG_CITY);
+        if (configValue != null) {
+            countryParameters.add(configValue.toString());
         }
     }
 
@@ -307,9 +310,10 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
 
     @Override
     public boolean isInDayset(String daysetName, ZonedDateTime date) {
-        if (daysets.containsKey(daysetName)) {
+        Set<DayOfWeek> dayset = daysets.get(daysetName);
+        if (dayset != null) {
             DayOfWeek dow = date.getDayOfWeek();
-            return daysets.get(daysetName).contains(dow);
+            return dayset.contains(dow);
         } else {
             logger.warn("This dayset is not configured : {}", daysetName);
             return false;
@@ -391,8 +395,9 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
             case 2:
                 part = getValidPart(parts[0]);
                 option = new ParameterOption(getValidPart(parts[1]), name);
-                if (regions.containsKey(part)) {
-                    regions.get(part).add(option);
+                List<ParameterOption> regionsPart = regions.get(part);
+                if (regionsPart != null) {
+                    regionsPart.add(option);
                 } else {
                     final List<ParameterOption> options = new ArrayList<>();
                     options.add(option);
@@ -402,8 +407,9 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
             case 3:
                 part = getValidPart(parts[1]);
                 option = new ParameterOption(getValidPart(parts[2]), name);
-                if (cities.containsKey(part)) {
-                    cities.get(part).add(option);
+                List<ParameterOption> citiesPart = cities.get(part);
+                if (citiesPart != null) {
+                    citiesPart.add(option);
                 } else {
                     final List<ParameterOption> options = new ArrayList<>();
                     options.add(option);

--- a/bundles/org.openhab.core.ephemeris/src/main/resources/jollyday/holidays/Holidays_dk.xml
+++ b/bundles/org.openhab.core.ephemeris/src/main/resources/jollyday/holidays/Holidays_dk.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tns:Configuration hierarchy="dk" description="Denmark" xmlns:tns="http://www.example.org/Holiday"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.example.org/Holiday /Holiday.xsd">
+	<tns:Holidays>
+		<tns:Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+		<tns:Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+		<tns:Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+		<tns:ChristianHoliday type="EASTER"/>
+		<tns:ChristianHoliday type="MAUNDY_THURSDAY"/>
+		<tns:ChristianHoliday type="GOOD_FRIDAY"/>
+		<tns:ChristianHoliday type="EASTER_MONDAY"/>
+		<tns:ChristianHoliday type="GENERAL_PRAYER_DAY" validTo="2023"/>
+		<tns:ChristianHoliday type="ASCENSION_DAY"/>
+		<tns:ChristianHoliday type="WHIT_MONDAY"/>
+		<tns:ChristianHoliday type="PENTECOST"/>
+	</tns:Holidays>
+</tns:Configuration>

--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -47,6 +47,7 @@ import org.openhab.core.test.java.JavaOSGiTest;
 public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
     private static final String INTERNAL_DAYSET = "internal";
     private static final URI CONFIG_URI = URI.create("system:ephemeris");
+    private static final String COUNTRY_DENMARK_KEY = "dk";
     private static final String COUNTRY_AUSTRALIA_KEY = "au";
     private static final String COUNTRY_AUSTRALIA_NAME = "Australia";
     private static final String REGION_BAVARIA_KEY = "by";
@@ -261,6 +262,20 @@ public class EphemerisManagerImplOSGiTest extends JavaOSGiTest {
 
         vacation = ephemerisManager.isBankHoliday(secondday);
         assertFalse(vacation);
+    }
+
+    @Test
+    public void testIsBankHolidayWhenGeneralPrayerDay2023() {
+        ZonedDateTime generalPrayerDay = ZonedDateTime.of(2023, 05, 05, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
+        ephemerisManager.modified(Map.of(CONFIG_COUNTRY, COUNTRY_DENMARK_KEY));
+        assertTrue(ephemerisManager.isBankHoliday(generalPrayerDay));
+    }
+
+    @Test
+    public void testIsBankHolidayWhenGeneralPrayerDay2024() {
+        ZonedDateTime generalPrayerDay = ZonedDateTime.of(2024, 04, 26, 0, 0, 0, 0, ZoneId.of("Europe/Paris"));
+        ephemerisManager.modified(Map.of(CONFIG_COUNTRY, COUNTRY_DENMARK_KEY));
+        assertFalse(ephemerisManager.isBankHoliday(generalPrayerDay));
     }
 
     @Test


### PR DESCRIPTION
The version of Jollyday we are using was abandoned years ago, so the holiday definitions we are using are getting outdated as well.

This pull request introduces the possibility to override holiday definitions in core, and as an example contains updated Danish definitions, ending Great Prayer Day this year, since our government has [abolished](https://www.thelocal.dk/20230228/great-prayer-day-abolished-by-danish-parliament) it from next year.

The obvious disadvantage is that we would then take over the maintenance. But on the other hand, they are not maintained upstream anymore, so at least it would improve the user experience. Additionally, it would not change the API, so upgrading to **focus-shift** later will be seamless for users.

Related to #3544