### PR TITLE
Consider auto-update policy from channel types

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AutoUpdatePolicy.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AutoUpdatePolicy.java
@@ -46,12 +46,12 @@ public enum AutoUpdatePolicy {
      * Parses the input string into an {@link AutoUpdatePolicy}.
      *
      * @param input the input string
-     * @return the parsed AutoUpdatePolicy
+     * @return the parsed AutoUpdatePolicy or null if the input was null
      * @throws IllegalArgumentException if the input couldn't be parsed.
      */
-    public static AutoUpdatePolicy parse(@Nullable String input) {
+    public static @Nullable AutoUpdatePolicy parse(@Nullable String input) {
         if (input == null) {
-            return DEFAULT;
+            return null;
         }
 
         for (AutoUpdatePolicy value : values()) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
@@ -32,22 +32,22 @@ import org.openhab.core.thing.dto.ThingDTOMapper;
 @NonNullByDefault
 public class ThingChannelsTest extends JavaOSGiTest {
 
+    private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("bindingId", "thingTypeId");
+    private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "thingLabel");
+
     private static final List<String> CHANNEL_IDS = List.of("polarBear", "alligator", "hippopotamus", "aardvark",
             "whiteRabbit", "redHerring", "orangutan", "kangaroo", "rubberDuck", "timorousBeastie");
 
     @Test
     public void testThingChannelOrder() {
-        ThingTypeUID thingTypeUID = new ThingTypeUID("bindingId", "thingTypeId");
-        ThingUID thingUID = new ThingUID(thingTypeUID, "thingLabel");
-
         // create and fill the list of origin channels
         List<Channel> originChannels = new ArrayList<>();
         CHANNEL_IDS.forEach(channelId -> originChannels
-                .add(ChannelBuilder.create(new ChannelUID(thingUID, channelId), null).build()));
+                .add(ChannelBuilder.create(new ChannelUID(THING_UID, channelId), null).build()));
         assertEquals(CHANNEL_IDS.size(), originChannels.size());
 
         // build a thing with the origin channels
-        Thing thing = ThingBuilder.create(thingTypeUID, thingUID).withChannels(originChannels).build();
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(originChannels).build();
 
         List<Channel> resultChannels;
 
@@ -64,5 +64,11 @@ public class ThingChannelsTest extends JavaOSGiTest {
         for (int i = 0; i < CHANNEL_IDS.size(); i++) {
             assertTrue(CHANNEL_IDS.get(i).equals(resultChannels.get(i).getUID().getId()));
         }
+    }
+
+    @Test
+    public void testAutoUpdatePolicyNotSetOnNewChannels() {
+        Channel channel = ChannelBuilder.create(new ChannelUID(THING_UID, CHANNEL_IDS.get(0)), null).build();
+        assertNull(channel.getAutoUpdatePolicy());
     }
 }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.thing.internal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeRegistry;
+import org.openhab.core.thing.type.ChannelTypeUID;
+
+/**
+ * Tests for {@link AutoUpdateManager}.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+@NonNullByDefault
+public class AutoUpdateManagerTest extends JavaTest {
+
+    private static final ChannelTypeUID CHANNEL_TYPE_UID = new ChannelTypeUID("binding:channelType");
+    private static final ChannelUID CHANNEL_UID = new ChannelUID("binding:thingtype1:thing1:channel1");
+    private static final String ITEM_NAME = "TestItem";
+
+    private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
+    private @NonNullByDefault({}) ThingRegistry thingRegistry;
+    private @NonNullByDefault({}) MetadataRegistry metadataRegistry;
+    private @NonNullByDefault({}) EventPublisher eventPublisher;
+    private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private @NonNullByDefault({}) AutoUpdateManager autoUpdateManager;
+    private @NonNullByDefault({}) Item item;
+    private @NonNullByDefault({}) Thing thing;
+
+    @BeforeEach
+    public void setup() {
+        channelTypeRegistry = mock(ChannelTypeRegistry.class);
+        eventPublisher = mock(EventPublisher.class);
+        itemChannelLinkRegistry = mock(ItemChannelLinkRegistry.class);
+        assertNotNull(itemChannelLinkRegistry);
+
+        thingRegistry = mock(ThingRegistry.class);
+        thing = mock(Thing.class);
+        metadataRegistry = mock(MetadataRegistry.class);
+
+        Channel channel = ChannelBuilder.create(CHANNEL_UID).withType(CHANNEL_TYPE_UID).build();
+
+        autoUpdateManager = new AutoUpdateManager(Collections.emptyMap(), channelTypeRegistry, eventPublisher,
+                itemChannelLinkRegistry, metadataRegistry, thingRegistry);
+
+        item = mock(Item.class);
+        when(item.getName()).thenReturn(ITEM_NAME);
+        when(item.getAcceptedDataTypes()).thenReturn(List.of(OnOffType.class));
+        when(itemChannelLinkRegistry.getLinks(any(String.class)))
+                .thenReturn(Set.of(new ItemChannelLink(ITEM_NAME, CHANNEL_UID)));
+        when(thingRegistry.get(any(ThingUID.class))).thenReturn(thing);
+        when(thing.getStatus()).thenReturn(ThingStatus.ONLINE);
+        when(thing.getHandler()).thenReturn(mock(ThingHandler.class));
+        when(thing.getChannel(any(String.class))).thenReturn(channel);
+    }
+
+    @Test
+    public void testAutoUpdateVetoFromChannelType() {
+        when(channelTypeRegistry.getChannelType(any(ChannelTypeUID.class)))
+                .thenReturn(ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "label", CoreItemFactory.SWITCH).withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build());
+
+        autoUpdateManager.receiveCommand(ItemEventFactory.createCommandEvent(ITEM_NAME, OnOffType.ON), item);
+
+        // No event should have been sent
+        verify(eventPublisher, never()).post(any(Event.class));
+    }
+}

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -164,9 +164,6 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         SystemProfileFactory profileFactory = getService(ProfileTypeProvider.class, SystemProfileFactory.class);
 
         assertNotNull(profileFactory);
-        if (profileFactory == null) {
-            throw new IllegalStateException("thing is null");
-        }
 
         manager = new CommunicationManager(autoUpdateManagerMock, channelTypeRegistryMock, profileFactory, iclRegistry,
                 itemRegistryMock, itemStateConverterMock, eventPublisherMock, safeCaller, thingRegistryMock);


### PR DESCRIPTION
When the Main UI creates things/channels through the REST API, it does not set autoUpdatePolicy for the channels, which makes the core use "RECOMMEND" as a policy without looking at a potential information at the channel type definition.

This PR leaves the autoUpdatePolicy for the channels unset, so that the AutoUpdateManager then checks for the information in the channel type.

See also https://github.com/openhab/openhab-addons/pull/14809#issuecomment-1510455008