### PR TITLE
Bump Netty version to 4.1.92.Final

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -155,23 +155,23 @@
 	</feature>
 
 	<feature name="openhab.tp-netty" description="Netty bundles" version="${project.version}">
-		<capability>openhab.tp;feature=netty;version=4.1.72.Final</capability>
-		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-common/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.72.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-tcnative-classes/2.0.46.Final</bundle>
+		<capability>openhab.tp;feature=netty;version=4.1.92.Final</capability>
+		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-common/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.92.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-tcnative-classes/2.0.60.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">


### PR DESCRIPTION
Bump Netty to latest versions.

https://netty.io/news/2023/04/25/4-1-92-Final.html

Also requires this PR
https://github.com/openhab/openhab-addons/pull/14878

Signed-off-by: Matthew Skinner <matt@pcmus.com>