### PR TITLE
[core] Switch `DateTimeType` to `Instant` internally for consistent time-zone handling

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -441,7 +441,7 @@ public class RuleResource implements RESTResource {
             return defaultSupplier.get();
         }
         final DateTimeType dateTime = new DateTimeType(sTime);
-        return dateTime.getInstant().atZone(timeZoneProvider.getTimeZone());
+        return dateTime.getZonedDateTime(timeZoneProvider.getTimeZone());
     }
 
     @GET

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -76,6 +76,7 @@ import org.openhab.core.common.registry.RegistryChangedRunnableListener;
 import org.openhab.core.config.core.ConfigUtil;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.events.Event;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.DTOMapper;
 import org.openhab.core.io.rest.JSONResponse;
 import org.openhab.core.io.rest.RESTConstants;
@@ -133,6 +134,7 @@ public class RuleResource implements RESTResource {
     private final RuleManager ruleManager;
     private final RuleRegistry ruleRegistry;
     private final ManagedRuleProvider managedRuleProvider;
+    private final TimeZoneProvider timeZoneProvider;
     private final RegistryChangedRunnableListener<Rule> resetLastModifiedChangeListener = new RegistryChangedRunnableListener<>(
             () -> lastModified = null);
 
@@ -144,11 +146,13 @@ public class RuleResource implements RESTResource {
             final @Reference DTOMapper dtoMapper, //
             final @Reference RuleManager ruleManager, //
             final @Reference RuleRegistry ruleRegistry, //
-            final @Reference ManagedRuleProvider managedRuleProvider) {
+            final @Reference ManagedRuleProvider managedRuleProvider, //
+            final @Reference TimeZoneProvider timeZoneProvider) {
         this.dtoMapper = dtoMapper;
         this.ruleManager = ruleManager;
         this.ruleRegistry = ruleRegistry;
         this.managedRuleProvider = managedRuleProvider;
+        this.timeZoneProvider = timeZoneProvider;
 
         this.ruleRegistry.addRegistryChangeListener(resetLastModifiedChangeListener);
     }
@@ -431,9 +435,9 @@ public class RuleResource implements RESTResource {
         return Response.ok(ruleExecutions.toList()).build();
     }
 
-    private static ZonedDateTime parseTime(String sTime) {
+    private ZonedDateTime parseTime(String sTime) {
         final DateTimeType dateTime = new DateTimeType(sTime);
-        return dateTime.getZonedDateTime();
+        return dateTime.getInstant().atZone(timeZoneProvider.getTimeZone());
     }
 
     private static long daysBetween(ZonedDateTime d1, ZonedDateTime d2) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
@@ -178,8 +178,7 @@ public class DateTimeTriggerHandler extends BaseTriggerModuleHandler
             cronExpression = CronAdjuster.REBOOT;
         } else if (value instanceof DateTimeType dateTimeType) {
             boolean itemIsTimeOnly = dateTimeType.toString().startsWith("1970-01-01T");
-            cronExpression = dateTimeType.getZonedDateTime().withZoneSameInstant(ZoneId.systemDefault())
-                    .plusSeconds(offset.longValue())
+            cronExpression = dateTimeType.getInstant().atZone(ZoneId.systemDefault()).plusSeconds(offset.longValue())
                     .format(timeOnly || itemIsTimeOnly ? CRON_TIMEONLY_FORMATTER : CRON_FORMATTER);
             startScheduler();
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
@@ -178,7 +178,7 @@ public class DateTimeTriggerHandler extends BaseTriggerModuleHandler
             cronExpression = CronAdjuster.REBOOT;
         } else if (value instanceof DateTimeType dateTimeType) {
             boolean itemIsTimeOnly = dateTimeType.toString().startsWith("1970-01-01T");
-            cronExpression = dateTimeType.getInstant().atZone(ZoneId.systemDefault()).plusSeconds(offset.longValue())
+            cronExpression = dateTimeType.getZonedDateTime(ZoneId.systemDefault()).plusSeconds(offset.longValue())
                     .format(timeOnly || itemIsTimeOnly ? CRON_TIMEONLY_FORMATTER : CRON_FORMATTER);
             startScheduler();
         } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -161,7 +161,7 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
         State itemState = item.getState();
         if (itemState instanceof DateTimeType dateTimeState) {
             Instant itemTime = dateTimeState.getInstant();
-            Instant compareTime = getCompareTime(state).toInstant();
+            Instant compareTime = getCompareTime(state);
             return itemTime.compareTo(compareTime) <= 0;
         } else if (itemState instanceof QuantityType qtState) {
             if (compareState instanceof DecimalType type) {
@@ -198,7 +198,7 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
         State itemState = item.getState();
         if (itemState instanceof DateTimeType dateTimeState) {
             Instant itemTime = dateTimeState.getInstant();
-            Instant compareTime = getCompareTime(state).toInstant();
+            Instant compareTime = getCompareTime(state);
             return itemTime.compareTo(compareTime) >= 0;
         } else if (itemState instanceof QuantityType qtState) {
             if (compareState instanceof DecimalType type) {
@@ -253,36 +253,36 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
         eventSubscriberRegistration.unregister();
     }
 
-    private ZonedDateTime getCompareTime(String input) {
+    private Instant getCompareTime(String input) {
         if (input.isBlank()) {
             // no parameter given, use now
-            return ZonedDateTime.now();
+            return Instant.now();
         }
         try {
-            return ZonedDateTime.parse(input);
+            return ZonedDateTime.parse(input).toInstant();
         } catch (DateTimeParseException ignored) {
         }
         try {
             return LocalDateTime.parse(input, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                    .atZone(timeZoneProvider.getTimeZone());
+                    .atZone(timeZoneProvider.getTimeZone()).toInstant();
         } catch (DateTimeParseException ignored) {
         }
         try {
             int dayPosition = input.indexOf("D");
             if (dayPosition == -1) {
                 // no date in string, add period symbol and time separator
-                return ZonedDateTime.now().plus(Duration.parse("PT" + input));
+                return Instant.now().plus(Duration.parse("PT" + input));
             } else if (dayPosition == input.length() - 1) {
                 // day is the last symbol, only add the period symbol
-                return ZonedDateTime.now().plus(Duration.parse("P" + input));
+                return Instant.now().plus(Duration.parse("P" + input));
             } else {
                 // add period symbol and time separator
-                return ZonedDateTime.now().plus(Duration
+                return Instant.now().plus(Duration
                         .parse("P" + input.substring(0, dayPosition + 1) + "T" + input.substring(dayPosition + 1)));
             }
         } catch (DateTimeParseException e) {
             logger.warn("Couldn't get a comparable time from '{}', using now", input);
         }
-        return ZonedDateTime.now();
+        return Instant.now();
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.internal.module.handler;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -158,9 +159,9 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
         Item item = itemRegistry.getItem(itemName);
         State compareState = TypeParser.parseState(item.getAcceptedDataTypes(), state);
         State itemState = item.getState();
-        if (itemState instanceof DateTimeType type) {
-            ZonedDateTime itemTime = type.getZonedDateTime();
-            ZonedDateTime compareTime = getCompareTime(state);
+        if (itemState instanceof DateTimeType dateTimeState) {
+            Instant itemTime = dateTimeState.getInstant();
+            Instant compareTime = getCompareTime(state).toInstant();
             return itemTime.compareTo(compareTime) <= 0;
         } else if (itemState instanceof QuantityType qtState) {
             if (compareState instanceof DecimalType type) {
@@ -195,9 +196,9 @@ public class ItemStateConditionHandler extends BaseConditionModuleHandler implem
         Item item = itemRegistry.getItem(itemName);
         State compareState = TypeParser.parseState(item.getAcceptedDataTypes(), state);
         State itemState = item.getState();
-        if (itemState instanceof DateTimeType type) {
-            ZonedDateTime itemTime = type.getZonedDateTime();
-            ZonedDateTime compareTime = getCompareTime(state);
+        if (itemState instanceof DateTimeType dateTimeState) {
+            Instant itemTime = dateTimeState.getInstant();
+            Instant compareTime = getCompareTime(state).toInstant();
             return itemTime.compareTo(compareTime) >= 0;
         } else if (itemState instanceof QuantityType qtState) {
             if (compareState instanceof DecimalType type) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -340,7 +340,7 @@ public class PersistenceResource implements RESTResource {
 
     private ZonedDateTime convertTime(String sTime) {
         DateTimeType dateTime = new DateTimeType(sTime);
-        return dateTime.getInstant().atZone(timeZoneProvider.getTimeZone());
+        return dateTime.getZonedDateTime(timeZoneProvider.getTimeZone());
     }
 
     private Response getItemHistoryDTO(@Nullable String serviceId, String itemName, @Nullable String timeBegin,

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -340,7 +340,7 @@ public class PersistenceResource implements RESTResource {
 
     private ZonedDateTime convertTime(String sTime) {
         DateTimeType dateTime = new DateTimeType(sTime);
-        return dateTime.getZonedDateTime();
+        return dateTime.getInstant().atZone(timeZoneProvider.getTimeZone());
     }
 
     private Response getItemHistoryDTO(@Nullable String serviceId, String itemName, @Nullable String timeBegin,

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -12,9 +12,7 @@
  */
 package org.openhab.core.io.rest.core.item;
 
-import java.time.Instant;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -56,10 +54,6 @@ public class EnrichedItemDTOMapper {
 
     private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
-    private static final String DATE_FORMAT_PATTERN_WITH_TZ_RFC = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS]]Z";
-    private static final DateTimeFormatter FORMATTER_TZ_RFC = DateTimeFormatter
-            .ofPattern(DATE_FORMAT_PATTERN_WITH_TZ_RFC);
-
     private static final Logger LOGGER = LoggerFactory.getLogger(EnrichedItemDTOMapper.class);
 
     /**
@@ -100,7 +94,7 @@ public class EnrichedItemDTOMapper {
             if (dateTime == null) {
                 state = item.getState().toFullString();
             } else {
-                state = formatDateTime(dateTime.getInstant(), zoneId);
+                state = dateTime.toFullString(zoneId);
             }
         } else {
             state = item.getState().toFullString();
@@ -153,24 +147,6 @@ public class EnrichedItemDTOMapper {
         }
 
         return enrichedItemDTO;
-    }
-
-    private static String formatDateTime(Instant instant, ZoneId zoneId) {
-        String formatted = instant.atZone(zoneId).format(FORMATTER_TZ_RFC);
-        if (formatted.contains(".")) {
-            String sign = "";
-            if (formatted.contains("+")) {
-                sign = "+";
-            } else if (formatted.contains("-")) {
-                sign = "-";
-            }
-            if (!sign.isEmpty()) {
-                // the formatted string contains 9 fraction-of-second digits
-                // truncate at most 2 trailing groups of 000s
-                return formatted.replace("000" + sign, sign).replace("000" + sign, sign);
-            }
-        }
-        return formatted;
     }
 
     private static @Nullable StateDescription considerTransformation(@Nullable StateDescription stateDescription) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.core.io.rest.core.item;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -29,7 +32,9 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.dto.ItemDTO;
 import org.openhab.core.items.dto.ItemDTOMapper;
+import org.openhab.core.library.items.DateTimeItem;
 import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.transform.TransformationService;
@@ -51,6 +56,10 @@ public class EnrichedItemDTOMapper {
 
     private static final Pattern EXTRACT_TRANSFORM_FUNCTION_PATTERN = Pattern.compile("(.*?)\\((.*)\\):(.*)");
 
+    private static final String DATE_FORMAT_PATTERN_WITH_TZ_RFC = "yyyy-MM-dd'T'HH:mm[:ss[.SSSSSSSSS]]Z";
+    private static final DateTimeFormatter FORMATTER_TZ_RFC = DateTimeFormatter
+            .ofPattern(DATE_FORMAT_PATTERN_WITH_TZ_RFC);
+
     private static final Logger LOGGER = LoggerFactory.getLogger(EnrichedItemDTOMapper.class);
 
     /**
@@ -63,28 +72,39 @@ public class EnrichedItemDTOMapper {
      * @param uriBuilder if present the URI builder contains one template that will be replaced by the specific item
      *            name
      * @param locale locale (can be null)
+     * @param zoneId time-zone id (can be null)
      * @return item DTO object
      */
     public static EnrichedItemDTO map(Item item, boolean drillDown, @Nullable Predicate<Item> itemFilter,
-            @Nullable UriBuilder uriBuilder, @Nullable Locale locale) {
+            @Nullable UriBuilder uriBuilder, @Nullable Locale locale, @Nullable ZoneId zoneId) {
         ItemDTO itemDTO = ItemDTOMapper.map(item);
-        return map(item, itemDTO, drillDown, itemFilter, uriBuilder, locale, new ArrayList<>());
+        return map(item, itemDTO, drillDown, itemFilter, uriBuilder, locale, zoneId, new ArrayList<>());
     }
 
     private static EnrichedItemDTO mapRecursive(Item item, @Nullable Predicate<Item> itemFilter,
-            @Nullable UriBuilder uriBuilder, @Nullable Locale locale, List<Item> parents) {
+            @Nullable UriBuilder uriBuilder, @Nullable Locale locale, @Nullable ZoneId zoneId, List<Item> parents) {
         ItemDTO itemDTO = ItemDTOMapper.map(item);
-        return map(item, itemDTO, true, itemFilter, uriBuilder, locale, parents);
+        return map(item, itemDTO, true, itemFilter, uriBuilder, locale, zoneId, parents);
     }
 
     private static EnrichedItemDTO map(Item item, ItemDTO itemDTO, boolean drillDown,
             @Nullable Predicate<Item> itemFilter, @Nullable UriBuilder uriBuilder, @Nullable Locale locale,
-            List<Item> parents) {
+            @Nullable ZoneId zoneId, List<Item> parents) {
         if (item instanceof GroupItem) {
             // only add as parent item if it is a group, otherwise duplicate memberships trigger false warnings
             parents.add(item);
         }
-        String state = item.getState().toFullString();
+        String state;
+        if (item instanceof DateTimeItem dateTimeItem && zoneId != null) {
+            DateTimeType dateTime = dateTimeItem.getStateAs(DateTimeType.class);
+            if (dateTime == null) {
+                state = item.getState().toFullString();
+            } else {
+                state = formatDateTime(dateTime.getInstant(), zoneId);
+            }
+        } else {
+            state = item.getState().toFullString();
+        }
         String transformedState = considerTransformation(item, locale);
         if (state.equals(transformedState)) {
             transformedState = null;
@@ -117,7 +137,8 @@ public class EnrichedItemDTOMapper {
                                 "Recursive group membership found: {} is a member of {}, but it is also one of its ancestors.",
                                 member.getName(), groupItem.getName());
                     } else if (itemFilter == null || itemFilter.test(member)) {
-                        members.add(mapRecursive(member, itemFilter, uriBuilder, locale, new ArrayList<>(parents)));
+                        members.add(
+                                mapRecursive(member, itemFilter, uriBuilder, locale, zoneId, new ArrayList<>(parents)));
                     }
                 }
                 memberDTOs = members.toArray(new EnrichedItemDTO[0]);
@@ -132,6 +153,24 @@ public class EnrichedItemDTOMapper {
         }
 
         return enrichedItemDTO;
+    }
+
+    private static String formatDateTime(Instant instant, ZoneId zoneId) {
+        String formatted = instant.atZone(zoneId).format(FORMATTER_TZ_RFC);
+        if (formatted.contains(".")) {
+            String sign = "";
+            if (formatted.contains("+")) {
+                sign = "+";
+            } else if (formatted.contains("-")) {
+                sign = "-";
+            }
+            if (!sign.isEmpty()) {
+                // the formatted string contains 9 fraction-of-second digits
+                // truncate at most 2 trailing groups of 000s
+                return formatted.replace("000" + sign, sign).replace("000" + sign, sign);
+            }
+        }
+        return formatted;
     }
 
     private static @Nullable StateDescription considerTransformation(@Nullable StateDescription stateDescription) {

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -55,31 +55,32 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
             subGroup.addMember(stringItem);
         }
 
-        EnrichedGroupItemDTO dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, false, null, null, null);
+        EnrichedGroupItemDTO dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, false, null, null, null,
+                null);
         assertThat(dto.members.length, is(0));
 
-        dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true, null, null, null);
+        dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true, null, null, null, null);
         assertThat(dto.members.length, is(3));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(1));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> CoreItemFactory.NUMBER.equals(i.getType()), null, null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()), null, null, null);
         assertThat(dto.members.length, is(1));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, null, null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, null, null, null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(0));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
-                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, null, null);
+                i -> CoreItemFactory.NUMBER.equals(i.getType()) || i instanceof GroupItem, null, null, null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(0));
 
         dto = (EnrichedGroupItemDTO) EnrichedItemDTOMapper.map(group, true,
                 i -> CoreItemFactory.NUMBER.equals(i.getType()) || i.getType().equals(CoreItemFactory.STRING)
                         || i instanceof GroupItem,
-                null, null);
+                null, null, null);
         assertThat(dto.members.length, is(2));
         assertThat(((EnrichedGroupItemDTO) dto.members[0]).members.length, is(1));
     }
@@ -92,7 +93,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         groupItem1.addMember(groupItem2);
         groupItem2.addMember(groupItem1);
 
-        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
+        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null, null));
 
         assertLogMessage(EnrichedItemDTOMapper.class, LogLevel.ERROR,
                 "Recursive group membership found: group1 is a member of group2, but it is also one of its ancestors.");
@@ -108,7 +109,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         groupItem2.addMember(groupItem3);
         groupItem3.addMember(groupItem1);
 
-        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
+        assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null, null));
 
         assertLogMessage(EnrichedItemDTOMapper.class, LogLevel.ERROR,
                 "Recursive group membership found: group1 is a member of group3, but it is also one of its ancestors.");
@@ -124,7 +125,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         groupItem1.addMember(numberItem);
         groupItem2.addMember(numberItem);
 
-        EnrichedItemDTOMapper.map(groupItem1, true, null, null, null);
+        EnrichedItemDTOMapper.map(groupItem1, true, null, null, null, null);
 
         assertNoLogMessage(EnrichedItemDTOMapper.class);
     }
@@ -139,7 +140,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         groupItem1.addMember(groupItem3);
         groupItem2.addMember(groupItem3);
 
-        EnrichedItemDTOMapper.map(groupItem1, true, null, null, null);
+        EnrichedItemDTOMapper.map(groupItem1, true, null, null, null, null);
 
         assertNoLogMessage(EnrichedItemDTOMapper.class);
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.sitemap.internal.SitemapEvent;
 import org.openhab.core.io.rest.sitemap.internal.WidgetsChangeListener;
 import org.openhab.core.items.GroupItem;
@@ -87,6 +88,7 @@ public class SitemapSubscriptionService implements ModelRepositoryChangeListener
     }
 
     private final ItemUIRegistry itemUIRegistry;
+    private final TimeZoneProvider timeZoneProvider;
 
     private final List<SitemapProvider> sitemapProviders = new ArrayList<>();
 
@@ -107,8 +109,9 @@ public class SitemapSubscriptionService implements ModelRepositoryChangeListener
 
     @Activate
     public SitemapSubscriptionService(Map<String, Object> config, final @Reference ItemUIRegistry itemUIRegistry,
-            BundleContext bundleContext) {
+            final @Reference TimeZoneProvider timeZoneProvider, BundleContext bundleContext) {
         this.itemUIRegistry = itemUIRegistry;
+        this.timeZoneProvider = timeZoneProvider;
         this.bundleContext = bundleContext;
         applyConfig(config);
     }
@@ -264,7 +267,7 @@ public class SitemapSubscriptionService implements ModelRepositoryChangeListener
         String sitemapWithPageId = getScopeIdentifier(sitemapName, pageId);
         ListenerRecord listener = pageChangeListeners.computeIfAbsent(sitemapWithPageId, v -> {
             WidgetsChangeListener newListener = new WidgetsChangeListener(sitemapName, pageId, itemUIRegistry,
-                    collectWidgets(sitemapName, pageId));
+                    timeZoneProvider, collectWidgets(sitemapName, pageId));
             ServiceRegistration<?> registration = bundleContext.registerService(EventSubscriber.class.getName(),
                     newListener, null);
             return new ListenerRecord(newListener, registration);

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -62,6 +62,7 @@ import org.openhab.core.auth.Role;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.JSONResponse;
 import org.openhab.core.io.rest.LocaleService;
 import org.openhab.core.io.rest.RESTConstants;
@@ -189,6 +190,7 @@ public class SitemapResource
     private final ItemUIRegistry itemUIRegistry;
     private final SitemapSubscriptionService subscriptions;
     private final LocaleService localeService;
+    private final TimeZoneProvider timeZoneProvider;
 
     private final java.util.List<SitemapProvider> sitemapProviders = new ArrayList<>();
 
@@ -204,9 +206,11 @@ public class SitemapResource
     public SitemapResource( //
             final @Reference ItemUIRegistry itemUIRegistry, //
             final @Reference LocaleService localeService, //
+            final @Reference TimeZoneProvider timeZoneProvider, //
             final @Reference SitemapSubscriptionService subscriptions) {
         this.itemUIRegistry = itemUIRegistry;
         this.localeService = localeService;
+        this.timeZoneProvider = timeZoneProvider;
         this.subscriptions = subscriptions;
 
         broadcaster = new SseBroadcaster<>();
@@ -596,7 +600,7 @@ public class SitemapResource
                 boolean isMapview = "mapview".equalsIgnoreCase(widgetTypeName);
                 Predicate<Item> itemFilter = (i -> CoreItemFactory.LOCATION.equals(i.getType()));
                 bean.item = EnrichedItemDTOMapper.map(item, isMapview, itemFilter,
-                        UriBuilder.fromUri(uri).path("items/{itemName}"), locale);
+                        UriBuilder.fromUri(uri).path("items/{itemName}"), locale, timeZoneProvider.getTimeZone());
                 bean.state = itemUIRegistry.getState(widget).toFullString();
                 // In case the widget state is identical to the item state, its value is set to null.
                 if (bean.state != null && bean.state.equals(bean.item.state)) {

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.core.item.EnrichedItemDTOMapper;
 import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService.SitemapSubscriptionCallback;
 import org.openhab.core.items.Item;
@@ -65,6 +66,7 @@ public class WidgetsChangeListener implements EventSubscriber {
     private final String sitemapName;
     private final String pageId;
     private final ItemUIRegistry itemUIRegistry;
+    private final TimeZoneProvider timeZoneProvider;
     private EList<Widget> widgets;
     private Set<Item> items;
     private final HashSet<String> filterItems = new HashSet<>();
@@ -79,11 +81,12 @@ public class WidgetsChangeListener implements EventSubscriber {
      * @param itemUIRegistry the ItemUIRegistry which is needed for the functionality
      * @param widgets the list of widgets that are part of the page.
      */
-    public WidgetsChangeListener(String sitemapName, String pageId, ItemUIRegistry itemUIRegistry,
-            EList<Widget> widgets) {
+    public WidgetsChangeListener(String sitemapName, String pageId, final ItemUIRegistry itemUIRegistry,
+            final TimeZoneProvider timeZoneProvider, EList<Widget> widgets) {
         this.sitemapName = sitemapName;
         this.pageId = pageId;
         this.itemUIRegistry = itemUIRegistry;
+        this.timeZoneProvider = timeZoneProvider;
 
         updateItemsAndWidgets(widgets);
     }
@@ -248,7 +251,8 @@ public class WidgetsChangeListener implements EventSubscriber {
                     .substring(widget.eClass().getInstanceTypeName().lastIndexOf(".") + 1);
             boolean drillDown = "mapview".equalsIgnoreCase(widgetTypeName);
             Predicate<Item> itemFilter = (i -> CoreItemFactory.LOCATION.equals(i.getType()));
-            event.item = EnrichedItemDTOMapper.map(itemToBeSent, drillDown, itemFilter, null, null);
+            event.item = EnrichedItemDTOMapper.map(itemToBeSent, drillDown, itemFilter, null, null,
+                    timeZoneProvider.getTimeZone());
 
             // event.state is an adjustment of the item state to the widget type.
             stateToBeSent = itemBelongsToWidget ? state : itemToBeSent.getState();

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.LocaleService;
 import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService;
 import org.openhab.core.items.GenericItem;
@@ -119,6 +120,7 @@ public class SitemapResourceTest extends JavaTest {
     private @Mock @NonNullByDefault({}) HttpHeaders headersMock;
     private @Mock @NonNullByDefault({}) Sitemap defaultSitemapMock;
     private @Mock @NonNullByDefault({}) ItemUIRegistry itemUIRegistryMock;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
     private @Mock @NonNullByDefault({}) LocaleService localeServiceMock;
     private @Mock @NonNullByDefault({}) HttpServletRequest requestMock;
     private @Mock @NonNullByDefault({}) SitemapProvider sitemapProviderMock;
@@ -129,10 +131,12 @@ public class SitemapResourceTest extends JavaTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        subscriptions = new SitemapSubscriptionService(Collections.emptyMap(), itemUIRegistryMock, bundleContextMock);
+        subscriptions = new SitemapSubscriptionService(Collections.emptyMap(), itemUIRegistryMock, timeZoneProviderMock,
+                bundleContextMock);
         subscriptions.addSitemapProvider(sitemapProviderMock);
 
-        sitemapResource = new SitemapResource(itemUIRegistryMock, localeServiceMock, subscriptions);
+        sitemapResource = new SitemapResource(itemUIRegistryMock, localeServiceMock, timeZoneProviderMock,
+                subscriptions);
 
         when(uriInfoMock.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromPath(SITEMAP_PATH));
         when(uriInfoMock.getBaseUriBuilder()).thenReturn(UriBuilder.fromPath(SITEMAP_PATH));

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.io.rest.sse.internal;
 
-import java.time.DateTimeException;
 import java.util.HashMap;
 import java.util.IllegalFormatException;
 import java.util.Locale;
@@ -33,7 +32,6 @@ import org.openhab.core.io.rest.sse.internal.dto.StateDTO;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
-import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.service.StartLevelService;
@@ -186,12 +184,6 @@ public class SseItemStatesEventBuilder {
 
                         if (quantityState != null) {
                             state = quantityState;
-                        }
-                    } else if (state instanceof DateTimeType type) {
-                        // Translate a DateTimeType state to the local time zone
-                        try {
-                            state = type.toLocaleZone();
-                        } catch (DateTimeException e) {
                         }
                     }
 

--- a/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.io.rest.LocaleService;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
@@ -76,6 +77,7 @@ public class SseItemStatesEventBuilderTest {
 
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) LocaleService localeServiceMock;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
     private @Mock @NonNullByDefault({}) StartLevelService startLevelServiceMock;
 
     private @Mock @NonNullByDefault({}) Item itemMock;
@@ -112,7 +114,7 @@ public class SseItemStatesEventBuilderTest {
         Mockito.when(itemMock.getName()).thenReturn(ITEM_NAME);
 
         sseItemStatesEventBuilder = new SseItemStatesEventBuilder(itemRegistryMock, localeServiceMock,
-                startLevelServiceMock);
+                timeZoneProviderMock, startLevelServiceMock);
     }
 
     @AfterEach

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
@@ -12,14 +12,11 @@
  */
 package org.openhab.core.thing.internal.profiles;
 
-import java.time.DateTimeException;
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.internal.i18n.I18nProviderImpl;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.thing.profiles.ProfileCallback;
 import org.openhab.core.thing.profiles.ProfileContext;
@@ -36,22 +33,18 @@ import org.slf4j.LoggerFactory;
 /**
  * Applies the given parameter "offset" to a {@link DateTimeType} state.
  *
- * Options for the "timezone" parameter are provided by the {@link I18nProviderImpl}.
- *
  * @author Christoph Weitkamp - Initial contribution
  */
 @NonNullByDefault
 public class TimestampOffsetProfile implements StateProfile {
 
     static final String OFFSET_PARAM = "offset";
-    static final String TIMEZONE_PARAM = "timezone";
 
     private final Logger logger = LoggerFactory.getLogger(TimestampOffsetProfile.class);
 
     private final ProfileCallback callback;
 
     private final Duration offset;
-    private @Nullable ZoneId timeZone;
 
     public TimestampOffsetProfile(ProfileCallback callback, ProfileContext context) {
         this.callback = callback;
@@ -67,19 +60,6 @@ public class TimestampOffsetProfile implements StateProfile {
                     "Parameter '{}' is not of type String or Number. Please make sure it is one of both, e.g. 3 or \"-1\".",
                     OFFSET_PARAM);
             offset = Duration.ZERO;
-        }
-
-        String timeZoneParam = toStringOrNull(context.getConfiguration().get(TIMEZONE_PARAM));
-        logger.debug("Configuring profile with {} parameter '{}'", TIMEZONE_PARAM, timeZoneParam);
-        if (timeZoneParam == null || timeZoneParam.isBlank()) {
-            timeZone = null;
-        } else {
-            try {
-                timeZone = ZoneId.of(timeZoneParam);
-            } catch (DateTimeException e) {
-                logger.debug("Error setting time zone '{}': {}", timeZoneParam, e.getMessage());
-                timeZone = null;
-            }
         }
     }
 
@@ -98,20 +78,20 @@ public class TimestampOffsetProfile implements StateProfile {
 
     @Override
     public void onCommandFromItem(Command command) {
-        callback.handleCommand((Command) applyOffsetAndTimezone(command, false));
+        callback.handleCommand((Command) applyOffset(command, false));
     }
 
     @Override
     public void onCommandFromHandler(Command command) {
-        callback.sendCommand((Command) applyOffsetAndTimezone(command, true));
+        callback.sendCommand((Command) applyOffset(command, true));
     }
 
     @Override
     public void onStateUpdateFromHandler(State state) {
-        callback.sendUpdate((State) applyOffsetAndTimezone(state, true));
+        callback.sendUpdate((State) applyOffset(state, true));
     }
 
-    private Type applyOffsetAndTimezone(Type type, boolean towardsItem) {
+    private Type applyOffset(Type type, boolean towardsItem) {
         if (type instanceof UnDefType) {
             // we cannot adjust UNDEF or NULL values, thus we simply return them without reporting an error or warning
             return type;
@@ -120,20 +100,15 @@ public class TimestampOffsetProfile implements StateProfile {
         Duration finalOffset = towardsItem ? offset : offset.negated();
         Type result;
         if (type instanceof DateTimeType timeType) {
-            ZonedDateTime zdt = timeType.getZonedDateTime();
+            Instant instant = timeType.getInstant();
 
             // apply offset
             if (!Duration.ZERO.equals(offset)) {
                 // we do not need apply an offset equals to 0
-                zdt = zdt.plus(finalOffset);
+                instant = instant.plus(finalOffset);
             }
 
-            // apply time zone
-            ZoneId localTimeZone = timeZone;
-            if (localTimeZone != null && !zdt.getZone().equals(localTimeZone) && towardsItem) {
-                zdt = zdt.withZoneSameInstant(localTimeZone);
-            }
-            result = new DateTimeType(zdt);
+            result = new DateTimeType(instant);
         } else {
             logger.warn(
                     "Offset '{}' cannot be applied to the incompatible state '{}' sent from the binding. Returning original state.",

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/timestampOffsetProfile.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/timestampOffsetProfile.xml
@@ -12,10 +12,5 @@
 				in the reverse
 				direction.</description>
 		</parameter>
-		<parameter name="timezone" type="text">
-			<label>Time Zone</label>
-			<description>A time zone to be applied on the state towards the item.</description>
-			<advanced>true</advanced>
-		</parameter>
 	</config-description>
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/SystemProfiles.properties
@@ -21,7 +21,5 @@ profile-type.system.timestamp-change.label = Timestamp on Change
 profile-type.system.timestamp-offset.label = Timestamp Offset
 profile.config.system.timestamp-offset.offset.label = Offset
 profile.config.system.timestamp-offset.offset.description = Offset to be applied on the state towards the item. The negative offset will be applied in the reverse direction.
-profile.config.system.timestamp-offset.timezone.label = Time Zone
-profile.config.system.timestamp-offset.timezone.description = A time zone to be applied on the state.
 profile-type.system.timestamp-trigger.label = Timestamp on Trigger
 profile-type.system.timestamp-update.label = Timestamp on Update

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.thing.internal.profiles;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -95,8 +94,7 @@ public class TimestampOffsetProfileTest {
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
                 ((DateTimeType) cmd).getZonedDateTime().minusSeconds(parameterSet.seconds));
-        assertEquals(ZoneOffset.UTC, updateResult.getZonedDateTime().getOffset());
-        assertEquals(expectedResult.getZonedDateTime(), updateResult.getZonedDateTime());
+        assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
     @ParameterizedTest
@@ -116,11 +114,7 @@ public class TimestampOffsetProfileTest {
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
                 ((DateTimeType) cmd).getZonedDateTime().plusSeconds(parameterSet.seconds));
-        String timeZone = parameterSet.timeZone;
-        if (timeZone != null) {
-            expectedResult = expectedResult.toZone(timeZone);
-        }
-        assertEquals(expectedResult.getZonedDateTime(), updateResult.getZonedDateTime());
+        assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
     @ParameterizedTest
@@ -140,11 +134,7 @@ public class TimestampOffsetProfileTest {
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
                 ((DateTimeType) state).getZonedDateTime().plusSeconds(parameterSet.seconds));
-        String timeZone = parameterSet.timeZone;
-        if (timeZone != null) {
-            expectedResult = expectedResult.toZone(timeZone);
-        }
-        assertEquals(expectedResult.getZonedDateTime(), updateResult.getZonedDateTime());
+        assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
     private TimestampOffsetProfile createProfile(ProfileCallback callback, String offset, @Nullable String timeZone) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,28 +43,23 @@ public class TimestampOffsetProfileTest {
 
     public static class ParameterSet {
         public final long seconds;
-        public final @Nullable String timeZone;
 
-        public ParameterSet(long seconds, @Nullable String timeZone) {
+        public ParameterSet(long seconds) {
             this.seconds = seconds;
-            this.timeZone = timeZone;
         }
     }
 
     public static Collection<Object[]> parameters() {
         return List.of(new Object[][] { //
-                { new ParameterSet(0, null) }, //
-                { new ParameterSet(30, null) }, //
-                { new ParameterSet(-30, null) }, //
-                { new ParameterSet(0, "Europe/Berlin") }, //
-                { new ParameterSet(30, "Europe/Berlin") }, //
-                { new ParameterSet(-30, "Europe/Berlin") } });
+                { new ParameterSet(0) }, //
+                { new ParameterSet(30) }, //
+                { new ParameterSet(-30) } });
     }
 
     @Test
     public void testUNDEFOnStateUpdateFromHandler() {
         ProfileCallback callback = mock(ProfileCallback.class);
-        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(60), null);
+        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(60));
 
         State state = UnDefType.UNDEF;
         offsetProfile.onStateUpdateFromHandler(state);
@@ -81,8 +75,7 @@ public class TimestampOffsetProfileTest {
     @MethodSource("parameters")
     public void testOnCommandFromItem(ParameterSet parameterSet) {
         ProfileCallback callback = mock(ProfileCallback.class);
-        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds),
-                parameterSet.timeZone);
+        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds));
 
         Command cmd = DateTimeType.valueOf("2021-03-30T10:58:47.033+0000");
         offsetProfile.onCommandFromItem(cmd);
@@ -93,7 +86,7 @@ public class TimestampOffsetProfileTest {
         Command result = capture.getValue();
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
-                ((DateTimeType) cmd).getZonedDateTime().minusSeconds(parameterSet.seconds));
+                ((DateTimeType) cmd).getInstant().minusSeconds(parameterSet.seconds));
         assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
@@ -101,8 +94,7 @@ public class TimestampOffsetProfileTest {
     @MethodSource("parameters")
     public void testOnCommandFromHandler(ParameterSet parameterSet) {
         ProfileCallback callback = mock(ProfileCallback.class);
-        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds),
-                parameterSet.timeZone);
+        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds));
 
         Command cmd = new DateTimeType("2021-03-30T10:58:47.033+0000");
         offsetProfile.onCommandFromHandler(cmd);
@@ -113,7 +105,7 @@ public class TimestampOffsetProfileTest {
         Command result = capture.getValue();
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
-                ((DateTimeType) cmd).getZonedDateTime().plusSeconds(parameterSet.seconds));
+                ((DateTimeType) cmd).getInstant().plusSeconds(parameterSet.seconds));
         assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
@@ -121,8 +113,7 @@ public class TimestampOffsetProfileTest {
     @MethodSource("parameters")
     public void testOnStateUpdateFromHandler(ParameterSet parameterSet) {
         ProfileCallback callback = mock(ProfileCallback.class);
-        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds),
-                parameterSet.timeZone);
+        TimestampOffsetProfile offsetProfile = createProfile(callback, Long.toString(parameterSet.seconds));
 
         State state = new DateTimeType("2021-03-30T10:58:47.033+0000");
         offsetProfile.onStateUpdateFromHandler(state);
@@ -133,17 +124,14 @@ public class TimestampOffsetProfileTest {
         State result = capture.getValue();
         DateTimeType updateResult = (DateTimeType) result;
         DateTimeType expectedResult = new DateTimeType(
-                ((DateTimeType) state).getZonedDateTime().plusSeconds(parameterSet.seconds));
+                ((DateTimeType) state).getInstant().plusSeconds(parameterSet.seconds));
         assertEquals(expectedResult.getInstant(), updateResult.getInstant());
     }
 
-    private TimestampOffsetProfile createProfile(ProfileCallback callback, String offset, @Nullable String timeZone) {
+    private TimestampOffsetProfile createProfile(ProfileCallback callback, String offset) {
         ProfileContext context = mock(ProfileContext.class);
         Map<String, Object> properties = new HashMap<>();
         properties.put(TimestampOffsetProfile.OFFSET_PARAM, offset);
-        if (timeZone != null) {
-            properties.put(TimestampOffsetProfile.TIMEZONE_PARAM, timeZone);
-        }
         when(context.getConfiguration()).thenReturn(new Configuration(properties));
         return new TimestampOffsetProfile(callback, context);
     }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampProfileTest.java
@@ -15,7 +15,7 @@ package org.openhab.core.thing.internal.profiles;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -40,7 +40,7 @@ public class TimestampProfileTest extends JavaTest {
         ProfileCallback callback = mock(ProfileCallback.class);
         TimestampUpdateProfile timestampProfile = new TimestampUpdateProfile(callback);
 
-        ZonedDateTime now = ZonedDateTime.now();
+        Instant now = Instant.now();
         timestampProfile.onStateUpdateFromHandler(new DecimalType(23));
 
         ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
@@ -48,7 +48,7 @@ public class TimestampProfileTest extends JavaTest {
 
         State result = capture.getValue();
         DateTimeType updateResult = (DateTimeType) result;
-        ZonedDateTime timestamp = updateResult.getZonedDateTime();
+        Instant timestamp = updateResult.getInstant();
         long difference = ChronoUnit.MINUTES.between(now, timestamp);
         assertTrue(difference < 1);
     }
@@ -66,7 +66,7 @@ public class TimestampProfileTest extends JavaTest {
         State result = capture.getValue();
         DateTimeType changeResult = (DateTimeType) result;
 
-        waitForAssert(() -> assertTrue(ZonedDateTime.now().isAfter(changeResult.getZonedDateTime())));
+        waitForAssert(() -> assertTrue(Instant.now().isAfter(changeResult.getInstant())));
 
         // The state is unchanged, no additional call to the callback
         timestampProfile.onStateUpdateFromHandler(new DecimalType(23));
@@ -77,6 +77,6 @@ public class TimestampProfileTest extends JavaTest {
         verify(callback, times(2)).sendUpdate(capture.capture());
         result = capture.getValue();
         DateTimeType updatedResult = (DateTimeType) result;
-        assertTrue(updatedResult.getZonedDateTime().isAfter(changeResult.getZonedDateTime()));
+        assertTrue(updatedResult.getInstant().isAfter(changeResult.getInstant()));
     }
 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfileTest.java
@@ -15,7 +15,7 @@ package org.openhab.core.thing.internal.profiles;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -38,14 +38,14 @@ public class TimestampTriggerProfileTest {
         ProfileCallback callback = mock(ProfileCallback.class);
         TriggerProfile profile = new TimestampTriggerProfile(callback);
 
-        ZonedDateTime now = ZonedDateTime.now();
+        Instant now = Instant.now();
         profile.onTriggerFromHandler(CommonTriggerEvents.PRESSED);
         ArgumentCaptor<State> capture = ArgumentCaptor.forClass(State.class);
         verify(callback, times(1)).sendUpdate(capture.capture());
 
         State result = capture.getValue();
         DateTimeType updateResult = (DateTimeType) result;
-        ZonedDateTime timestamp = updateResult.getZonedDateTime();
+        Instant timestamp = updateResult.getInstant();
         long difference = ChronoUnit.MINUTES.between(now, timestamp);
         assertTrue(difference < 1);
     }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.ConfigurableService;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
@@ -137,6 +138,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     protected final Set<ItemUIProvider> itemUIProviders = new HashSet<>();
 
     private final ItemRegistry itemRegistry;
+    private final TimeZoneProvider timeZoneProvider;
 
     private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<>());
 
@@ -153,8 +155,10 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Activate
-    public ItemUIRegistryImpl(@Reference ItemRegistry itemRegistry) {
+    public ItemUIRegistryImpl(final @Reference ItemRegistry itemRegistry,
+            final @Reference TimeZoneProvider timeZoneProvider) {
         this.itemRegistry = itemRegistry;
+        this.timeZoneProvider = timeZoneProvider;
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -467,10 +471,20 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                             String type = matcher.group(1);
                             String function = matcher.group(2);
                             String value = matcher.group(3);
-                            formatPattern = type + "(" + function + "):" + state.format(value);
-                            transformFailbackValue = state.toString();
+                            formatPattern = type + "(" + function + "):";
+                            if (state instanceof DateTimeType dateTimeState) {
+                                formatPattern += dateTimeState.format(value, timeZoneProvider.getTimeZone());
+                                transformFailbackValue = dateTimeState.toFullString(timeZoneProvider.getTimeZone());
+                            } else {
+                                formatPattern += state.format(value);
+                                transformFailbackValue = state.toString();
+                            }
                         } else {
-                            formatPattern = state.format(formatPattern);
+                            if (state instanceof DateTimeType dateTimeState) {
+                                formatPattern = dateTimeState.format(formatPattern, timeZoneProvider.getTimeZone());
+                            } else {
+                                formatPattern = state.format(formatPattern);
+                            }
                         }
                     } catch (IllegalArgumentException e) {
                         logger.warn("Exception while formatting value '{}' of item {} with format '{}': {}", state,

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.ui.internal.items;
 
-import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -454,12 +453,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         if (quantityState != null) {
                             quantityState = convertStateToWidgetUnit(quantityState, w);
                             state = quantityState;
-                        }
-                    } else if (state instanceof DateTimeType type) {
-                        // Translate a DateTimeType state to the local time zone
-                        try {
-                            state = type.toLocaleZone();
-                        } catch (DateTimeException ignored) {
                         }
                     }
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.ui.internal.items;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1145,9 +1145,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 } catch (NumberFormatException e) {
                     logger.debug("matchStateToValue: Decimal format exception: ", e);
                 }
-            } else if (state instanceof DateTimeType type) {
-                ZonedDateTime val = type.getZonedDateTime();
-                ZonedDateTime now = ZonedDateTime.now();
+            } else if (state instanceof DateTimeType dateTimeState) {
+                Instant val = dateTimeState.getInstant();
+                Instant now = Instant.now();
                 long secsDif = ChronoUnit.SECONDS.between(val, now);
 
                 try {

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import java.text.DecimalFormatSymbols;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
@@ -36,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
@@ -99,22 +101,24 @@ public class ItemUIRegistryImplTest {
     // we need to get the decimal separator of the default locale for our tests
     private static final char SEP = (new DecimalFormatSymbols().getDecimalSeparator());
     private static final String ITEM_NAME = "Item";
+    private static final String DEFAULT_TIME_ZONE = "GMT-6";
 
     private @NonNullByDefault({}) ItemUIRegistryImpl uiRegistry;
 
     private @Mock @NonNullByDefault({}) ItemRegistry registryMock;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
     private @Mock @NonNullByDefault({}) Widget widgetMock;
     private @Mock @NonNullByDefault({}) Item itemMock;
 
     @BeforeEach
     public void setup() throws Exception {
-        uiRegistry = new ItemUIRegistryImpl(registryMock);
+        uiRegistry = new ItemUIRegistryImpl(registryMock, timeZoneProviderMock);
 
         when(widgetMock.getItem()).thenReturn(ITEM_NAME);
         when(registryMock.getItem(ITEM_NAME)).thenReturn(itemMock);
+        when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.of(DEFAULT_TIME_ZONE));
 
-        // Set default time zone to GMT-6
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT-6"));
+        TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.library.types;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -41,12 +41,12 @@ public interface DateTimeGroupFunction extends GroupFunction {
         @Override
         public State calculate(@Nullable Set<Item> items) {
             if (items != null && !items.isEmpty()) {
-                ZonedDateTime max = null;
+                Instant max = null;
                 for (Item item : items) {
                     DateTimeType itemState = item.getStateAs(DateTimeType.class);
                     if (itemState != null) {
-                        if (max == null || max.isBefore(itemState.getZonedDateTime())) {
-                            max = itemState.getZonedDateTime();
+                        if (max == null || max.isBefore(itemState.getInstant())) {
+                            max = itemState.getInstant();
                         }
                     }
                 }
@@ -84,12 +84,12 @@ public interface DateTimeGroupFunction extends GroupFunction {
         @Override
         public State calculate(@Nullable Set<Item> items) {
             if (items != null && !items.isEmpty()) {
-                ZonedDateTime max = null;
+                Instant max = null;
                 for (Item item : items) {
                     DateTimeType itemState = item.getStateAs(DateTimeType.class);
                     if (itemState != null) {
-                        if (max == null || max.isAfter(itemState.getZonedDateTime())) {
-                            max = itemState.getZonedDateTime();
+                        if (max == null || max.isAfter(itemState.getInstant())) {
+                            max = itemState.getInstant();
                         }
                     }
                 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -225,7 +225,11 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
 
     @Override
     public String toFullString() {
-        String formatted = getZonedDateTime().format(FORMATTER_TZ_RFC);
+        return toFullString(ZoneId.systemDefault());
+    }
+
+    public String toFullString(ZoneId zoneId) {
+        String formatted = instant.atZone(zoneId).format(FORMATTER_TZ_RFC);
         if (formatted.contains(".")) {
             String sign = "";
             if (formatted.contains("+")) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -166,11 +166,16 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
 
     @Override
     public String format(@Nullable String pattern) {
+        return format(pattern, ZoneId.systemDefault());
+    }
+
+    public String format(@Nullable String pattern, ZoneId zoneId) {
+        ZonedDateTime zonedDateTime = instant.atZone(zoneId);
         if (pattern == null) {
-            return DateTimeFormatter.ofPattern(DATE_PATTERN).format(getZonedDateTime());
+            return DateTimeFormatter.ofPattern(DATE_PATTERN).format(zonedDateTime);
         }
 
-        return String.format(pattern, getZonedDateTime());
+        return String.format(pattern, zonedDateTime);
     }
 
     public String format(Locale locale, String pattern) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -142,13 +142,25 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
     }
 
     /**
-     * Get object represented as a {@link ZonedDateTime} with system
-     * default time-zone applied
+     * @deprecated
+     *             Get object represented as a {@link ZonedDateTime} with system
+     *             default time-zone applied
      *
      * @return a {@link ZonedDateTime} representation of the object
      */
+    @Deprecated
     public ZonedDateTime getZonedDateTime() {
-        return instant.atZone(ZoneId.systemDefault());
+        return getZonedDateTime(ZoneId.systemDefault());
+    }
+
+    /**
+     * Get object represented as a {@link ZonedDateTime} with the
+     * the provided time-zone applied
+     *
+     * @return a {@link ZonedDateTime} representation of the object
+     */
+    public ZonedDateTime getZonedDateTime(ZoneId zoneId) {
+        return instant.atZone(zoneId);
     }
 
     /**

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.library.types;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,36 +37,36 @@ public class DateTimeGroupFunctionTest {
 
     @Test
     public void testLatestFunction() {
-        ZonedDateTime expectedDateTime = ZonedDateTime.now();
+        Instant expectedDateTime = Instant.now();
         Set<Item> items = new HashSet<>();
         items.add(new TestItem("TestItem1", new DateTimeType(expectedDateTime)));
         items.add(new TestItem("TestItem2", UnDefType.UNDEF));
-        items.add(new TestItem("TestItem3", new DateTimeType(expectedDateTime.minusDays(10))));
-        items.add(new TestItem("TestItem4", new DateTimeType(expectedDateTime.minusYears(1))));
+        items.add(new TestItem("TestItem3", new DateTimeType(expectedDateTime.minus(10, ChronoUnit.DAYS))));
+        items.add(new TestItem("TestItem4", new DateTimeType(expectedDateTime.minus(366, ChronoUnit.DAYS))));
         items.add(new TestItem("TestItem5", UnDefType.UNDEF));
         items.add(new TestItem("TestItem6", new DateTimeType(expectedDateTime.minusSeconds(1))));
 
         GroupFunction function = new DateTimeGroupFunction.Latest();
         State state = function.calculate(items);
 
-        assertTrue(expectedDateTime.isEqual(((DateTimeType) state).getZonedDateTime()));
+        assertTrue(expectedDateTime.equals(((DateTimeType) state).getInstant()));
     }
 
     @Test
     public void testEarliestFunction() {
-        ZonedDateTime expectedDateTime = ZonedDateTime.now();
+        Instant expectedDateTime = Instant.now();
         Set<Item> items = new HashSet<>();
         items.add(new TestItem("TestItem1", new DateTimeType(expectedDateTime)));
         items.add(new TestItem("TestItem2", UnDefType.UNDEF));
-        items.add(new TestItem("TestItem3", new DateTimeType(expectedDateTime.plusDays(10))));
-        items.add(new TestItem("TestItem4", new DateTimeType(expectedDateTime.plusYears(1))));
+        items.add(new TestItem("TestItem3", new DateTimeType(expectedDateTime.plus(10, ChronoUnit.DAYS))));
+        items.add(new TestItem("TestItem4", new DateTimeType(expectedDateTime.plus(366, ChronoUnit.DAYS))));
         items.add(new TestItem("TestItem5", UnDefType.UNDEF));
         items.add(new TestItem("TestItem6", new DateTimeType(expectedDateTime.plusSeconds(1))));
 
         GroupFunction function = new DateTimeGroupFunction.Earliest();
         State state = function.calculate(items);
 
-        assertTrue(expectedDateTime.isEqual(((DateTimeType) state).getZonedDateTime()));
+        assertTrue(expectedDateTime.equals(((DateTimeType) state).getInstant()));
     }
 
     private static class TestItem extends GenericItem {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.library.types;
 
 import static java.util.Map.entry;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,11 +31,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -399,5 +402,26 @@ public class DateTimeTypeTest {
         int durationInNano = (int) TimeUnit.NANOSECONDS.convert(milliseconds, TimeUnit.MILLISECONDS);
 
         return LocalDateTime.of(year, month + 1, dayOfMonth, hourOfDay, minute, second, durationInNano);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForToFullStringWithZone")
+    void toFullStringWithZone(String instant, ZoneId zoneId, String expected) {
+        DateTimeType dt = new DateTimeType(Instant.parse(instant));
+        String actual = dt.toFullString(zoneId);
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForToFullStringWithZone() {
+        return Stream.of( //
+                Arguments.of("2024-11-11T20:39:00Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.000+0000"), //
+                Arguments.of("2024-11-11T20:39:00.000000000Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.000+0000"), //
+                Arguments.of("2024-11-11T20:39:00.000000001Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.000000001+0000"), //
+                Arguments.of("2024-11-11T20:39:00.123000000Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.123+0000"), //
+                Arguments.of("2024-11-11T20:39:00.123456000Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.123456+0000"), //
+                Arguments.of("2024-11-11T20:39:00.123456789Z", ZoneId.of("UTC"), "2024-11-11T20:39:00.123456789+0000"), //
+                Arguments.of("2024-11-11T20:39:00.123Z", ZoneId.of("Europe/Paris"), "2024-11-11T21:39:00.123+0100"), //
+                Arguments.of("2024-11-11T04:59:59.999Z", ZoneId.of("America/New_York"), "2024-11-10T23:59:59.999-0500") //
+        );
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -377,6 +377,24 @@ public class DateTimeTypeTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("provideTestCasesForFormatWithZone")
+    void formatWithZone(String instant, @Nullable String pattern, ZoneId zoneId, String expected) {
+        DateTimeType dt = new DateTimeType(Instant.parse(instant));
+        String actual = dt.format(pattern, zoneId);
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    private static Stream<Arguments> provideTestCasesForFormatWithZone() {
+        return Stream.of( //
+                Arguments.of("2024-11-11T20:39:01Z", null, ZoneId.of("UTC"), "2024-11-11T20:39:01"), //
+                Arguments.of("2024-11-11T20:39:01Z", "%1$td.%1$tm.%1$tY %1$tH:%1$tM", ZoneId.of("Europe/Paris"),
+                        "11.11.2024 21:39"), //
+                Arguments.of("2024-11-11T20:39:01Z", "%1$td.%1$tm.%1$tY %1$tH:%1$tM", ZoneId.of("US/Alaska"),
+                        "11.11.2024 11:39") //
+        );
+    }
+
     private DateTimeType createDateTimeType(ParameterSet parameterSet) throws DateTimeException {
         Map<String, Integer> inputTimeMap = parameterSet.inputTimeMap;
         TimeZone inputTimeZone = parameterSet.inputTimeZone;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -285,15 +285,18 @@ public class DateTimeTypeTest {
         DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
         DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");
         DateTimeType dt3 = new DateTimeType("2019-06-12T19:30:00+0200");
+        DateTimeType dt4 = new DateTimeType("2019-06-12T19:30:00+0200");
         assertThat(dt1, is(dt2));
 
         ZonedDateTime zdt1 = dt1.getZonedDateTime();
         ZonedDateTime zdt2 = dt2.getZonedDateTime();
         ZonedDateTime zdt3 = dt3.getZonedDateTime();
+        ZonedDateTime zdt4 = dt4.getZonedDateTime(ZoneId.of("UTC"));
         assertThat(zdt1.getZone(), is(zdt2.getZone()));
         assertThat(zdt1, is(zdt2));
         assertThat(zdt1, is(zdt3.withZoneSameInstant(zdt1.getZone())));
         assertThat(zdt2, is(zdt3.withZoneSameInstant(zdt2.getZone())));
+        assertThat(zdt1, is(zdt4));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -183,19 +183,19 @@ public class DateTimeTypeTest {
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), initTimeMap(), TimeZone.getTimeZone("UTC"),
                         "2014-03-30T10:58:47.033+0000", "2014-03-30T10:58:47.033+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), initTimeMap(), TimeZone.getTimeZone("CET"),
-                        "2014-03-30T10:58:47.033+0200", "2014-03-30T08:58:47.033+0000") },
+                        "2014-03-30T08:58:47.033+0000", "2014-03-30T08:58:47.033+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), "2014-03-30T10:58:47.23",
                         "2014-03-30T10:58:47.230+0000", "2014-03-30T10:58:47.230+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), "2014-03-30T10:58:47UTC",
                         "2014-03-30T10:58:47.000+0000", "2014-03-30T10:58:47.000+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("CET"), initTimeMap(), TimeZone.getTimeZone("UTC"),
-                        "2014-03-30T10:58:47.033+0000", "2014-03-30T12:58:47.033+0200") },
+                        "2014-03-30T12:58:47.033+0200", "2014-03-30T12:58:47.033+0200") },
                 { new ParameterSet(TimeZone.getTimeZone("CET"), initTimeMap(), TimeZone.getTimeZone("CET"),
                         "2014-03-30T10:58:47.033+0200", "2014-03-30T10:58:47.033+0200") },
                 { new ParameterSet(TimeZone.getTimeZone("CET"), "2014-03-30T10:58:47CET",
                         "2014-03-30T10:58:47.000+0200", "2014-03-30T10:58:47.000+0200") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT+5"), "2014-03-30T10:58:47.000Z",
-                        "2014-03-30T10:58:47.000+0000", "2014-03-30T15:58:47.000+0500") },
+                        "2014-03-30T15:58:47.000+0500", "2014-03-30T15:58:47.000+0500") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT+2"), null, null, "2014-03-30T10:58:47",
                         "2014-03-30T10:58:47.000+0200", "2014-03-30T10:58:47.000+0200", null,
                         "%1$td.%1$tm.%1$tY %1$tH:%1$tM", "30.03.2014 10:58") },
@@ -203,15 +203,15 @@ public class DateTimeTypeTest {
                         "2014-03-30T10:58:47.033+0000", "2014-03-30T10:58:47.033+0000") },
                 // Parameter set with an invalid time zone id as input, leading to GMT being considered
                 { new ParameterSet(TimeZone.getTimeZone("CET"), initTimeMap(), TimeZone.getTimeZone("+02:00"),
-                        "2014-03-30T10:58:47.033+0000", "2014-03-30T12:58:47.033+0200") },
+                        "2014-03-30T12:58:47.033+0200", "2014-03-30T12:58:47.033+0200") },
                 // Parameter set with an invalid time zone id as input, leading to GMT being considered
                 { new ParameterSet(TimeZone.getTimeZone("GMT+2"), initTimeMap(), TimeZone.getTimeZone("GML"),
-                        "2014-03-30T10:58:47.033+0000", "2014-03-30T12:58:47.033+0200") },
+                        "2014-03-30T12:58:47.033+0200", "2014-03-30T12:58:47.033+0200") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT-2"), initTimeMap(), TimeZone.getTimeZone("GMT+3"), null,
-                        "2014-03-30T10:58:47.033+0300", "2014-03-30T05:58:47.033-0200", Locale.GERMAN,
-                        "%1$tA %1$td.%1$tm.%1$tY %1$tH:%1$tM", "Sonntag 30.03.2014 10:58") },
+                        "2014-03-30T05:58:47.033-0200", "2014-03-30T05:58:47.033-0200", Locale.GERMAN,
+                        "%1$tA %1$td.%1$tm.%1$tY %1$tH:%1$tM", "Sonntag 30.03.2014 05:58") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT-2"), initTimeMap(), TimeZone.getTimeZone("GMT-4"),
-                        "2014-03-30T10:58:47.033-0400", "2014-03-30T12:58:47.033-0200") },
+                        "2014-03-30T12:58:47.033-0200", "2014-03-30T12:58:47.033-0200") },
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), "10:58:47", "1970-01-01T10:58:47.000+0000",
                         "1970-01-01T10:58:47.000+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("UTC"), "10:58", "1970-01-01T10:58:00.000+0000",
@@ -295,16 +295,21 @@ public class DateTimeTypeTest {
 
     @Test
     public void instantParsingTest() {
-        DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
-        DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");
-        DateTimeType dt3 = new DateTimeType("2019-06-12T19:30:00+0200");
+        DateTimeType dt1 = new DateTimeType(Instant.parse("2019-06-12T17:30:00Z"));
+        DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00Z");
+        DateTimeType dt3 = new DateTimeType("2019-06-12T17:30:00+0000");
+        DateTimeType dt4 = new DateTimeType("2019-06-12T19:30:00+0200");
         assertThat(dt1, is(dt2));
+        assertThat(dt2, is(dt3));
+        assertThat(dt3, is(dt4));
 
         Instant i1 = dt1.getInstant();
         Instant i2 = dt2.getInstant();
         Instant i3 = dt3.getInstant();
+        Instant i4 = dt4.getInstant();
         assertThat(i1, is(i2));
-        assertThat(i1, is(i3));
+        assertThat(i2, is(i3));
+        assertThat(i3, is(i4));
     }
 
     @Test
@@ -367,25 +372,6 @@ public class DateTimeTypeTest {
         } else {
             assertEquals(parameterSet.expectedFormattedResult, dt.format(pattern));
         }
-    }
-
-    @ParameterizedTest
-    @MethodSource("parameters")
-    public void changingZoneTest(ParameterSet parameterSet) {
-        TimeZone.setDefault(parameterSet.defaultTimeZone);
-        DateTimeType dt = createDateTimeType(parameterSet);
-        DateTimeType dt2 = dt.toLocaleZone();
-        assertEquals(parameterSet.expectedResultLocalTZ, dt2.toFullString());
-        dt2 = dt.toZone(parameterSet.defaultTimeZone.toZoneId());
-        assertEquals(parameterSet.expectedResultLocalTZ, dt2.toFullString());
-    }
-
-    @ParameterizedTest
-    @MethodSource("parameters")
-    public void changingZoneThrowsExceptionTest(ParameterSet parameterSet) {
-        TimeZone.setDefault(parameterSet.defaultTimeZone);
-        DateTimeType dt = createDateTimeType(parameterSet);
-        assertThrows(DateTimeException.class, () -> dt.toZone("XXX"));
     }
 
     private DateTimeType createDateTimeType(ParameterSet parameterSet) throws DateTimeException {

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
@@ -57,7 +57,7 @@ public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
         item1.setState(new DecimalType("12.34"));
         item1.setStateDescriptionService(stateDescriptionServiceMock);
 
-        EnrichedItemDTO enrichedDTO = EnrichedItemDTOMapper.map(item1, false, null, null, null);
+        EnrichedItemDTO enrichedDTO = EnrichedItemDTOMapper.map(item1, false, null, null, null, null);
         assertThat(enrichedDTO, is(notNullValue()));
         assertThat(enrichedDTO.name, is("Item1"));
         assertThat(enrichedDTO.state, is("12.34"));


### PR DESCRIPTION
Proposal for switching `DateTimeType` to use `Instant` internally rather than `ZonedDateTime`.

This will effectively discard time-zone information from the _source_ of the `DateTimeType` and leave it to consumers to apply time-zone at the moment of _presentation_, according to the configured time-zone in openHAB regional settings or in the browser.

Configured time-zone is now applied for:
- REST API
- SSE item state events
- Item UI registry (affecting e.g. sitemaps)

Consequential changes because `DateTimeType` is now "zone-less":
- Parameter `timezone` for `TimestampOffsetProfile` has been removed. openhab/openhab-docs#2403 has been prepared.
- Methods `toZone` and `toLocaleZone` have been marked as deprecated and all usages have been refactored. I would suggest to remove them in 5.0 (or maybe even before when all bindings are refactored, see openhab/openhab-addons#17725).
- All usages of `getZonedDateTime` have been refactored.

The following demonstrates the difference between old and new behavior.

REST API calls are for `http://localhost:8080/rest/items/DateTimeTest` and the returned `state` is shown in the comparison table:
```json
{
    "link": "http://localhost:8080/rest/items/DateTimeTest",
    "state": "2024-10-31T21:00:00.000+0100",
    "stateDescription": {
        "pattern": "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS",
        "readOnly": false,
        "options": []
    },
    "editable": true,
    "type": "DateTime",
    "name": "DateTimeTest",
    "label": "",
    "category": "",
    "tags": [],
    "groupNames": []
}
```

Updates are made in Karaf using commands like:
```shell
openhab:update DateTimeTest 2024-10-31T21:00:00+01:00
```

| Step                                     | Before                       | Now                              |
|------------------------------------------|------------------------------|----------------------------------|
| System time-zone: Europe/Copenhagen      |                              |                                  |
| Set openHAB time-zone: Europe/Copenhagen |                              |                                  |
| Update to: 2024-10-01T20:00:00Z          |                              |                                  |
| Observe REST API result                  | 2024-10-01T20:00:00.000+0000 | 2024-10-01T**22:00:00.000+0200** |
| Observe /settings/items/                 | 2024-10-01T20:00:00.000+0000 | 2024-10-01T**22:00:00.000+0200** |
| Observe /settings/items/DateTimeTest     | 2024-10-01 22:00:00          | 2024-10-01 22:00:00              |
| Observe sitemap                          | 2024-10-01 22:00:00          | 2024-10-01 22:00:00              |
| Update to: 2024-10-31T20:00:00Z          |                              |                                  |
| Observe REST API result                  | 2024-10-31T20:00:00.000+0000 | 2024-10-31T**21:00:00.000+0100** |
| Observe /settings/items/                 | 2024-10-31T20:00:00.000+0000 | 2024-10-31T**21:00:00.000+0100** |
| Observe /settings/items/DateTimeTest     | 2024-10-31 21:00:00          | 2024-10-31 21:00:00              |
| Observe sitemap                          | 2024-10-31 21:00:00          | 2024-10-31 21:00:00              |
| Update to: 2024-10-31T21:00:00+01:00     |                              |                                  |
| Observe REST API result                  | 2024-10-31T21:00:00.000+0100 | 2024-10-31T21:00:00.000+0100     |
| Observe /settings/items/                 | 2024-10-31T21:00:00.000+0100 | 2024-10-31T21:00:00.000+0100     |
| Observe /settings/items/DateTimeTest     | 2024-10-31 21:00:00          | 2024-10-31 21:00:00              |
| Observe sitemap                          | 2024-10-31 21:00:00          | 2024-10-31 21:00:00              |
| Set time-zone: US/Alaska                 |                              |                                  |
| Observe REST API result                  | 2024-10-31T21:00:00.000+0100 | 2024-10-31T**12:00:00.000-0800** |
| Observe /settings/items/                 | 2024-10-31T21:00:00.000+0100 | 2024-10-31T**12:00:00.000-0800** |
| Observe /settings/items/DateTimeTest     | 2024-10-31 21:00:00          | 2024-10-31 **12:00:00**          |
| Observe sitemap                          | 2024-10-31 21:00:00          | 2024-10-31 **12:00:00**          |
| Update to: 2024-10-31T**12:00:00-0800**  |                              |                                  |
| Observe REST API result                  | 2024-10-31T12:00:00.000-0800 | 2024-10-31T12:00:00.000-0800     |
| Observe /settings/items/                 | 2024-10-31T12:00:00.000-0800 | 2024-10-31T12:00:00.000-0800     |
| Observe /settings/items/DateTimeTest     | 2024-10-31 21:00:00          | 2024-10-31 **12:00:00**          |
| Observe sitemap                          | 2024-10-31 21:00:00          | 2024-10-31 **12:00:00**          |

As it can be seen from the table, we now have consistent results.

Example DSL rule:

```java
var dt = ZonedDateTime.of(2024, 4, 26, 0, 0, 0, 0, ZoneId.systemDefault())
DateTimeTest1.postUpdate(new DateTimeType(dt))
DateTimeTest2.postUpdate(new DateTimeType(dt.toInstant().atZone(ZoneId.of("UTC"))))
DateTimeTest3.postUpdate(new DateTimeType(dt.toInstant()))
```

Previous result with system time-zone CET/DST:

```
[openhab.event.ItemStateChangedEvent ] - Item 'DateTimeTest1' changed from NULL to 2024-04-26T00:00:00.000+0200
[openhab.event.ItemStateChangedEvent ] - Item 'DateTimeTest2' changed from NULL to 2024-04-25T22:00:00.000+0000
```

New result with same system time-zone:

```
[openhab.event.ItemStateChangedEvent ] - Item 'DateTimeTest1' changed from NULL to 2024-04-26T00:00:00.000+0200
[openhab.event.ItemStateChangedEvent ] - Item 'DateTimeTest2' changed from NULL to 2024-04-26T00:00:00.000+0200
[openhab.event.ItemStateChangedEvent ] - Item 'DateTimeTest3' changed from NULL to 2024-04-26T00:00:00.000+0200
```

Summary of benefits for developers:
- In cases where `TimeZoneProvider` is used only to generate a `DateTimeType` with the correct time-zone, this can now be completely removed. This simplifies the code. See openhab/openhab-addons#17725 for examples.
- The default `DateTimeType` constructor can now be used (without losing correct time-zone).
- In cases where the configured time-zone was not correctly applied, this will now work properly without any changes.
- The change is fully backwards compatible, although two methods have been deprecated: `toZone` and `toLocaleZone`. I will go through usages and remove them, since they no longer make sense. See openhab/openhab-addons#17725.
- Pull request reviews should be a bit smoother, since add-on maintainers will no longer have to assist contributors in constructing a proper `DateTimeType` using `TimeZoneProvider`.

And for users:
- There will now be consistent behavior across all bindings, where previously time-zone could differ between bindings and even within same binding: System time-zone or openHAB time-zone.
- There will now be consistent behavior across different parts of the UI, where previously some parts used the time-zone contained in the `DateTimeType` (which could be either depending on binding) and other parts used system time-zone.
- A change in time-zone will have immediate effect for the UI without requiring state updates for the items.

And finally limitations:
- It is no longer possible to send a `DateTimeType` command to a binding with a specified time-zone. The bindings will have to provide a time-zone if needed (e.g. time-zone from device, openHAB configuration or system time-zone). I have not found any bindings using this possibility, so I don't think this will cause any issues.

Resolves #2898