### PR TITLE
Allow OnOffType as valid conversion types for HSBType and PercentType

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -46,6 +46,8 @@ import org.openhab.core.items.events.ItemCommandEvent;
 import org.openhab.core.items.events.ItemStateUpdatedEvent;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
@@ -467,6 +469,9 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
         if (acceptedTypes.contains(originalType.getClass())) {
             return originalType;
+        } else if (acceptedTypes.contains(OnOffType.class) && originalType instanceof State state
+                && PercentType.class.isAssignableFrom(originalType.getClass())) {
+            return (@Nullable T) state.as(OnOffType.class);
         } else {
             // Look for class hierarchy and convert appropriately
             for (Class<? extends T> typeClass : acceptedTypes) {


### PR DESCRIPTION
This fixes a regression that has been recently introduced (most likely through the refactoring of the CommunicationManager).
I couldn't figure out what change exactly causes the regression, but at least this PR fixes it.

The bug is the following: I have a Color item with a Switch channel attached using the Follow profile - this controls an LED on my KNX wall switch to show whether the light is on or off. In the past, a HSBType state update was correctly converted to ON/OFF and sent out to the channel, which is no longer the case with the current code base.