### PR TITLE
Fix non-unique module handler identifiers

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandlerFactory.java
@@ -60,7 +60,7 @@ public abstract class BaseModuleHandlerFactory implements ModuleHandlerFactory {
     @Override
     @SuppressWarnings("null")
     public @Nullable ModuleHandler getHandler(Module module, String ruleUID) {
-        String id = ruleUID + module.getId();
+        String id = getModuleIdentifier(ruleUID, module.getId());
         ModuleHandler handler = handlers.get(id);
         handler = handler == null ? internalCreate(module, ruleUID) : handler;
         if (handler != null) {
@@ -80,8 +80,12 @@ public abstract class BaseModuleHandlerFactory implements ModuleHandlerFactory {
 
     @Override
     public void ungetHandler(Module module, String ruleUID, ModuleHandler handler) {
-        if (handlers.remove(ruleUID + module.getId(), handler)) {
+        if (handlers.remove(getModuleIdentifier(ruleUID, module.getId()), handler)) {
             handler.dispose();
         }
+    }
+
+    protected String getModuleIdentifier(String ruleUid, String moduleId) {
+        return ruleUid + "$" + moduleId;
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
@@ -92,7 +92,7 @@ public class CompositeModuleHandlerFactory extends BaseModuleHandlerFactory impl
     @SuppressWarnings({ "unchecked" })
     @Override
     public void ungetHandler(Module module, String childModulePrefix, ModuleHandler handler) {
-        ModuleHandler handlerOfModule = getHandlers().get(childModulePrefix + module.getId());
+        ModuleHandler handlerOfModule = getHandlers().get(getModuleIdentifier(childModulePrefix, module.getId()));
         if (handlerOfModule instanceof AbstractCompositeModuleHandler) {
             AbstractCompositeModuleHandler<ModuleImpl, ?, ?> h = (AbstractCompositeModuleHandler<ModuleImpl, ?, ?>) handlerOfModule;
             Set<ModuleImpl> modules = h.moduleHandlerMap.keySet();


### PR DESCRIPTION
Fixes #3505 

The cause is the naming of the module handlers. Internally the `BaseModuleHandlerFactory` stores the modules in a `Map` where the key is `ruleUid+moduleId`. 

Textual defined rules have `ruleUid` that consists of the filename, a dash and a number that denotes the position of the rule in the file, so in a file `foo.rules`, the first rule gets a `foo-1`, the 11th gets `foo-11`. Within a rule, the modules are numbered from 0 to n. So the if the first rule has 10 triggers, the last module handler is stored with a key `foo-110`. When the 11th rule is added and has a trigger of the same type as first trigger, the `BaseModuleHandlerFactory` generates the same key and returns the already created handler for 10th trigger of rule 1 instead creating a new handler.

This PR changes the key to `<ruleUid>$<moduleId>`. This should be safe because `$` is not an allowed character for the module id and collisions are prevented.