### PR TITLE
[rest] Add endpoint for UoM information

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
@@ -23,9 +23,11 @@ import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
+import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.io.rest.RESTResource;
 import org.openhab.core.io.rest.internal.resources.beans.SystemInfoBean;
+import org.openhab.core.io.rest.internal.resources.beans.UoMInfoBean;
 import org.openhab.core.service.StartLevelService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -64,10 +66,12 @@ public class SystemInfoResource implements RESTResource {
     public static final String PATH_SYSTEMINFO = "systeminfo";
 
     private final StartLevelService startLevelService;
+    private final UnitProvider unitProvider;
 
     @Activate
-    public SystemInfoResource(@Reference StartLevelService startLevelService) {
+    public SystemInfoResource(@Reference StartLevelService startLevelService, @Reference UnitProvider unitProvider) {
         this.startLevelService = startLevelService;
+        this.unitProvider = unitProvider;
     }
 
     @GET
@@ -77,6 +81,16 @@ public class SystemInfoResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SystemInfoBean.class))) })
     public Response getSystemInfo(@Context UriInfo uriInfo) {
         final SystemInfoBean bean = new SystemInfoBean(startLevelService.getStartLevel());
+        return Response.ok(bean).build();
+    }
+
+    @GET
+    @Path("/uom")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(operationId = "getUoMInformation", summary = "Get all supported dimensions and their system units.", responses = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UoMInfoBean.class))) })
+    public Response getUoMInfo(@Context UriInfo uriInfo) {
+        final UoMInfoBean bean = new UoMInfoBean(unitProvider);
         return Response.ok(bean).build();
     }
 }

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/UoMInfoBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/UoMInfoBean.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.io.rest.internal.resources.beans;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.i18n.UnitProvider;
+import org.openhab.core.types.util.UnitUtils;
+
+/**
+ * This is a java bean that is used to define UoM information for the REST interface.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public class UoMInfoBean {
+
+    public final UoMInfo uomInfo;
+
+    public static class UoMInfo {
+        public final List<DimensionInfo> dimensions;
+
+        public static class DimensionInfo {
+            public final String dimension;
+            public final String systemUnit;
+
+            public DimensionInfo(String dimension, String systemUnit) {
+                this.dimension = dimension;
+                this.systemUnit = systemUnit;
+            }
+        }
+
+        @SuppressWarnings({ "unchecked" })
+        public UoMInfo(UnitProvider unitProvider) {
+            dimensions = unitProvider.getAllDimensions().stream().map(dimension -> {
+                Unit<?> unit = unitProvider.getUnit((Class<? extends Quantity>) dimension);
+                String dimensionName = Objects.requireNonNull(UnitUtils.getDimensionName(unit));
+                return new DimensionInfo(dimensionName, unit.toString());
+            }).sorted(Comparator.comparing(a -> a.dimension)).toList();
+        }
+    }
+
+    public UoMInfoBean(UnitProvider unitProvider) {
+        uomInfo = new UoMInfo(unitProvider);
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/UnitProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/UnitProvider.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.i18n;
 
+import java.util.Collection;
+
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.spi.SystemOfUnits;
@@ -44,4 +46,6 @@ public interface UnitProvider {
      * @return the {@link SystemOfUnits} which is currently set, must not be null.
      */
     SystemOfUnits getMeasurementSystem();
+
+    Collection<Class<? extends Quantity<?>>> getAllDimensions();
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -17,11 +17,13 @@ import static org.openhab.core.library.unit.MetricPrefix.HECTO;
 import java.text.MessageFormat;
 import java.time.DateTimeException;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import javax.measure.Quantity;
 import javax.measure.Unit;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -378,6 +378,11 @@ public class I18nProviderImpl
         return SIUnits.getInstance();
     }
 
+    @Override
+    public Collection<Class<? extends Quantity<?>>> getAllDimensions() {
+        return Set.copyOf(getDimensionMap().keySet());
+    }
+
     public static Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> getDimensionMap() {
         Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap = new HashMap<>();
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
@@ -12,7 +12,9 @@
  */
 package org.openhab.core.internal.i18n;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import javax.measure.Quantity;
 import javax.measure.Unit;
@@ -44,5 +46,10 @@ public class TestUnitProvider implements UnitProvider {
     @Override
     public SystemOfUnits getMeasurementSystem() {
         return SIUnits.getInstance();
+    }
+
+    @Override
+    public Collection<Class<? extends Quantity<?>>> getAllDimensions() {
+        return Set.of();
     }
 }


### PR DESCRIPTION
Currently the list of available dimensions for `Number` items is hard-coded in Main UI. The reason is that there is no way to determine the available dimensions at runtime. This endpoint adds that, so that the list can be created dynamically and will automatically be up-to-date if new dimensions (like #3608 or #3408) are added.