### PR TITLE
Fix Upgradetool does not remember last executed step

### DIFF
--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
@@ -123,6 +123,7 @@ public class Upgrader {
 
         metadataStorage.flush();
         upgradeRecords.put(ITEM_COPY_UNIT_TO_METADATA, new UpgradeRecord(ZonedDateTime.now()));
+        upgradeRecords.flush();
     }
 
     public void linkUpgradeJsProfile() {
@@ -162,6 +163,7 @@ public class Upgrader {
 
         linkStorage.flush();
         upgradeRecords.put(LINK_UPGRADE_JS_PROFILE, new UpgradeRecord(ZonedDateTime.now()));
+        upgradeRecords.flush();
     }
 
     private static class UpgradeRecord {


### PR DESCRIPTION
The JSON database that stores the already executed steps was not always properly flushed. This could result in the last step not being properly persisted, resulting in a new execution on next update. 