### PR TITLE
Move RuleHLI service from voice to system

### DIFF
--- a/bundles/org.openhab.core.model.script/resources/OH-INF/config/hli.xml
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/config/hli.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
 		https://openhab.org/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="voice:rulehli">
+	<config-description uri="system:rulehli">
 		<parameter name="item" type="text">
 			<context>item</context>
 			<filter><criteria name="type">String</criteria></filter>

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Voice Command Item
-voice.config.rulehli.item.description = The String Item to pass voice commands to.
+system.config.rulehli.item.label = Voice Command Item
+system.config.rulehli.item.description = The String Item to pass voice commands to.
 
-service.voice.rulehli.label = Rule Voice Interpreter
+service.system.rulehli.label = Rule Voice Interpreter

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_cs.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_cs.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item hlasového příkazu
-voice.config.rulehli.item.description = String Item, do které se vloží hlasový příkaz.
+system.config.rulehli.item.label = Item hlasového příkazu
+system.config.rulehli.item.description = String Item, do které se vloží hlasový příkaz.
 
-service.voice.rulehli.label = Hlasový tlumočník
+service.system.rulehli.label = Hlasový tlumočník

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_da.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_da.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Stemmekommando-item
-voice.config.rulehli.item.description = Streng-item'et der skal sendes stemmekommandoer til.
+system.config.rulehli.item.label = Stemmekommando-item
+system.config.rulehli.item.description = Streng-item'et der skal sendes stemmekommandoer til.
 
-service.voice.rulehli.label = Regel-stemmefortolker
+service.system.rulehli.label = Regel-stemmefortolker

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_de.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_de.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item für Sprachanweisungen
-voice.config.rulehli.item.description = Das String-Item an das Sprachanweisungen übergeben werden sollen.
+system.config.rulehli.item.label = Item für Sprachanweisungen
+system.config.rulehli.item.description = Das String-Item an das Sprachanweisungen übergeben werden sollen.
 
-service.voice.rulehli.label = Regelbasierter Sprachinterpreter
+service.system.rulehli.label = Regelbasierter Sprachinterpreter

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_el.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_el.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Στοιχείο Φωνητικής Εντολής
-voice.config.rulehli.item.description = Το στοιχείο κειμένου για να περάσει τις φωνητικές εντολές.
+system.config.rulehli.item.label = Στοιχείο Φωνητικής Εντολής
+system.config.rulehli.item.description = Το στοιχείο κειμένου για να περάσει τις φωνητικές εντολές.
 
-service.voice.rulehli.label = Διερμηνέας Κανόνων Φωνής
+service.system.rulehli.label = Διερμηνέας Κανόνων Φωνής

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_fi.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_fi.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Äänikomennon Item
-voice.config.rulehli.item.description = Tekstimuotoinen Item, jolle äänikomennot välitetään.
+system.config.rulehli.item.label = Äänikomennon Item
+system.config.rulehli.item.description = Tekstimuotoinen Item, jolle äänikomennot välitetään.
 
-service.voice.rulehli.label = Sääntöpohjainen äänitulkki
+service.system.rulehli.label = Sääntöpohjainen äänitulkki

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_fr.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_fr.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item de commande vocale
-voice.config.rulehli.item.description = L'item pour passer des commandes vocales.
+system.config.rulehli.item.label = Item de commande vocale
+system.config.rulehli.item.description = L'item pour passer des commandes vocales.
 
-service.voice.rulehli.label = Interprêteur de règle vocale
+service.system.rulehli.label = Interprêteur de règle vocale

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_he.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_he.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = פקודה קולית
-voice.config.rulehli.item.description = ה-Item אליו יועברו הפקודות הקוליות.
+system.config.rulehli.item.label = פקודה קולית
+system.config.rulehli.item.description = ה-Item אליו יועברו הפקודות הקוליות.
 
-service.voice.rulehli.label = מתורגמן כללים קולי
+service.system.rulehli.label = מתורגמן כללים קולי

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_hu.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_hu.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Hangvezérlés elem
-voice.config.rulehli.item.description = A szöveg elem, amely a hangüzeneteket fogadja.
+system.config.rulehli.item.label = Hangvezérlés elem
+system.config.rulehli.item.description = A szöveg elem, amely a hangüzeneteket fogadja.
 
-service.voice.rulehli.label = Szabály hang értelmező
+service.system.rulehli.label = Szabály hang értelmező

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_it.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_it.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item Comando Vocale
-voice.config.rulehli.item.description = La Stringa dell'Item passata al comando vocale.
+system.config.rulehli.item.label = Item Comando Vocale
+system.config.rulehli.item.description = La Stringa dell'Item passata al comando vocale.
 
-service.voice.rulehli.label = Regola Inteprete Vocale
+service.system.rulehli.label = Regola Inteprete Vocale

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_nl.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_nl.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Spraakopdracht Item
-voice.config.rulehli.item.description = Het String Item om spraakopdrachten naar door te geven.
+system.config.rulehli.item.label = Spraakopdracht Item
+system.config.rulehli.item.description = Het String Item om spraakopdrachten naar door te geven.
 
-service.voice.rulehli.label = Rule Spraak Interpreter
+service.system.rulehli.label = Rule Spraak Interpreter

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_no.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_no.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Stemmekommando Item
-voice.config.rulehli.item.description = Streng Item'et stemmekommandoer skal sendes til.
+system.config.rulehli.item.label = Stemmekommando Item
+system.config.rulehli.item.description = Streng Item'et stemmekommandoer skal sendes til.
 
-service.voice.rulehli.label = Regelbasert Stemmetolk
+service.system.rulehli.label = Regelbasert Stemmetolk

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_pl.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_pl.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Element komendy głosowej
-voice.config.rulehli.item.description = Element do którego mają być przekazywane polecenia głosowe.
+system.config.rulehli.item.label = Element komendy głosowej
+system.config.rulehli.item.description = Element do którego mają być przekazywane polecenia głosowe.
 
-service.voice.rulehli.label = Interpretator reguł głosu
+service.system.rulehli.label = Interpretator reguł głosu

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_pt.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_pt.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item de Comando de Voz
-voice.config.rulehli.item.description = O Item de texto para passar comandos de voz.
+system.config.rulehli.item.label = Item de Comando de Voz
+system.config.rulehli.item.description = O Item de texto para passar comandos de voz.
 
-service.voice.rulehli.label = Interpretador de voz
+service.system.rulehli.label = Interpretador de voz

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_ru.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_ru.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item голосовых команд
-voice.config.rulehli.item.description = Строковый Item для передачи голосовых команд.
+system.config.rulehli.item.label = Item голосовых команд
+system.config.rulehli.item.description = Строковый Item для передачи голосовых команд.
 
-service.voice.rulehli.label = Управление голосовым интерпретатором
+service.system.rulehli.label = Управление голосовым интерпретатором

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_sl.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_sl.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Predmet glasovnega ukaza
-voice.config.rulehli.item.description = Besedilni predmet, ki se mu naj posreduje ukaz.
+system.config.rulehli.item.label = Predmet glasovnega ukaza
+system.config.rulehli.item.description = Besedilni predmet, ki se mu naj posreduje ukaz.
 
-service.voice.rulehli.label = Tolmač glasovnih ukazov
+service.system.rulehli.label = Tolmač glasovnih ukazov

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_sv.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_sv.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Item för röstkommando
-voice.config.rulehli.item.description = Sträng-Item att skicka röstkommandon till.
+system.config.rulehli.item.label = Item för röstkommando
+system.config.rulehli.item.description = Sträng-Item att skicka röstkommandon till.
 
-service.voice.rulehli.label = Rösttolkare för regler
+service.system.rulehli.label = Rösttolkare för regler

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_uk.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_uk.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = Голосова команда
-voice.config.rulehli.item.description = Пункт для передачі голосових команд.
+system.config.rulehli.item.label = Голосова команда
+system.config.rulehli.item.description = Пункт для передачі голосових команд.
 
-service.voice.rulehli.label = Правило голосового інтерпретера
+service.system.rulehli.label = Правило голосового інтерпретера

--- a/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_zh.properties
+++ b/bundles/org.openhab.core.model.script/resources/OH-INF/i18n/hli_zh.properties
@@ -1,4 +1,4 @@
-voice.config.rulehli.item.label = 语音命令
-voice.config.rulehli.item.description = 要传递语音命令的字符串。
+system.config.rulehli.item.label = 语音命令
+system.config.rulehli.item.description = 要传递语音命令的字符串。
 
-service.voice.rulehli.label = 语音规则解释器
+service.system.rulehli.label = 语音规则解释器

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
@@ -47,13 +47,13 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(immediate = true, service = HumanLanguageInterpreter.class, configurationPid = "org.openhab.rulehli", //
         property = Constants.SERVICE_PID + "=org.openhab.rulehli")
-@ConfigurableService(category = "voice", label = "Rule Voice Interpreter", description_uri = RuleHumanLanguageInterpreter.CONFIG_URI)
+@ConfigurableService(category = "system", label = "Rule Voice Interpreter", description_uri = RuleHumanLanguageInterpreter.CONFIG_URI)
 public class RuleHumanLanguageInterpreter implements HumanLanguageInterpreter {
 
     private final Logger logger = LoggerFactory.getLogger(RuleHumanLanguageInterpreter.class);
 
     // constants for the configuration properties
-    protected static final String CONFIG_URI = "voice:rulehli";
+    protected static final String CONFIG_URI = "system:rulehli";
 
     private String itemName = "VoiceCommand";
 


### PR DESCRIPTION
This is needed to clean-up UI. The categories should be used for add-ons while core services should use `system`. This is non-breaking, configurations ill be preserved.