### PR TITLE
Fix exception in TransformationHelper

### DIFF
--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
@@ -125,6 +125,8 @@ public class TransformationHelper {
             return service.transform(function, value);
         } catch (IllegalFormatException e) {
             throw new TransformationException("Cannot format state '" + state + "' to format '" + format + "'", e);
+        } catch (RuntimeException e) {
+            throw new TransformationException("Transformation service threw an exception: " + e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/1867

Runtime exceptions thrown by transformation services propagated from the `TransformationHelper` to the `EnrichtedItemDTOMapper` to the `ItemResource`. In general transformation services should throw `TransformationException` and this should be fixed there but in this case safe-guarding the `TransformationHelper` makes sense because of the severity of issues created by fault add-ons.