### PR TITLE
Remove package support from FeatureInstaller

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -83,8 +83,6 @@ public class FeatureInstaller implements ConfigurationListener {
     protected static final String CONFIG_URI = "system:addons";
 
     public static final String PREFIX = "openhab-";
-    public static final String PREFIX_PACKAGE = "package-";
-    public static final String MINIMAL_PACKAGE = "minimal";
 
     private static final String CFG_REMOTE = "remote";
     private static final String PAX_URL_PID = "org.ops4j.pax.url.mvn";
@@ -191,13 +189,6 @@ public class FeatureInstaller implements ConfigurationListener {
                 waitForConfigUpdateEvent();
             }
 
-            if (installPackage(config)) {
-                changed = true;
-                // our package selection has changed, so let's wait for the values to be available in config admin
-                // which we will receive as another call to modified
-                continue;
-            }
-
             if (installAddons(config)) {
                 changed = true;
             }
@@ -278,7 +269,7 @@ public class FeatureInstaller implements ConfigurationListener {
     private void changeAddonConfig(String type, String id, BiFunction<Collection<String>, String, Boolean> method)
             throws IOException {
         Configuration cfg = configurationAdmin.getConfiguration(OpenHAB.ADDONS_SERVICE_PID, null);
-        Dictionary<String, Object> props = cfg.getProperties();
+        Dictionary<String, Object> props = Objects.requireNonNullElse(cfg.getProperties(), new Hashtable<>());
         Object typeProp = props.get(type);
         String[] addonIds = typeProp != null ? typeProp.toString().split(",") : new String[0];
         Set<String> normalizedIds = new HashSet<>(); // sets don't allow duplicates
@@ -510,27 +501,6 @@ public class FeatureInstaller implements ConfigurationListener {
         } catch (Exception e) {
             logger.debug("Failed uninstalling '{}': {}", name, e.getMessage());
         }
-    }
-
-    private boolean installPackage(final Map<String, Object> config) {
-        boolean configChanged = false;
-        Object packageName = config.get(OpenHAB.CFG_PACKAGE);
-        if (packageName instanceof String currentPackage) {
-            String fullName = PREFIX + PREFIX_PACKAGE + currentPackage.strip();
-            if (!MINIMAL_PACKAGE.equals(currentPackage)) {
-                configChanged = installFeature(fullName);
-            }
-
-            // uninstall all other packages
-            try {
-                Stream.of(featuresService.listFeatures()).map(Feature::getName)
-                        .filter(feature -> feature.startsWith(PREFIX + PREFIX_PACKAGE) && !feature.equals(fullName))
-                        .forEach(this::uninstallFeature);
-            } catch (Exception e) {
-                logger.error("Failed retrieving features: {}", e.getMessage(), debugException(e));
-            }
-        }
-        return configChanged;
     }
 
     private void postInstalledEvent(String featureName) {


### PR DESCRIPTION
Packages are no longer needed since we have the setup wizard in place.

See https://github.com/openhab/openhab-distro/pull/1543