### PR TITLE
Improve performance for state update handling 

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -21,10 +21,12 @@ import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
@@ -56,6 +58,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Role;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventSubscriber;
 import org.openhab.core.io.rest.JSONResponse;
 import org.openhab.core.io.rest.LocaleService;
 import org.openhab.core.io.rest.RESTConstants;
@@ -67,7 +71,8 @@ import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService.SitemapSubscr
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
-import org.openhab.core.items.StateChangeListener;
+import org.openhab.core.items.events.ItemEvent;
+import org.openhab.core.items.events.ItemStateChangedEvent;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.model.sitemap.SitemapProvider;
@@ -126,7 +131,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  * @author Laurent Garnier - Added support for icon color
  */
-@Component(service = RESTResource.class)
+@Component(service = { RESTResource.class, EventSubscriber.class })
 @JaxrsResource
 @JaxrsName(SitemapResource.PATH_SITEMAPS)
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
@@ -136,7 +141,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = SitemapResource.PATH_SITEMAPS)
 @NonNullByDefault
 public class SitemapResource
-        implements RESTResource, SitemapSubscriptionCallback, SseBroadcaster.Listener<SseSinkInfo> {
+        implements RESTResource, SitemapSubscriptionCallback, SseBroadcaster.Listener<SseSinkInfo>, EventSubscriber {
 
     private final Logger logger = LoggerFactory.getLogger(SitemapResource.class);
 
@@ -176,6 +181,7 @@ public class SitemapResource
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
     private @Nullable ScheduledFuture<?> cleanSubscriptionsJob;
+    private Set<BlockingStateChangeListener> stateChangeListeners = new CopyOnWriteArraySet<>();
 
     @Activate
     public SitemapResource( //
@@ -683,13 +689,11 @@ public class SitemapResource
     private boolean waitForChanges(EList<Widget> widgets) {
         long startTime = (new Date()).getTime();
         boolean timeout = false;
-        BlockingStateChangeListener listener = new BlockingStateChangeListener();
-        // let's get all items for these widgets
-        Set<GenericItem> items = getAllItems(widgets);
-        for (GenericItem item : items) {
-            item.addStateChangeListener(listener);
-        }
-        while (!listener.hasChangeOccurred() && !timeout) {
+        Set<String> items = getAllItems(widgets).stream().map(Item::getName).collect(Collectors.toSet());
+        BlockingStateChangeListener listener = new BlockingStateChangeListener(items);
+        stateChangeListeners.add(listener);
+
+        while (!listener.hasChanged() && !timeout) {
             timeout = (new Date()).getTime() - startTime > TIMEOUT_IN_MS;
             try {
                 Thread.sleep(300);
@@ -698,9 +702,8 @@ public class SitemapResource
                 break;
             }
         }
-        for (GenericItem item : items) {
-            item.removeStateChangeListener(listener);
-        }
+
+        stateChangeListeners.remove(listener);
         return timeout;
     }
 
@@ -779,34 +782,16 @@ public class SitemapResource
         return items;
     }
 
-    /**
-     * This is a state change listener, which is merely used to determine, if a
-     * state change has occurred on one of a list of items.
-     *
-     * @author Kai Kreuzer - Initial contribution
-     *
-     */
-    private static class BlockingStateChangeListener implements StateChangeListener {
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return Set.of(ItemStateChangedEvent.TYPE);
+    }
 
-        private boolean changed = false;
-
-        @Override
-        public void stateChanged(Item item, State oldState, State newState) {
-            changed = true;
-        }
-
-        /**
-         * determines, whether a state change has occurred since its creation
-         *
-         * @return true, if a state has changed
-         */
-        public boolean hasChangeOccurred() {
-            return changed;
-        }
-
-        @Override
-        public void stateUpdated(Item item, State state) {
-            // ignore if the state did not change
+    @Override
+    public void receive(Event event) {
+        if (event instanceof ItemEvent itemEvent) {
+            String itemName = itemEvent.getItemName();
+            stateChangeListeners.forEach(l -> l.itemChanged(itemName));
         }
     }
 
@@ -851,5 +836,24 @@ public class SitemapResource
         logger.debug("SSE connection for subscription {} has been closed.", info.subscriptionId);
         subscriptions.removeSubscription(info.subscriptionId);
         knownSubscriptions.remove(info.subscriptionId);
+    }
+
+    private static class BlockingStateChangeListener {
+        private final Set<String> items;
+        private boolean changed = false;
+
+        public BlockingStateChangeListener(Set<String> items) {
+            this.items = items;
+        }
+
+        public void itemChanged(String item) {
+            if (items.contains(item)) {
+                changed = true;
+            }
+        }
+
+        public boolean hasChanged() {
+            return changed;
+        }
     }
 }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -18,7 +18,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.Mockito.*;
 
-import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -45,7 +44,7 @@ import org.openhab.core.io.rest.LocaleService;
 import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemNotFoundException;
-import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.model.sitemap.SitemapProvider;
@@ -158,11 +157,13 @@ public class SitemapResourceTest extends JavaTest {
 
     @Test
     public void whenLongPollingShouldObserveItems() {
+        ItemEvent itemEvent = mock(ItemEvent.class);
+        when(itemEvent.getItemName()).thenReturn(item.getName());
         new Thread(() -> {
             try {
                 Thread.sleep(STATE_UPDATE_WAIT_TIME); // wait for the #getPageData call and listeners to attach to the
                                                       // item
-                item.setState(PercentType.ZERO);
+                sitemapResource.receive(itemEvent);
             } catch (InterruptedException e) {
             }
         }).start();
@@ -180,11 +181,13 @@ public class SitemapResourceTest extends JavaTest {
 
     @Test
     public void whenLongPollingShouldObserveItemsFromVisibilityRules() {
+        ItemEvent itemEvent = mock(ItemEvent.class);
+        when(itemEvent.getItemName()).thenReturn(visibilityRuleItem.getName());
         new Thread(() -> {
             try {
                 Thread.sleep(STATE_UPDATE_WAIT_TIME); // wait for the #getPageData call and listeners to attach to the
                                                       // item
-                visibilityRuleItem.setState(new DecimalType(BigDecimal.ONE));
+                sitemapResource.receive(itemEvent);
             } catch (InterruptedException e) {
             }
         }).start();
@@ -202,11 +205,13 @@ public class SitemapResourceTest extends JavaTest {
 
     @Test
     public void whenLongPollingShouldObserveItemsFromLabelColorConditions() {
+        ItemEvent itemEvent = mock(ItemEvent.class);
+        when(itemEvent.getItemName()).thenReturn(labelColorItem.getName());
         new Thread(() -> {
             try {
                 Thread.sleep(STATE_UPDATE_WAIT_TIME); // wait for the #getPageData call and listeners to attach to the
                                                       // item
-                labelColorItem.setState(new DecimalType(BigDecimal.ONE));
+                sitemapResource.receive(itemEvent);
             } catch (InterruptedException e) {
             }
         }).start();
@@ -224,11 +229,13 @@ public class SitemapResourceTest extends JavaTest {
 
     @Test
     public void whenLongPollingShouldObserveItemsFromValueColorConditions() {
+        ItemEvent itemEvent = mock(ItemEvent.class);
+        when(itemEvent.getItemName()).thenReturn(valueColorItem.getName());
         new Thread(() -> {
             try {
                 Thread.sleep(STATE_UPDATE_WAIT_TIME); // wait for the #getPageData call and listeners to attach to the
                                                       // item
-                valueColorItem.setState(new DecimalType(BigDecimal.ONE));
+                sitemapResource.receive(itemEvent);
             } catch (InterruptedException e) {
             }
         }).start();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
@@ -13,14 +13,18 @@
 package org.openhab.core.internal.events;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -47,9 +51,7 @@ public class EventHandler implements AutoCloseable {
     private final Map<String, Set<EventSubscriber>> typedEventSubscribers;
     private final Map<String, EventFactory> typedEventFactories;
 
-    private final ScheduledExecutorService watcher = Executors
-            .newSingleThreadScheduledExecutor(new NamedThreadFactory("eventwatcher"));
-    private final ExecutorService executor = Executors.newSingleThreadExecutor(new NamedThreadFactory("eventexecutor"));
+    private final Map<EventSubscriber, ExecutorRecord> executors = new HashMap<>();
 
     /**
      * Create a new event handler.
@@ -63,10 +65,19 @@ public class EventHandler implements AutoCloseable {
         this.typedEventFactories = typedEventFactories;
     }
 
+    private synchronized ExecutorRecord createExecutorRecord(EventSubscriber subscriber) {
+        return new ExecutorRecord(
+                Executors.newSingleThreadExecutor(new NamedThreadFactory("eventexecutor-" + executors.size())),
+                Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("eventwatcher-" + executors.size())),
+                new AtomicInteger());
+    }
+
     @Override
     public void close() {
-        watcher.shutdownNow();
-        executor.shutdownNow();
+        executors.values().forEach(r -> {
+            r.executor.shutdownNow();
+            r.watcher.shutdownNow();
+        });
     }
 
     public void handleEvent(org.osgi.service.event.Event osgiEvent) {
@@ -140,8 +151,16 @@ public class EventHandler implements AutoCloseable {
             EventFilter filter = eventSubscriber.getEventFilter();
             if (filter == null || filter.apply(event)) {
                 logger.trace("Delegate event to subscriber ({}).", eventSubscriber.getClass());
-                executor.submit(() -> {
-                    ScheduledFuture<?> logTimeout = watcher.schedule(
+                ExecutorRecord executorRecord = Objects
+                        .requireNonNull(executors.computeIfAbsent(eventSubscriber, this::createExecutorRecord));
+                int queueSize = executorRecord.count().incrementAndGet();
+                if (queueSize > 1000) {
+                    logger.warn(
+                            "The queue for a subscriber of type '{}' exceeds 1000 elements. System may be unstable.",
+                            eventSubscriber.getClass());
+                }
+                CompletableFuture.runAsync(() -> {
+                    ScheduledFuture<?> logTimeout = executorRecord.watcher().schedule(
                             () -> logger.warn("Dispatching event to subscriber '{}' takes more than {}ms.",
                                     eventSubscriber, EVENTSUBSCRIBER_EVENTHANDLING_MAX_MS),
                             EVENTSUBSCRIBER_EVENTHANDLING_MAX_MS, TimeUnit.MILLISECONDS);
@@ -152,10 +171,13 @@ public class EventHandler implements AutoCloseable {
                                 EventSubscriber.class.getName(), ex.getMessage(), ex);
                     }
                     logTimeout.cancel(false);
-                });
+                }, executorRecord.executor()).thenRun(executorRecord.count::decrementAndGet);
             } else {
                 logger.trace("Skip event subscriber ({}) because of its filter.", eventSubscriber.getClass());
             }
         }
+    }
+
+    private record ExecutorRecord(ExecutorService executor, ScheduledExecutorService watcher, AtomicInteger count) {
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
@@ -151,8 +151,8 @@ public class EventHandler implements AutoCloseable {
             EventFilter filter = eventSubscriber.getEventFilter();
             if (filter == null || filter.apply(event)) {
                 logger.trace("Delegate event to subscriber ({}).", eventSubscriber.getClass());
-                ExecutorRecord executorRecord = Objects
-                        .requireNonNull(executors.computeIfAbsent(eventSubscriber.getClass(), this::createExecutorRecord));
+                ExecutorRecord executorRecord = Objects.requireNonNull(
+                        executors.computeIfAbsent(eventSubscriber.getClass(), this::createExecutorRecord));
                 int queueSize = executorRecord.count().incrementAndGet();
                 if (queueSize > 1000) {
                     logger.warn(


### PR DESCRIPTION
Fixes #3620 

There are two improvements in this PR:

- The `EventHandler` now uses a "one-thread-per-subscriber` policy. This prevents single "slow" consumers from blocking others but still preserves event order.
- The `PageChangeListener` and the `SitemapResource` have been refactored to use events instead implementing `StateChangeListener`. 

