### PR TITLE
[rest] Add unit to item response

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
@@ -25,8 +25,8 @@ import org.openhab.core.types.StateDescription;
 public class EnrichedGroupItemDTO extends EnrichedItemDTO {
 
     public EnrichedGroupItemDTO(ItemDTO itemDTO, EnrichedItemDTO[] members, String link, String state,
-            String transformedState, StateDescription stateDescription) {
-        super(itemDTO, link, state, transformedState, stateDescription, null);
+            String transformedState, StateDescription stateDescription, String unitSymbol) {
+        super(itemDTO, link, state, transformedState, stateDescription, null, unitSymbol);
         this.members = members;
         this.groupType = ((GroupItemDTO) itemDTO).groupType;
         this.function = ((GroupItemDTO) itemDTO).function;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
@@ -24,6 +24,7 @@ import org.openhab.core.types.StateDescription;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Kai Kreuzer - Added metadata
+ * @author Mark Herwege - Added default unit symbol
  */
 public class EnrichedItemDTO extends ItemDTO {
 
@@ -31,12 +32,13 @@ public class EnrichedItemDTO extends ItemDTO {
     public String state;
     public String transformedState;
     public StateDescription stateDescription;
+    public String unitSymbol;
     public CommandDescription commandDescription;
     public Map<String, Object> metadata;
     public Boolean editable;
 
     public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String transformedState,
-            StateDescription stateDescription, CommandDescription commandDescription) {
+            StateDescription stateDescription, CommandDescription commandDescription, String unitSymbol) {
         this.type = itemDTO.type;
         this.name = itemDTO.name;
         this.label = itemDTO.label;
@@ -48,5 +50,6 @@ public class EnrichedItemDTO extends ItemDTO {
         this.transformedState = transformedState;
         this.stateDescription = stateDescription;
         this.commandDescription = commandDescription;
+        this.unitSymbol = unitSymbol;
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -27,6 +27,7 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.dto.ItemDTO;
 import org.openhab.core.items.dto.ItemDTOMapper;
+import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.types.StateDescription;
@@ -93,6 +94,10 @@ public class EnrichedItemDTOMapper {
 
         EnrichedItemDTO enrichedItemDTO;
 
+        String unitSymbol = null;
+        if (item instanceof NumberItem numberItem) {
+            unitSymbol = numberItem.getUnitSymbol();
+        }
         if (item instanceof GroupItem groupItem) {
             EnrichedItemDTO[] memberDTOs;
             if (drillDown) {
@@ -111,10 +116,10 @@ public class EnrichedItemDTOMapper {
                 memberDTOs = new EnrichedItemDTO[0];
             }
             enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, transformedState,
-                    stateDescription);
+                    stateDescription, unitSymbol);
         } else {
             enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, transformedState, stateDescription,
-                    item.getCommandDescription(locale));
+                    item.getCommandDescription(locale), unitSymbol);
         }
 
         return enrichedItemDTO;


### PR DESCRIPTION
This extends the enrichedItemDTO with a unitSymbol field, representing the default unit for a number item. This would be the value configured in unit metadata or the default for the dimension.

This field is required to better support sitemap input widgets in apps. When no unit is provided in the label pattern or state description, it allows the input widget to show the default unit symbol. Combined with https://github.com/openhab/openhab-core/pull/3644 this would allow to make the functionality for the input widget equivalent to the proposed functionality for BasicUI.