### PR TITLE
Replace `StringBuffer` usages with `StringBuilder`

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -266,7 +266,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         this.ruleRegistry = ruleRegistry;
         this.readyService = readyService;
 
-        listener = new RegistryChangeListener<Rule>() {
+        listener = new RegistryChangeListener<>() {
             @Override
             public void added(Rule rule) {
                 RuleEngineImpl.this.addRule(rule);
@@ -337,8 +337,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         synchronized (this) {
             Set<String> rulesPerModule = mapModuleTypeToRules.get(moduleTypeName);
             if (rulesPerModule != null) {
-                rules = new HashSet<>();
-                rules.addAll(rulesPerModule);
+                rules = new HashSet<>(rulesPerModule);
             }
         }
         if (rules != null) {
@@ -366,8 +365,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         synchronized (this) {
             Set<String> rulesPerModule = mapModuleTypeToRules.get(moduleTypeName);
             if (rulesPerModule != null) {
-                rules = new HashSet<>();
-                rules.addAll(rulesPerModule);
+                rules = new HashSet<>(rulesPerModule);
             }
         }
         if (rules != null) {
@@ -402,8 +400,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
                 moduleHandlerFactories.put(moduleTypeName, moduleHandlerFactory);
                 Set<String> rulesPerModule = mapModuleTypeToRules.get(moduleTypeName);
                 if (rulesPerModule != null) {
-                    rules = new HashSet<>();
-                    rules.addAll(rulesPerModule);
+                    rules = new HashSet<>(rulesPerModule);
                 }
             }
             if (rules != null) {
@@ -505,10 +502,8 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         final boolean activated = activateRule(rule);
         if (activated) {
             Future<?> f = scheduleTasks.remove(rUID);
-            if (f != null) {
-                if (!f.isDone()) {
-                    f.cancel(true);
-                }
+            if ((f != null) && !f.isDone()) {
+                f.cancel(true);
             }
         }
     }
@@ -942,7 +937,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             for (Entry<String, List<String>> e : mapMissingHandlers.entrySet()) {
                 String rUID = e.getKey();
                 List<String> missingTypes = e.getValue();
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append("Missing handlers: ");
                 for (String typeUID : missingTypes) {
                     sb.append(typeUID).append(", ");
@@ -1097,7 +1092,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             throw new IllegalStateException("context cannot be null at that point - please report a bug.");
         }
         if (connections != null) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (Connection c : connections) {
                 String outputModuleId = c.getOutputModuleId();
                 if (outputModuleId != null) {
@@ -1438,7 +1433,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     private void executeRulesWithStartLevel() {
         getScheduledExecutor().submit(() -> {
             ruleRegistry.getAll().stream() //
-                    .filter(r -> mustTrigger(r)) //
+                    .filter(this::mustTrigger) //
                     .forEach(r -> runNow(r.getUID(), true,
                             Map.of(SystemTriggerHandler.OUT_STARTLEVEL, StartLevelService.STARTLEVEL_RULES)));
             started = true;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -500,7 +500,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
             if (isOptionalConfig(configDescriptions)) {
                 return;
             } else {
-                StringBuffer statusDescription = new StringBuffer();
+                StringBuilder statusDescription = new StringBuilder();
                 String msg = " '%s';";
                 for (ConfigDescriptionParameter configParameter : configDescriptions) {
                     if (configParameter.isRequired()) {
@@ -517,7 +517,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
                 processValue(configurations.remove(configParameterName), configParameter);
             }
             if (!configurations.isEmpty()) {
-                StringBuffer statusDescription = new StringBuffer();
+                StringBuilder statusDescription = new StringBuilder();
                 String msg = " '%s';";
                 for (String name : configurations.keySet()) {
                     statusDescription.append(String.format(msg, name));
@@ -610,7 +610,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      */
     private void resolveModuleConfigReferences(List<? extends Module> modules, Map<String, ?> ruleConfiguration) {
         if (modules != null) {
-            StringBuffer statusDescription = new StringBuffer();
+            StringBuilder statusDescription = new StringBuilder();
             for (Module module : modules) {
                 try {
                     ReferenceResolver.updateConfiguration(module.getConfiguration(), ruleConfiguration, logger);

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
@@ -33,7 +33,7 @@ public class ConsoleInterpreter {
     public static String getHelp(final String base, final String separator,
             Collection<ConsoleCommandExtension> extensions) {
         final List<String> usages = ConsoleInterpreter.getUsages(extensions);
-        final StringBuffer buffer = new StringBuffer();
+        final StringBuilder buffer = new StringBuilder();
 
         buffer.append("---openHAB commands---\n\t");
         for (int i = 0; i < usages.size(); i++) {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
@@ -46,7 +46,7 @@ public class MagicServiceConfig {
 
     @Override
     public String toString() {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder();
         for (Field field : this.getClass().getDeclaredFields()) {
             Object value;
             try {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/FirmwareUpdateConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/FirmwareUpdateConsoleCommandExtension.java
@@ -132,7 +132,7 @@ public final class FirmwareUpdateConsoleCommandExtension extends AbstractConsole
         FirmwareStatusInfo firmwareStatusInfo = firmwareUpdateService.getFirmwareStatusInfo(thingUID);
 
         if (firmwareStatusInfo != null) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(String.format("Firmware status for thing with UID %s is %s.", thingUID,
                     firmwareStatusInfo.getFirmwareStatus()));
 


### PR DESCRIPTION
See: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/StringBuilder.html

> This class provides an API compatible with StringBuffer, but with no guarantee of synchronization.
> This class is designed for use as a drop-in replacement for StringBuffer in places where the string buffer was being used by a single thread (as is generally the case).
> Where possible, it is recommended that this class be used in preference to StringBuffer as it will be faster under most implementations.