### PR TITLE
[persistence] Don't require `relative`, `inverted` and `unit` fields for filter configuration over REST

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -79,13 +79,26 @@ public class PersistenceServiceConfigurationDTOMapper {
         Map<String, PersistenceStrategy> strategyMap = dto.cronStrategies.stream()
                 .collect(Collectors.toMap(e -> e.name, e -> new PersistenceCronStrategy(e.name, e.cronExpression)));
 
-        Map<String, PersistenceFilter> filterMap = Stream.of(
-                dto.thresholdFilters.stream()
-                        .map(f -> new PersistenceThresholdFilter(f.name, f.value, f.unit, f.relative)),
-                dto.timeFilters.stream().map(f -> new PersistenceTimeFilter(f.name, f.value.intValue(), f.unit)),
-                dto.equalsFilters.stream().map(f -> new PersistenceEqualsFilter(f.name, f.values, f.inverted)),
-                dto.includeFilters.stream()
-                        .map(f -> new PersistenceIncludeFilter(f.name, f.lower, f.upper, f.unit, f.inverted)))
+        Map<String, PersistenceFilter> filterMap = Stream.of(dto.thresholdFilters.stream().peek(f -> {
+            if (f.unit == null)
+                f.unit = "";
+            if (f.relative == null)
+                f.relative = false;
+        }).map(f -> new PersistenceThresholdFilter(f.name, f.value, f.unit, f.relative)),
+                dto.timeFilters.stream().peek(f -> {
+                    if (f.unit == null)
+                        f.unit = "s";
+                }).map(f -> new PersistenceTimeFilter(f.name, f.value.intValue(), f.unit)),
+                dto.equalsFilters.stream().peek(f -> {
+                    if (f.inverted == null)
+                        f.inverted = false;
+                }).map(f -> new PersistenceEqualsFilter(f.name, f.values, f.inverted)),
+                dto.includeFilters.stream().peek(f -> {
+                    if (f.unit == null)
+                        f.unit = "";
+                    if (f.inverted == null)
+                        f.inverted = false;
+                }).map(f -> new PersistenceIncludeFilter(f.name, f.lower, f.upper, f.unit, f.inverted)))
                 .flatMap(Function.identity()).collect(Collectors.toMap(PersistenceFilter::getName, e -> e));
 
         List<PersistenceStrategy> defaults = dto.defaults.stream()


### PR DESCRIPTION
While creating the persistence edit page, I noticed that PUT `/rest/persistence/{serviceId}` requests fail when the boolean properties `inverted` and `relative` of some persistence filters are not set. First, I ensured that they are set when the UI saves the persistence configuration, however IMO this should be in core.
Setting up a treshold filter with the UI, it did not work because the `unit` field was blank (I got an NPE from `PersistenceTresholdFilter`, and the `PersistenceIncludeFilter` would also throw a NPE.

This PR sets reasonable defaults for those fields that are required by core, but not neccassarily set by the user.

/cc @J-N-K 