### PR TITLE
Make firmwareStatus field not final in DTO object

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
@@ -31,7 +31,7 @@ public class EnrichedThingDTO extends AbstractThingDTO {
 
     public List<EnrichedChannelDTO> channels;
     public ThingStatusInfo statusInfo;
-    public final FirmwareStatusDTO firmwareStatus;
+    public FirmwareStatusDTO firmwareStatus;
     public boolean editable;
 
     /**


### PR DESCRIPTION
Fix #3679

If not, calls of method limitToFields by PR #3335 fails when the list of fields does not contain firmwareStatus.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>