### PR TITLE
[voice] Reduce collisions on exact match and use item synonyms

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.NextPreviousType;
@@ -48,8 +49,8 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
 
     @Activate
     public StandardInterpreter(final @Reference EventPublisher eventPublisher,
-            final @Reference ItemRegistry itemRegistry) {
-        super(eventPublisher, itemRegistry);
+            final @Reference ItemRegistry itemRegistry, @Reference MetadataRegistry metadataRegistry) {
+        super(eventPublisher, itemRegistry, metadataRegistry);
     }
 
     @Override

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -12,16 +12,8 @@
  */
 package org.openhab.core.voice.text;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.ResourceBundle;
-import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -567,8 +559,8 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      */
     protected List<Item> getMatchingItems(ResourceBundle language, String[] labelFragments,
             @Nullable Class<?> commandType) {
-        List<Item> items = new ArrayList<>();
-        List<Item> exactMatchItems = new ArrayList<>();
+        Set<Item> items = new HashSet<>();
+        Set<Item> exactMatchItems = new HashSet<>();
         Map<Item, List<Set<String>>> map = getItemTokens(language.getLocale());
         for (Entry<Item, List<Set<String>>> entry : map.entrySet()) {
             Item item = entry.getKey();
@@ -601,16 +593,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
                             }
                         }
                         if (insert) {
-                            for (int i = 0; i < items.size(); i++) {
-                                String itemName = items.get(i).getName();
-                                if (itemName.startsWith(name)) {
-                                    logger.debug(
-                                            "Discarding partial matched item '{}' because its name starts with '{}'",
-                                            itemName, name);
-                                    items.remove(i);
-                                    i--;
-                                }
-                            }
+                            items.removeIf((matchedItem) -> matchedItem.getName().startsWith(name));
                             items.add(item);
                             if (exactMatch) {
                                 exactMatchItems.add(item);
@@ -627,7 +610,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             logger.debug("Exact matched items against {}{}: {}", labelFragments, typeDetails,
                     exactMatchItems.stream().map(Item::getName).toArray(String[]::new));
         }
-        return items.size() != 1 && exactMatchItems.size() == 1 ? exactMatchItems : items;
+        return new ArrayList<>(items.size() != 1 && exactMatchItems.size() == 1 ? exactMatchItems : items);
     }
 
     /**

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -621,7 +621,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             }
         }
         if (logger.isDebugEnabled()) {
-            String typeDetails = commandType != null ? " that accept " + commandType : "";
+            String typeDetails = commandType != null ? " that accept " + commandType.getSimpleName() : "";
             logger.debug("Partial matched items against {}{}: {}", labelFragments, typeDetails,
                     items.stream().map(Item::getName).toArray(String[]::new));
             logger.debug("Exact matched items against {}{}: {}", labelFragments, typeDetails,

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -200,9 +200,10 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     /**
      * Retrieves the list of identifier token sets per item currently contained in the {@link ItemRegistry}.
-     * Each item entry in the resulting hash map will feature a list of different token sets. Each token set
-     * represents one possible way "through" a chain of parent groups, where each groups tokenized name is
-     * part of the set.
+     * Each item entry in the resulting hash map will feature a list of different token lists. Each list
+     * represents one possible way "through" a chain of parent groups, where each groups name is tokenized
+     * into a list of strings and included as a member of the chain. Item synonym metadata options are
+     * used as alternative labels creating new alternative chains for the item.
      *
      * @param locale The locale that is to be used for preparing the tokens.
      * @return the list of identifier token sets per item
@@ -646,6 +647,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         for (Item si : items) {
             if (name.startsWith(si.getName())) {
                 insert = false;
+                break;
             }
         }
         if (insert) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -622,19 +622,9 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
                 logger.debug("Exact match: {}", exactMatch);
                 if (allMatch) {
                     if (commandType == null || item.getAcceptedCommandTypes().contains(commandType)) {
-                        String name = item.getName();
-                        boolean insert = true;
-                        for (Item si : items) {
-                            if (name.startsWith(si.getName())) {
-                                insert = false;
-                            }
-                        }
-                        if (insert) {
-                            items.removeIf((matchedItem) -> matchedItem.getName().startsWith(name));
-                            items.add(item);
-                            if (exactMatch) {
-                                exactMatchItems.add(item);
-                            }
+                        insertAndDiscardParents(items, item);
+                        if (exactMatch) {
+                            insertAndDiscardParents(exactMatchItems, item);
                         }
                     }
                 }
@@ -648,6 +638,20 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
                     exactMatchItems.stream().map(Item::getName).collect(Collectors.joining(", ")));
         }
         return new ArrayList<>(items.size() != 1 && exactMatchItems.size() == 1 ? exactMatchItems : items);
+    }
+
+    private static void insertAndDiscardParents(Set<Item> items, Item item) {
+        String name = item.getName();
+        boolean insert = true;
+        for (Item si : items) {
+            if (name.startsWith(si.getName())) {
+                insert = false;
+            }
+        }
+        if (insert) {
+            items.removeIf((matchedItem) -> matchedItem.getName().startsWith(name));
+            items.add(item);
+        }
     }
 
     /**

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -603,7 +603,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             Item item = entry.getKey();
             for (List<List<String>> parts : entry.getValue()) {
                 boolean exactMatch = false;
-                logger.debug("Checking tokens {} against the item tokens {}", labelFragments, parts);
+                logger.trace("Checking tokens {} against the item tokens {}", labelFragments, parts);
                 List<String> lowercaseLabelFragments = Arrays.stream(labelFragments)
                         .map(lf -> lf.toLowerCase(language.getLocale())).toList();
                 List<String> unmatchedFragments = new ArrayList<>(lowercaseLabelFragments);
@@ -618,13 +618,13 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
                     }
                 }
                 boolean allMatch = unmatchedFragments.isEmpty();
-                logger.debug("Partial match: {}", allMatch);
-                logger.debug("Exact match: {}", exactMatch);
+                logger.trace("Partial match: {}", allMatch);
+                logger.trace("Exact match: {}", exactMatch);
                 if (allMatch) {
                     if (commandType == null || item.getAcceptedCommandTypes().contains(commandType)) {
-                        insertAndDiscardParents(items, item);
+                        insertDiscardingMembers(items, item);
                         if (exactMatch) {
-                            insertAndDiscardParents(exactMatchItems, item);
+                            insertDiscardingMembers(exactMatchItems, item);
                         }
                     }
                 }
@@ -640,7 +640,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         return new ArrayList<>(items.size() != 1 && exactMatchItems.size() == 1 ? exactMatchItems : items);
     }
 
-    private static void insertAndDiscardParents(Set<Item> items, Item item) {
+    private static void insertDiscardingMembers(Set<Item> items, Item item) {
         String name = item.getName();
         boolean insert = true;
         for (Item si : items) {

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -13,10 +13,13 @@
 package org.openhab.core.voice.internal.text;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +28,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
 import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.items.events.ItemEventFactory;
 import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.voice.text.InterpretationException;
 
 /**
@@ -46,33 +52,68 @@ public class StandardInterpreterTest {
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) MetadataRegistry metadataRegistryMock;
     private @NonNullByDefault({}) StandardInterpreter standardInterpreter;
+    private static final String OK_RESPONSE = "Ok.";
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        List<Item> items = new ArrayList<>();
-        var computerItem = new SwitchItem("computer");
-        computerItem.setLabel("Computer");
-        MetadataKey computerMetadataKey = new MetadataKey("synonyms", computerItem.getName());
-        Mockito.when(metadataRegistryMock.get(computerMetadataKey))
-                .thenReturn(new Metadata(computerMetadataKey, "PC,Bedroom PC", null));
-        var computerScreenItem = new SwitchItem("screen");
-        computerScreenItem.setLabel("Computer Screen");
-        items.add(computerItem);
-        items.add(computerScreenItem);
-        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
-        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
         this.standardInterpreter = new StandardInterpreter(eventPublisherMock, itemRegistryMock, metadataRegistryMock);
     }
 
     @Test
     public void noNameCollisionOnSingleExactMatch() throws InterpretationException {
-        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
+        var computerItem = new SwitchItem("computer");
+        computerItem.setLabel("Computer");
+        var computerScreenItem = new SwitchItem("screen");
+        computerScreenItem.setLabel("Computer Screen");
+        List<Item> items = List.of(computerItem, computerScreenItem);
+        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
+        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+    }
+
+    @Test
+    public void noNameCollisionOnSingleExactMatchForGroups() throws InterpretationException {
+        var computerItem = Mockito.spy(new GroupItem("computer"));
+        computerItem.setLabel("Computer");
+        var computerSwitchItem = new SwitchItem("computer_power");
+        computerSwitchItem.setLabel("Power");
+        var screenItem = Mockito.spy(new GroupItem("screen"));
+        screenItem.setLabel("Computer Screen");
+        var screenSwitchItem = new SwitchItem("screen_power");
+        screenSwitchItem.setLabel("Power");
+        Mockito.when(computerItem.getMembers()).thenReturn(Set.of(computerSwitchItem));
+        Mockito.when(screenItem.getMembers()).thenReturn(Set.of(screenSwitchItem));
+        List<Item> items = List.of(computerItem, computerSwitchItem, screenItem, screenSwitchItem);
+        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
+        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(computerSwitchItem.getName(), OnOffType.OFF));
     }
 
     @Test
     public void allowUseItemSynonyms() throws InterpretationException {
-        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off pc"));
-        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off bedroom pc"));
+        var computerItem = new SwitchItem("computer");
+        computerItem.setLabel("Computer");
+        MetadataKey computerMetadataKey = new MetadataKey("synonyms", computerItem.getName());
+        Mockito.when(metadataRegistryMock.get(computerMetadataKey))
+                .thenReturn(new Metadata(computerMetadataKey, "PC,Bedroom PC", null));
+        List<Item> items = List.of(computerItem);
+        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
+        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off pc"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off bedroom pc"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Locale;
@@ -24,9 +25,10 @@ import java.util.Set;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
@@ -45,6 +47,7 @@ import org.openhab.core.voice.text.InterpretationException;
  * @author Miguel Álvarez - Initial contribution
  */
 @NonNullByDefault
+@ExtendWith(MockitoExtension.class)
 public class StandardInterpreterTest {
 
     private @Mock @NonNullByDefault({}) EventPublisher eventPublisherMock;
@@ -56,7 +59,6 @@ public class StandardInterpreterTest {
 
     @BeforeEach
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
         this.standardInterpreter = new StandardInterpreter(eventPublisherMock, itemRegistryMock, metadataRegistryMock);
     }
 
@@ -67,8 +69,7 @@ public class StandardInterpreterTest {
         var computerScreenItem = new SwitchItem("screen");
         computerScreenItem.setLabel("Computer Screen");
         List<Item> items = List.of(computerItem, computerScreenItem);
-        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
-        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        when(itemRegistryMock.getItems()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
@@ -84,11 +85,10 @@ public class StandardInterpreterTest {
         screenItem.setLabel("Computer Screen");
         var screenSwitchItem = new SwitchItem("screen_power");
         screenSwitchItem.setLabel("Power");
-        Mockito.when(computerItem.getMembers()).thenReturn(Set.of(computerSwitchItem));
-        Mockito.when(screenItem.getMembers()).thenReturn(Set.of(screenSwitchItem));
+        when(computerItem.getMembers()).thenReturn(Set.of(computerSwitchItem));
+        when(screenItem.getMembers()).thenReturn(Set.of(screenSwitchItem));
         List<Item> items = List.of(computerItem, computerSwitchItem, screenItem, screenSwitchItem);
-        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
-        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        when(itemRegistryMock.getItems()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerSwitchItem.getName(), OnOffType.OFF));
@@ -99,11 +99,10 @@ public class StandardInterpreterTest {
         var computerItem = new SwitchItem("computer");
         computerItem.setLabel("Computer");
         MetadataKey computerMetadataKey = new MetadataKey("synonyms", computerItem.getName());
-        Mockito.when(metadataRegistryMock.get(computerMetadataKey))
+        when(metadataRegistryMock.get(computerMetadataKey))
                 .thenReturn(new Metadata(computerMetadataKey, "PC,Bedroom PC", null));
         List<Item> items = List.of(computerItem);
-        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
-        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        when(itemRegistryMock.getItems()).thenReturn(items);
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -66,7 +66,7 @@ public class StandardInterpreterTest {
     }
 
     @Test
-    public void thereAreNoNameCollisions() throws InterpretationException {
+    public void noNameCollisionOnSingleExactMatch() throws InterpretationException {
         assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
     }
 

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.voice.internal.text;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataRegistry;
+import org.openhab.core.library.items.SwitchItem;
+import org.openhab.core.voice.text.InterpretationException;
+
+/**
+ * Test the standard interpreter
+ *
+ * @author Miguel Álvarez - Initial contribution
+ */
+@NonNullByDefault
+public class StandardInterpreterTest {
+
+    private @Mock @NonNullByDefault({}) EventPublisher eventPublisherMock;
+
+    private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
+    private @Mock @NonNullByDefault({}) MetadataRegistry metadataRegistryMock;
+    private @NonNullByDefault({}) StandardInterpreter standardInterpreter;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        List<Item> items = new ArrayList<>();
+        var computerItem = new SwitchItem("computer");
+        computerItem.setLabel("Computer");
+        MetadataKey computerMetadataKey = new MetadataKey("synonyms", computerItem.getName());
+        Mockito.when(metadataRegistryMock.get(computerMetadataKey))
+                .thenReturn(new Metadata(computerMetadataKey, "PC,Bedroom PC", null));
+        var computerScreenItem = new SwitchItem("screen");
+        computerScreenItem.setLabel("Computer Screen");
+        items.add(computerItem);
+        items.add(computerScreenItem);
+        Mockito.when(itemRegistryMock.getAll()).thenReturn(items);
+        Mockito.when(itemRegistryMock.getItems()).thenReturn(items);
+        this.standardInterpreter = new StandardInterpreter(eventPublisherMock, itemRegistryMock, metadataRegistryMock);
+    }
+
+    @Test
+    public void thereAreNoNameCollisions() throws InterpretationException {
+        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off computer"));
+    }
+
+    @Test
+    public void allowUseItemSynonyms() throws InterpretationException {
+        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off pc"));
+        assertEquals("Ok.", standardInterpreter.interpret(Locale.ENGLISH, "turn off bedroom pc"));
+    }
+}


### PR DESCRIPTION
Hi openHAB maintainers, I would like to add this changes to the StandardInterpreter so it uses the item synonyms and to reduce collision between items labels in case of single exact match. I think the changes can be seen as a bug fix as the current item resolution method is unchanged an takes priority in case of succeed.

Note that I have added a test suite for the StandardInterpreter with tests cases for the changes included and also some debug logs to the AbstractRuleBasedInterpreter getMatchingItems method so users have a way to know what the collisions are.

Hope everything is in place.

Best regards