### PR TITLE
[voice] Add length limit to TTS handled by cache

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
@@ -53,6 +53,7 @@ public class TTSLRUCacheImpl implements TTSCache {
 
     // a small default cache size for all the TTS services (in kB)
     private static final long DEFAULT_CACHE_SIZE_TTS = 10240;
+    private static final int DEFAULT_MAX_TEXT_LENGTH_CACHE_TTS = 150;
 
     static final String CONFIG_CACHE_SIZE_TTS = "cacheSizeTTS";
     static final String CONFIG_ENABLE_CACHE_TTS = "enableCacheTTS";
@@ -68,10 +69,11 @@ public class TTSLRUCacheImpl implements TTSCache {
      */
     protected long cacheSizeTTS = DEFAULT_CACHE_SIZE_TTS * 1024;
     /**
-     * Length text limit. If exceeded, the cache will passthrough the request without storing it.
-     * (One can safely assume that long TTS are generated for report, probably not meant to be repeated)
+     * The maximum length of texts handled by the TTS cache (in character). If exceeded, will pass the text to
+     * the TTS without storing it. (One can safely assume that long TTS are generated for report, probably not meant to
+     * be repeated)
      */
-    private long maxTextLengthCacheTTS = 150;
+    private long maxTextLengthCacheTTS = DEFAULT_MAX_TEXT_LENGTH_CACHE_TTS;
     protected boolean enableCacheTTS = true;
 
     private StorageService storageService;
@@ -96,7 +98,7 @@ public class TTSLRUCacheImpl implements TTSCache {
         this.cacheSizeTTS = ConfigParser.valueAsOrElse(config.get(CONFIG_CACHE_SIZE_TTS), Long.class,
                 DEFAULT_CACHE_SIZE_TTS) * 1024;
         this.maxTextLengthCacheTTS = ConfigParser.valueAsOrElse(config.get(CONFIG_MAX_TEXTLENGTH_CACHE_TTS),
-                Integer.class, 150);
+                Integer.class, DEFAULT_MAX_TEXT_LENGTH_CACHE_TTS);
 
         if (enableCacheTTS) {
             this.lruMediaCache = new LRUMediaCache<>(storageService, cacheSizeTTS, VOICE_TTS_CACHE_PID,

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/config/voice.xml
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/config/voice.xml
@@ -59,6 +59,12 @@
 			<description>The limit size of the TTS cache (in kB).</description>
 			<default>10240</default>
 		</parameter>
+		<parameter name="maxTextLengthCacheTTS" type="integer">
+			<label>TTS Cache Maximum Text Length</label>
+			<description>The limit length of a text handled by the TTS cache. If exceeded, will passthrough to the TTS without
+				storing it. 0 for no limit.</description>
+			<default>150</default>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/config/voice.xml
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/config/voice.xml
@@ -61,8 +61,8 @@
 		</parameter>
 		<parameter name="maxTextLengthCacheTTS" type="integer">
 			<label>TTS Cache Maximum Text Length</label>
-			<description>The limit length of a text handled by the TTS cache. If exceeded, will passthrough to the TTS without
-				storing it. 0 for no limit.</description>
+			<description>The maximum length of texts handled by the TTS cache (in character). If exceeded, will pass the text to
+				the TTS without storing it. 0 for no limit.</description>
 			<default>150</default>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
@@ -17,6 +17,12 @@ system.config.voice.listeningMelody.description = A melody to be played to adver
 system.config.voice.listeningMelody.option.Bb = Bb
 system.config.voice.listeningMelody.option.F# = F#
 system.config.voice.listeningMelody.option.E = E
+system.config.voice.enableCacheTTS.label = Enable TTS caching
+system.config.voice.enableCacheTTS.description = true to allow TTS services to cache audio files on disk.
+system.config.voice.cacheSizeTTS.label = TTS Cache Size
+system.config.voice.cacheSizeTTS.description = The limit size of the TTS cache (in kB).
+system.config.voice.maxTextLengthCacheTTS.label = TTS Cache Maximum Text Length
+system.config.voice.maxTextLengthCacheTTS.description = The limit length of a text handled by the TTS cache. If exceeded, will passthrough to the TTS without storing it. 0 for no limit.
 
 error.ks-error = Encountered error while spotting keywords, {0}
 error.stt-error = Encountered error while recognizing text, {0}


### PR DESCRIPTION
During the TTS cache development, there was some discussion about adding a boolean to enable / disable cache per request. We didn't keep that because it makes the API complicated.
But time passed and new usages arise, and maybe it now can be discussed, on a new form ?

For example, there is now a ChatGPT binding. It is possible to make some  advanced chat/queries with a LLM. Most of the time, the chat response are lengthy. And so one "discussion" with a LLM can clog the LRU cache and removes older entries worth keeping.

Proposal :
We can use the TTS length as a simple way to differentiate TTS sentences that should be cached, automatically. 
TTS we should cache are those that can be repeated, and they are nearly always pretty short. examples :
"Ok, I'll do that"
"Hello, what can I do for you ?",
"You've got a message"
"Please close the garage door".

On the other side, one can safely assume that long TTS are generated for report of some kind (meteo, chatGPT ?), probably not meant to be repeated. They are also the ones taking the most space in the cache.

I put a 150 default character limit (configurable). To be discussed if the whole idea worth something.
