### PR TITLE
[Sitemap UI] Do not break format defined in label with extra spaces

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -515,7 +515,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                             "Item '{}' with unit, nothing allowed after unit in label pattern '{}', dropping postfix",
                             itemName, pattern);
                 }
-                pattern = pattern.substring(0, matcherEnd) + (!unit.isBlank() ? " " + unit : "");
+                pattern = unit.isBlank() ? pattern.substring(0, matcherEnd)
+                        : pattern.substring(0, pattern.indexOf(unit, matcherEnd) + unit.length());
             }
         } catch (ItemNotFoundException e) {
             logger.warn("Cannot retrieve item '{}' for widget {}", itemName, w.eClass().getInstanceTypeName());


### PR DESCRIPTION
Fix openhab/openhab-webui#1953

Fix a regression introduced by PR #3644

Signed-off-by: Laurent Garnier <lg.hc@free.fr>