### PR TITLE
Use Eclipse formatter 4.25 with Spotless

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -137,10 +137,9 @@ public class AutomaticInboxProcessorTest {
         when(thingHandlerFactoryMock.supportsThingType(eq(THING_TYPE_UID3))).thenReturn(true);
         when(thingHandlerFactoryMock.createThing(any(ThingTypeUID.class), any(Configuration.class), any(ThingUID.class),
                 nullable(ThingUID.class)))
-                        .then(invocation -> ThingBuilder
-                                .create((ThingTypeUID) invocation.getArguments()[0],
-                                        (ThingUID) invocation.getArguments()[2])
-                                .withConfiguration((Configuration) invocation.getArguments()[1]).build());
+                .then(invocation -> ThingBuilder
+                        .create((ThingTypeUID) invocation.getArguments()[0], (ThingUID) invocation.getArguments()[2])
+                        .withConfiguration((Configuration) invocation.getArguments()[1]).build());
 
         inbox = new PersistentInbox(new VolatileStorageService(), mock(DiscoveryServiceRegistry.class),
                 thingRegistryMock, thingProviderMock, thingTypeRegistryMock, configDescriptionRegistryMock);

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -97,10 +97,10 @@ public class PersistentInboxTest {
         when(thingHandlerFactoryMock.createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_UID), any()))
                 .then(invocation -> ThingBuilder.create(THING_TYPE_UID, "test")
                         .withConfiguration((Configuration) invocation.getArguments()[1]).build());
-        when(thingHandlerFactoryMock
-                .createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_OTHER_UID), any()))
-                        .then(invocation -> ThingBuilder.create(THING_TYPE_UID, THING_OTHER_ID)
-                                .withConfiguration((Configuration) invocation.getArguments()[1]).build());
+        when(thingHandlerFactoryMock.createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_OTHER_UID),
+                any()))
+                .then(invocation -> ThingBuilder.create(THING_TYPE_UID, THING_OTHER_ID)
+                        .withConfiguration((Configuration) invocation.getArguments()[1]).build());
         inbox = new PersistentInbox(storageServiceMock, mock(DiscoveryServiceRegistry.class), thingRegistryMock,
                 thingProviderMock, thingTypeRegistryMock, configDescriptionRegistryMock);
         inbox.addThingHandlerFactory(thingHandlerFactoryMock);

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
@@ -92,7 +92,7 @@ public class CommonWebSocketServletTest {
 
     @Test
     public void createWebsocketUsingAdapterPath() throws URISyntaxException {
-        when(request.getRequestURI()).thenReturn(new URI("http://127.0.0.1:8080/ws/"+ testAdapterId));
+        when(request.getRequestURI()).thenReturn(new URI("http://127.0.0.1:8080/ws/" + testAdapterId));
         webSocketCreatorAC.getValue().createWebSocket(request, response);
         verify(testWsAdapter, times(1)).createWebSocket(request, response);
     }

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceEqualsFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceEqualsFilterTest.java
@@ -53,7 +53,7 @@ public class PersistenceEqualsFilterTest {
 
     @ParameterizedTest
     @MethodSource("argumentProvider")
-    public void equalsFilterTest(State state, Collection<String> values,  boolean expected) {
+    public void equalsFilterTest(State state, Collection<String> values, boolean expected) {
         when(item.getState()).thenReturn(state);
 
         PersistenceEqualsFilter filter = new PersistenceEqualsFilter("filter", values, false);
@@ -62,7 +62,7 @@ public class PersistenceEqualsFilterTest {
 
     @ParameterizedTest
     @MethodSource("argumentProvider")
-    public void notEqualsFilterTest(State state, Collection<String> values,  boolean expected) {
+    public void notEqualsFilterTest(State state, Collection<String> values, boolean expected) {
         when(item.getState()).thenReturn(state);
 
         PersistenceEqualsFilter filter = new PersistenceEqualsFilter("filter", values, true);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceIncludeFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceIncludeFilterTest.java
@@ -48,7 +48,7 @@ public class PersistenceIncludeFilterTest {
 
     @ParameterizedTest
     @MethodSource("argumentProvider")
-    public void includeFilterTest(State state, BigDecimal lower,  BigDecimal upper, String unit, boolean expected) {
+    public void includeFilterTest(State state, BigDecimal lower, BigDecimal upper, String unit, boolean expected) {
         when(item.getState()).thenReturn(state);
 
         PersistenceIncludeFilter filter = new PersistenceIncludeFilter("filter", lower, upper, unit, false);
@@ -57,7 +57,7 @@ public class PersistenceIncludeFilterTest {
 
     @ParameterizedTest
     @MethodSource("notArgumentProvider")
-    public void notIncludeFilterTest(State state, BigDecimal lower,  BigDecimal upper, String unit, boolean expected) {
+    public void notIncludeFilterTest(State state, BigDecimal lower, BigDecimal upper, String unit, boolean expected) {
         when(item.getState()).thenReturn(state);
 
         PersistenceIncludeFilter filter = new PersistenceIncludeFilter("filter", lower, upper, unit, true);

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -97,7 +97,8 @@ public class AutoUpdateManagerTest extends JavaTest {
     @Test
     public void testAutoUpdateVetoFromChannelType() {
         when(channelTypeRegistry.getChannelType(any(ChannelTypeUID.class)))
-                .thenReturn(ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "label", CoreItemFactory.SWITCH).withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build());
+                .thenReturn(ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "label", CoreItemFactory.SWITCH)
+                        .withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build());
 
         autoUpdateManager.receiveCommand(ItemEventFactory.createCommandEvent(ITEM_NAME, OnOffType.ON), item);
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,9 @@
     <sat.version>0.15.0</sat.version>
     <slf4j.version>1.7.32</slf4j.version>
     <xtext.version>2.29.0</xtext.version>
-    <spotless.version>2.35.0</spotless.version>
-    <spotless.eclipse.version>4.26</spotless.eclipse.version>
+    <spotless.version>2.37.0</spotless.version>
+    <!-- Eclipse Java formatter version 4.26+ does not check test files -->
+    <spotless.eclipse.version>4.25</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>
   </properties>
 


### PR DESCRIPTION
This is the result after running:

`mvn spotless:apply -Dspotless.eclipse.version=4.25`

Perhaps we should just revert the version in the property?
I still don't know of any negative side effects and the PR will probably also build successfully while it is uses 4.26.

See also https://github.com/openhab/openhab-core/issues/3515#issuecomment-1493256202.
