### PR TITLE
[rest] Add missing fields to /rest/items?staticDataOnly=true resource

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -263,7 +263,7 @@ public class ItemResource implements RESTResource {
                     .peek(dto -> addMetadata(dto, namespaces, null)) //
                     .peek(dto -> dto.editable = isEditable(dto.name));
             itemStream = dtoMapper.limitToFields(itemStream,
-                    "name,label,type,groupType,function,category,editable,groupNames,link,tags,metadata");
+                    "name,label,type,groupType,function,category,editable,groupNames,link,tags,metadata,commandDescription,stateDescription");
 
             CacheControl cc = new CacheControl();
             cc.setMustRevalidate(true);


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/1958.

I have checked the contents of those two fields, they should not change without a user-change to the Item.

@openhab/core-maintainers Can this please be merged for openHAB 4? The linked UI issue is a regression from https://github.com/openhab/openhab-webui/pull/1661 and https://github.com/openhab/openhab-core/pull/3335.

@ghys FYI.