### PR TITLE
[persistence] Handle null value for unit field of filters

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
@@ -15,6 +15,7 @@ package org.openhab.core.persistence.filter;
 import java.math.BigDecimal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
@@ -38,11 +39,12 @@ public class PersistenceIncludeFilter extends PersistenceFilter {
     private final String unit;
     private final boolean inverted;
 
-    public PersistenceIncludeFilter(String name, BigDecimal lower, BigDecimal upper, String unit, boolean inverted) {
+    public PersistenceIncludeFilter(String name, BigDecimal lower, BigDecimal upper, @Nullable String unit,
+            boolean inverted) {
         super(name);
         this.lower = lower;
         this.upper = upper;
-        this.unit = unit;
+        this.unit = (unit == null) ? "" : unit;
         this.inverted = inverted;
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import javax.measure.UnconvertibleException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
@@ -47,10 +48,10 @@ public class PersistenceThresholdFilter extends PersistenceFilter {
 
     private final transient Map<String, State> valueCache = new HashMap<>();
 
-    public PersistenceThresholdFilter(String name, BigDecimal value, String unit, boolean relative) {
+    public PersistenceThresholdFilter(String name, BigDecimal value, @Nullable String unit, boolean relative) {
         super(name);
         this.value = value;
-        this.unit = unit;
+        this.unit = (unit == null) ? "" : unit;
         this.relative = relative;
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceTimeFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceTimeFilter.java
@@ -38,10 +38,10 @@ public class PersistenceTimeFilter extends PersistenceFilter {
     private transient @Nullable Duration duration;
     private final transient Map<String, ZonedDateTime> nextPersistenceTimes = new HashMap<>();
 
-    public PersistenceTimeFilter(String name, int value, String unit) {
+    public PersistenceTimeFilter(String name, int value, @Nullable String unit) {
         super(name);
         this.value = value;
-        this.unit = unit;
+        this.unit = (unit == null) ? "s" : unit;
     }
 
     public int getValue() {


### PR DESCRIPTION
Setting up a treshold filter with the UI, it did not work because the unit field was blank. I got an NPE from PersistenceTresholdFilter, and the PersistenceIncludeFilter would also throw a NPE in that case. For PersistenceTimeFilter, defaulting to "s" is just cosmetic.

@J-N-K Picks-up PR #3681 and should be merged for the 4.0 release, because the UI does not prevent the unit field from being null.
