### PR TITLE
Provide correct version information for XChart in NOTICE

### DIFF
--- a/bundles/org.openhab.core.ui/NOTICE
+++ b/bundles/org.openhab.core.ui/NOTICE
@@ -15,10 +15,10 @@ https://github.com/openhab/openhab-core
 
 == Third-party Content
 
-xchart-2.6.1
+xchart-3.1.0
 * License: Apache License, 2.0
 * Project: http://knowm.org/open-source/xchart
-* Source: https://github.com/timmolter/XChart/tree/xchart-2.6.1
+* Source: https://github.com/timmolter/XChart/tree/xchart-3.1.0
 
 == Third-party license(s)
 


### PR DESCRIPTION
@kaikreuzer This is basically the PR you requested. We want to make sure we provide accurate information about the XChart version used in our NOTICE file. For some reason it was outdated.