### PR TITLE
[Auth Filter] Fix implicit user role for websocket connections

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AuthFilter.java
@@ -296,7 +296,7 @@ public class AuthFilter implements ContainerRequestFilter {
                         return authenticateBasicAuth(authValue);
                 }
             }
-        } else if (isImplicitUserRole(servletRequest)) {
+        } else if (isImplicitUserRole(request)) {
             return new AnonymousUserSecurityContext();
         }
         return null;
@@ -332,7 +332,7 @@ public class AuthFilter implements ContainerRequestFilter {
     private String getClientIp(HttpServletRequest request) throws UnknownHostException {
         String ipForwarded = Objects.requireNonNullElse(request.getHeader("x-forwarded-for"), "");
         String clientIp = ipForwarded.split(",")[0];
-        return clientIp.isBlank() ? servletRequest.getRemoteAddr() : clientIp;
+        return clientIp.isBlank() ? request.getRemoteAddr() : clientIp;
     }
 
     private static class CIDR {


### PR DESCRIPTION
Hi openHAB maintainers.

I just discovered testing the version 4.0.0 RC1 that I left a bug on the check of the trusted networks for the WebSocket connections.

I just by mistake couple of times servletRequest instead of request which do not api the api call validations as in that case both point to the same ref, but causes a null pointer exception when validating a websocket connection.

This issue is reproducible when you have implicitRole disabled but trustedNetworks configured in the "API Security" options and connect over WebSocket to the server (using the functionality exposed by the bundle org.openhab.core.io.websocket).