### PR TITLE
[persistence] Handle `null` value for `relative` & `inverted` props of filters

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceEqualsFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceEqualsFilter.java
@@ -15,6 +15,7 @@ package org.openhab.core.persistence.filter;
 import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.Item;
 
 /**
@@ -29,10 +30,10 @@ public class PersistenceEqualsFilter extends PersistenceFilter {
     private final Collection<String> values;
     private final boolean inverted;
 
-    public PersistenceEqualsFilter(String name, Collection<String> values, boolean inverted) {
+    public PersistenceEqualsFilter(String name, Collection<String> values, @Nullable Boolean inverted) {
         super(name);
         this.values = values;
-        this.inverted = inverted;
+        this.inverted = (inverted == null) ? false : inverted;
     }
 
     public Collection<String> getValues() {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
@@ -40,12 +40,12 @@ public class PersistenceIncludeFilter extends PersistenceFilter {
     private final boolean inverted;
 
     public PersistenceIncludeFilter(String name, BigDecimal lower, BigDecimal upper, @Nullable String unit,
-            boolean inverted) {
+            @Nullable Boolean inverted) {
         super(name);
         this.lower = lower;
         this.upper = upper;
         this.unit = (unit == null) ? "" : unit;
-        this.inverted = inverted;
+        this.inverted = (inverted == null) ? false : inverted;
     }
 
     public BigDecimal getLower() {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
@@ -48,11 +48,12 @@ public class PersistenceThresholdFilter extends PersistenceFilter {
 
     private final transient Map<String, State> valueCache = new HashMap<>();
 
-    public PersistenceThresholdFilter(String name, BigDecimal value, @Nullable String unit, boolean relative) {
+    public PersistenceThresholdFilter(String name, BigDecimal value, @Nullable String unit,
+            @Nullable Boolean relative) {
         super(name);
         this.value = value;
         this.unit = (unit == null) ? "" : unit;
-        this.relative = relative;
+        this.relative = (relative == null) ? false : relative;
     }
 
     public BigDecimal getValue() {


### PR DESCRIPTION
This allows the UI to remove some specific checks that are performed on every save, and simplifies usage of the API for external applications.