### PR TITLE
Return units in persistence extension commands and support future persisted states

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -444,7 +444,7 @@ public class PersistenceExtensions {
     /**
      * Returns the next state of a given <code>item</code>.
      *
-     * @param item the item to get the previous state value for
+     * @param item the item to get the next state value for
      * @param skipEqual if true, skips equal state values and searches the first state not equal the current state
      * @return the next state or <code>null</code> if no next state could be found, or if the default
      *         persistence service is not configured or does not refer to a {@link QueryablePersistenceService}
@@ -1439,9 +1439,8 @@ public class PersistenceExtensions {
      *
      * @param item the item for which we will sum its persisted state values since <code>timestamp</code>
      * @param timestamp the point in time from which to start the summation
-     * @return the sum of the state values since <code>timestamp</code>, or {@link DecimalType#ZERO} if no historic
-     *         states could be found or if the default persistence service does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return the sum of the state values since <code>timestamp</code>, or null if <code>timestamp</code> is in the
+     *         future or the default persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public @Nullable static State sumSince(Item item, ZonedDateTime timestamp) {
         return internalSumBetween(item, timestamp, null);
@@ -1453,9 +1452,8 @@ public class PersistenceExtensions {
      *
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
      * @param timestamp the point in time to which to start the summation
-     * @return the sum of the state values to <code>timestamp</code>, or {@link DecimalType#ZERO} if no historic
-     *         states could be found or if the default persistence service does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return the sum of the state values until <code>timestamp</code>, or null if <code>timestamp</code> is in the
+     *         past or the default persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public @Nullable static State sumUntil(Item item, ZonedDateTime timestamp) {
         return internalSumBetween(item, null, timestamp);
@@ -1469,8 +1467,8 @@ public class PersistenceExtensions {
      *            <code>end</code>
      * @param begin the point in time from which to start the summation
      * @param end the point in time to which to start the summation
-     * @return the sum of the state values between the given points in time, or {@link DecimalType#ZERO} if no historic
-     *         states could be found or if the default persistence service does not refer to a
+     * @return the sum of the state values between the given points in time, or null if <code>begin</code> is after
+     *         <code>end</code> or if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public @Nullable static State sumBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
@@ -1484,9 +1482,8 @@ public class PersistenceExtensions {
      * @param item the item for which we will sum its persisted state values since <code>timestamp</code>
      * @param timestamp the point in time from which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the sum of the state values since the given point in time, or {@link DecimalType#ZERO} if no historic
-     *         states could be found for the <code>item</code> or if <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return the sum of the state values since <code>timestamp</code>, or null if <code>timestamp</code> is in the
+     *         future or <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public @Nullable static State sumSince(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalSumBetween(item, timestamp, null, serviceId);
@@ -1499,9 +1496,8 @@ public class PersistenceExtensions {
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
      * @param timestamp the point in time to which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the sum of the state values to the given point in time, or {@link DecimalType#ZERO} if no historic
-     *         states could be found for the <code>item</code> or if <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return the sum of the state values until <code>timestamp</code>, or null if <code>timestamp</code> is in the
+     *         past or <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public @Nullable static State sumUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalSumBetween(item, null, timestamp, serviceId);
@@ -1516,9 +1512,8 @@ public class PersistenceExtensions {
      * @param begin the point in time from which to start the summation
      * @param end the point in time to which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the sum of the state values between the given points in time, or {@link DecimalType#ZERO} if no historic
-     *         states could be found for the <code>item</code> or if <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return the sum of the state values between the given points in time, or null if <code>begin</code> is after
+     *         <code>end</code> or <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public @Nullable static State sumBetween(Item item, ZonedDateTime begin, ZonedDateTime end, String serviceId) {
         return internalSumBetween(item, begin, end, serviceId);

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1678,6 +1678,27 @@ public class PersistenceExtensions {
      * Gets the evolution rate of the state of a given {@link Item} since a certain point in time.
      * The default {@link PersistenceService} is used.
      *
+     * This method has been deprecated and {@link #evolutionRateSince(Item, ZonedDateTime)} should be used instead.
+     *
+     * @param item the item to get the evolution rate value for
+     * @param timestamp the point in time from which to compute the evolution rate
+     * @return the evolution rate in percent (positive and negative) between now and then, or <code>null</code> if
+     *         there is no default persistence service available, the default persistence service is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>, or if there is a state but it is zero (which would cause a
+     *         divide-by-zero error)
+     */
+    @Deprecated
+    public static @Nullable DecimalType evolutionRate(Item item, ZonedDateTime timestamp) {
+        LoggerFactory.getLogger(PersistenceExtensions.class).info(
+                "The evolutionRate method has been deprecated and will be removed in a future version, use evolutionRateSince instead.");
+        return internalEvolutionRateBetween(item, timestamp, null);
+    }
+
+    /**
+     * Gets the evolution rate of the state of a given {@link Item} since a certain point in time.
+     * The default {@link PersistenceService} is used.
+     *
      * @param item the item to get the evolution rate value for
      * @param timestamp the point in time from which to compute the evolution rate
      * @return the evolution rate in percent (positive and negative) between now and then, or <code>null</code> if
@@ -1721,6 +1742,30 @@ public class PersistenceExtensions {
      */
     public static @Nullable DecimalType evolutionRateBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalEvolutionRateBetween(item, begin, end);
+    }
+
+    /**
+     * Gets the evolution rate of the state of a given {@link Item} since a certain point in time.
+     * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * This method has been deprecated and {@link #evolutionRateSince(Item, ZonedDateTime, String)} should be used
+     * instead.
+     *
+     * @param item the {@link Item} to get the evolution rate value for
+     * @param timestamp the point in time from which to compute the evolution rate
+     * @param serviceId the name of the {@link PersistenceService} to use
+     * @return the evolution rate in percent (positive and negative) between now and then, or <code>null</code> if
+     *         the persistence service given by <code>serviceId</code> is not available or is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given
+     *         <code>item</code> at the given <code>timestamp</code> using the persistence service given by
+     *         <code>serviceId</code>, or if there is a state but it is zero (which would cause a divide-by-zero
+     *         error)
+     */
+    @Deprecated
+    public static @Nullable DecimalType evolutionRate(Item item, ZonedDateTime timestamp, String serviceId) {
+        LoggerFactory.getLogger(PersistenceExtensions.class).info(
+                "The evolutionRate method has been deprecated and will be removed in a future version, use evolutionRateSince instead.");
+        return internalEvolutionRateBetween(item, timestamp, null, serviceId);
     }
 
     /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -2043,8 +2043,10 @@ public class PersistenceExtensions {
      *
      * @param item the item for which to retrieve the historic item
      * @param timestamp the point in time from which to retrieve the states
-     * @return the historic items since the given point in time, or <code>null</code> if no historic items could be
-     *         found.
+     * @return the historic items since the given point in time, or <code>null</code>
+     *         if the default persistence service is not available or does not refer to a
+     *         {@link QueryablePersistenceService}
+     * 
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesSince(Item item, ZonedDateTime timestamp) {
         return internalGetAllStatesBetween(item, timestamp, null);
@@ -2056,8 +2058,9 @@ public class PersistenceExtensions {
      *
      * @param item the item for which to retrieve the future item
      * @param timestamp the point in time to which to retrieve the states
-     * @return the future items to the given point in time, or <code>null</code> if no future items could be
-     *         found.
+     * @return the future items to the given point in time, or <code>null</code>
+     *         if the default persistence service is not available or does not refer to a
+     *         {@link QueryablePersistenceService}
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesTill(Item item, ZonedDateTime timestamp) {
         return internalGetAllStatesBetween(item, null, timestamp);
@@ -2070,8 +2073,9 @@ public class PersistenceExtensions {
      * @param item the item for which to retrieve the historic item
      * @param begin the point in time from which to retrieve the states
      * @param end the point in time to which to retrieve the states
-     * @return the historic items between the given points in time, or <code>null</code> if no historic items could be
-     *         found.
+     * @return the historic items between the given points in time, or <code>null</code>
+     *         if the default persistence service is not available or does not refer to a
+     *         {@link QueryablePersistenceService}
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesBetween(Item item, ZonedDateTime begin,
             ZonedDateTime end) {
@@ -2085,8 +2089,8 @@ public class PersistenceExtensions {
      * @param item the item for which to retrieve the historic item
      * @param timestamp the point in time from which to retrieve the states
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the future items to the given point in time, or <code>null</code> if no historic items could be
-     *         found or if the provided <code>serviceId</code> does not refer to an available
+     * @return the historic items since the given point in time, or <code>null</code>
+     *         if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesSince(Item item, ZonedDateTime timestamp,
@@ -2101,8 +2105,8 @@ public class PersistenceExtensions {
      * @param item the item for which to retrieve the future item
      * @param timestamp the point in time to which to retrieve the states
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic items since the given point in time, or <code>null</code> if no historic items could be
-     *         found or if the provided <code>serviceId</code> does not refer to an available
+     * @return the future items to the given point in time, or <code>null</code>
+     *         if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesTill(Item item, ZonedDateTime timestamp,
@@ -2118,8 +2122,8 @@ public class PersistenceExtensions {
      * @param begin the point in time from which to retrieve the states
      * @param end the point in time to which to retrieve the states
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic items between the given points in time, or <code>null</code> if no historic items could be
-     *         found or if the provided <code>serviceId</code> does not refer to an available
+     * @return the historic items between the given points in time, or <code>null</code>
+     *         if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesBetween(Item item, ZonedDateTime begin,

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -147,7 +147,7 @@ public class PersistenceExtensions {
 
     private static void internalPersist(Item item, ZonedDateTime timestamp, State state, String serviceId) {
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof ModifiablePersistenceService modifiableService) {
+        if (service instanceof ModifiablePersistenceService modifiableService) {
             modifiableService.store(item, timestamp, state, serviceId);
             return;
         }
@@ -189,7 +189,7 @@ public class PersistenceExtensions {
         PersistenceService service = getService(serviceId);
         TimeZoneProvider tzProvider = timeZoneProvider;
         ZoneId timeZone = tzProvider != null ? tzProvider.getTimeZone() : ZoneId.systemDefault();
-        if (service != null && service instanceof ModifiablePersistenceService modifiableService) {
+        if (service instanceof ModifiablePersistenceService modifiableService) {
             timeSeries.getStates()
                     .forEach(s -> modifiableService.store(item, s.timestamp().atZone(timeZone), s.state(), serviceId));
             return;
@@ -277,7 +277,7 @@ public class PersistenceExtensions {
             return null;
         }
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof QueryablePersistenceService qService) {
+        if (service instanceof QueryablePersistenceService qService) {
             FilterCriteria filter = new FilterCriteria();
             filter.setEndDate(timestamp);
             filter.setItemName(item.getName());
@@ -286,12 +286,11 @@ public class PersistenceExtensions {
             Iterable<HistoricItem> result = qService.query(filter);
             if (result.iterator().hasNext()) {
                 return result.iterator().next();
-            } else {
-                return null;
             }
+        } else {
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         }
-        LoggerFactory.getLogger(PersistenceExtensions.class)
-                .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         return null;
     }
 
@@ -352,7 +351,7 @@ public class PersistenceExtensions {
 
     private static @Nullable ZonedDateTime internalAdjacentUpdate(Item item, boolean forward, String serviceId) {
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof QueryablePersistenceService qService) {
+        if (service instanceof QueryablePersistenceService qService) {
             FilterCriteria filter = new FilterCriteria();
             filter.setItemName(item.getName());
             if (forward) {
@@ -365,12 +364,11 @@ public class PersistenceExtensions {
             Iterable<HistoricItem> result = qService.query(filter);
             if (result.iterator().hasNext()) {
                 return result.iterator().next().getTimestamp();
-            } else {
-                return null;
             }
+        } else {
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         }
-        LoggerFactory.getLogger(PersistenceExtensions.class)
-                .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         return null;
     }
 
@@ -484,7 +482,7 @@ public class PersistenceExtensions {
     private static @Nullable HistoricItem internalAdjacentState(Item item, boolean skipEqual, boolean forward,
             String serviceId) {
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof QueryablePersistenceService qService) {
+        if (service instanceof QueryablePersistenceService qService) {
             FilterCriteria filter = new FilterCriteria();
             filter.setItemName(item.getName());
             if (forward) {
@@ -516,9 +514,10 @@ public class PersistenceExtensions {
                     items = null;
                 }
             }
+        } else {
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         }
-        LoggerFactory.getLogger(PersistenceExtensions.class)
-                .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         return null;
     }
 
@@ -2182,7 +2181,7 @@ public class PersistenceExtensions {
     private static @Nullable Iterable<HistoricItem> internalGetAllStatesBetween(Item item,
             @Nullable ZonedDateTime begin, @Nullable ZonedDateTime end, String serviceId) {
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof QueryablePersistenceService qService) {
+        if (service instanceof QueryablePersistenceService qService) {
             FilterCriteria filter = new FilterCriteria();
             ZonedDateTime now = ZonedDateTime.now();
             if ((begin == null && end == null) || (begin != null && end == null && begin.isAfter(now))
@@ -2206,9 +2205,10 @@ public class PersistenceExtensions {
             filter.setOrdering(Ordering.ASCENDING);
 
             return qService.query(filter);
+        } else {
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         }
-        LoggerFactory.getLogger(PersistenceExtensions.class)
-                .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         return null;
     }
 
@@ -2300,7 +2300,7 @@ public class PersistenceExtensions {
     private static void internalRemoveAllStatesBetween(Item item, @Nullable ZonedDateTime begin,
             @Nullable ZonedDateTime end, String serviceId) {
         PersistenceService service = getService(serviceId);
-        if (service != null && service instanceof ModifiablePersistenceService mService) {
+        if (service instanceof ModifiablePersistenceService mService) {
             FilterCriteria filter = new FilterCriteria();
             ZonedDateTime now = ZonedDateTime.now();
             if ((begin == null && end == null) || (begin != null && end == null && begin.isAfter(now))
@@ -2324,10 +2324,10 @@ public class PersistenceExtensions {
             filter.setOrdering(Ordering.ASCENDING);
 
             mService.remove(filter);
-            return;
+        } else {
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         }
-        LoggerFactory.getLogger(PersistenceExtensions.class)
-                .warn("There is no queryable persistence service registered with the id '{}'", serviceId);
         return;
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -663,12 +663,12 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Checks if the state of a given <code>item</code> will be updated till a certain point in time.
+     * Checks if the state of a given <code>item</code> will be updated until a certain point in time.
      * The default persistence service is used.
      *
      * @param item the item to check for state updates
      * @param timestamp the point in time to end the check
-     * @return <code>true</code> if item state is updated, <code>false</code> if either item is not updated till
+     * @return <code>true</code> if item state is updated, <code>false</code> if either item is not updated until
      *         <code>timestamp</code>, <code>null</code> if the default persistence does not refer to a
      *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
      *         available
@@ -709,7 +709,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Checks if the state of a given <code>item</code> will be updated till a certain point in time.
+     * Checks if the state of a given <code>item</code> will be updated until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item to check for state changes
@@ -770,12 +770,12 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the historic item with the maximum value of the state of a given <code>item</code> till
+     * Gets the historic item with the maximum value of the state of a given <code>item</code> until
      * a certain point in time. The default persistence service is used.
      *
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to end the check
-     * @return a historic item with the maximum state value till the given point in time, or a {@link HistoricItem}
+     * @return a historic item with the maximum state value until the given point in time, or a {@link HistoricItem}
      *         constructed from the <code>item</code> if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
@@ -815,13 +815,13 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the historic item with the maximum value of the state of a given <code>item</code> till
+     * Gets the historic item with the maximum value of the state of a given <code>item</code> until
      * a certain point in time. The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to end the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return a {@link HistoricItem} with the maximum state value till the given point in time, or a
+     * @return a {@link HistoricItem} with the maximum state value until the given point in time, or a
      *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
      *         maximum value or if the given <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
@@ -891,12 +891,12 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the historic item with the minimum value of the state of a given <code>item</code> till
+     * Gets the historic item with the minimum value of the state of a given <code>item</code> until
      * a certain point in time. The default persistence service is used.
      *
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time to which to search for the minimum state value
-     * @return the historic item with the minimum state value till the given point in time or a {@link HistoricItem}
+     * @return the historic item with the minimum state value until the given point in time or a {@link HistoricItem}
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
      */
@@ -935,13 +935,13 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the historic item with the minimum value of the state of a given <code>item</code> till
+     * Gets the historic item with the minimum value of the state of a given <code>item</code> until
      * a certain point in time. The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time to which to search for the minimum state value
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic item with the minimum state value till the given point in time, or a {@link HistoricItem}
+     * @return the historic item with the minimum state value until the given point in time, or a {@link HistoricItem}
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the given <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}.
      */
@@ -1010,7 +1010,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the variance of the state of the given {@link Item} till a certain point in time.
+     * Gets the variance of the state of the given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
      *
      * @param item the {@link Item} to get the variance for
@@ -1054,7 +1054,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the variance of the state of the given {@link Item} till a certain point in time.
+     * Gets the variance of the state of the given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the {@link Item} to get the variance for
@@ -1147,7 +1147,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the standard deviation of the state of the given {@link Item} till a certain point in time.
+     * Gets the standard deviation of the state of the given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
@@ -1200,7 +1200,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the standard deviation of the state of the given {@link Item} till a certain point in time.
+     * Gets the standard deviation of the state of the given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
@@ -1279,7 +1279,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the average value of the state of a given {@link Item} till a certain point in time.
+     * Gets the average value of the state of a given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
      *
      * @param item the {@link Item} to get the average value for
@@ -1324,7 +1324,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the average value of the state of a given {@link Item} till a certain point in time.
+     * Gets the average value of the state of a given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the {@link Item} to get the average value for
@@ -1448,7 +1448,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the sum of the state of a given <code>item</code> till a certain point in time.
+     * Gets the sum of the state of a given <code>item</code> until a certain point in time.
      * The default persistence service is used.
      *
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
@@ -1493,7 +1493,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the sum of the state of a given <code>item</code> till a certain point in time.
+     * Gets the sum of the state of a given <code>item</code> until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
@@ -1571,7 +1571,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the difference value of the state of a given <code>item</code> till a certain point in time.
+     * Gets the difference value of the state of a given <code>item</code> until a certain point in time.
      * The default persistence service is used.
      *
      * @param item the item to get the average state value for
@@ -1617,7 +1617,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the difference value of the state of a given <code>item</code> till a certain point in time.
+     * Gets the difference value of the state of a given <code>item</code> until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item to get the delta for
@@ -1694,7 +1694,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the evolution rate of the state of a given {@link Item} till a certain point in time.
+     * Gets the evolution rate of the state of a given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
      *
      * @param item the item to get the evolution rate value for
@@ -1745,7 +1745,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the evolution rate of the state of a given {@link Item} till a certain point in time.
+     * Gets the evolution rate of the state of a given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the {@link Item} to get the evolution rate value for
@@ -2053,7 +2053,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Retrieves the future items for a given <code>item</code> till a certain point in time.
+     * Retrieves the future items for a given <code>item</code> until a certain point in time.
      * The default persistence service is used.
      *
      * @param item the item for which to retrieve the future item
@@ -2099,7 +2099,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Retrieves the future items for a given <code>item</code> till a certain point in time
+     * Retrieves the future items for a given <code>item</code> until a certain point in time
      * through a {@link PersistenceService} identified by the <code>serviceId</code>.
      *
      * @param item the item for which to retrieve the future item
@@ -2183,7 +2183,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Removes from persistence the future items for a given <code>item</code> till a certain point in time.
+     * Removes from persistence the future items for a given <code>item</code> until a certain point in time.
      * The default persistence service is used.
      * This will only have effect if the p{@link PersistenceService} is a {@link ModifiablePersistenceService}.
      *
@@ -2221,7 +2221,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Removes from persistence the future items for a given <code>item</code> till a certain point in time
+     * Removes from persistence the future items for a given <code>item</code> until a certain point in time
      * through a {@link PersistenceService} identified by the <code>serviceId</code>.
      * This will only have effect if the p{@link PersistenceService} is a {@link ModifiablePersistenceService}.
      *

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -187,7 +187,8 @@ public class PersistenceExtensions {
 
     private static void internalPersist(Item item, TimeSeries timeSeries, String serviceId) {
         PersistenceService service = getService(serviceId);
-        ZoneId timeZone = timeZoneProvider != null ? timeZoneProvider.getTimeZone() : ZoneId.systemDefault();
+        TimeZoneProvider tzProvider = timeZoneProvider;
+        ZoneId timeZone = tzProvider != null ? tzProvider.getTimeZone() : ZoneId.systemDefault();
         if (service != null && service instanceof ModifiablePersistenceService modifiableService) {
             timeSeries.getStates()
                     .forEach(s -> modifiableService.store(item, s.timestamp().atZone(timeZone), s.state(), serviceId));
@@ -2214,12 +2215,14 @@ public class PersistenceExtensions {
     }
 
     private static @Nullable PersistenceService getService(String serviceId) {
-        return registry != null ? registry.get(serviceId) : null;
+        PersistenceServiceRegistry reg = registry;
+        return reg != null ? reg.get(serviceId) : null;
     }
 
     private static @Nullable String getDefaultServiceId() {
-        if (registry != null) {
-            String id = registry.getDefaultId();
+        PersistenceServiceRegistry reg = registry;
+        if (reg != null) {
+            String id = reg.getDefaultId();
             if (id != null) {
                 return id;
             } else {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -551,7 +551,7 @@ public class PersistenceExtensions {
      *         if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Boolean changedTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable Boolean changedUntil(Item item, ZonedDateTime timestamp) {
         return internalChangedBetween(item, null, timestamp);
     }
 
@@ -595,7 +595,7 @@ public class PersistenceExtensions {
      *         <code>null</code> if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Boolean changedTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable Boolean changedUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalChangedBetween(item, null, timestamp, serviceId);
     }
 
@@ -673,7 +673,7 @@ public class PersistenceExtensions {
      *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
      *         available
      */
-    public static @Nullable Boolean updatedTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable Boolean updatedUntil(Item item, ZonedDateTime timestamp) {
         return internalUpdatedBetween(item, null, timestamp);
     }
 
@@ -719,7 +719,7 @@ public class PersistenceExtensions {
      *         since <code>timestamp</code>, <code>null</code> if the given <code>serviceId</code> does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Boolean updatedTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable Boolean updatedUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalUpdatedBetween(item, null, timestamp, serviceId);
     }
 
@@ -779,7 +779,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code> if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable HistoricItem maximumTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable HistoricItem maximumUntil(Item item, ZonedDateTime timestamp) {
         return internalMaximumBetween(item, null, timestamp);
     }
 
@@ -826,7 +826,7 @@ public class PersistenceExtensions {
      *         maximum value or if the given <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable HistoricItem maximumTill(final Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable HistoricItem maximumUntil(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMaximumBetween(item, null, timestamp, serviceId);
     }
 
@@ -900,7 +900,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
      */
-    public static @Nullable HistoricItem minimumTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable HistoricItem minimumUntil(Item item, ZonedDateTime timestamp) {
         return internalMinimumBetween(item, null, timestamp);
     }
 
@@ -945,7 +945,7 @@ public class PersistenceExtensions {
      *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
      *         the given <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}.
      */
-    public static @Nullable HistoricItem minimumTill(final Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable HistoricItem minimumUntil(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMinimumBetween(item, null, timestamp, serviceId);
     }
 
@@ -1019,7 +1019,7 @@ public class PersistenceExtensions {
      *         available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state for the
      *         given <code>item</code> at the given <code>timestamp</code>
      */
-    public static @Nullable State varianceTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable State varianceUntil(Item item, ZonedDateTime timestamp) {
         return internalVarianceBetween(item, null, timestamp);
     }
 
@@ -1064,7 +1064,7 @@ public class PersistenceExtensions {
      *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or if there
      *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
      */
-    public static @Nullable State varianceTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable State varianceUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalVarianceBetween(item, null, timestamp, serviceId);
     }
 
@@ -1159,7 +1159,7 @@ public class PersistenceExtensions {
      *         service available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state
      *         for the given <code>item</code> at the given <code>timestamp</code>
      */
-    public static @Nullable State deviationTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable State deviationUntil(Item item, ZonedDateTime timestamp) {
         return internalDeviationBetween(item, timestamp, null);
     }
 
@@ -1213,7 +1213,7 @@ public class PersistenceExtensions {
      *         <code>serviceId</code> it is not available or is not a {@link QueryablePersistenceService}, or if there
      *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
      */
-    public static @Nullable State deviationTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable State deviationUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalDeviationBetween(item, null, timestamp, serviceId);
     }
 
@@ -1288,7 +1288,7 @@ public class PersistenceExtensions {
      *         previous states could be found or if the default persistence service does not refer to an available
      *         {@link QueryablePersistenceService}. The current state is included in the calculation.
      */
-    public static @Nullable State averageTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable State averageUntil(Item item, ZonedDateTime timestamp) {
         return internalAverageBetween(item, null, timestamp);
     }
 
@@ -1335,7 +1335,7 @@ public class PersistenceExtensions {
      *         refer to an available {@link QueryablePersistenceService}. The current state is included in the
      *         calculation.
      */
-    public static @Nullable State averageTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable State averageUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalAverageBetween(item, null, timestamp, serviceId);
     }
 
@@ -1457,7 +1457,7 @@ public class PersistenceExtensions {
      *         states could be found or if the default persistence service does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public @Nullable static State sumTill(Item item, ZonedDateTime timestamp) {
+    public @Nullable static State sumUntil(Item item, ZonedDateTime timestamp) {
         return internalSumBetween(item, null, timestamp);
     }
 
@@ -1503,7 +1503,7 @@ public class PersistenceExtensions {
      *         states could be found for the <code>item</code> or if <code>serviceId</code> does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public @Nullable static State sumTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public @Nullable static State sumUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalSumBetween(item, null, timestamp, serviceId);
     }
 
@@ -1581,7 +1581,7 @@ public class PersistenceExtensions {
      *         there is no persisted state for the given <code>item</code> at the given <code>timestamp</code> available
      *         in the default persistence service
      */
-    public static @Nullable State deltaTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable State deltaUntil(Item item, ZonedDateTime timestamp) {
         return internalDeltaBetween(item, null, timestamp);
     }
 
@@ -1628,7 +1628,7 @@ public class PersistenceExtensions {
      *         <code>item</code> at the given <code>timestamp</code> using the persistence service named
      *         <code>serviceId</code>
      */
-    public static @Nullable State deltaTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable State deltaUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalDeltaBetween(item, null, timestamp, serviceId);
     }
 
@@ -1705,7 +1705,7 @@ public class PersistenceExtensions {
      *         the given <code>timestamp</code>, or if there is a state but it is zero (which would cause a
      *         divide-by-zero error)
      */
-    public static @Nullable DecimalType evolutionRateTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable DecimalType evolutionRateUntil(Item item, ZonedDateTime timestamp) {
         return internalEvolutionRateBetween(item, null, timestamp);
     }
 
@@ -1758,7 +1758,7 @@ public class PersistenceExtensions {
      *         <code>serviceId</code>, or if there is a state but it is zero (which would cause a divide-by-zero
      *         error)
      */
-    public static @Nullable DecimalType evolutionRateTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable DecimalType evolutionRateUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalEvolutionRateBetween(item, null, timestamp, serviceId);
     }
 
@@ -1832,7 +1832,7 @@ public class PersistenceExtensions {
      *         if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Long countTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable Long countUntil(Item item, ZonedDateTime timestamp) {
         return internalCountBetween(item, null, timestamp);
     }
 
@@ -1877,7 +1877,7 @@ public class PersistenceExtensions {
      *         if the persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Long countTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable Long countUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalCountBetween(item, null, timestamp, serviceId);
     }
 
@@ -1940,7 +1940,7 @@ public class PersistenceExtensions {
      *         if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Long countStateChangesTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable Long countStateChangesUntil(Item item, ZonedDateTime timestamp) {
         return internalCountStateChangesBetween(item, null, timestamp);
     }
 
@@ -1985,7 +1985,7 @@ public class PersistenceExtensions {
      *         if the persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Long countStateChangesTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static @Nullable Long countStateChangesUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalCountStateChangesBetween(item, null, timestamp, serviceId);
     }
 
@@ -2046,7 +2046,7 @@ public class PersistenceExtensions {
      * @return the historic items since the given point in time, or <code>null</code>
      *         if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
-     * 
+     *
      */
     public static @Nullable Iterable<HistoricItem> getAllStatesSince(Item item, ZonedDateTime timestamp) {
         return internalGetAllStatesBetween(item, timestamp, null);
@@ -2062,7 +2062,7 @@ public class PersistenceExtensions {
      *         if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Iterable<HistoricItem> getAllStatesTill(Item item, ZonedDateTime timestamp) {
+    public static @Nullable Iterable<HistoricItem> getAllStatesUntil(Item item, ZonedDateTime timestamp) {
         return internalGetAllStatesBetween(item, null, timestamp);
     }
 
@@ -2109,7 +2109,7 @@ public class PersistenceExtensions {
      *         if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
-    public static @Nullable Iterable<HistoricItem> getAllStatesTill(Item item, ZonedDateTime timestamp,
+    public static @Nullable Iterable<HistoricItem> getAllStatesUntil(Item item, ZonedDateTime timestamp,
             String serviceId) {
         return internalGetAllStatesBetween(item, null, timestamp, serviceId);
     }
@@ -2190,7 +2190,7 @@ public class PersistenceExtensions {
      * @param item the item for which to remove the future item
      * @param timestamp the point in time to which to remove the states
      */
-    public static void removeAllStatesTill(Item item, ZonedDateTime timestamp) {
+    public static void removeAllStatesUntil(Item item, ZonedDateTime timestamp) {
         internalRemoveAllStatesBetween(item, null, timestamp);
     }
 
@@ -2229,7 +2229,7 @@ public class PersistenceExtensions {
      * @param timestamp the point in time to which to remove the states
      * @param serviceId the name of the {@link PersistenceService} to use
      */
-    public static void removeAllStatesTill(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static void removeAllStatesUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         internalRemoveAllStatesBetween(item, null, timestamp, serviceId);
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -2212,7 +2212,7 @@ public class PersistenceExtensions {
      * @param timestamp the point in time from which to remove the states
      * @param serviceId the name of the {@link PersistenceService} to use
      */
-    public void removeAllStatesSince(Item item, ZonedDateTime timestamp, String serviceId) {
+    public static void removeAllStatesSince(Item item, ZonedDateTime timestamp, String serviceId) {
         internalRemoveAllStatesBetween(item, timestamp, null, serviceId);
     }
 

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -259,8 +259,7 @@ public class PersistenceExtensions {
      * @param timestamp the point in time for which the persisted item should be retrieved
      * @param serviceId the name of the {@link PersistenceService} to use
      * @return the persisted item at the given point in time, or <code>null</code> if no persisted item could be found
-     *         or
-     *         if the provided <code>serviceId</code> does not refer to an available
+     *         or if the provided <code>serviceId</code> does not refer to an available
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem persistedState(Item item, ZonedDateTime timestamp, String serviceId) {
@@ -301,8 +300,7 @@ public class PersistenceExtensions {
      *
      * @param item the item for which the last historic update time is to be returned
      * @return point in time of the last historic update to <code>item</code>, or <code>null</code> if there are no
-     *         historic
-     *         persisted updates or the default persistence service is not available or a
+     *         historic persisted updates or the default persistence service is not available or not a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable ZonedDateTime lastUpdate(Item item) {
@@ -315,8 +313,7 @@ public class PersistenceExtensions {
      * @param item the item for which the last historic update time is to be returned
      * @param serviceId the name of the {@link PersistenceService} to use
      * @return point in time of the last historic update to <code>item</code>, or <code>null</code> if there are no
-     *         historic
-     *         persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
+     *         historic persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
      *         available {@link QueryablePersistenceService}
      */
     public static @Nullable ZonedDateTime lastUpdate(Item item, String serviceId) {
@@ -328,8 +325,7 @@ public class PersistenceExtensions {
      *
      * @param item the item for which the first future update time is to be returned
      * @return point in time of the first future update to <code>item</code>, or <code>null</code> if there are no
-     *         future
-     *         persisted updates or the default persistence service is not available or a
+     *         future persisted updates or the default persistence service is not available or not a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable ZonedDateTime nextUpdate(Item item) {
@@ -342,8 +338,7 @@ public class PersistenceExtensions {
      * @param item the item for which the first future update time is to be returned
      * @param serviceId the name of the {@link PersistenceService} to use
      * @return point in time of the first future update to <code>item</code>, or <code>null</code> if there are no
-     *         future
-     *         persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
+     *         future persisted updates or if persistence service given by <code>serviceId</code> does not refer to an
      *         available {@link QueryablePersistenceService}
      */
     public static @Nullable ZonedDateTime nextUpdate(Item item, String serviceId) {
@@ -534,8 +529,8 @@ public class PersistenceExtensions {
      * @param item the item to check for state changes
      * @param timestamp the point in time to start the check
      * @return <code>true</code> if item state has changed, <code>false</code> if it has not changed, <code>null</code>
-     *         if the default persistence service is not available or does not refer to a
-     *         {@link QueryablePersistenceService}
+     *         if <code>timestamp</code> is in the future, if the default persistence service is not available or does
+     *         not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean changedSince(Item item, ZonedDateTime timestamp) {
         return internalChangedBetween(item, timestamp, null);
@@ -548,8 +543,8 @@ public class PersistenceExtensions {
      * @param item the item to check for state changes
      * @param timestamp the point in time to end the check
      * @return <code>true</code> if item state will change, <code>false</code> if it will not change, <code>null</code>
-     *         if the default persistence service is not available or does not refer to a
-     *         {@link QueryablePersistenceService}
+     *         if <code>timestamp></code> is in the past, if the default persistence service is not available or does
+     *         not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean changedUntil(Item item, ZonedDateTime timestamp) {
         return internalChangedBetween(item, null, timestamp);
@@ -560,10 +555,10 @@ public class PersistenceExtensions {
      * The default persistence service is used.
      *
      * @param item the item to check for state changes
-     * @return <code>true</code> if item state changes, <code>false</code> if either item does not change in
-     *         the given interval, <code>null</code> if the default persistence does not refer to a
-     *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
-     *         available
+     * @return <code>true</code> if item state changes, <code>false</code> if the item does not change in
+     *         the given interval, <code>null</code> if <code>begin</code> is after <code>end</code>, if the default
+     *         persistence does not refer to a {@link QueryablePersistenceService}, or <code>null</code> if the default
+     *         persistence service is not available
      */
     public static @Nullable Boolean changedBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalChangedBetween(item, begin, end);
@@ -577,8 +572,8 @@ public class PersistenceExtensions {
      * @param timestamp the point in time to start the check
      * @param serviceId the name of the {@link PersistenceService} to use
      * @return <code>true</code> if item state has changed, or <code>false</code> if it has not changed,
-     *         <code>null</code> if the provided <code>serviceId</code> does not refer to an available
-     *         {@link QueryablePersistenceService}
+     *         <code>null</code> if <code>timestamp</code> is in the future, if the provided <code>serviceId</code> does
+     *         not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean changedSince(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalChangedBetween(item, timestamp, null, serviceId);
@@ -592,8 +587,8 @@ public class PersistenceExtensions {
      * @param timestamp the point in time to end the check
      * @param serviceId the name of the {@link PersistenceService} to use
      * @return <code>true</code> if item state will change, or <code>false</code> if it will not change,
-     *         <code>null</code> if the provided <code>serviceId</code> does not refer to an available
-     *         {@link QueryablePersistenceService}
+     *         <code>null</code> if <code>timestamp</code> is in the past, if the provided <code>serviceId</code> does
+     *         not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean changedUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalChangedBetween(item, null, timestamp, serviceId);
@@ -607,9 +602,9 @@ public class PersistenceExtensions {
      * @param begin the point in time to start the check
      * @param end the point in time to stop the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return <code>true</code> if item state changed or <code>false</code> if either the item does not change
-     *         in the given interval, <code>null</code> if the given <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return <code>true</code> if item state changed or <code>false</code> if the item does not change
+     *         in the given interval, <code>null</code> if <code>begin</code> is after <code>end</code>, if the given
+     *         <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean changedBetween(Item item, ZonedDateTime begin, ZonedDateTime end,
             String serviceId) {
@@ -653,10 +648,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to check for state updates
      * @param timestamp the point in time to start the check
-     * @return <code>true</code> if item state was updated, <code>false</code> if either item has not been updated since
-     *         <code>timestamp</code>, <code>null</code> if the default persistence does not refer to a
-     *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
-     *         available
+     * @return <code>true</code> if item state was updated, <code>false</code> if the item has not been updated since
+     *         <code>timestamp</code>, <code>null</code> if <code>timestamp</code> is in the future, if the default
+     *         persistence does not refer to a {@link QueryablePersistenceService}, or <code>null</code> if the default
+     *         persistence service is not available
      */
     public static @Nullable Boolean updatedSince(Item item, ZonedDateTime timestamp) {
         return internalUpdatedBetween(item, timestamp, null);
@@ -668,10 +663,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to check for state updates
      * @param timestamp the point in time to end the check
-     * @return <code>true</code> if item state is updated, <code>false</code> if either item is not updated until
-     *         <code>timestamp</code>, <code>null</code> if the default persistence does not refer to a
-     *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
-     *         available
+     * @return <code>true</code> if item state is updated, <code>false</code> if the item is not updated until
+     *         <code>timestamp</code>, <code>null</code> if <code>timestamp</code> is in the past, if the default
+     *         persistence does not refer to a {@link QueryablePersistenceService}, or <code>null</code> if the default
+     *         persistence service is not available
      */
     public static @Nullable Boolean updatedUntil(Item item, ZonedDateTime timestamp) {
         return internalUpdatedBetween(item, null, timestamp);
@@ -684,10 +679,10 @@ public class PersistenceExtensions {
      * @param item the item to check for state updates
      * @param begin the point in time to start the check
      * @param end the point in time to stop the check
-     * @return <code>true</code> if item state was updated, <code>false</code> if either item has not been updated in
-     *         the given interval, <code>null</code> if the default persistence does not refer to a
-     *         {@link QueryablePersistenceService}, or <code>null</code> if the default persistence service is not
-     *         available
+     * @return <code>true</code> if item state was updated, <code>false</code> if the item has not been updated in
+     *         the given interval, <code>null</code> if <code>begin</code> is after <code>end</code>, if the default
+     *         persistence does not refer to a {@link QueryablePersistenceService}, or <code>null</code> if the default
+     *         persistence service is not available
      */
     public static @Nullable Boolean updatedBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalUpdatedBetween(item, begin, end);
@@ -700,9 +695,9 @@ public class PersistenceExtensions {
      * @param item the item to check for state changes
      * @param timestamp the point in time to start the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return <code>true</code> if item state was updated or <code>false</code> if either the item has not been updated
-     *         since <code>timestamp</code>, <code>null</code> if the given <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return <code>true</code> if item state was updated or <code>false</code> if the item has not been updated
+     *         since <code>timestamp</code>, <code>null</code> if <code>timestamp</code> is in the future, if the given
+     *         <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean updatedSince(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalUpdatedBetween(item, timestamp, null, serviceId);
@@ -715,9 +710,9 @@ public class PersistenceExtensions {
      * @param item the item to check for state changes
      * @param timestamp the point in time to end the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return <code>true</code> if item state was updated or <code>false</code> if either the item is not updated
-     *         since <code>timestamp</code>, <code>null</code> if the given <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return <code>true</code> if item state was updated or <code>false</code> if the item is not updated
+     *         since <code>timestamp</code>, <code>null</code> if <code>timestamp</code> is in the past, if the given
+     *         <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean updatedUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalUpdatedBetween(item, null, timestamp, serviceId);
@@ -731,9 +726,9 @@ public class PersistenceExtensions {
      * @param begin the point in time to start the check
      * @param end the point in time to stop the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return <code>true</code> if item state was updated or <code>false</code> if either the item is not updated
-     *         in the given interval, <code>null</code> if the given <code>serviceId</code> does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return <code>true</code> if item state was updated or <code>false</code> if the item is not updated
+     *         in the given interval, <code>null</code> if <code>begin</code> is after <code>end</code>, if the given
+     *         <code>serviceId</code> does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable Boolean updatedBetween(Item item, ZonedDateTime begin, ZonedDateTime end,
             String serviceId) {
@@ -761,9 +756,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to start the check
-     * @return a historic item with the maximum state value since the given point in time, or a {@link HistoricItem}
-     *         constructed from the <code>item</code> if the default persistence service does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return a historic item with the maximum state value since the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         maximum value, <code>null</code> if <code>timestamp</code> is in the future or if the default
+     *         persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumSince(Item item, ZonedDateTime timestamp) {
         return internalMaximumBetween(item, timestamp, null);
@@ -775,9 +771,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to end the check
-     * @return a historic item with the maximum state value until the given point in time, or a {@link HistoricItem}
-     *         constructed from the <code>item</code> if the default persistence service does not refer to a
-     *         {@link QueryablePersistenceService}
+     * @return a historic item with the maximum state value until the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         maximum value, <code>null</code> if <code>timestamp</code> is in the past or if the default
+     *         persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumUntil(Item item, ZonedDateTime timestamp) {
         return internalMaximumBetween(item, null, timestamp);
@@ -790,9 +787,10 @@ public class PersistenceExtensions {
      * @param item the item to get the maximum state value for
      * @param begin the point in time to start the check
      * @param end the point in time to stop the check
-     * @return a {@link HistoricItem} with the maximum state value between two points in time, or <code>null</code>
-     *         if no states found or if the default persistence service does not refer to an available
-     *         {@link QueryablePersistenceService}
+     * @return a {@link HistoricItem} with the maximum state value between two points in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if no persisted states found, or
+     *         <code>null</code> if <code>begin</code> is after <code>end</end> or if the default persistence service
+     *         does not refer to an available{@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumBetween(final Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalMaximumBetween(item, begin, end);
@@ -805,10 +803,10 @@ public class PersistenceExtensions {
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to start the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return a {@link HistoricItem} with the maximum state value since the given point in time, or a
+     * @return a {@link HistoricItem} with the maximum state value since the given point in time, a
      *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
-     *         maximum value or if the given <code>serviceId</code> does not refer to an available
-     *         {@link QueryablePersistenceService}
+     *         maximum value, <code>null</code> if <code>timestamp</code> is in the future or if the given
+     *         <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumSince(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMaximumBetween(item, timestamp, null, serviceId);
@@ -821,10 +819,10 @@ public class PersistenceExtensions {
      * @param item the item to get the maximum state value for
      * @param timestamp the point in time to end the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return a {@link HistoricItem} with the maximum state value until the given point in time, or a
+     * @return a {@link HistoricItem} with the maximum state value until the given point in time, a
      *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
-     *         maximum value or if the given <code>serviceId</code> does not refer to an available
-     *         {@link QueryablePersistenceService}
+     *         maximum value, <code>null</code> if <code>timestamp</code> is in the past or if the given
+     *         <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumUntil(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMaximumBetween(item, null, timestamp, serviceId);
@@ -838,9 +836,10 @@ public class PersistenceExtensions {
      * @param begin the point in time to start the check
      * @param end the point in time to stop the check
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return a {@link HistoricItem} with the maximum state value between two points in time, or
-     *         <code>null</code> no states found or if the given <code>serviceId</code> does not refer to an
-     *         available {@link QueryablePersistenceService}
+     * @return a {@link HistoricItem} with the maximum state value between two points in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if no persisted states found, or
+     *         <code>null</code> if <code>begin</code> is after <code>end</end> or if the given <code>serviceId</code>
+     *         does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem maximumBetween(final Item item, ZonedDateTime begin, ZonedDateTime end,
             String serviceId) {
@@ -882,9 +881,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time from which to search for the minimum state value
-     * @return the historic item with the minimum state value since the given point in time or a {@link HistoricItem}
-     *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
-     *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
+     * @return a historic item with the minimum state value since the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         minimum value, <code>null</code> if <code>timestamp</code> is in the future or if the default
+     *         persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumSince(Item item, ZonedDateTime timestamp) {
         return internalMinimumBetween(item, timestamp, null);
@@ -896,9 +896,10 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time to which to search for the minimum state value
-     * @return the historic item with the minimum state value until the given point in time or a {@link HistoricItem}
-     *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
-     *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
+     * @return a historic item with the minimum state value until the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         minimum value, <code>null</code> if <code>timestamp</code> is in the past or if the default
+     *         persistence service does not refer to a {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumUntil(Item item, ZonedDateTime timestamp) {
         return internalMinimumBetween(item, null, timestamp);
@@ -911,9 +912,10 @@ public class PersistenceExtensions {
      * @param item the item to get the minimum state value for
      * @param begin the beginning point in time
      * @param end the ending point in time to
-     * @return the historic item with the minimum state value between the given points in time, or <code>null</code> if
-     *         not state was found or if
-     *         the default persistence service does not refer to an available {@link QueryablePersistenceService}
+     * @return a {@link HistoricItem} with the minimum state value between two points in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if no persisted states found, or
+     *         <code>null</code> if <code>begin</code> is after <code>end</end> or if the default persistence service
+     *         does not refer to an available{@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumBetween(final Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalMinimumBetween(item, begin, end);
@@ -926,9 +928,10 @@ public class PersistenceExtensions {
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time from which to search for the minimum state value
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic item with the minimum state value since the given point in time, or a {@link HistoricItem}
-     *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
-     *         the given <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}.
+     * @return a {@link HistoricItem} with the minimum state value since the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         minimum value, <code>null</code> if <code>timestamp</code> is in the future or if the given
+     *         <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumSince(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMinimumBetween(item, timestamp, null, serviceId);
@@ -941,9 +944,10 @@ public class PersistenceExtensions {
      * @param item the item to get the minimum state value for
      * @param timestamp the point in time to which to search for the minimum state value
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic item with the minimum state value until the given point in time, or a {@link HistoricItem}
-     *         constructed from the <code>item</code>'s state if <code>item</code>'s state is the minimum value or if
-     *         the given <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}.
+     * @return a {@link HistoricItem} with the minimum state value until the given point in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if <code>item</code>'s state is the
+     *         minimum value, <code>null</code> if <code>timestamp</code> is in the past or if the given
+     *         <code>serviceId</code> does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumUntil(final Item item, ZonedDateTime timestamp, String serviceId) {
         return internalMinimumBetween(item, null, timestamp, serviceId);
@@ -957,9 +961,10 @@ public class PersistenceExtensions {
      * @param begin the beginning point in time
      * @param end the end point in time to
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the historic item with the minimum state value between the given points in time, or <code>null</code> if
-     *         not state was found or if the given <code>serviceId</code> does not refer to an available
-     *         {@link QueryablePersistenceService}
+     * @return a {@link HistoricItem} with the minimum state value between two points in time, a
+     *         {@link HistoricItem} constructed from the <code>item</code>'s state if no persisted states found, or
+     *         <code>null</code> if <code>begin</code> is after <code>end</end> or if the given <code>serviceId</code>
+     *         does not refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable HistoricItem minimumBetween(final Item item, ZonedDateTime begin, ZonedDateTime end,
             String serviceId) {
@@ -1001,9 +1006,9 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
-     * @return the variance between then and now, or <code>null</code> if there is no default persistence service
-     *         available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state for the
-     *         given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between then and now, or <code>null</code> if <code>timestamp</code> is in the future, if
+     *         there is no default persistence service available, or it is not a {@link QueryablePersistenceService}, or
+     *         if there is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
      */
     public static @Nullable State varianceSince(Item item, ZonedDateTime timestamp) {
         return internalVarianceBetween(item, timestamp, null);
@@ -1015,9 +1020,9 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
-     * @return the variance between now and then, or <code>null</code> if there is no default persistence service
-     *         available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state for the
-     *         given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between now and then, or <code>null</code> if <code>timestamp</code> is in the past, if
+     *         there is no default persistence service available, or it is not a {@link QueryablePersistenceService}, or
+     *         if there is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
      */
     public static @Nullable State varianceUntil(Item item, ZonedDateTime timestamp) {
         return internalVarianceBetween(item, null, timestamp);
@@ -1030,9 +1035,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the variance for
      * @param begin the point in time from which to compute the variance
      * @param end the end time for the computation
-     * @return the variance between both points of time, or <code>null</code> if there is no default persistence service
-     *         available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state for the
-     *         given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between both points of time, or <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if there is no default persistence service available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the
+     *         given <code>item</code> between <code>begin</code> and <code>end</code>
      */
     public static @Nullable State varianceBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalVarianceBetween(item, begin, end);
@@ -1045,9 +1051,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the variance between then and now, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between then and now, or <code>null</code> if <code>timestamp</code> is in the future, if
+     *         the persistence service given by <code>serviceId</code> is not available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State varianceSince(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalVarianceBetween(item, timestamp, null, serviceId);
@@ -1060,9 +1067,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the variance between now and then, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between now and then, or <code>null</code> if <code>timestamp</code> is in the past, if the
+     *         persistence service given by <code>serviceId</code> is not available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State varianceUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalVarianceBetween(item, null, timestamp, serviceId);
@@ -1076,9 +1084,11 @@ public class PersistenceExtensions {
      * @param begin the point in time from which to compute
      * @param end the end time for the computation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the variance between the given points in time, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the variance between both points of time, or <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if the persistence service given by
+     *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or it is not
+     *         a {@link QueryablePersistenceService}, or if there is no persisted state for the
+     *         given <code>item</code> between <code>begin</code> and <code>end</code>
      */
     public static @Nullable State varianceBetween(Item item, ZonedDateTime begin, ZonedDateTime end, String serviceId) {
         return internalVarianceBetween(item, begin, end, serviceId);
@@ -1138,9 +1148,10 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to get the standard deviation for
      * @param timestamp the point in time from which to compute the standard deviation
-     * @return the standard deviation between then and now, or <code>null</code> if there is no default persistence
-     *         service available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state
-     *         for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the standard deviation between then and now, or <code>null</code> if <code>timestamp</code> is in the
+     *         future, if there is no default persistence service available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State deviationSince(Item item, ZonedDateTime timestamp) {
         return internalDeviationBetween(item, timestamp, null);
@@ -1155,9 +1166,10 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to get the standard deviation for
      * @param timestamp the point in time to which to compute the standard deviation
-     * @return the standard deviation between now and then, or <code>null</code> if there is no default persistence
-     *         service available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state
-     *         for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the standard deviation between now and then, or <code>null</code> if <code>timestamp</code> is in the
+     *         past, if there is no default persistence service available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State deviationUntil(Item item, ZonedDateTime timestamp) {
         return internalDeviationBetween(item, timestamp, null);
@@ -1173,9 +1185,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the standard deviation for
      * @param begin the point in time from which to compute
      * @param end the end time for the computation
-     * @return the standard deviation between now and then, or <code>null</code> if there is no default persistence
-     *         service available, or it is not a {@link QueryablePersistenceService}, or if there is no persisted state
-     *         for the given <code>item</code> in the given interval
+     * @return the standard deviation between both points of time, or <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if there is no default persistence service available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the
+     *         given <code>item</code> between <code>begin</code> and <code>end</code>
      */
     public static @Nullable State deviationBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
         return internalDeviationBetween(item, begin, end);
@@ -1191,9 +1204,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the standard deviation for
      * @param timestamp the point in time from which to compute the standard deviation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the standard deviation between now and then, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> it is not available or is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the standard deviation between then and now, or <code>null</code> if <code>timestamp</code> is in the
+     *         future, if the persistence service given by <code>serviceId</code> is not available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State deviationSince(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalDeviationBetween(item, timestamp, null, serviceId);
@@ -1209,9 +1223,10 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the standard deviation for
      * @param timestamp the point in time to which to compute the standard deviation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the standard deviation between now and then, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> it is not available or is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> at the given <code>timestamp</code>
+     * @return the standard deviation between now and then, or <code>null</code> if <code>timestamp</code> is in the
+     *         past, if the persistence service given by <code>serviceId</code> is not available, or it is not a
+     *         {@link QueryablePersistenceService}, or if there is no persisted state for the given <code>item</code> at
+     *         the given <code>timestamp</code>
      */
     public static @Nullable State deviationUntil(Item item, ZonedDateTime timestamp, String serviceId) {
         return internalDeviationBetween(item, null, timestamp, serviceId);
@@ -1228,9 +1243,11 @@ public class PersistenceExtensions {
      * @param begin the point in time from which to compute
      * @param end the end time for the computation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the standard deviation between now and then, or <code>null</code> if the persistence service given by
-     *         <code>serviceId</code> it is not available or is not a {@link QueryablePersistenceService}, or if there
-     *         is no persisted state for the given <code>item</code> in the given interval
+     * @return the standard deviation between both points of time, or <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if the persistence service given by
+     *         <code>serviceId</code> is not available, or it is not a {@link QueryablePersistenceService}, or it is not
+     *         a {@link QueryablePersistenceService}, or if there is no persisted state for the
+     *         given <code>item</code> between <code>begin</code> and <code>end</code>
      */
     public static @Nullable State deviationBetween(Item item, ZonedDateTime begin, ZonedDateTime end,
             String serviceId) {
@@ -1284,8 +1301,8 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to get the average value for
      * @param timestamp the point in time to which to search for the average value
-     * @return the average value to <code>timestamp</code> or <code>null</code> if no
-     *         previous states could be found or if the default persistence service does not refer to an available
+     * @return the average value until <code>timestamp</code> or <code>null</code> if no
+     *         future states could be found or if the default persistence service does not refer to an available
      *         {@link QueryablePersistenceService}. The current state is included in the calculation.
      */
     public static @Nullable State averageUntil(Item item, ZonedDateTime timestamp) {
@@ -1299,8 +1316,8 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the average value for
      * @param begin the point in time from which to start the summation
      * @param end the point in time to which to start the summation
-     * @return the average value since <code>timestamp</code> or <code>null</code> if no
-     *         previous states could be found or if the default persistence service does not refer to an available
+     * @return the average value between <code>begin</code> and <code>end</code> or <code>null</code> if no
+     *         states could be found or if the default persistence service does not refer to an available
      *         {@link QueryablePersistenceService}.
      */
     public static @Nullable State averageBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
@@ -1330,8 +1347,8 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to get the average value for
      * @param timestamp the point in time to which to search for the average value
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the average value to <code>timestamp</code>, or <code>null</code> if no
-     *         previous states could be found or if the persistence service given by <code>serviceId</code> does not
+     * @return the average value until <code>timestamp</code>, or <code>null</code> if no
+     *         future states could be found or if the persistence service given by <code>serviceId</code> does not
      *         refer to an available {@link QueryablePersistenceService}. The current state is included in the
      *         calculation.
      */
@@ -1347,8 +1364,8 @@ public class PersistenceExtensions {
      * @param begin the point in time from which to start the summation
      * @param end the point in time to which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the average value since <code>timestamp</code>, or <code>null</code> if no
-     *         previous states could be found or if the persistence service given by <code>serviceId</code> does not
+     * @return the average value between <code>begin</code> and <code>end</code>, or <code>null</code> if no
+     *         states could be found or if the persistence service given by <code>serviceId</code> does not
      *         refer to an available {@link QueryablePersistenceService}
      */
     public static @Nullable State averageBetween(Item item, ZonedDateTime begin, ZonedDateTime end, String serviceId) {
@@ -1382,13 +1399,6 @@ public class PersistenceExtensions {
         HistoricItem lastItem = null;
         ZonedDateTime firstTimestamp = null;
 
-        // if (beginTime.equals(now)) {
-        // HistoricItem historicItem = internalPersistedState(item, now, serviceId);
-        // if (historicItem != null) {
-        // lastItem = new RetimedHistoricItem(historicItem, now);
-        // firstTimestamp = now;
-        // }
-        // }
         while (it.hasNext()) {
             HistoricItem thisItem = it.next();
             if (lastItem != null) {
@@ -1406,14 +1416,6 @@ public class PersistenceExtensions {
             }
             lastItem = thisItem;
         }
-        // if (endTime.equals(now) && lastItem != null && lastItem.getState() instanceof State state) {
-        // DecimalType dtState = state.as(DecimalType.class);
-        // if (dtState != null) {
-        // BigDecimal value = dtState.toBigDecimal();
-        // BigDecimal weight = BigDecimal.valueOf(Duration.between(lastItem.getTimestamp(), now).toMillis());
-        // sum = sum.add(value.multiply(weight));
-        // }
-        // }
 
         if (firstTimestamp != null) {
             BigDecimal totalDuration = BigDecimal.valueOf(Duration.between(firstTimestamp, endTime).toMillis());
@@ -1554,7 +1556,7 @@ public class PersistenceExtensions {
      * Gets the difference value of the state of a given <code>item</code> since a certain point in time.
      * The default persistence service is used.
      *
-     * @param item the item to get the average state value for
+     * @param item the item to get the delta state value for
      * @param timestamp the point in time from which to compute the delta
      * @return the difference between now and then, or <code>null</code> if there is no default persistence
      *         service available, the default persistence service is not a {@link QueryablePersistenceService}, or if
@@ -1569,7 +1571,7 @@ public class PersistenceExtensions {
      * Gets the difference value of the state of a given <code>item</code> until a certain point in time.
      * The default persistence service is used.
      *
-     * @param item the item to get the average state value for
+     * @param item the item to get the delta state value for
      * @param timestamp the point in time to which to compute the delta
      * @return the difference between then and now, or <code>null</code> if there is no default persistence
      *         service available, the default persistence service is not a {@link QueryablePersistenceService}, or if
@@ -1581,7 +1583,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the difference value of the state of a given <code>item</code> between two certain point in time.
+     * Gets the difference value of the state of a given <code>item</code> between two points in time.
      * The default persistence service is used.
      *
      * @param item the item to get the delta for
@@ -1628,7 +1630,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Gets the difference value of the state of a given <code>item</code> between two certain point in time.
+     * Gets the difference value of the state of a given <code>item</code> between two points in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * @param item the item to get the delta for
@@ -1796,7 +1798,7 @@ public class PersistenceExtensions {
             valueStop = getItemValue(item);
         }
 
-        if (valueStart != null && valueStop != null) {
+        if (valueStart != null && valueStop != null && !valueStart.equals(DecimalType.ZERO)) {
             return new DecimalType(valueStop.toBigDecimal().subtract(valueStart.toBigDecimal())
                     .divide(valueStart.toBigDecimal(), MathContext.DECIMAL64).movePointRight(2));
         }
@@ -1809,8 +1811,8 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to query
      * @param timestamp the beginning point in time
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the default persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>timestamp</code> is in the
+     *         future, if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countSince(Item item, ZonedDateTime timestamp) {
@@ -1823,8 +1825,8 @@ public class PersistenceExtensions {
      *
      * @param item the {@link Item} to query
      * @param timestamp the ending point in time
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the default persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>timestamp</code> is in the
+     *         past, if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countUntil(Item item, ZonedDateTime timestamp) {
@@ -1838,8 +1840,8 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to query
      * @param begin the beginning point in time
      * @param end the end point in time
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the default persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if the default persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countBetween(Item item, ZonedDateTime begin, ZonedDateTime end) {
@@ -1853,8 +1855,8 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to query
      * @param begin the beginning point in time
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>timestamp</code> is in the
+     *         future, if the persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countSince(Item item, ZonedDateTime begin, String serviceId) {
@@ -1868,8 +1870,8 @@ public class PersistenceExtensions {
      * @param item the {@link Item} to query
      * @param timestamp the ending point in time
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>timestamp</code> is in the
+     *         past, if the persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countUntil(Item item, ZonedDateTime timestamp, String serviceId) {
@@ -1884,8 +1886,8 @@ public class PersistenceExtensions {
      * @param begin the beginning point in time
      * @param end the end point in time
      * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the number of values persisted for this item, <code>null</code>
-     *         if the persistence service is not available or does not refer to a
+     * @return the number of values persisted for this item, <code>null</code> if <code>begin</code> is after
+     *         <code>end</code>, if the persistence service is not available or does not refer to a
      *         {@link QueryablePersistenceService}
      */
     public static @Nullable Long countBetween(Item item, ZonedDateTime begin, ZonedDateTime end, String serviceId) {
@@ -2062,7 +2064,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Retrieves the historic items for a given <code>item</code> between two certain points in time.
+     * Retrieves the historic items for a given <code>item</code> between two points in time.
      * The default persistence service is used.
      *
      * @param item the item for which to retrieve the historic item
@@ -2110,7 +2112,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Retrieves the historic items for a given <code>item</code> beetween two certain points in time
+     * Retrieves the historic items for a given <code>item</code> between two points in time
      * through a {@link PersistenceService} identified by the <code>serviceId</code>.
      *
      * @param item the item for which to retrieve the historic item
@@ -2190,7 +2192,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Removes from persistence the historic items for a given <code>item</code> between two certain points in time.
+     * Removes from persistence the historic items for a given <code>item</code> between two points in time.
      * The default persistence service is used.
      * This will only have effect if the p{@link PersistenceService} is a {@link ModifiablePersistenceService}.
      *
@@ -2229,7 +2231,7 @@ public class PersistenceExtensions {
     }
 
     /**
-     * Removes from persistence the historic items for a given <code>item</code> beetween two certain points in time
+     * Removes from persistence the historic items for a given <code>item</code> beetween two points in time
      * through a {@link PersistenceService} identified by the <code>serviceId</code>.
      * This will only have effect if the p{@link PersistenceService} is a {@link ModifiablePersistenceService}.
      *

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -427,7 +427,6 @@ public class PersistenceExtensions {
      */
     public static @Nullable HistoricItem previousState(Item item, boolean skipEqual, String serviceId) {
         return internalAdjacentState(item, skipEqual, false, serviceId);
-
     }
 
     /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1390,8 +1390,8 @@ public class PersistenceExtensions {
         // }
         while (it.hasNext()) {
             HistoricItem thisItem = it.next();
-            if (lastItem != null && lastItem.getState() instanceof State state) {
-                DecimalType dtState = state.as(DecimalType.class);
+            if (lastItem != null) {
+                DecimalType dtState = lastItem.getState().as(DecimalType.class);
                 if (dtState != null) {
                     BigDecimal value = dtState.toBigDecimal();
                     BigDecimal weight = BigDecimal

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -282,14 +282,14 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testMaximumTillDecimalType() {
-        HistoricItem historicItem = PersistenceExtensions.maximumTill(numberItem,
+    public void testMaximumUntilDecimalType() {
+        HistoricItem historicItem = PersistenceExtensions.maximumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
         assertEquals(value(FUTURE_START), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumTill(numberItem,
+        historicItem = PersistenceExtensions.maximumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(value(FUTURE_INTERMEDIATE_VALUE_3), historicItem.getState());
@@ -297,7 +297,7 @@ public class PersistenceExtensionsTest {
                 historicItem.getTimestamp());
 
         // default persistence service
-        historicItem = PersistenceExtensions.maximumTill(numberItem,
+        historicItem = PersistenceExtensions.maximumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
@@ -362,14 +362,14 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testMaximumTillQuantityType() {
-        HistoricItem historicItem = PersistenceExtensions.maximumTill(quantityItem,
+    public void testMaximumUntilQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.maximumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
         assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumTill(quantityItem,
+        historicItem = PersistenceExtensions.maximumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_3), SIUnits.CELSIUS), historicItem.getState());
@@ -377,7 +377,7 @@ public class PersistenceExtensionsTest {
                 historicItem.getTimestamp());
 
         // default persistence service
-        historicItem = PersistenceExtensions.maximumTill(quantityItem,
+        historicItem = PersistenceExtensions.maximumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
@@ -443,23 +443,23 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testMaximumTillOnOffType() {
+    public void testMaximumUntilOnOffType() {
         ZonedDateTime now = ZonedDateTime.now();
-        HistoricItem historicItem = PersistenceExtensions.maximumTill(switchItem,
+        HistoricItem historicItem = PersistenceExtensions.maximumUntil(switchItem,
                 now.plusHours(SWITCH_OFF_INTERMEDIATE_2), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(switchValue(SWITCH_ON_2), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_3),
+        historicItem = PersistenceExtensions.maximumUntil(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_3),
                 SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(switchValue(SWITCH_ON_3), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
+        historicItem = PersistenceExtensions.maximumUntil(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(switchValue(SWITCH_ON_3), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21),
+        historicItem = PersistenceExtensions.maximumUntil(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21),
                 SERVICE_ID);
         assertNull(historicItem);
     }
@@ -486,20 +486,20 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testMinimumTillDecimalType() {
-        HistoricItem historicItem = PersistenceExtensions.minimumTill(numberItem,
+    public void testMinimumUntilDecimalType() {
+        HistoricItem historicItem = PersistenceExtensions.minimumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
         assertEquals(value(HISTORIC_END), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumTill(numberItem,
+        historicItem = PersistenceExtensions.minimumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(value(HISTORIC_END), historicItem.getState());
 
         // default persistence service
-        historicItem = PersistenceExtensions.minimumTill(numberItem,
+        historicItem = PersistenceExtensions.minimumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
@@ -565,20 +565,20 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testMinimumTillQuantityType() {
-        HistoricItem historicItem = PersistenceExtensions.minimumTill(quantityItem,
+    public void testMinimumUntilQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.minimumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
         assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumTill(quantityItem,
+        historicItem = PersistenceExtensions.minimumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
 
         // default persistence service
-        historicItem = PersistenceExtensions.minimumTill(quantityItem,
+        historicItem = PersistenceExtensions.minimumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
@@ -666,7 +666,7 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testVarianceTillDecimalType() {
+    public void testVarianceUntilDecimalType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
@@ -677,14 +677,14 @@ public class PersistenceExtensionsTest {
                                 .mapToDouble(i -> Double.valueOf(i)))
                 .map(d -> Math.pow(d - expectedAverage, 2)).sum()
                 / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1);
-        State variance = PersistenceExtensions.varianceTill(numberItem, endStored, SERVICE_ID);
+        State variance = PersistenceExtensions.varianceUntil(numberItem, endStored, SERVICE_ID);
         assertNotNull(variance);
         DecimalType dt = variance.as(DecimalType.class);
         assertNotNull(dt);
         assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
-        variance = PersistenceExtensions.varianceTill(numberItem, endStored);
+        variance = PersistenceExtensions.varianceUntil(numberItem, endStored);
         assertNull(variance);
     }
 
@@ -765,7 +765,7 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testVarianceTillQuantityType() {
+    public void testVarianceUntilQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
@@ -776,7 +776,7 @@ public class PersistenceExtensionsTest {
                                 .mapToDouble(i -> Double.valueOf(i)))
                 .map(d -> Math.pow(d - expectedAverage, 2)).sum()
                 / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1);
-        State variance = PersistenceExtensions.varianceTill(quantityItem, endStored, SERVICE_ID);
+        State variance = PersistenceExtensions.varianceUntil(quantityItem, endStored, SERVICE_ID);
         assertNotNull(variance);
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
@@ -784,7 +784,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
-        variance = PersistenceExtensions.varianceTill(quantityItem, endStored);
+        variance = PersistenceExtensions.varianceUntil(quantityItem, endStored);
         assertNull(variance);
     }
 
@@ -867,7 +867,7 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testDeviationTillDecimalType() {
+    public void testDeviationUntilDecimalType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
@@ -878,14 +878,14 @@ public class PersistenceExtensionsTest {
                                 .mapToDouble(i -> Double.valueOf(i)))
                 .map(d -> Math.pow(d - expectedAverage, 2)).sum()
                 / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1));
-        State deviation = PersistenceExtensions.deviationTill(numberItem, endStored, SERVICE_ID);
+        State deviation = PersistenceExtensions.deviationUntil(numberItem, endStored, SERVICE_ID);
         assertNotNull(deviation);
         DecimalType dt = deviation.as(DecimalType.class);
         assertNotNull(dt);
         assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
-        deviation = PersistenceExtensions.deviationTill(numberItem, endStored);
+        deviation = PersistenceExtensions.deviationUntil(numberItem, endStored);
         assertNull(deviation);
     }
 
@@ -965,7 +965,7 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testDeviationTillQuantityType() {
+    public void testDeviationUntilQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
@@ -976,7 +976,7 @@ public class PersistenceExtensionsTest {
                                 .mapToDouble(i -> Double.valueOf(i)))
                 .map(d -> Math.pow(d - expectedAverage, 2)).sum()
                 / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1));
-        State deviation = PersistenceExtensions.deviationTill(quantityItem, endStored, SERVICE_ID);
+        State deviation = PersistenceExtensions.deviationUntil(quantityItem, endStored, SERVICE_ID);
         assertNotNull(deviation);
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
@@ -984,7 +984,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
-        deviation = PersistenceExtensions.deviationTill(quantityItem, endStored);
+        deviation = PersistenceExtensions.deviationUntil(quantityItem, endStored);
         assertNull(deviation);
     }
 
@@ -1067,17 +1067,17 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testAverageTillDecimalType() {
+    public void testAverageUntilDecimalType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
-        State average = PersistenceExtensions.averageTill(numberItem, end, SERVICE_ID);
+        State average = PersistenceExtensions.averageUntil(numberItem, end, SERVICE_ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
-        average = PersistenceExtensions.averageTill(numberItem, end);
+        average = PersistenceExtensions.averageUntil(numberItem, end);
         assertNull(average);
     }
 
@@ -1146,10 +1146,10 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testAverageTillQuantityType() {
+    public void testAverageUntilQuantityType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
-        State average = PersistenceExtensions.averageTill(quantityItem, end, SERVICE_ID);
+        State average = PersistenceExtensions.averageUntil(quantityItem, end, SERVICE_ID);
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
         assertNotNull(qt);
@@ -1157,7 +1157,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
-        average = PersistenceExtensions.averageTill(quantityItem, end);
+        average = PersistenceExtensions.averageUntil(quantityItem, end);
         assertNull(average);
     }
 
@@ -1245,42 +1245,42 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testAverageTillOnOffType() {
+    public void testAverageUntilOnOffType() {
         // switch is 5h ON, 5h OFF, and 5h ON (from now)
 
         ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        State average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
+        State average = PersistenceExtensions.averageUntil(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(),
                 is(closeTo((SWITCH_OFF_3 - SWITCH_ON_3 + SWITCH_OFF_2) / (1.0 * SWITCH_END), 0.01)));
 
-        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_2), SERVICE_ID);
+        average = PersistenceExtensions.averageUntil(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_2), SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(SWITCH_OFF_2 / (1.0 * SWITCH_OFF_INTERMEDIATE_2), 0.01)));
 
-        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_ON_3), SERVICE_ID);
+        average = PersistenceExtensions.averageUntil(switchItem, now.plusHours(SWITCH_ON_3), SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(SWITCH_OFF_2 / (1.0 * SWITCH_ON_3), 0.01)));
 
-        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_22), SERVICE_ID);
+        average = PersistenceExtensions.averageUntil(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_22), SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(SWITCH_ON_INTERMEDIATE_22 / (1.0 * SWITCH_ON_INTERMEDIATE_22), 0.01)));
 
-        average = PersistenceExtensions.averageTill(switchItem, now.plusMinutes(1), SERVICE_ID);
+        average = PersistenceExtensions.averageUntil(switchItem, now.plusMinutes(1), SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(1d, 0.01)));
 
-        average = PersistenceExtensions.averageTill(switchItem, now.minusHours(1), SERVICE_ID);
+        average = PersistenceExtensions.averageUntil(switchItem, now.minusHours(1), SERVICE_ID);
         assertNull(average);
     }
 
@@ -1315,28 +1315,28 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testAverageTillDecimalTypeIrregularTimespans() {
+    public void testAverageUntilDecimalTypeIrregularTimespans() {
         ZonedDateTime now = ZonedDateTime.now();
         int historicHours = 0;
         int futureHours = 27;
 
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
-        State average = PersistenceExtensions.averageTill(numberItem, now.plusHours(futureHours),
+        State average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / futureHours, 0.01)));
 
-        average = PersistenceExtensions.averageTill(numberItem, now.plusHours(futureHours).minusHours(2),
+        average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours).minusHours(2),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 / (futureHours - 2.0), 0.01)));
 
-        average = PersistenceExtensions.averageTill(numberItem, now.plusMinutes(30),
+        average = PersistenceExtensions.averageUntil(numberItem, now.plusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
@@ -1378,8 +1378,8 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testSumTillDecimalType() {
-        State sum = PersistenceExtensions.sumTill(numberItem,
+    public void testSumUntilDecimalType() {
+        State sum = PersistenceExtensions.sumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         DecimalType dt = sum.as(DecimalType.class);
@@ -1387,7 +1387,7 @@ public class PersistenceExtensionsTest {
         assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), dt.doubleValue(), 0.001);
 
         // default persistence service
-        sum = PersistenceExtensions.sumTill(numberItem,
+        sum = PersistenceExtensions.sumUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(sum);
     }
@@ -1455,8 +1455,8 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testSumTillQuantityType() {
-        State sum = PersistenceExtensions.sumTill(quantityItem,
+    public void testSumUntilQuantityType() {
+        State sum = PersistenceExtensions.sumUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
@@ -1564,8 +1564,8 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testDeltaTill() {
-        State delta = PersistenceExtensions.deltaTill(numberItem,
+    public void testDeltaUntil() {
+        State delta = PersistenceExtensions.deltaUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(delta);
         DecimalType dt = delta.as(DecimalType.class);
@@ -1574,7 +1574,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dtState);
         assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - dtState.doubleValue(), dt.doubleValue(), 0.001);
 
-        delta = PersistenceExtensions.deltaTill(quantityItem,
+        delta = PersistenceExtensions.deltaUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(delta);
         QuantityType<?> qt = delta.as(QuantityType.class);
@@ -1585,7 +1585,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
-        delta = PersistenceExtensions.deltaTill(numberItem,
+        delta = PersistenceExtensions.deltaUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(delta);
     }
@@ -1681,15 +1681,15 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testEvolutionRateTill() {
-        DecimalType rate = PersistenceExtensions.evolutionRateTill(numberItem,
+    public void testEvolutionRateUntil() {
+        DecimalType rate = PersistenceExtensions.evolutionRateUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(rate);
         // ((then - now) / now) * 100
         assertThat(rate.doubleValue(),
                 is(closeTo(100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - STATE.doubleValue()) / STATE.doubleValue(), 0.001)));
 
-        rate = PersistenceExtensions.evolutionRateTill(quantityItem,
+        rate = PersistenceExtensions.evolutionRateUntil(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(rate);
         // ((then - now) / now) * 100
@@ -1697,7 +1697,7 @@ public class PersistenceExtensionsTest {
                 is(closeTo(100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - STATE.doubleValue()) / STATE.doubleValue(), 0.001)));
 
         // default persistence service
-        rate = PersistenceExtensions.evolutionRateTill(numberItem,
+        rate = PersistenceExtensions.evolutionRateUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(rate);
     }
@@ -1938,13 +1938,13 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testChangedTill() {
-        Boolean changed = PersistenceExtensions.changedTill(numberItem,
+    public void testChangedUntil() {
+        Boolean changed = PersistenceExtensions.changedUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(changed, true);
 
         // default persistence service
-        changed = PersistenceExtensions.changedTill(numberItem,
+        changed = PersistenceExtensions.changedUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(changed);
     }
@@ -1995,13 +1995,13 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testUpdatedTill() {
-        Boolean updated = PersistenceExtensions.updatedTill(numberItem,
+    public void testUpdatedUntil() {
+        Boolean updated = PersistenceExtensions.updatedUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(updated, true);
 
         // default persistence service
-        updated = PersistenceExtensions.updatedTill(numberItem,
+        updated = PersistenceExtensions.updatedUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(updated);
     }
@@ -2063,21 +2063,21 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testCountTill() {
-        Long counts = PersistenceExtensions.countTill(numberItem,
+    public void testCountUntil() {
+        Long counts = PersistenceExtensions.countUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(0, counts);
 
-        counts = PersistenceExtensions.countTill(numberItem,
+        counts = PersistenceExtensions.countUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1, counts);
 
-        counts = PersistenceExtensions.countTill(numberItem,
+        counts = PersistenceExtensions.countUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_START + 1, counts);
 
         // default persistence service
-        counts = PersistenceExtensions.countTill(numberItem,
+        counts = PersistenceExtensions.countUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(counts);
     }
@@ -2134,21 +2134,21 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testCountStateChangesTill() {
-        Long counts = PersistenceExtensions.countStateChangesTill(numberItem,
+    public void testCountStateChangesUntil() {
+        Long counts = PersistenceExtensions.countStateChangesUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(0, counts);
 
-        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+        counts = PersistenceExtensions.countStateChangesUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START, counts);
 
-        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+        counts = PersistenceExtensions.countStateChangesUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_START, counts);
 
         // default persistence service
-        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+        counts = PersistenceExtensions.countStateChangesUntil(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(counts);
     }
@@ -2230,43 +2230,43 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testRemoveAllStatesTill() {
+    public void testRemoveAllStatesUntil() {
         ZonedDateTime now = ZonedDateTime.now();
         int historicHours = 27;
         int futureHours = 27;
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
-        assertNotNull(PersistenceExtensions.getAllStatesTill(numberItem, now.plusHours(futureHours),
+        assertNotNull(PersistenceExtensions.getAllStatesUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID));
-        assertThat(PersistenceExtensions.countTill(numberItem, now.plusHours(futureHours),
+        assertThat(PersistenceExtensions.countUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID), is(5L));
         HistoricItem historicItem = PersistenceExtensions.nextState(numberItem, TestCachedValuesPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(new DecimalType(0)));
 
-        PersistenceExtensions.removeAllStatesTill(numberItem, now.plusHours(1), TestCachedValuesPersistenceService.ID);
-        assertNotNull(PersistenceExtensions.getAllStatesTill(numberItem, now.plusHours(futureHours),
+        PersistenceExtensions.removeAllStatesUntil(numberItem, now.plusHours(1), TestCachedValuesPersistenceService.ID);
+        assertNotNull(PersistenceExtensions.getAllStatesUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID));
-        assertThat(PersistenceExtensions.countTill(numberItem, now.plusHours(futureHours),
+        assertThat(PersistenceExtensions.countUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID), is(4L));
         historicItem = PersistenceExtensions.nextState(numberItem, TestCachedValuesPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(new DecimalType(50)));
 
-        PersistenceExtensions.removeAllStatesTill(numberItem, now.plusHours(2), TestCachedValuesPersistenceService.ID);
-        assertNotNull(PersistenceExtensions.getAllStatesTill(numberItem, now.plusHours(futureHours),
+        PersistenceExtensions.removeAllStatesUntil(numberItem, now.plusHours(2), TestCachedValuesPersistenceService.ID);
+        assertNotNull(PersistenceExtensions.getAllStatesUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID));
-        assertThat(PersistenceExtensions.countTill(numberItem, now.plusHours(futureHours),
+        assertThat(PersistenceExtensions.countUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID), is(3L));
         historicItem = PersistenceExtensions.nextState(numberItem, TestCachedValuesPersistenceService.ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(new DecimalType(0)));
 
-        PersistenceExtensions.removeAllStatesTill(numberItem, now.plusHours(futureHours + 1),
+        PersistenceExtensions.removeAllStatesUntil(numberItem, now.plusHours(futureHours + 1),
                 TestCachedValuesPersistenceService.ID);
-        assertNotNull(PersistenceExtensions.getAllStatesTill(numberItem, now.plusHours(futureHours),
+        assertNotNull(PersistenceExtensions.getAllStatesUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID));
-        assertThat(PersistenceExtensions.countTill(numberItem, now.plusHours(futureHours),
+        assertThat(PersistenceExtensions.countUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID), is(0L));
         historicItem = PersistenceExtensions.nextState(numberItem, TestCachedValuesPersistenceService.ID);
         assertNull(historicItem);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -12,21 +12,13 @@
  */
 package org.openhab.core.persistence.extensions;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
+import static org.openhab.core.persistence.extensions.TestPersistenceService.*;
 
-import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -45,24 +37,28 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.i18n.UnitProvider;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ItemUtil;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
-import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.SIUnits;
+import org.openhab.core.library.unit.Units;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
+import org.openhab.core.types.State;
 
 /**
  * @author Kai Kreuzer - Initial contribution
  * @author Chris Jackson - Initial contribution
  * @author Jan N. Klug - Fix averageSince calculation
  * @author Jan N. Klug - Interval method tests and refactoring
+ * @author Mark Herwege - Changed return types to State for some interval methods to also return unit
+ * @author Mark Herwege - Extended for future dates
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -75,6 +71,7 @@ public class PersistenceExtensionsTest {
 
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
+    private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
 
     private @NonNullByDefault({}) GenericItem numberItem, quantityItem, switchItem;
 
@@ -88,9 +85,15 @@ public class PersistenceExtensionsTest {
                 TEST_QUANTITY_NUMBER);
         switchItem = itemFactory.createItem(CoreItemFactory.SWITCH, TEST_SWITCH);
 
+        numberItem.setState(STATE);
+        quantityItem.setState(new QuantityType<Temperature>(STATE, SIUnits.CELSIUS));
+        switchItem.setState(SWITCH_STATE);
+
         when(itemRegistryMock.get(TEST_NUMBER)).thenReturn(numberItem);
         when(itemRegistryMock.get(TEST_QUANTITY_NUMBER)).thenReturn(quantityItem);
         when(itemRegistryMock.get(TEST_SWITCH)).thenReturn(switchItem);
+
+        when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.systemDefault());
 
         new PersistenceExtensions(new PersistenceServiceRegistry() {
             private final PersistenceService testPersistenceService = new TestPersistenceService(itemRegistryMock);
@@ -114,305 +117,549 @@ public class PersistenceExtensionsTest {
 
             @Override
             public @Nullable PersistenceService get(@Nullable String serviceId) {
-                return TestPersistenceService.ID.equals(serviceId) ? testPersistenceService : null;
+                return TestPersistenceService.SERVICE_ID.equals(serviceId) ? testPersistenceService : null;
             }
-        });
+        }, timeZoneProviderMock);
     }
 
     @Test
-    public void testHistoricStateDecimalType() {
-        HistoricItem historicItem = PersistenceExtensions.historicState(numberItem,
-                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+    public void testPersistedStateDecimalType() {
+        HistoricItem historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
-        assertEquals("2012", historicItem.getState().toString());
+        assertEquals(value(HISTORIC_END), historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(numberItem,
-                ZonedDateTime.of(2011, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2011", historicItem.getState().toString());
+        assertEquals(value(HISTORIC_INTERMEDIATE_VALUE_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(numberItem,
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2011", historicItem.getState().toString());
+        assertEquals(value(HISTORIC_INTERMEDIATE_VALUE_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(numberItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(numberItem, ZonedDateTime.now(), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2000", historicItem.getState().toString());
+        assertEquals(value(TestPersistenceService.HISTORIC_END), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(HISTORIC_END), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(FUTURE_START), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(FUTURE_INTERMEDIATE_VALUE_3), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(FUTURE_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(FUTURE_END), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(AFTER_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(FUTURE_END), historicItem.getState());
 
         // default persistence service
-        historicItem = PersistenceExtensions.historicState(numberItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        historicItem = PersistenceExtensions.persistedState(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
 
     @Test
-    public void testHistoricStateQuantityType() {
-        HistoricItem historicItem = PersistenceExtensions.historicState(quantityItem,
-                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+    public void testPersistedStateQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("2012 °C", historicItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(quantityItem,
-                ZonedDateTime.of(2011, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 12, 31, 0, 0, 0, 0, ZoneId.systemDefault()),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2011 °C", historicItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), SIUnits.CELSIUS),
+                historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(quantityItem,
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2011 °C", historicItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), SIUnits.CELSIUS),
+                historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(quantityItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(quantityItem, ZonedDateTime.now(), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2000 °C", historicItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_3), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(FUTURE_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(FUTURE_END), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(AFTER_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(FUTURE_END), SIUnits.CELSIUS), historicItem.getState());
 
         // default persistence service
-        historicItem = PersistenceExtensions.historicState(quantityItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        historicItem = PersistenceExtensions.persistedState(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(historicItem);
     }
 
     @Test
-    public void testHistoricSwitchState() {
+    public void testPersistedStateOnOffType() {
         ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.HOURS).minusMinutes(1);
-        HistoricItem historicItem = PersistenceExtensions.historicState(switchItem, now.minusHours(15),
-                TestPersistenceService.ID);
+        HistoricItem historicItem = PersistenceExtensions.persistedState(switchItem, now.plusHours(SWITCH_START),
+                SERVICE_ID);
         assertNull(historicItem);
 
-        historicItem = PersistenceExtensions.historicState(switchItem, now.minusHours(14), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_1),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.historicState(switchItem, now.minusHours(4), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.persistedState(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_1),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.OFF, historicItem.getState());
+        assertEquals(switchValue(SWITCH_OFF_INTERMEDIATE_1), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_2),
+                SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(switchValue(SWITCH_OFF_INTERMEDIATE_2), historicItem.getState());
+
+        historicItem = PersistenceExtensions.persistedState(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_3),
+                SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_3), historicItem.getState());
+
     }
 
     @Test
     public void testMaximumSinceDecimalType() {
-        numberItem.setState(new DecimalType(1));
         HistoricItem historicItem = PersistenceExtensions.maximumSince(numberItem,
-                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
-        assertEquals("2012", historicItem.getState().toString());
+        assertEquals(value(HISTORIC_END), historicItem.getState());
 
         historicItem = PersistenceExtensions.maximumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2012", historicItem.getState().toString());
-        assertEquals(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), historicItem.getTimestamp());
+        assertEquals(value(HISTORIC_END), historicItem.getState());
+        assertEquals(ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                historicItem.getTimestamp());
 
         // default persistence service
         historicItem = PersistenceExtensions.maximumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
+    }
+
+    @Test
+    public void testMaximumTillDecimalType() {
+        HistoricItem historicItem = PersistenceExtensions.maximumTill(numberItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("1", historicItem.getState().toString());
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertEquals(value(FUTURE_START), historicItem.getState());
+
+        historicItem = PersistenceExtensions.maximumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(FUTURE_INTERMEDIATE_VALUE_3), historicItem.getState());
+        assertEquals(ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                historicItem.getTimestamp());
+
+        // default persistence service
+        historicItem = PersistenceExtensions.maximumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMaximumBetweenDecimalType() {
         HistoricItem historicItem = PersistenceExtensions.maximumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
-        assertThat(historicItem.getState().toString(), is("2011"));
+        assertThat(historicItem.getState(), is(value(HISTORIC_INTERMEDIATE_VALUE_2)));
 
         historicItem = PersistenceExtensions.maximumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(historicItem, is(nullValue()));
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertThat(historicItem.getState(), is(value(FUTURE_INTERMEDIATE_VALUE_4)));
+
+        historicItem = PersistenceExtensions.maximumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertThat(historicItem.getState(), is(value(FUTURE_INTERMEDIATE_VALUE_4)));
+
+        // default persistence service
+        historicItem = PersistenceExtensions.maximumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMaximumSinceQuantityType() {
-        quantityItem.setState(QuantityType.valueOf(1, SIUnits.CELSIUS));
         HistoricItem historicItem = PersistenceExtensions.maximumSince(quantityItem,
-                ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertThat(historicItem.getState().toString(), is("2012 °C"));
+        assertThat(historicItem.getState(), is(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS)));
 
         historicItem = PersistenceExtensions.maximumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
-        assertThat(historicItem.getState().toString(), is("2012 °C"));
-        assertThat(historicItem.getTimestamp(), is(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS)));
+        assertThat(historicItem.getTimestamp(),
+                is(ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())));
 
         // default persistence service
         historicItem = PersistenceExtensions.maximumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(historicItem, is(notNullValue()));
-        assertThat(historicItem.getState().toString(), is("1 °C"));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
+
+        // test with alternative unit
+        quantityItem.setState(QuantityType.valueOf(5000, Units.KELVIN));
+        historicItem = PersistenceExtensions.maximumSince(quantityItem,
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(), is(new QuantityType<>(4726.85, SIUnits.CELSIUS)));
+    }
+
+    @Test
+    public void testMaximumTillQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.maximumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.maximumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_3), SIUnits.CELSIUS), historicItem.getState());
+        assertEquals(ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                historicItem.getTimestamp());
+
+        // default persistence service
+        historicItem = PersistenceExtensions.maximumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMaximumBetweenQuantityType() {
         HistoricItem historicItem = PersistenceExtensions.maximumBetween(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertThat(historicItem.getState().toString(), is("2011 °C"));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_2), SIUnits.CELSIUS)));
 
         historicItem = PersistenceExtensions.maximumBetween(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(historicItem, is(nullValue()));
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_4), SIUnits.CELSIUS)));
+
+        historicItem = PersistenceExtensions.maximumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_4), SIUnits.CELSIUS)));
+
+        // default persistence service
+        historicItem = PersistenceExtensions.maximumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
-    public void testMaximumSinceSwitch() {
-        switchItem.setState(OnOffType.OFF);
-
+    public void testMaximumSinceOnOffType() {
         ZonedDateTime now = ZonedDateTime.now();
-        HistoricItem historicItem = PersistenceExtensions.maximumSince(switchItem, now.minusHours(15),
-                TestPersistenceService.ID);
+        HistoricItem historicItem = PersistenceExtensions.maximumSince(switchItem, now.plusHours(SWITCH_START),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumSince(switchItem, now.minusHours(6), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.maximumSince(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_1),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_2), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumSince(switchItem, now.minusHours(1), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.maximumSince(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_2), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumSince(switchItem, now, TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.maximumSince(switchItem, now, SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_2), historicItem.getState());
 
-        historicItem = PersistenceExtensions.maximumSince(switchItem, now.plusHours(1), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.maximumSince(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_22),
+                SERVICE_ID);
+        assertNull(historicItem);
+    }
+
+    @Test
+    public void testMaximumTillOnOffType() {
+        ZonedDateTime now = ZonedDateTime.now();
+        HistoricItem historicItem = PersistenceExtensions.maximumTill(switchItem,
+                now.plusHours(SWITCH_OFF_INTERMEDIATE_2), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.OFF, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_2), historicItem.getState());
+
+        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_3),
+                SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(switchValue(SWITCH_ON_3), historicItem.getState());
+
+        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(switchValue(SWITCH_ON_3), historicItem.getState());
+
+        historicItem = PersistenceExtensions.maximumTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21),
+                SERVICE_ID);
+        assertNull(historicItem);
     }
 
     @Test
     public void testMinimumSinceDecimalType() {
-        numberItem.setState(new DecimalType(5000));
         HistoricItem historicItem = PersistenceExtensions.minimumSince(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
-        assertEquals("5000", historicItem.getState().toString());
+        assertEquals(value(HISTORIC_START), historicItem.getState());
 
         historicItem = PersistenceExtensions.minimumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2005", historicItem.getState().toString());
-        assertEquals(ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), historicItem.getTimestamp());
+        assertEquals(value(HISTORIC_INTERMEDIATE_VALUE_1), historicItem.getState());
+        assertEquals(ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                historicItem.getTimestamp());
 
         // default persistence service
         historicItem = PersistenceExtensions.minimumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
+    }
+
+    @Test
+    public void testMinimumTillDecimalType() {
+        HistoricItem historicItem = PersistenceExtensions.minimumTill(numberItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("5000", historicItem.getState().toString());
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertEquals(value(HISTORIC_END), historicItem.getState());
+
+        historicItem = PersistenceExtensions.minimumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(value(HISTORIC_END), historicItem.getState());
+
+        // default persistence service
+        historicItem = PersistenceExtensions.minimumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMinimumBetweenDecimalType() {
         HistoricItem historicItem = PersistenceExtensions.minimumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
-        assertThat(historicItem.getState().toString(), is("2005"));
+        assertThat(historicItem.getState(), is(value(HISTORIC_INTERMEDIATE_VALUE_1)));
 
         historicItem = PersistenceExtensions.minimumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(historicItem, is(nullValue()));
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertThat(historicItem.getState(), is(value(FUTURE_INTERMEDIATE_VALUE_3)));
+
+        historicItem = PersistenceExtensions.minimumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(DecimalType.class)));
+        assertThat(historicItem.getState(), is(value(HISTORIC_INTERMEDIATE_VALUE_1)));
+
+        // default persistence service
+        historicItem = PersistenceExtensions.minimumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMinimumSinceQuantityType() {
-        quantityItem.setState(QuantityType.valueOf(5000, SIUnits.CELSIUS));
         HistoricItem historicItem = PersistenceExtensions.minimumSince(quantityItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("5000 °C", historicItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_START), SIUnits.CELSIUS), historicItem.getState());
 
         historicItem = PersistenceExtensions.minimumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("2005 °C", historicItem.getState().toString());
-        assertEquals(ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), historicItem.getTimestamp());
+        assertEquals(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), SIUnits.CELSIUS),
+                historicItem.getState());
+        assertEquals(ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                historicItem.getTimestamp());
 
         // default persistence service
         historicItem = PersistenceExtensions.minimumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
+
+        // test with alternative unit
+        quantityItem.setState(QuantityType.valueOf(273.15, Units.KELVIN));
+        historicItem = PersistenceExtensions.minimumSince(quantityItem,
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals("5000 °C", historicItem.getState().toString());
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(), is(new QuantityType<>(0, SIUnits.CELSIUS)));
+    }
+
+    @Test
+    public void testMinimumTillQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.minimumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
+
+        historicItem = PersistenceExtensions.minimumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), historicItem.getState());
+
+        // default persistence service
+        historicItem = PersistenceExtensions.minimumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
     public void testMinimumBetweenQuantityType() {
         HistoricItem historicItem = PersistenceExtensions.minimumBetween(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(historicItem, is(notNullValue()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
         assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
-        assertThat(historicItem.getState().toString(), is("2005 °C"));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), SIUnits.CELSIUS)));
 
         historicItem = PersistenceExtensions.minimumBetween(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(historicItem, is(nullValue()));
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(FUTURE_INTERMEDIATE_VALUE_3), SIUnits.CELSIUS)));
+
+        historicItem = PersistenceExtensions.minimumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), SIUnits.CELSIUS)));
+
+        // default persistence service
+        historicItem = PersistenceExtensions.minimumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(historicItem);
     }
 
     @Test
-    public void testMinimumSinceSwitch() {
-        switchItem.setState(OnOffType.ON);
-
+    public void testMinimumSinceOnOffType() {
         ZonedDateTime now = ZonedDateTime.now();
-        HistoricItem historicItem = PersistenceExtensions.minimumSince(switchItem, now.minusHours(15),
-                TestPersistenceService.ID);
+        HistoricItem historicItem = PersistenceExtensions.minimumSince(switchItem, now.plusHours(SWITCH_START),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.OFF, historicItem.getState());
+        assertEquals(switchValue(SWITCH_OFF_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumSince(switchItem, now.minusHours(6), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.minimumSince(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_1),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.OFF, historicItem.getState());
+        assertEquals(switchValue(SWITCH_OFF_INTERMEDIATE_1), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumSince(switchItem, now.minusHours(1), TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.minimumSince(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21),
+                SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_21), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumSince(switchItem, now, TestPersistenceService.ID);
+        historicItem = PersistenceExtensions.minimumSince(switchItem, now, SERVICE_ID);
         assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_22), historicItem.getState());
 
-        historicItem = PersistenceExtensions.minimumSince(switchItem, now.plusHours(1), TestPersistenceService.ID);
-        assertNotNull(historicItem);
-        assertEquals(OnOffType.ON, historicItem.getState());
+        historicItem = PersistenceExtensions.minimumSince(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_22),
+                SERVICE_ID);
+        assertNull(historicItem);
     }
 
     @Test
-    public void testVarianceSince() {
-        numberItem.setState(new DecimalType(3025));
+    public void testVarianceSinceDecimalType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
-        ZonedDateTime startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-
-        long storedInterval = Duration.between(startStored, endStored).toDays();
-        long recentInterval = Duration.between(endStored, ZonedDateTime.now()).toDays();
-        double expectedAverage = ((2003.0 + 2011.0) / 2.0 * storedInterval + 2012.0 * recentInterval)
-                / (storedInterval + recentInterval);
-
-        double expected = IntStream.of(2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012)
-                .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
-                .sum() / 10d;
-        DecimalType variance = PersistenceExtensions.varianceSince(numberItem, startStored, TestPersistenceService.ID);
+        double expected = DoubleStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
+                        .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (HISTORIC_END + 1 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+        State variance = PersistenceExtensions.varianceSince(numberItem, startStored, SERVICE_ID);
         assertNotNull(variance);
-        assertEquals(expected, variance.doubleValue(), 0.01);
+        DecimalType dt = variance.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
         variance = PersistenceExtensions.varianceSince(numberItem, startStored);
@@ -420,39 +667,200 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
-    public void testVarianceBetween() {
-        ZonedDateTime startStored = ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+    public void testVarianceTillDecimalType() {
+        ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
 
-        double expected = DoubleStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011)
-                .map(d -> Math.pow(d - (2005.0 + 2010.0) / 2.0, 2)).sum() / 7d;
+        double expected = DoubleStream
+                .concat(DoubleStream.of(STATE.doubleValue()),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
+                                .mapToDouble(i -> Double.valueOf(i)))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1);
+        State variance = PersistenceExtensions.varianceTill(numberItem, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        DecimalType dt = variance.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
 
-        DecimalType variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored,
-                TestPersistenceService.ID);
-        assertThat(variance, is(notNullValue()));
-        assertThat(variance.doubleValue(), is(closeTo(expected, 0.01)));
+        // default persistence service
+        variance = PersistenceExtensions.varianceTill(numberItem, endStored);
+        assertNull(variance);
+    }
+
+    @Test
+    public void testVarianceBetweenDecimalType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage1 = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+
+        double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
+                / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+
+        State variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        DecimalType dt = variance.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1);
+
+        variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        dt = variance.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        expected = IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+
+        variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        dt = variance.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
 
         // default persistence service
         variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored);
-        assertThat(variance, is(nullValue()));
+        assertNull(variance);
+    }
+
+    @Test
+    public void testVarianceSinceQuantityType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+
+        double expected = DoubleStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
+                        .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (HISTORIC_END + 1 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+        State variance = PersistenceExtensions.varianceSince(quantityItem, startStored, SERVICE_ID);
+        assertNotNull(variance);
+        QuantityType<?> qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+
+        // default persistence service
+        variance = PersistenceExtensions.varianceSince(quantityItem, startStored);
+        assertNull(variance);
+    }
+
+    @Test
+    public void testVarianceTillQuantityType() {
+        ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+
+        double expected = DoubleStream
+                .concat(DoubleStream.of(STATE.doubleValue()),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
+                                .mapToDouble(i -> Double.valueOf(i)))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1);
+        State variance = PersistenceExtensions.varianceTill(quantityItem, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        QuantityType<?> qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+
+        // default persistence service
+        variance = PersistenceExtensions.varianceTill(quantityItem, endStored);
+        assertNull(variance);
+    }
+
+    @Test
+    public void testVarianceBetweenQuantityType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage1 = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+
+        double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
+                / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+
+        State variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        QuantityType<?> qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+
+        startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1);
+
+        variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+
+        startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        expected = IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+
+        variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(variance);
+        qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+
+        // default persistence service
+        variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored);
+        assertNull(variance);
     }
 
     @Test
     public void testDeviationSinceDecimalType() {
-        ZonedDateTime startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
-        long storedInterval = Duration.between(startStored, endStored).toDays();
-        long recentInterval = Duration.between(endStored, ZonedDateTime.now()).toDays();
-        double expectedAverage = ((2003.0 + 2011.0) / 2.0 * storedInterval + 2012.0 * recentInterval)
-                / (storedInterval + recentInterval);
-
-        double expected = Math.sqrt(DoubleStream.of(2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012)
-                .map(d -> Math.pow(d - expectedAverage, 2)).sum() / 10d);
-        DecimalType deviation = PersistenceExtensions.deviationSince(numberItem, startStored,
-                TestPersistenceService.ID);
+        double expected = Math.sqrt(DoubleStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
+                        .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (HISTORIC_END + 1 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+        State deviation = PersistenceExtensions.deviationSince(numberItem, startStored, SERVICE_ID);
         assertNotNull(deviation);
-        assertEquals(expected, deviation.doubleValue(), 0.01);
+        DecimalType dt = deviation.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(numberItem, startStored);
@@ -460,42 +868,97 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testDeviationTillDecimalType() {
+        ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+
+        double expected = Math.sqrt(DoubleStream
+                .concat(DoubleStream.of(STATE.doubleValue()),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
+                                .mapToDouble(i -> Double.valueOf(i)))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1));
+        State deviation = PersistenceExtensions.deviationTill(numberItem, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        DecimalType dt = deviation.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        // default persistence service
+        deviation = PersistenceExtensions.deviationTill(numberItem, endStored);
+        assertNull(deviation);
+    }
+
+    @Test
     public void testDeviationBetweenDecimalType() {
-        ZonedDateTime startStored = ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
-        double expected = Math.sqrt(DoubleStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011)
-                .map(d -> Math.pow(d - (2005.0 + 2010.0) / 2.0, 2)).sum() / 7d);
+        double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
+                .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+        State deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        DecimalType dt = deviation.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
 
-        DecimalType deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored,
-                TestPersistenceService.ID);
-        assertThat(deviation, is(notNullValue()));
-        assertThat(deviation.doubleValue(), is(closeTo(expected, 0.01)));
+        startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1));
+
+        deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        dt = deviation.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        expected = Math.sqrt(IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+
+        deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        dt = deviation.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored);
-        assertThat(deviation, is(nullValue()));
+        assertNull(deviation);
     }
 
     @Test
     public void testDeviationSinceQuantityType() {
-        quantityItem.setState(QuantityType.valueOf(3025, SIUnits.CELSIUS));
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
-        ZonedDateTime startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-
-        long storedInterval = Duration.between(startStored, endStored).toDays();
-        long recentInterval = Duration.between(endStored, ZonedDateTime.now()).toDays();
-        double expectedAverage = ((2003.0 + 2011.0) / 2.0 * storedInterval + 2012.0 * recentInterval)
-                / (storedInterval + recentInterval);
-
-        double expected = Math.sqrt(DoubleStream.of(2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012)
-                .map(d -> Math.pow(d - expectedAverage, 2)).sum() / 10d);
-
-        DecimalType deviation = PersistenceExtensions.deviationSince(quantityItem, startStored,
-                TestPersistenceService.ID);
+        double expected = Math.sqrt(DoubleStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
+                        .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (HISTORIC_END + 1 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+        State deviation = PersistenceExtensions.deviationSince(quantityItem, startStored, SERVICE_ID);
         assertNotNull(deviation);
-        assertEquals(expected, deviation.doubleValue(), 0.01);
+        QuantityType<?> qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(quantityItem, startStored);
@@ -503,42 +966,322 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testDeviationTillQuantityType() {
+        ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+
+        double expected = Math.sqrt(DoubleStream
+                .concat(DoubleStream.of(STATE.doubleValue()),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
+                                .mapToDouble(i -> Double.valueOf(i)))
+                .map(d -> Math.pow(d - expectedAverage, 2)).sum()
+                / (1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1));
+        State deviation = PersistenceExtensions.deviationTill(quantityItem, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        QuantityType<?> qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        deviation = PersistenceExtensions.deviationTill(quantityItem, endStored);
+        assertNull(deviation);
+    }
+
+    @Test
     public void testDeviationBetweenQuantityType() {
-        ZonedDateTime startStored = ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
-        double expected = Math.sqrt(DoubleStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011)
-                .map(d -> Math.pow(d - (2005.0 + 2010.0) / 2.0, 2)).sum() / 7d);
+        double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
+                .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+        State deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        QuantityType<?> qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
-        DecimalType deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored,
-                TestPersistenceService.ID);
-        assertThat(deviation, is(notNullValue()));
-        assertThat(deviation.doubleValue(), is(closeTo(expected, 0.01)));
+        startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1));
+
+        deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        expected = Math.sqrt(IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
+                / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+
+        deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored, SERVICE_ID);
+        assertNotNull(deviation);
+        qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored);
-        assertThat(deviation, is(nullValue()));
+        assertNull(deviation);
     }
 
     @Test
     public void testAverageSinceDecimalType() {
-        ZonedDateTime startStored = ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        DecimalType average = PersistenceExtensions.averageSince(numberItem, startStored, TestPersistenceService.ID);
-        assertNull(average);
-
-        startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        long storedInterval = Duration.between(startStored, endStored).toDays();
-        long recentInterval = Duration.between(endStored, ZonedDateTime.now()).toDays();
-        double expected = ((2003.0 + 2011.0) / 2.0 * storedInterval + 2012.0 * recentInterval)
-                / (storedInterval + recentInterval);
-
-        average = PersistenceExtensions.averageSince(numberItem, startStored, TestPersistenceService.ID);
+        ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = average(BEFORE_START, null);
+        State average = PersistenceExtensions.averageSince(numberItem, start, SERVICE_ID);
         assertNotNull(average);
-        assertEquals(expected, average.doubleValue(), 0.01);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        average = PersistenceExtensions.averageSince(numberItem, start, SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
 
         // default persistence service
-        average = PersistenceExtensions.averageSince(numberItem, startStored);
+        average = PersistenceExtensions.averageSince(numberItem, start);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageTillDecimalType() {
+        ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        State average = PersistenceExtensions.averageTill(numberItem, end, SERVICE_ID);
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        // default persistence service
+        average = PersistenceExtensions.averageTill(numberItem, end);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageBetweenDecimalType() {
+        ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+
+        double expected = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        State average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        // default persistence service
+        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageSinceQuantityType() {
+        ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = average(BEFORE_START, null);
+        State average = PersistenceExtensions.averageSince(quantityItem, start, SERVICE_ID);
+        assertNotNull(average);
+        QuantityType<?> qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        average = PersistenceExtensions.averageSince(quantityItem, start, SERVICE_ID);
+        assertNotNull(average);
+        qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        average = PersistenceExtensions.averageSince(quantityItem, start);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageTillQuantityType() {
+        ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        State average = PersistenceExtensions.averageTill(quantityItem, end, SERVICE_ID);
+        assertNotNull(average);
+        QuantityType<?> qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        average = PersistenceExtensions.averageTill(quantityItem, end);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageBetweenQuantityType() {
+        ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expected = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        State average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
+
+        assertNotNull(average);
+        QuantityType<?> qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+
+        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
+        assertNotNull(average);
+        qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+
+        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
+        assertNotNull(average);
+        qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageSinceOnOffType() {
+        // switch is 5h ON, 5h OFF, and 5h ON (until now)
+
+        ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        State average = PersistenceExtensions.averageSince(switchItem, now.plusHours(SWITCH_START), SERVICE_ID);
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(),
+                is(closeTo((SWITCH_OFF_1 - SWITCH_ON_1 - SWITCH_ON_2) / (-1.0 * SWITCH_START), 0.01)));
+
+        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_1), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(-SWITCH_ON_2 / (-1.0 * SWITCH_OFF_INTERMEDIATE_1), 0.01)));
+
+        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(SWITCH_ON_2), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(-SWITCH_ON_2 / (-1.0 * SWITCH_ON_2), 0.01)));
+
+        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_21), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(),
+                is(closeTo(-SWITCH_ON_INTERMEDIATE_21 / (-1.0 * SWITCH_ON_INTERMEDIATE_21), 0.01)));
+
+        average = PersistenceExtensions.averageSince(switchItem, now, SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(1d, 0.01)));
+
+        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(1), SERVICE_ID);
+        assertNull(average);
+    }
+
+    @Test
+    public void testAverageTillOnOffType() {
+        // switch is 5h ON, 5h OFF, and 5h ON (from now)
+
+        ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+        State average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_END), SERVICE_ID);
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(),
+                is(closeTo((SWITCH_OFF_3 - SWITCH_ON_3 + SWITCH_OFF_2) / (1.0 * SWITCH_END), 0.01)));
+
+        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_OFF_INTERMEDIATE_2), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(SWITCH_OFF_2 / (1.0 * SWITCH_OFF_INTERMEDIATE_2), 0.01)));
+
+        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_ON_3), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(SWITCH_OFF_2 / (1.0 * SWITCH_ON_3), 0.01)));
+
+        average = PersistenceExtensions.averageTill(switchItem, now.plusHours(SWITCH_ON_INTERMEDIATE_22), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(SWITCH_ON_INTERMEDIATE_22 / (1.0 * SWITCH_ON_INTERMEDIATE_22), 0.01)));
+
+        average = PersistenceExtensions.averageTill(switchItem, now.plusMinutes(1), SERVICE_ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(1d, 0.01)));
+
+        average = PersistenceExtensions.averageTill(switchItem, now.minusHours(1), SERVICE_ID);
         assertNull(average);
     }
 
@@ -568,7 +1311,7 @@ public class PersistenceExtensionsTest {
             public @Nullable PersistenceService get(@Nullable String serviceId) {
                 return TestCachedValuesPersistenceService.ID.equals(serviceId) ? persistenceService : null;
             }
-        });
+        }, timeZoneProviderMock);
 
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime beginStored = now.minusHours(27);
@@ -578,177 +1321,261 @@ public class PersistenceExtensionsTest {
         persistenceService.addHistoricItem(beginStored.plusHours(2), new DecimalType(0), TEST_NUMBER);
         persistenceService.addHistoricItem(beginStored.plusHours(25), new DecimalType(50), TEST_NUMBER);
         persistenceService.addHistoricItem(beginStored.plusHours(26), new DecimalType(0), TEST_NUMBER);
+        numberItem.setState(new DecimalType(0));
 
-        DecimalType average = PersistenceExtensions.averageSince(numberItem, beginStored,
+        State average = PersistenceExtensions.averageSince(numberItem, beginStored,
                 TestCachedValuesPersistenceService.ID);
-        assertThat(average.doubleValue(), is(closeTo((100.0 + 50.0) / 27.0, 0.01)));
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / 27.0, 0.01)));
 
         average = PersistenceExtensions.averageSince(numberItem, beginStored.plusHours(3),
                 TestCachedValuesPersistenceService.ID);
-        assertThat(average.doubleValue(), is(closeTo(50.0 / 24.0, 0.01)));
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(50.0 / 24.0, 0.01)));
 
         average = PersistenceExtensions.averageSince(numberItem, now.minusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
-        assertThat(average.doubleValue(), is(closeTo(0, 0.01)));
-    }
-
-    @Test
-    public void testAverageBetweenDecimalType() {
-        ZonedDateTime beginStored = ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        DecimalType average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored,
-                TestPersistenceService.ID);
-
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo((2005.0 + 2010.0) / 2.0, 0.01)));
-
-        // default persistence service
-        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored);
-        assertThat(average, is(nullValue()));
-    }
-
-    @Test
-    public void testAverageSinceQuantityType() {
-        quantityItem.setState(QuantityType.valueOf(3025, SIUnits.CELSIUS));
-
-        ZonedDateTime startStored = ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        DecimalType average = PersistenceExtensions.averageSince(quantityItem, startStored, TestPersistenceService.ID);
-        assertNull(average);
-
-        startStored = ZonedDateTime.of(2003, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        long storedInterval = Duration.between(startStored, endStored).toDays();
-        long recentInterval = Duration.between(endStored, ZonedDateTime.now()).toDays();
-        double expected = ((2003.0 + 2011.0) / 2.0 * storedInterval + 2012.0 * recentInterval)
-                / (storedInterval + recentInterval);
-
-        average = PersistenceExtensions.averageSince(quantityItem, startStored, TestPersistenceService.ID);
         assertNotNull(average);
-        assertEquals(expected, average.doubleValue(), 0.01);
-
-        // default persistence service
-        average = PersistenceExtensions.averageSince(quantityItem, startStored);
-        assertNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
     }
 
     @Test
-    public void testAverageBetweenQuantityType() {
-        ZonedDateTime beginStored = ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        ZonedDateTime endStored = ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        DecimalType average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored,
-                TestPersistenceService.ID);
+    public void testAverageTillDecimalTypeIrregularTimespans() {
+        TestCachedValuesPersistenceService persistenceService = new TestCachedValuesPersistenceService();
+        new PersistenceExtensions(new PersistenceServiceRegistry() {
 
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo((2005.0 + 2010.0) / 2, 0.01)));
+            @Override
+            public @Nullable String getDefaultId() {
+                // not available
+                return null;
+            }
 
-        // default persistence service
-        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored);
-        assertThat(average, is(nullValue()));
-    }
+            @Override
+            public @Nullable PersistenceService getDefault() {
+                // not available
+                return null;
+            }
 
-    @Test
-    public void testAverageSinceSwitch() {
-        // switch is 5h ON, 6h OFF, and 4h ON (until now)
+            @Override
+            public Set<PersistenceService> getAll() {
+                return Set.of(persistenceService);
+            }
 
-        ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        DecimalType average = PersistenceExtensions.averageSince(switchItem, now.minusHours(15),
-                TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(9.0 / 15.0, 0.01)));
+            @Override
+            public @Nullable PersistenceService get(@Nullable String serviceId) {
+                return TestCachedValuesPersistenceService.ID.equals(serviceId) ? persistenceService : null;
+            }
+        }, timeZoneProviderMock);
 
-        average = PersistenceExtensions.averageSince(switchItem, now.minusHours(7), TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(4.0 / 7.0, 0.01)));
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime beginStored = now.plusHours(1);
 
-        average = PersistenceExtensions.averageSince(switchItem, now.minusHours(6), TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(0.833, 0.2)));
+        persistenceService.addHistoricItem(beginStored, new DecimalType(0), TEST_NUMBER);
+        persistenceService.addHistoricItem(beginStored.plusHours(1), new DecimalType(0), TEST_NUMBER);
+        persistenceService.addHistoricItem(beginStored.plusHours(2), new DecimalType(50), TEST_NUMBER);
+        persistenceService.addHistoricItem(beginStored.plusHours(3), new DecimalType(0), TEST_NUMBER);
+        persistenceService.addHistoricItem(beginStored.plusHours(25), new DecimalType(100), TEST_NUMBER);
+        numberItem.setState(new DecimalType(0));
 
-        average = PersistenceExtensions.averageSince(switchItem, now.minusHours(5), TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(1d, 0.2)));
+        State average = PersistenceExtensions.averageTill(numberItem, beginStored.plusHours(26),
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(average);
+        DecimalType dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / 27.0, 0.01)));
 
-        average = PersistenceExtensions.averageSince(switchItem, now.minusHours(1), TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(1d, 0.001)));
+        average = PersistenceExtensions.averageTill(numberItem, beginStored.plusHours(24),
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(50.0 / 25.0, 0.01)));
 
-        average = PersistenceExtensions.averageSince(switchItem, now, TestPersistenceService.ID);
-        assertThat(average, is(notNullValue()));
-        assertThat(average.doubleValue(), is(closeTo(1d, 0.001)));
-
-        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(1), TestPersistenceService.ID);
-        assertThat(average, is(nullValue()));
+        average = PersistenceExtensions.averageTill(numberItem, now.plusMinutes(30),
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(average);
+        dt = average.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
     }
 
     @Test
     public void testAverageBetweenZeroDuration() {
         ZonedDateTime now = ZonedDateTime.now();
-        assertDoesNotThrow(
-                () -> PersistenceExtensions.averageBetween(quantityItem, now, now, TestPersistenceService.ID));
-        assertThat(PersistenceExtensions.averageBetween(quantityItem, now, now, TestPersistenceService.ID),
-                is(nullValue()));
+        State state = PersistenceExtensions.averageBetween(quantityItem, now, now, SERVICE_ID);
+        assertNotNull(state);
+        QuantityType<?> qt = state.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(HISTORIC_END, qt.doubleValue(), 0.01);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
     }
 
     @Test
     public void testSumSinceDecimalType() {
-        DecimalType sum = PersistenceExtensions.sumSince(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        State sum = PersistenceExtensions.sumSince(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(0.0, sum.doubleValue(), 0.001);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), dt.doubleValue(), 0.001);
 
         sum = PersistenceExtensions.sumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(IntStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012).sum(), sum.doubleValue(), 0.001);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), dt.doubleValue(), 0.001);
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(sum);
+    }
+
+    @Test
+    public void testSumTillDecimalType() {
+        State sum = PersistenceExtensions.sumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(0.0, sum.doubleValue(), 0.001);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), dt.doubleValue(), 0.001);
+
+        // default persistence service
+        sum = PersistenceExtensions.sumTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(sum);
     }
 
     @Test
     public void testSumBetweenDecimalType() {
-        DecimalType sum = PersistenceExtensions.sumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(sum, is(notNullValue()));
-        assertThat(sum.doubleValue(), is(closeTo(14056.0, 0.1)));
+        State sum = PersistenceExtensions.sumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
+                dt.doubleValue(), 0.001);
 
         sum = PersistenceExtensions.sumBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
+                dt.doubleValue(), 0.001);
 
-        assertThat(sum, is(notNullValue()));
-        assertThat(sum.doubleValue(), is(closeTo(0.0, 0.1)));
+        sum = PersistenceExtensions.sumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(
+                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
+                dt.doubleValue(), 0.001);
+
+        // default persistence service
+        sum = PersistenceExtensions.sumBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(sum);
     }
 
     @Test
     public void testSumSinceQuantityType() {
-        DecimalType sum = PersistenceExtensions.sumSince(quantityItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        State sum = PersistenceExtensions.sumSince(quantityItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(0.0, sum.doubleValue(), 0.001);
+        QuantityType<?> qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         sum = PersistenceExtensions.sumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(IntStream.of(2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012).sum(), sum.doubleValue(), 0.001);
+        qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(sum);
+    }
+
+    @Test
+    public void testSumTillQuantityType() {
+        State sum = PersistenceExtensions.sumTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
-        assertEquals(0.0, sum.doubleValue(), 0.001);
+        QuantityType<?> qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        sum = PersistenceExtensions.sumSince(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(sum);
+    }
+
+    @Test
+    public void testSumBetweenQuantityType() {
+        State sum = PersistenceExtensions.sumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        QuantityType<?> qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
+                qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        sum = PersistenceExtensions.sumBetween(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
+                qt.doubleValue(), 0.001);
+
+        sum = PersistenceExtensions.sumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(
+                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
+                qt.doubleValue(), 0.001);
+
+        // default persistence service
+        sum = PersistenceExtensions.sumBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+
+        assertNull(sum);
     }
 
     @Test
     public void testLastUpdate() {
-        numberItem.setState(new DecimalType(2005));
-        ZonedDateTime lastUpdate = PersistenceExtensions.lastUpdate(numberItem, TestPersistenceService.ID);
+        ZonedDateTime lastUpdate = PersistenceExtensions.lastUpdate(numberItem, SERVICE_ID);
         assertNotNull(lastUpdate);
-        assertEquals(ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), lastUpdate);
+        assertEquals(ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), lastUpdate);
 
         // default persistence service
         lastUpdate = PersistenceExtensions.lastUpdate(numberItem);
@@ -756,116 +1583,270 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testNextUpdate() {
+        ZonedDateTime nextUpdate = PersistenceExtensions.nextUpdate(numberItem, SERVICE_ID);
+        assertNotNull(nextUpdate);
+        assertEquals(ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), nextUpdate);
+
+        // default persistence service
+        nextUpdate = PersistenceExtensions.lastUpdate(numberItem);
+        assertNull(nextUpdate);
+    }
+
+    @Test
     public void testDeltaSince() {
-        numberItem.setState(new DecimalType(2012));
-        DecimalType delta = PersistenceExtensions.deltaSince(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        State delta = PersistenceExtensions.deltaSince(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNull(delta);
 
         delta = PersistenceExtensions.deltaSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(delta);
-        assertEquals(7, delta.doubleValue(), 0.001);
+        DecimalType dt = delta.as(DecimalType.class);
+        assertNotNull(dt);
+        DecimalType dtState = numberItem.getState().as(DecimalType.class);
+        assertNotNull(dtState);
+        assertEquals(dtState.doubleValue() - HISTORIC_INTERMEDIATE_VALUE_1, dt.doubleValue(), 0.001);
 
-        numberItem.setState(new QuantityType<>(2012, SIUnits.CELSIUS));
-        delta = PersistenceExtensions.deltaSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+        delta = PersistenceExtensions.deltaSince(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(delta);
-        assertEquals(7, delta.doubleValue(), 0.001);
+        QuantityType<?> qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        QuantityType<?> qtState = quantityItem.getState().as(QuantityType.class);
+        assertNotNull(qtState);
+        assertEquals(qtState.doubleValue() - HISTORIC_INTERMEDIATE_VALUE_1, qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         delta = PersistenceExtensions.deltaSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(delta);
+    }
+
+    @Test
+    public void testDeltaTill() {
+        State delta = PersistenceExtensions.deltaTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        DecimalType dt = delta.as(DecimalType.class);
+        assertNotNull(dt);
+        DecimalType dtState = numberItem.getState().as(DecimalType.class);
+        assertNotNull(dtState);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - dtState.doubleValue(), dt.doubleValue(), 0.001);
+
+        delta = PersistenceExtensions.deltaTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        QuantityType<?> qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        QuantityType<?> qtState = quantityItem.getState().as(QuantityType.class);
+        assertNotNull(qtState);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - dtState.doubleValue(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        // default persistence service
+        delta = PersistenceExtensions.deltaTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertNull(delta);
     }
 
     @Test
     public void testDeltaBetween() {
-        DecimalType delta = PersistenceExtensions.deltaBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(delta, is(notNullValue()));
-        assertThat(delta.doubleValue(), is(closeTo(6, 0.001)));
+        State delta = PersistenceExtensions.deltaBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        DecimalType dt = delta.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1, dt.doubleValue(), 0.001);
 
         delta = PersistenceExtensions.deltaBetween(quantityItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(delta, is(notNullValue()));
-        assertThat(delta.doubleValue(), is(closeTo(6, 0.001)));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        QuantityType<?> qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1, qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        delta = PersistenceExtensions.deltaBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        dt = delta.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3, dt.doubleValue(), 0.001);
+
+        delta = PersistenceExtensions.deltaBetween(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3, qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+
+        delta = PersistenceExtensions.deltaBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        dt = delta.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - HISTORIC_INTERMEDIATE_VALUE_1, dt.doubleValue(), 0.001);
+
+        delta = PersistenceExtensions.deltaBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - HISTORIC_INTERMEDIATE_VALUE_1, qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         delta = PersistenceExtensions.deltaBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(delta, is(nullValue()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(delta);
     }
 
     @Test
-    public void testEvolutionRate() {
-        numberItem.setState(new DecimalType(2012));
-        DecimalType rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+    public void testEvolutionRateSince() {
+        DecimalType rate = PersistenceExtensions.evolutionRateSince(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertThat(rate, is(nullValue()));
 
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(rate, is(notNullValue()));
+        rate = PersistenceExtensions.evolutionRateSince(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
         // ((now - then) / then) * 100
-        assertThat(rate.doubleValue(), is(closeTo(0.349, 0.001)));
+        assertThat(rate.doubleValue(),
+                is(closeTo(
+                        100.0 * (STATE.doubleValue() - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                        0.001)));
 
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(rate, is(notNullValue()));
+        rate = PersistenceExtensions.evolutionRateSince(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
         // ((now - then) / then) * 100
-        assertThat(rate.doubleValue(), is(closeTo(0.299, 0.001)));
-
-        numberItem.setState(new QuantityType<>(2012, SIUnits.CELSIUS));
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(rate, is(notNullValue()));
-        // ((now - then) / then) * 100
-        assertThat(rate.doubleValue(), is(closeTo(0.349, 0.001)));
-
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertThat(rate, is(notNullValue()));
-        // ((now - then) / then) * 100
-        assertThat(rate.doubleValue(), is(closeTo(0.299, 0.001)));
+        assertThat(rate.doubleValue(),
+                is(closeTo(
+                        100.0 * (STATE.doubleValue() - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                        0.001)));
 
         // default persistence service
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(rate, is(nullValue()));
+        rate = PersistenceExtensions.evolutionRateSince(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(rate);
+    }
 
-        rate = PersistenceExtensions.evolutionRate(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertThat(rate, is(nullValue()));
+    @Test
+    public void testEvolutionRateTill() {
+        DecimalType rate = PersistenceExtensions.evolutionRateTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((then - now) / now) * 100
+        assertThat(rate.doubleValue(),
+                is(closeTo(100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - STATE.doubleValue()) / STATE.doubleValue(), 0.001)));
+
+        rate = PersistenceExtensions.evolutionRateTill(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((then - now) / now) * 100
+        assertThat(rate.doubleValue(),
+                is(closeTo(100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - STATE.doubleValue()) / STATE.doubleValue(), 0.001)));
+
+        // default persistence service
+        rate = PersistenceExtensions.evolutionRateTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(rate);
+    }
+
+    @Test
+    public void testEvolutionRateBetween() {
+        DecimalType rate = PersistenceExtensions.evolutionRateBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3) / FUTURE_INTERMEDIATE_VALUE_3,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(quantityItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3) / FUTURE_INTERMEDIATE_VALUE_3,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (FUTURE_INTERMEDIATE_VALUE_3 - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                0.001)));
+
+        // default persistence service
+        rate = PersistenceExtensions.evolutionRateBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(rate);
     }
 
     @Test
     public void testPreviousStateDecimalTypeNoSkip() {
-        HistoricItem prevStateItem = PersistenceExtensions.previousState(numberItem, false, TestPersistenceService.ID);
+        HistoricItem prevStateItem = PersistenceExtensions.previousState(numberItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
         assertThat(prevStateItem.getState(), is(instanceOf(DecimalType.class)));
-        assertEquals("2012", prevStateItem.getState().toString());
+        assertEquals(value(HISTORIC_END), prevStateItem.getState());
 
         numberItem.setState(new DecimalType(4321));
-        prevStateItem = PersistenceExtensions.previousState(numberItem, false, TestPersistenceService.ID);
+        prevStateItem = PersistenceExtensions.previousState(numberItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012", prevStateItem.getState().toString());
+        assertEquals(value(HISTORIC_END), prevStateItem.getState());
 
-        numberItem.setState(new DecimalType(2012));
-        prevStateItem = PersistenceExtensions.previousState(numberItem, false, TestPersistenceService.ID);
+        numberItem.setState(new DecimalType(HISTORIC_END));
+        prevStateItem = PersistenceExtensions.previousState(numberItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012", prevStateItem.getState().toString());
+        assertEquals(value(HISTORIC_END), prevStateItem.getState());
 
         numberItem.setState(new DecimalType(3025));
-        prevStateItem = PersistenceExtensions.previousState(numberItem, false, TestPersistenceService.ID);
+        prevStateItem = PersistenceExtensions.previousState(numberItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012", prevStateItem.getState().toString());
+        assertEquals(value(HISTORIC_END), prevStateItem.getState());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(numberItem, false);
@@ -874,26 +1855,25 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testPreviousStateQuantityTypeNoSkip() {
-        HistoricItem prevStateItem = PersistenceExtensions.previousState(quantityItem, false,
-                TestPersistenceService.ID);
+        HistoricItem prevStateItem = PersistenceExtensions.previousState(quantityItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
         assertThat(prevStateItem.getState(), is(instanceOf(QuantityType.class)));
-        assertEquals("2012 °C", prevStateItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), prevStateItem.getState());
 
         quantityItem.setState(QuantityType.valueOf(4321, SIUnits.CELSIUS));
-        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
+        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012 °C", prevStateItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), prevStateItem.getState());
 
-        quantityItem.setState(QuantityType.valueOf(2012, SIUnits.CELSIUS));
-        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
+        quantityItem.setState(QuantityType.valueOf(HISTORIC_END, SIUnits.CELSIUS));
+        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012 °C", prevStateItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), prevStateItem.getState());
 
         quantityItem.setState(QuantityType.valueOf(3025, SIUnits.CELSIUS));
-        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, TestPersistenceService.ID);
+        prevStateItem = PersistenceExtensions.previousState(quantityItem, false, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2012 °C", prevStateItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END), SIUnits.CELSIUS), prevStateItem.getState());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(quantityItem, false);
@@ -902,10 +1882,10 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testPreviousStateDecimalTypeSkip() {
-        numberItem.setState(new DecimalType(2012));
-        HistoricItem prevStateItem = PersistenceExtensions.previousState(numberItem, true, TestPersistenceService.ID);
+        numberItem.setState(new DecimalType(HISTORIC_END));
+        HistoricItem prevStateItem = PersistenceExtensions.previousState(numberItem, true, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2011", prevStateItem.getState().toString());
+        assertEquals(value(HISTORIC_END - 1), prevStateItem.getState());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(numberItem, true);
@@ -914,10 +1894,10 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testPreviousStateQuantityTypeSkip() {
-        quantityItem.setState(QuantityType.valueOf(2012, SIUnits.CELSIUS));
-        HistoricItem prevStateItem = PersistenceExtensions.previousState(quantityItem, true, TestPersistenceService.ID);
+        quantityItem.setState(QuantityType.valueOf(HISTORIC_END, SIUnits.CELSIUS));
+        HistoricItem prevStateItem = PersistenceExtensions.previousState(quantityItem, true, SERVICE_ID);
         assertNotNull(prevStateItem);
-        assertEquals("2011 °C", prevStateItem.getState().toString());
+        assertEquals(new QuantityType<>(value(HISTORIC_END - 1), SIUnits.CELSIUS), prevStateItem.getState());
 
         // default persistence service
         prevStateItem = PersistenceExtensions.previousState(quantityItem, true);
@@ -925,151 +1905,342 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testNextStateDecimalTypeNoSkip() {
+        HistoricItem nextStateItem = PersistenceExtensions.nextState(numberItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertThat(nextStateItem.getState(), is(instanceOf(DecimalType.class)));
+        assertEquals(value(FUTURE_START), nextStateItem.getState());
+
+        numberItem.setState(new DecimalType(4321));
+        nextStateItem = PersistenceExtensions.nextState(numberItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(value(FUTURE_START), nextStateItem.getState());
+
+        numberItem.setState(new DecimalType(FUTURE_START));
+        nextStateItem = PersistenceExtensions.nextState(numberItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(value(FUTURE_START), nextStateItem.getState());
+
+        numberItem.setState(new DecimalType(3025));
+        nextStateItem = PersistenceExtensions.nextState(numberItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(value(FUTURE_START), nextStateItem.getState());
+
+        // default persistence service
+        nextStateItem = PersistenceExtensions.nextState(numberItem, false);
+        assertNull(nextStateItem);
+    }
+
+    @Test
+    public void testNextStateQuantityTypeNoSkip() {
+        HistoricItem nextStateItem = PersistenceExtensions.nextState(quantityItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertThat(nextStateItem.getState(), is(instanceOf(QuantityType.class)));
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), nextStateItem.getState());
+
+        quantityItem.setState(QuantityType.valueOf(4321, SIUnits.CELSIUS));
+        nextStateItem = PersistenceExtensions.nextState(quantityItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), nextStateItem.getState());
+
+        quantityItem.setState(QuantityType.valueOf(FUTURE_START, SIUnits.CELSIUS));
+        nextStateItem = PersistenceExtensions.nextState(quantityItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), nextStateItem.getState());
+
+        quantityItem.setState(QuantityType.valueOf(3025, SIUnits.CELSIUS));
+        nextStateItem = PersistenceExtensions.nextState(quantityItem, false, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(new QuantityType<>(value(FUTURE_START), SIUnits.CELSIUS), nextStateItem.getState());
+
+        // default persistence service
+        nextStateItem = PersistenceExtensions.nextState(quantityItem, false);
+        assertNull(nextStateItem);
+    }
+
+    @Test
+    public void testNextStateDecimalTypeSkip() {
+        numberItem.setState(new DecimalType(FUTURE_START));
+        HistoricItem nextStateItem = PersistenceExtensions.nextState(numberItem, true, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(value(FUTURE_START + 1), nextStateItem.getState());
+
+        // default persistence service
+        nextStateItem = PersistenceExtensions.nextState(numberItem, true);
+        assertNull(nextStateItem);
+    }
+
+    @Test
+    public void testNextStateQuantityTypeSkip() {
+        quantityItem.setState(QuantityType.valueOf(FUTURE_START, SIUnits.CELSIUS));
+        HistoricItem nextStateItem = PersistenceExtensions.nextState(quantityItem, true, SERVICE_ID);
+        assertNotNull(nextStateItem);
+        assertEquals(new QuantityType<>(value(FUTURE_START + 1), SIUnits.CELSIUS), nextStateItem.getState());
+
+        // default persistence service
+        nextStateItem = PersistenceExtensions.nextState(quantityItem, true);
+        assertNull(nextStateItem);
+    }
+
+    @Test
     public void testChangedSince() {
-        boolean changed = PersistenceExtensions.changedSince(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertFalse(changed);
+        Boolean changed = PersistenceExtensions.changedSince(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, true);
 
         changed = PersistenceExtensions.changedSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertTrue(changed);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, true);
 
         // default persistence service
         changed = PersistenceExtensions.changedSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertFalse(changed);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(changed);
+    }
+
+    @Test
+    public void testChangedTill() {
+        Boolean changed = PersistenceExtensions.changedTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, true);
+
+        // default persistence service
+        changed = PersistenceExtensions.changedTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(changed);
     }
 
     @Test
     public void testChangedBetween() {
-        boolean changed = PersistenceExtensions.changedBetween(numberItem,
-                ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2019, 5, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertFalse(changed);
+        Boolean changed = PersistenceExtensions.changedBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 5, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, false);
 
         changed = PersistenceExtensions.changedBetween(numberItem,
-                ZonedDateTime.of(2006, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2008, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertTrue(changed);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, true);
+
+        changed = PersistenceExtensions.changedBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 5, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, false);
+
+        changed = PersistenceExtensions.changedBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(changed, true);
 
         // default persistence service
         changed = PersistenceExtensions.changedBetween(numberItem,
-                ZonedDateTime.of(2004, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertFalse(changed);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(changed);
     }
 
     @Test
     public void testUpdatedSince() {
-        boolean updated = PersistenceExtensions.updatedSince(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertFalse(updated);
+        Boolean updated = PersistenceExtensions.updatedSince(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
 
         updated = PersistenceExtensions.updatedSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertTrue(updated);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
 
         // default persistence service
         updated = PersistenceExtensions.updatedSince(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertFalse(updated);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(updated);
+    }
+
+    @Test
+    public void testUpdatedTill() {
+        Boolean updated = PersistenceExtensions.updatedTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
+
+        // default persistence service
+        updated = PersistenceExtensions.updatedTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(updated);
     }
 
     @Test
     public void testUpdatedBetween() {
-        boolean updated = PersistenceExtensions.updatedBetween(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertFalse(updated);
+        Boolean updated = PersistenceExtensions.updatedBetween(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
 
         updated = PersistenceExtensions.updatedBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertTrue(updated);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
 
         updated = PersistenceExtensions.updatedBetween(numberItem,
-                ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertTrue(updated);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_NOVALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_NOVALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                SERVICE_ID);
+        assertEquals(updated, false);
+
+        updated = PersistenceExtensions.updatedBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, false);
+
+        updated = PersistenceExtensions.updatedBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(updated, true);
 
         // default persistence service
         updated = PersistenceExtensions.updatedBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertFalse(updated);
-    }
-
-    @Test
-    public void testCountBetween() {
-        long counts = PersistenceExtensions.countBetween(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(0, counts);
-
-        counts = PersistenceExtensions.countBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(7, counts);
-
-        counts = PersistenceExtensions.countBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertEquals(0, counts);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(updated);
     }
 
     @Test
     public void testCountSince() {
-        long counts = PersistenceExtensions.countSince(numberItem,
-                ZonedDateTime.of(1980, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(33, counts);
+        Long counts = PersistenceExtensions.countSince(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1, counts);
 
         counts = PersistenceExtensions.countSince(numberItem,
-                ZonedDateTime.of(2007, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(6, counts);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_2 + 1, counts);
 
         counts = PersistenceExtensions.countSince(numberItem,
-                ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_NOVALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                SERVICE_ID);
         assertEquals(0, counts);
 
+        // default persistence service
         counts = PersistenceExtensions.countSince(numberItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
+    }
+
+    @Test
+    public void testCountTill() {
+        Long counts = PersistenceExtensions.countTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(0, counts);
+
+        counts = PersistenceExtensions.countTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1, counts);
+
+        counts = PersistenceExtensions.countTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_START + 1, counts);
+
+        // default persistence service
+        counts = PersistenceExtensions.countTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
+    }
+
+    @Test
+    public void testCountBetween() {
+        Long counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_1 - HISTORIC_START + 1, counts);
+
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1, counts);
+
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1, counts);
+
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1,
+                counts);
+
+        // default persistence service
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
     }
 
     @Test
     public void testCountStateChangesSince() {
-        long counts = PersistenceExtensions.countStateChangesSince(numberItem,
-                ZonedDateTime.of(1980, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(32, counts);
+        Long counts = PersistenceExtensions.countStateChangesSince(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1, counts);
 
         counts = PersistenceExtensions.countStateChangesSince(numberItem,
-                ZonedDateTime.of(2007, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(5, counts);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_2, counts);
 
         counts = PersistenceExtensions.countStateChangesSince(numberItem,
-                ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_NOVALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                SERVICE_ID);
         assertEquals(0, counts);
 
+        // default persistence service
         counts = PersistenceExtensions.countStateChangesSince(numberItem,
-                ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
+    }
+
+    @Test
+    public void testCountStateChangesTill() {
+        Long counts = PersistenceExtensions.countStateChangesTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_NOVALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertEquals(0, counts);
+
+        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START, counts);
+
+        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_START, counts);
+
+        // default persistence service
+        counts = PersistenceExtensions.countStateChangesTill(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
     }
 
     @Test
     public void testCountStateChangesBetween() {
-        long counts = PersistenceExtensions.countStateChangesBetween(numberItem,
-                ZonedDateTime.of(1940, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(0, counts);
+        Long counts = PersistenceExtensions.countStateChangesBetween(numberItem,
+                ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_1 - HISTORIC_START, counts);
 
         counts = PersistenceExtensions.countStateChangesBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), TestPersistenceService.ID);
-        assertEquals(6, counts);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1, counts);
 
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1, counts);
+
+        counts = PersistenceExtensions.countBetween(numberItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertEquals(FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1,
+                counts);
+
+        // default persistence service
         counts = PersistenceExtensions.countStateChangesBetween(numberItem,
-                ZonedDateTime.of(2005, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                ZonedDateTime.of(2011, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
-        assertEquals(0, counts);
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
+        assertNull(counts);
     }
 }

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -258,7 +258,6 @@ public class PersistenceExtensionsTest {
                 SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_3), historicItem.getState());
-
     }
 
     @Test

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -45,10 +46,6 @@ public class TestCachedValuesPersistenceService implements ModifiablePersistence
     public TestCachedValuesPersistenceService() {
     }
 
-    public void addHistoricItem(ZonedDateTime timestamp, State state, String itemName) {
-        historicItems.add(new CachedHistoricItem(timestamp, state, itemName));
-    }
-
     @Override
     public String getId() {
         return ID;
@@ -64,6 +61,7 @@ public class TestCachedValuesPersistenceService implements ModifiablePersistence
 
     @Override
     public void store(Item item, ZonedDateTime date, State state) {
+        historicItems.add(new CachedHistoricItem(date, state, item.getName()));
     }
 
     @Override
@@ -72,7 +70,7 @@ public class TestCachedValuesPersistenceService implements ModifiablePersistence
 
     @Override
     public boolean remove(FilterCriteria filter) throws IllegalArgumentException {
-        return true;
+        return historicItems.removeAll(StreamSupport.stream(query(filter).spliterator(), false).toList());
     }
 
     @Override

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
@@ -25,8 +25,8 @@ import org.openhab.core.items.Item;
 import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
+import org.openhab.core.persistence.ModifiablePersistenceService;
 import org.openhab.core.persistence.PersistenceItemInfo;
-import org.openhab.core.persistence.QueryablePersistenceService;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 
@@ -36,7 +36,7 @@ import org.openhab.core.types.State;
  * @author Florian Binder - Initial contribution
  */
 @NonNullByDefault
-public class TestCachedValuesPersistenceService implements QueryablePersistenceService {
+public class TestCachedValuesPersistenceService implements ModifiablePersistenceService {
 
     public static final String ID = "testCachedHistoricItems";
 
@@ -63,6 +63,19 @@ public class TestCachedValuesPersistenceService implements QueryablePersistenceS
     }
 
     @Override
+    public void store(Item item, ZonedDateTime date, State state) {
+    }
+
+    @Override
+    public void store(Item item, ZonedDateTime date, State state, @Nullable String alias) {
+    }
+
+    @Override
+    public boolean remove(FilterCriteria filter) throws IllegalArgumentException {
+        return true;
+    }
+
+    @Override
     public Iterable<HistoricItem> query(FilterCriteria filter) {
         Stream<HistoricItem> stream = historicItems.stream();
 
@@ -70,16 +83,19 @@ public class TestCachedValuesPersistenceService implements QueryablePersistenceS
             throw new UnsupportedOperationException("state filtering is not supported yet");
         }
 
-        if (filter.getItemName() != null) {
-            stream = stream.filter(hi -> filter.getItemName().equals(hi.getName()));
+        String itemName = filter.getItemName();
+        if (itemName != null) {
+            stream = stream.filter(hi -> itemName.equals(hi.getName()));
         }
 
-        if (filter.getBeginDate() != null) {
-            stream = stream.filter(hi -> !filter.getBeginDate().isAfter(hi.getTimestamp()));
+        ZonedDateTime beginDate = filter.getBeginDate();
+        if (beginDate != null) {
+            stream = stream.filter(hi -> !beginDate.isAfter(hi.getTimestamp()));
         }
 
-        if (filter.getEndDate() != null) {
-            stream = stream.filter(hi -> !filter.getEndDate().isBefore(hi.getTimestamp()));
+        ZonedDateTime endDate = filter.getEndDate();
+        if (endDate != null) {
+            stream = stream.filter(hi -> !endDate.isBefore(hi.getTimestamp()));
         }
 
         if (filter.getOrdering() == Ordering.ASCENDING) {

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.persistence.extensions;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import javax.measure.Unit;
@@ -45,11 +47,44 @@ import org.openhab.core.types.State;
  * A simple persistence service used for unit tests
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Mark Herwege - Allow future values
  */
 @NonNullByDefault
 public class TestPersistenceService implements QueryablePersistenceService {
 
-    public static final String ID = "test";
+    public static final String SERVICE_ID = "test";
+
+    static final int SWITCH_START = -15;
+    static final int SWITCH_ON_1 = -15;
+    static final int SWITCH_ON_INTERMEDIATE_1 = -12;
+    static final int SWITCH_OFF_1 = -10;
+    static final int SWITCH_OFF_INTERMEDIATE_1 = -6;
+    static final int SWITCH_ON_2 = -5;
+    static final int SWITCH_ON_INTERMEDIATE_21 = -1;
+    static final int SWITCH_ON_INTERMEDIATE_22 = +1;
+    static final int SWITCH_OFF_2 = +5;
+    static final int SWITCH_OFF_INTERMEDIATE_2 = +7;
+    static final int SWITCH_ON_3 = +10;
+    static final int SWITCH_ON_INTERMEDIATE_3 = +12;
+    static final int SWITCH_OFF_3 = +15;
+    static final int SWITCH_END = +15;
+    static final OnOffType SWITCH_STATE = OnOffType.ON;
+
+    static final int BEFORE_START = 1940;
+    static final int HISTORIC_START = 1950;
+    static final int HISTORIC_INTERMEDIATE_VALUE_1 = 2005;
+    static final int HISTORIC_INTERMEDIATE_VALUE_2 = 2011;
+    static final int HISTORIC_END = 2012;
+    static final int HISTORIC_INTERMEDIATE_NOVALUE_3 = 2019;
+    static final int HISTORIC_INTERMEDIATE_NOVALUE_4 = 2021;
+    static final int FUTURE_INTERMEDIATE_NOVALUE_1 = 2051;
+    static final int FUTURE_INTERMEDIATE_NOVALUE_2 = 2056;
+    static final int FUTURE_START = 2060;
+    static final int FUTURE_INTERMEDIATE_VALUE_3 = 2070;
+    static final int FUTURE_INTERMEDIATE_VALUE_4 = 2077;
+    static final int FUTURE_END = 2100;
+    static final int AFTER_END = 2110;
+    static final DecimalType STATE = new DecimalType(HISTORIC_END);
 
     private final ItemRegistry itemRegistry;
 
@@ -59,7 +94,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
 
     @Override
     public String getId() {
-        return ID;
+        return SERVICE_ID;
     }
 
     @Override
@@ -73,18 +108,17 @@ public class TestPersistenceService implements QueryablePersistenceService {
     @Override
     public Iterable<HistoricItem> query(FilterCriteria filter) {
         if (PersistenceExtensionsTest.TEST_SWITCH.equals(filter.getItemName())) {
-            ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES),
-                    nowMinusFifteenHours = now.minusHours(15),
-                    beginDate = filter.getBeginDate() != null ? filter.getBeginDate() : nowMinusFifteenHours,
-                    endDate = filter.getEndDate() != null ? filter.getEndDate() : now;
-            if (endDate.isBefore(beginDate)) {
-                return List.of();
-            }
+            ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+            ZonedDateTime nowMinusHours = now.plusHours(SWITCH_START);
+            ZonedDateTime endDate = filter.getEndDate();
+            endDate = endDate != null ? endDate : now;
+            ZonedDateTime beginDate = filter.getBeginDate();
+            beginDate = beginDate != null ? beginDate : endDate.isAfter(now) ? now : endDate.minusHours(1);
 
-            List<HistoricItem> results = new ArrayList<>(16);
-            for (int i = 0; i <= 15; i++) {
-                final int hours = i;
-                final ZonedDateTime theDate = nowMinusFifteenHours.plusHours(hours);
+            List<HistoricItem> results = new ArrayList<>(31);
+            for (int i = SWITCH_START; i <= SWITCH_END; i++) {
+                final int hour = i;
+                final ZonedDateTime theDate = nowMinusHours.plusHours(i - SWITCH_START);
                 if (!theDate.isBefore(beginDate) && !theDate.isAfter(endDate)) {
                     results.add(new HistoricItem() {
                         @Override
@@ -94,7 +128,8 @@ public class TestPersistenceService implements QueryablePersistenceService {
 
                         @Override
                         public State getState() {
-                            return OnOffType.from(hours < 5 || hours > 10);
+                            return OnOffType.from(hour < SWITCH_OFF_1 || (hour >= SWITCH_ON_2 && hour < SWITCH_OFF_2)
+                                    || hour >= SWITCH_ON_3);
                         }
 
                         @Override
@@ -117,22 +152,27 @@ public class TestPersistenceService implements QueryablePersistenceService {
             }
             return stream.toList();
         } else {
-            int startValue = 1950;
-            int endValue = 2012;
+            int startValue = HISTORIC_START;
+            int endValue = FUTURE_END;
 
-            if (filter.getBeginDate() != null) {
-                startValue = filter.getBeginDate().getYear();
+            ZonedDateTime beginDate = filter.getBeginDate();
+            if (beginDate != null && beginDate.getYear() >= startValue) {
+                startValue = beginDate.getYear();
             }
-            if (filter.getEndDate() != null) {
-                endValue = filter.getEndDate().getYear();
+            ZonedDateTime endDate = filter.getEndDate();
+            if (endDate != null && endDate.getYear() <= endValue) {
+                endValue = endDate.getYear();
             }
 
-            if (endValue <= startValue || startValue < 1950) {
+            if (endValue <= startValue) {
                 return List.of();
             }
 
             List<HistoricItem> results = new ArrayList<>(endValue - startValue);
             for (int i = startValue; i <= endValue; i++) {
+                if (i > HISTORIC_END && i < FUTURE_START) {
+                    continue;
+                }
                 final int year = i;
                 results.add(new HistoricItem() {
                     @Override
@@ -181,5 +221,47 @@ public class TestPersistenceService implements QueryablePersistenceService {
     @Override
     public List<PersistenceStrategy> getDefaultStrategies() {
         return List.of();
+    }
+
+    static OnOffType switchValue(int hour) {
+        return (hour >= SWITCH_ON_1 && hour < SWITCH_OFF_1) || (hour >= SWITCH_ON_2 && hour < SWITCH_OFF_2)
+                || (hour >= SWITCH_ON_3 && hour < SWITCH_OFF_3) ? OnOffType.ON : OnOffType.OFF;
+    }
+
+    static DecimalType value(long year) {
+        if (year < HISTORIC_START) {
+            return DecimalType.ZERO;
+        } else if (year <= HISTORIC_END) {
+            return new DecimalType(year);
+        } else if (year < FUTURE_START) {
+            return new DecimalType(HISTORIC_END);
+        } else if (year <= FUTURE_END) {
+            return new DecimalType(year);
+        } else {
+            return new DecimalType(FUTURE_END);
+        }
+    }
+
+    static double average(@Nullable Integer beginYear, @Nullable Integer endYear) {
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime beginDate = beginYear != null
+                ? ZonedDateTime.of(beginYear >= HISTORIC_START ? beginYear : HISTORIC_START, 1, 1, 0, 0, 0, 0,
+                        ZoneId.systemDefault())
+                : now;
+        ZonedDateTime endDate = endYear != null ? ZonedDateTime.of(endYear, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
+                : now;
+        int begin = beginYear != null ? beginYear : now.getYear() + 1;
+        int end = endYear != null ? endYear : now.getYear();
+        long sum = LongStream.range(begin, end).map(y -> value(y).longValue() * Duration
+                .between(ZonedDateTime.of(Long.valueOf(y).intValue(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                        ZonedDateTime.of(Long.valueOf(y + 1).intValue(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                .toMillis()).sum();
+        sum += beginYear == null ? value(now.getYear()).longValue() * Duration
+                .between(now, ZonedDateTime.of(now.getYear() + 1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())).toMillis()
+                : 0;
+        sum += endYear == null ? value(now.getYear()).longValue() * Duration
+                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now).toMillis() : 0;
+        long duration = Duration.between(beginDate, endDate).toMillis();
+        return 1.0 * sum / duration;
     }
 }


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/3732
Closes https://github.com/openhab/openhab-core/issues/3896

This PR implements unit support in all PersistenceExtension commands, returning the full value including unit for Number item types with a dimension. It therefore changes return types from DecimalType to a State type, whereby the state can include the unit.
This has been tested to work with rules DSL, and it should be possible to extend other scripting languages to support this, making calculations with historic states of items with dimensions more straightforward.
This may require adapting user rules and is therefore a breaking change.

Secondly, this PR makes sure persistence extensions work properly with persisted items in the future:
- all `Between` commands have been adapted to be able to properly work across the `now` boundary,
- a series of `Untill` commands have been added, equivalent to the `Since` commands.
- `nexUpdate` and `nexState` commands have been added.
- the `historicState` command has been deprecated (but still available for backward compatibility) and replaced with `persistedState` also accepting future dates.
- the `evolutionRate` command has been renamed to `evolutionRateSince`, `evolutionRateUntill` and `evolutionRateBetween`, bringing it in line with the other commands. This change is required to allow one date signatures to differentiate between `Since` and `Untill`. `evolutionRate` is deprecated and kept for backward compatibility, and interpreted as `evolutionRateSince`.
- added `removeAllStates` `Since`, `Untill` and `Between` commands.

The code now also has full null annotations and checks. In doing so, changes were required to avoid potential null issues. Many of these null issues where due to null being interpreted as now for end dates before, which is not possible when time can be in the future.

The test classes where extended and refactored to also test for all future commands.

Signed-off by: Mark Herwege mark.herwege@telenet.be