### PR TITLE
Upgrade JUPnP to 2.7.1

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -202,7 +202,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -469,7 +469,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -208,11 +208,11 @@
 	</feature>
 
 	<feature name="openhab.tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">
-		<capability>openhab.tp;feature=jupnp;version=2.7.0</capability>
+		<capability>openhab.tp;feature=jupnp;version=2.7.1</capability>
 		<feature dependency="true">http</feature>
 		<feature dependency="true">scr</feature>
 		<feature dependency="true">openhab.tp-httpclient</feature>
-		<bundle>mvn:org.jupnp/org.jupnp/2.7.0</bundle>
+		<bundle>mvn:org.jupnp/org.jupnp/2.7.1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">


### PR DESCRIPTION
Fixes CVE-2020-12695

Previous upgrade (for reference): #3421