### PR TITLE
Move factory interface to public package

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
@@ -12,9 +12,12 @@
  */
 package org.openhab.core.thing.binding.generic;
 
+import java.util.function.Consumer;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.State;
 
 /**
  * The {@link ChannelHandler} defines the interface for converting received {@link ChannelHandlerContent}
@@ -40,4 +43,11 @@ public interface ChannelHandler {
      * @param command
      */
     void send(Command command);
+
+    @FunctionalInterface
+    public interface Factory {
+        ChannelHandler create(Consumer<State> updateState, Consumer<Command> postCommand,
+                @Nullable Consumer<String> sendHttpValue, ChannelTransformation stateTransformations,
+                ChannelTransformation commandTransformations, ChannelValueConverterConfig channelConfig);
+    }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
@@ -105,11 +105,4 @@ public abstract class AbstractTransformingChannelHandler implements ChannelHandl
      * @return the string representation of the command
      */
     protected abstract String toString(Command command);
-
-    @FunctionalInterface
-    public interface Factory {
-        ChannelHandler create(Consumer<State> updateState, Consumer<Command> postCommand,
-                @Nullable Consumer<String> sendHttpValue, ChannelTransformation stateTransformations,
-                ChannelTransformation commandTransformations, ChannelValueConverterConfig channelConfig);
-    }
 }


### PR DESCRIPTION
The factory interface should be available for usage in bindings, so it needs to be in an exported package. This was overlooked when the `AbstractTransformingChannelHandler` was moved to an internal package.