### PR TITLE
ZipException workarounds

### DIFF
--- a/itests/itest-include.bndrun
+++ b/itests/itest-include.bndrun
@@ -19,7 +19,9 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 
 # An unused random HTTP port is used during tests to prevent resource conflicts
 # This property is set by the build-helper-maven-plugin in the itests pom.xml
--runvm: -Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+-runvm: \
+	-Djdk.util.zip.disableZip64ExtraFieldValidation=true,\
+	-Dorg.osgi.service.http.port=${org.osgi.service.http.port}
 
 # The integration test itself does not export anything.
 Export-Package:

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <bnd.version>6.4.0</bnd.version>
     <commons.net.version>3.7.2</commons.net.version>
     <eea.version>2.3.0</eea.version>
-    <karaf.compile.version>4.4.0</karaf.compile.version>
+    <karaf.compile.version>4.4.3</karaf.compile.version>
     <karaf.tooling.version>4.4.3</karaf.tooling.version>
     <sat.version>0.15.0</sat.version>
     <slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION
I ran into some more build issues due to this "Improved ZIP64 Extra Field Validation" (see https://github.com/openhab/openhab-core/issues/3718)  now that Temurin 17.0.8 upgrades are available in APT repos.

The org.openhab.core.karaf bundle fails to build as Java thinks there are some issues with org.apache.karaf.features.core-4.4.0.jar. However `zip -T ...` thinks it's OK. So perhaps this is a false positive. It doesn't complain about org.apache.karaf.features.core-4.4.3.jar so let's use that instead.

Also the itests generate lots of ZipException stacktraces due to the issue with geronimo-osgi-locator.jar.