### PR TITLE
Fix logging in AbstractProvider implementations

### DIFF
--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
@@ -57,6 +57,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is the central part of the persistence management and delegation. It reads the persistence
@@ -70,6 +72,7 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class PersistenceModelManager extends AbstractProvider<PersistenceServiceConfiguration>
         implements ModelRepositoryChangeListener, PersistenceServiceConfigurationProvider {
+    private final Logger logger = LoggerFactory.getLogger(PersistenceModelManager.class);
     private final Map<String, PersistenceServiceConfiguration> configurations = new ConcurrentHashMap<>();
     private final ModelRepository modelRepository;
 

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -31,6 +31,8 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.ItemChannelLinkProvider;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link GenericItemChannelLinkProvider} link items to channel by reading bindings with type "channel".
@@ -43,6 +45,7 @@ import org.osgi.service.component.annotations.Component;
 public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannelLink>
         implements BindingConfigReader, ItemChannelLinkProvider {
 
+    private final Logger logger = LoggerFactory.getLogger(GenericItemChannelLinkProvider.class);
     /** caches binding configurations. maps itemNames to {@link BindingConfig}s */
     protected Map<String, Set<ItemChannelLink>> itemChannelLinkMap = new ConcurrentHashMap<>();
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractProvider.java
@@ -39,7 +39,7 @@ public abstract class AbstractProvider<@NonNull E> implements Provider<E> {
         UPDATED
     }
 
-    protected final Logger logger = LoggerFactory.getLogger(AbstractProvider.class);
+    private Logger logger = LoggerFactory.getLogger(AbstractProvider.class);
     protected List<ProviderChangeListener<E>> listeners = new CopyOnWriteArrayList<>();
 
     @Override


### PR DESCRIPTION
Implementations should not use the logger of the parent