### PR TITLE
Use workaround to fix high CPU usage by LinkedTransferQueue

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -202,7 +202,8 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>2.7.1</version>
+      <!-- Uses the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
+      <version>2.7.1.OH1</version>
       <scope>compile</scope>
     </dependency>
 
@@ -434,6 +435,14 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>5.12.1</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Provides the Java 11 LinkedTransferQueue used in workarounds for JDK-8301341 -->
+    <dependency>
+      <groupId>org.openhab</groupId>
+      <artifactId>base-fixes</artifactId>
+      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -469,7 +469,8 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>2.7.1</version>
+      <!-- Uses the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
+      <version>2.7.1.OH1</version>
       <scope>compile</scope>
     </dependency>
 
@@ -1088,6 +1089,14 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>5.12.1</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <!-- Provides the Java 11 LinkedTransferQueue used in workarounds for JDK-8301341 -->
+    <dependency>
+      <groupId>org.openhab</groupId>
+      <artifactId>base-fixes</artifactId>
+      <version>1.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/QueueingThreadPoolExecutor.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/QueueingThreadPoolExecutor.java
@@ -13,7 +13,6 @@
 package org.openhab.core.common;
 
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -24,6 +23,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
+import org.openhab.basefixes.util.concurrent.LinkedTransferQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -40,6 +40,7 @@
 		<requirement>openhab.tp;filter:="(feature=jna)"</requirement>
 		<feature dependency="true">openhab.tp-jna</feature>
 
+		<bundle>mvn:org.openhab/base-fixes/1.0.0</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.core/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery/${project.version}</bundle>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -212,7 +212,8 @@
 		<feature dependency="true">http</feature>
 		<feature dependency="true">scr</feature>
 		<feature dependency="true">openhab.tp-httpclient</feature>
-		<bundle>mvn:org.jupnp/org.jupnp/2.7.1</bundle>
+		<bundle>mvn:org.openhab/base-fixes/1.0.0</bundle>
+		<bundle>mvn:org.jupnp/org.jupnp/2.7.1.OH1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">

--- a/itests/org.openhab.core.addon.tests/itest.bndrun
+++ b/itests/org.openhab.core.addon.tests/itest.bndrun
@@ -60,4 +60,5 @@ Fragment-Host: org.openhab.core.addon
 	org.openhab.core.addon;version='[4.1.0,4.1.1)',\
 	org.openhab.core.addon.tests;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -68,4 +68,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.openhab.core.auth.oauth2client.tests;version='[4.1.0,4.1.1)',\
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.io.net;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -63,4 +63,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -61,4 +61,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core.tests;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.openhab.core.io.transport.mdns;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -65,4 +65,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -66,4 +66,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -74,4 +74,6 @@ Provide-Capability: \
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -54,4 +54,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.dispatch;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.dispatch.tests;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -63,4 +63,6 @@ feature.openhab-config: \
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.ephemeris;version='[4.1.0,4.1.1)',\
 	org.openhab.core.ephemeris.tests;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -72,4 +72,6 @@ Fragment-Host: org.openhab.core.io.net
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.io.net;version='[4.1.0,4.1.1)',\
 	org.openhab.core.io.net.tests;version='[4.1.0,4.1.1)',\
-	org.openhab.core.test;version='[4.1.0,4.1.1)'
+	org.openhab.core.test;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -106,4 +106,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.semantics;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -104,7 +104,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.model.item.tests;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.persistence;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.rule;version='[4.1.0,4.1.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.sitemap;version='[4.1.0,4.1.1)',\
@@ -114,4 +113,7 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
-	org.openhab.core.voice;version='[4.1.0,4.1.1)'
+	org.openhab.core.voice;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.openhab.core.model.thing.runtime;version='[4.1.0,4.1.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -117,4 +117,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
-	org.openhab.core.voice;version='[4.1.0,4.1.1)'
+	org.openhab.core.voice;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.openhab.core.model.thing.runtime;version='[4.1.0,4.1.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -110,7 +110,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.model.item;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.persistence;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.rule;version='[4.1.0,4.1.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script.tests;version='[4.1.0,4.1.1)',\
@@ -121,4 +120,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
-	org.openhab.core.voice;version='[4.1.0,4.1.1)'
+	org.openhab.core.voice;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.openhab.core.model.thing.runtime;version='[4.1.0,4.1.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -110,7 +110,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.model.item.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.persistence;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.rule;version='[4.1.0,4.1.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.script.runtime;version='[4.1.0,4.1.1)',\
 	org.openhab.core.model.sitemap;version='[4.1.0,4.1.1)',\
@@ -123,4 +122,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
-	org.openhab.core.voice;version='[4.1.0,4.1.1)'
+	org.openhab.core.voice;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -59,4 +59,6 @@ Fragment-Host: org.openhab.core.storage.json
 	org.openhab.core.storage.json.tests;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -58,4 +58,6 @@ Fragment-Host: org.openhab.core
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
-	org.openhab.core.tests;version='[4.1.0,4.1.1)'
+	org.openhab.core.tests;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -67,4 +67,5 @@ Fragment-Host: org.openhab.core.thing
 	org.openhab.core.test;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.thing.tests;version='[4.1.0,4.1.1)',\
-	org.openhab.core.transform;version='[4.1.0,4.1.1)'
+	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -72,4 +72,5 @@ Fragment-Host: org.openhab.core.voice
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
 	org.openhab.core.voice;version='[4.1.0,4.1.1)',\
-	org.openhab.core.voice.tests;version='[4.1.0,4.1.1)'
+	org.openhab.core.voice.tests;version='[4.1.0,4.1.1)',\
+	org.openhab.base-fixes;version='[1.0.0,1.0.1)'


### PR DESCRIPTION
This is a workaround for [JDK-8301341](https://bugs.openjdk.org/browse/JDK-8301341) by using the Java 11 `LinkedTransferQueue` with the `QueueingThreadPoolExecutor` in the Core and jUPnP.

---

Using the Java 11 `LinkedTransferQueue` is probably the most stable option because it did not cause these issues with OH3.

To be able to use the same artifact with jUPnP, jUPnP also needs to be build with Java 11 or newer (it's currently still compatible with Java 8).

I put the Java 11 `LinkedTransferQueue` in a [separate repo](https://github.com/wborn/openhab-base-fixes) because it has a GPLv2+CE license.
Perhaps the repo can also be moved to the openHAB organization?
Because Java and OpenJDK are trademarks, it is probably best to avoid these in repo and package names etc.

Let me know if you agree with the proposed artifact GAV parameters.
After that I can build the artifacts and they can be added to Artifactory.

Closes #3755