### PR TITLE
[sitemap] AND operator accepted in any condition + added optional conditional rules for icon

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -35,6 +35,11 @@ public class WidgetDTO {
 
     public String label;
     public String icon;
+    /**
+     * staticIcon is a boolean indicating if the widget state must be ignored when requesting the icon.
+     * It is set to true when the widget has either the staticIcon property set or the icon property set
+     * with conditional rules.
+     */
     public Boolean staticIcon;
     public String labelcolor;
     public String valuecolor;

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -25,7 +25,9 @@ LinkableWidget:
 
 Frame:
     {Frame} 'Frame' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -33,7 +35,9 @@ Frame:
 
 Text:
     {Text} 'Text' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -41,7 +45,9 @@ Text:
 
 Group:
     'Group' (('item=' item=GroupItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)* ']'))? &
@@ -49,7 +55,9 @@ Group:
 
 Image:
     'Image' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('url=' url=STRING)? & ('refresh=' refresh=INT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -58,7 +66,9 @@ Image:
 
 Video:
     'Video' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('url=' url=STRING) & ('encoding=' encoding=STRING)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -67,7 +77,9 @@ Video:
 
 Chart:
     'Chart' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('service=' service=STRING)? & ('refresh=' refresh=INT)? & ('period=' period=ID) &
     ('legend=' legend=BOOLEAN_OBJECT)? & ('forceasitem=' forceAsItem=BOOLEAN_OBJECT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
@@ -78,7 +90,9 @@ Chart:
 
 Webview:
     'Webview' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('height=' height=INT)? & ('url=' url=STRING) &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -87,7 +101,9 @@ Webview:
 
 Switch:
     'Switch' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('mappings=[' mappings+=Mapping (',' mappings+=Mapping)* ']')? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -96,7 +112,9 @@ Switch:
 
 Mapview:
     'Mapview' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('height=' height=INT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -105,7 +123,9 @@ Mapview:
 
 Slider:
     'Slider' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('sendFrequency=' frequency=INT)? & (switchEnabled?='switchSupport')? &
     ('minValue=' minValue=Number)? & ('maxValue=' maxValue=Number)? & ('step=' step=Number)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
@@ -115,7 +135,9 @@ Slider:
 
 Selection:
     'Selection' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('mappings=[' mappings+=Mapping (',' mappings+=Mapping)* ']')? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -124,7 +146,9 @@ Selection:
 
 Setpoint:
     'Setpoint' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('minValue=' minValue=Number)? & ('maxValue=' maxValue=Number)? & ('step=' step=Number)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -133,7 +157,9 @@ Setpoint:
 
 Colorpicker:
     'Colorpicker' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('sendFrequency=' frequency=INT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -142,7 +168,9 @@ Colorpicker:
 
 Input:
     'Input' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('inputHint=' inputHint=STRING)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -151,7 +179,9 @@ Input:
 
 Default:
     'Default' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? &
-    (('icon=' icon=Icon) | ('staticIcon=' staticIcon=Icon))? &
+    (('icon=' icon=Icon) |
+        ('icon=[' (dynamicIcon+=IconRule (',' dynamicIcon+=IconRule)*) ']') |
+        ('staticIcon=' staticIcon=Icon))? &
     ('height=' height=INT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
@@ -162,7 +192,7 @@ Mapping:
     cmd=Command '=' label=(ID | STRING);
 
 VisibilityRule:
-    (item=ID) (condition=('==' | '>' | '<' | '>=' | '<=' | '!=')) (sign=('-' | '+'))? (state=XState);
+    conditions+=Condition ('AND' conditions+=Condition)*;
 
 ItemRef:
     ID;
@@ -178,8 +208,13 @@ IconName:
     (ID '-')* ID;
 
 ColorArray:
-    ((item=ID)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState) '=')?
-    (arg=STRING);
+    ((conditions+=Condition ('AND' conditions+=Condition)*) '=')? (arg=STRING);
+
+IconRule:
+    ((conditions+=Condition ('AND' conditions+=Condition)*) '=')? (arg=Icon);
+
+Condition:
+    (item=ID)? (condition=('==' | '>' | '<' | '>=' | '<=' | '!='))? (sign=('-' | '+'))? (state=XState);
 
 Command returns ecore::EString:
     Number | ID | STRING;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -68,6 +68,7 @@ import org.openhab.core.library.types.StringType;
 import org.openhab.core.model.sitemap.sitemap.ColorArray;
 import org.openhab.core.model.sitemap.sitemap.Default;
 import org.openhab.core.model.sitemap.sitemap.Group;
+import org.openhab.core.model.sitemap.sitemap.IconRule;
 import org.openhab.core.model.sitemap.sitemap.LinkableWidget;
 import org.openhab.core.model.sitemap.sitemap.Mapping;
 import org.openhab.core.model.sitemap.sitemap.Sitemap;
@@ -109,6 +110,7 @@ import org.slf4j.LoggerFactory;
  * @author Erdoan Hadzhiyusein - Adapted the class to work with the new DateTimeType
  * @author Laurent Garnier - new method getIconColor
  * @author Mark Herwege - new method getFormatPattern(widget), clean pattern
+ * @author Laurent Garnier - new icon parameter based on conditional rules + multiple AND conditions
  */
 @NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.sitemap", //
@@ -638,11 +640,14 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         // the default is the widget type name, e.g. "switch"
         String category = widgetTypeName.toLowerCase();
 
+        String dynamicIcon = getDynamicIcon(w);
         // if an icon is defined for the widget, use it
         if (w.getIcon() != null) {
             category = w.getIcon();
         } else if (w.getStaticIcon() != null) {
             category = w.getStaticIcon();
+        } else if (dynamicIcon != null) {
+            category = dynamicIcon;
         } else {
             // otherwise check if any item ui provider provides an icon for this item
             String itemName = w.getItem();
@@ -800,6 +805,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         target.getLabelColor().addAll(EcoreUtil.copyAll(source.getLabelColor()));
         target.getValueColor().addAll(EcoreUtil.copyAll(source.getValueColor()));
         target.getIconColor().addAll(EcoreUtil.copyAll(source.getIconColor()));
+        target.getDynamicIcon().addAll(EcoreUtil.copyAll(source.getDynamicIcon()));
     }
 
     /**
@@ -1149,150 +1155,154 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return matched;
     }
 
-    private @Nullable String processColorDefinition(@Nullable State state, @Nullable List<ColorArray> colorList) {
+    private @Nullable String processColorDefinition(Widget w, @Nullable List<ColorArray> colorList, String colorType) {
         // Sanity check
-        if (colorList == null) {
+        if (colorList == null || colorList.isEmpty()) {
             return null;
         }
-        if (colorList.isEmpty()) {
-            return null;
-        }
+
+        logger.debug("Checking {} color for widget '{}'.", colorType, w.getLabel());
 
         String colorString = null;
 
-        // Check for the "arg". If it doesn't exist, assume there's just an
-        // static colour
-        if (colorList.size() == 1 && colorList.get(0).getState() == null) {
-            colorString = colorList.get(0).getArg();
-        } else {
-            // Loop through all elements looking for the definition associated
-            // with the supplied value
-            for (ColorArray color : colorList) {
-                // Use a local state variable in case it gets overridden below
-                State cmpState = state;
-
-                if (color.getState() == null) {
-                    // If no state associated to the condition, we consider the condition as fulfilled.
-                    // It allows defining a default color as last condition in particular.
-                    colorString = color.getArg();
-                    break;
-                }
-
-                // If there's an item defined here, get its state
-                String itemName = color.getItem();
-                if (itemName != null) {
-                    // Try and find the item to test.
-                    // If it's not found, return visible
-                    Item item;
-                    try {
-                        item = itemRegistry.getItem(itemName);
-
-                        // Get the item state
-                        cmpState = item.getState();
-                    } catch (ItemNotFoundException e) {
-                        logger.warn("Cannot retrieve color item {} for widget", color.getItem());
-                    }
-                }
-
-                // Handle the sign
-                String value;
-                if (color.getSign() != null) {
-                    value = color.getSign() + color.getState();
-                } else {
-                    value = color.getState();
-                }
-
-                if (cmpState != null && matchStateToValue(cmpState, value, color.getCondition())) {
-                    // We have the color for this value - break!
-                    colorString = color.getArg();
-                    break;
-                }
+        // Loop through all elements looking for the definition associated
+        // with the supplied value
+        for (ColorArray rule : colorList) {
+            if (allConditionsOk(rule.getConditions(), w)) {
+                // We have the color for this value - break!
+                colorString = rule.getArg();
+                break;
             }
         }
 
-        // Remove quotes off the colour - if they exist
         if (colorString == null) {
+            logger.debug("No {} color found for widget '{}'.", colorType, w.getLabel());
             return null;
         }
 
+        // Remove quotes off the colour - if they exist
         if (colorString.startsWith("\"") && colorString.endsWith("\"")) {
             colorString = colorString.substring(1, colorString.length() - 1);
         }
+        logger.debug("{} color for widget '{}' is '{}'.", colorType, w.getLabel(), colorString);
 
         return colorString;
     }
 
     @Override
     public @Nullable String getLabelColor(Widget w) {
-        return processColorDefinition(getState(w), w.getLabelColor());
+        return processColorDefinition(w, w.getLabelColor(), "label");
     }
 
     @Override
     public @Nullable String getValueColor(Widget w) {
-        return processColorDefinition(getState(w), w.getValueColor());
+        return processColorDefinition(w, w.getValueColor(), "value");
     }
 
     @Override
     public @Nullable String getIconColor(Widget w) {
-        return processColorDefinition(getState(w), w.getIconColor());
+        return processColorDefinition(w, w.getIconColor(), "icon");
+    }
+
+    @Override
+    public @Nullable String getDynamicIcon(Widget w) {
+        List<IconRule> ruleList = w.getDynamicIcon();
+        // Sanity check
+        if (ruleList == null || ruleList.isEmpty()) {
+            return null;
+        }
+
+        logger.debug("Checking icon for widget '{}'.", w.getLabel());
+
+        String icon = null;
+
+        // Loop through all elements looking for the definition associated
+        // with the supplied value
+        for (IconRule rule : ruleList) {
+            if (allConditionsOk(rule.getConditions(), w)) {
+                // We have the icon for this value - break!
+                icon = rule.getArg();
+                break;
+            }
+        }
+
+        if (icon == null) {
+            logger.debug("No icon found for widget '{}'.", w.getLabel());
+            return null;
+        }
+
+        // Remove quotes off the icon - if they exist
+        if (icon.startsWith("\"") && icon.endsWith("\"")) {
+            icon = icon.substring(1, icon.length() - 1);
+        }
+        logger.debug("icon for widget '{}' is '{}'.", w.getLabel(), icon);
+
+        return icon;
     }
 
     @Override
     public boolean getVisiblity(Widget w) {
         // Default to visible if parameters not set
         List<VisibilityRule> ruleList = w.getVisibility();
-        if (ruleList == null) {
-            return true;
-        }
-        if (ruleList.isEmpty()) {
+        if (ruleList == null || ruleList.isEmpty()) {
             return true;
         }
 
         logger.debug("Checking visiblity for widget '{}'.", w.getLabel());
 
-        for (VisibilityRule rule : w.getVisibility()) {
-            String itemName = rule.getItem();
-            if (itemName == null) {
-                continue;
-            }
-            if (rule.getState() == null) {
-                continue;
-            }
-
-            // Try and find the item to test.
-            // If it's not found, return visible
-            Item item;
-            try {
-                item = itemRegistry.getItem(itemName);
-            } catch (ItemNotFoundException e) {
-                logger.warn("Cannot retrieve visibility item {} for widget {}", rule.getItem(),
-                        w.eClass().getInstanceTypeName());
-
-                // Default to visible!
-                return true;
-            }
-
-            // Get the item state
-            State state = item.getState();
-
-            // Handle the sign
-            String value;
-            if (rule.getSign() != null) {
-                value = rule.getSign() + rule.getState();
-            } else {
-                value = rule.getState();
-            }
-
-            if (matchStateToValue(state, value, rule.getCondition())) {
-                // We have the name for this value!
+        for (VisibilityRule rule : ruleList) {
+            if (allConditionsOk(rule.getConditions(), w)) {
                 return true;
             }
         }
 
         logger.debug("Widget {} is not visible.", w.getLabel());
 
-        // The state wasn't in the list, so we don't display it
         return false;
+    }
+
+    private boolean allConditionsOk(@Nullable List<org.openhab.core.model.sitemap.sitemap.Condition> conditions,
+            Widget w) {
+        boolean allConditionsOk = true;
+        if (conditions != null) {
+            State defaultState = getState(w);
+
+            // Go through all AND conditions
+            for (org.openhab.core.model.sitemap.sitemap.Condition condition : conditions) {
+                // Use a local state variable in case it gets overridden below
+                State state = defaultState;
+
+                // If there's an item defined here, get its state
+                String itemName = condition.getItem();
+                if (itemName != null) {
+                    // Try and find the item to test.
+                    Item item;
+                    try {
+                        item = itemRegistry.getItem(itemName);
+
+                        // Get the item state
+                        state = item.getState();
+                    } catch (ItemNotFoundException e) {
+                        logger.warn("Cannot retrieve item {} for widget {}", itemName,
+                                w.eClass().getInstanceTypeName());
+                    }
+                }
+
+                // Handle the sign
+                String value;
+                if (condition.getSign() != null) {
+                    value = condition.getSign() + condition.getState();
+                } else {
+                    value = condition.getState();
+                }
+
+                if (state == null || !matchStateToValue(state, value, condition.getCondition())) {
+                    allConditionsOk = false;
+                    break;
+                }
+            }
+        }
+        return allConditionsOk;
     }
 
     enum Condition {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -35,6 +35,7 @@ import org.openhab.core.types.State;
  * @author Chris Jackson - Initial contribution
  * @author Laurent Garnier - new method getIconColor
  * @author Mark Herwege - new method getFormatPattern
+ * @author Laurent Garnier - new method getDynamicIcon
  */
 @NonNullByDefault
 public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
@@ -169,6 +170,16 @@ public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
      */
     @Nullable
     String getIconColor(Widget w);
+
+    /**
+     * Gets the dynamic icon for the widget. Checks conditional statements to
+     * find the icon based on the item value
+     *
+     * @param w Widget
+     * @return String with the icon reference
+     */
+    @Nullable
+    String getDynamicIcon(Widget w);
 
     /**
      * Gets the widget visibility based on the item state

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.emf.common.util.BasicEList;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,9 @@ import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.types.StringType;
 import org.openhab.core.model.sitemap.sitemap.ColorArray;
 import org.openhab.core.model.sitemap.sitemap.Colorpicker;
+import org.openhab.core.model.sitemap.sitemap.Condition;
 import org.openhab.core.model.sitemap.sitemap.Group;
+import org.openhab.core.model.sitemap.sitemap.IconRule;
 import org.openhab.core.model.sitemap.sitemap.Image;
 import org.openhab.core.model.sitemap.sitemap.Mapping;
 import org.openhab.core.model.sitemap.sitemap.Mapview;
@@ -70,6 +73,7 @@ import org.openhab.core.model.sitemap.sitemap.SitemapFactory;
 import org.openhab.core.model.sitemap.sitemap.Slider;
 import org.openhab.core.model.sitemap.sitemap.Switch;
 import org.openhab.core.model.sitemap.sitemap.Text;
+import org.openhab.core.model.sitemap.sitemap.VisibilityRule;
 import org.openhab.core.model.sitemap.sitemap.Widget;
 import org.openhab.core.types.CommandDescriptionBuilder;
 import org.openhab.core.types.CommandOption;
@@ -83,6 +87,7 @@ import org.openhab.core.ui.items.ItemUIProvider;
 
 /**
  * @author Kai Kreuzer - Initial contribution
+ * @author Laurent Garnier - Tests added for getCategory and getVisiblity including case with multiple AND conditions
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -736,18 +741,27 @@ public class ItemUIRegistryImplTest {
 
         when(widgetMock.getLabel()).thenReturn(testLabel);
 
-        ColorArray colorArray = mock(ColorArray.class);
-        when(colorArray.getState()).thenReturn("21");
-        when(colorArray.getCondition()).thenReturn("<");
-        when(colorArray.getArg()).thenReturn("yellow");
-        BasicEList<ColorArray> colorArrays = new BasicEList<>();
-        colorArrays.add(colorArray);
-        when(widgetMock.getLabelColor()).thenReturn(colorArrays);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("21");
+        when(conditon.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        ColorArray rule = mock(ColorArray.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("yellow");
+        BasicEList<ColorArray> rules = new BasicEList<>();
+        rules.add(rule);
+        when(widgetMock.getLabelColor()).thenReturn(rules);
 
         when(itemMock.getState()).thenReturn(new DecimalType(10f / 3f));
 
         String color = uiRegistry.getLabelColor(widgetMock);
         assertEquals("yellow", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(21f));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertNull(color);
     }
 
     @Test
@@ -756,18 +770,27 @@ public class ItemUIRegistryImplTest {
 
         when(widgetMock.getLabel()).thenReturn(testLabel);
 
-        ColorArray colorArray = mock(ColorArray.class);
-        when(colorArray.getState()).thenReturn("20");
-        when(colorArray.getCondition()).thenReturn("==");
-        when(colorArray.getArg()).thenReturn("yellow");
-        BasicEList<ColorArray> colorArrays = new BasicEList<>();
-        colorArrays.add(colorArray);
-        when(widgetMock.getLabelColor()).thenReturn(colorArrays);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("20");
+        when(conditon.getCondition()).thenReturn("==");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        ColorArray rule = mock(ColorArray.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("yellow");
+        BasicEList<ColorArray> rules = new BasicEList<>();
+        rules.add(rule);
+        when(widgetMock.getLabelColor()).thenReturn(rules);
 
         when(itemMock.getState()).thenReturn(new QuantityType<>("20 °C"));
 
         String color = uiRegistry.getLabelColor(widgetMock);
         assertEquals("yellow", color);
+
+        when(itemMock.getState()).thenReturn(new QuantityType<>("20.1 °C"));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertNull(color);
     }
 
     @Test
@@ -925,44 +948,108 @@ public class ItemUIRegistryImplTest {
 
         when(widgetMock.getLabel()).thenReturn(testLabel);
 
-        ColorArray colorArray = mock(ColorArray.class);
-        when(colorArray.getState()).thenReturn("21");
-        when(colorArray.getCondition()).thenReturn("<");
-        when(colorArray.getArg()).thenReturn("yellow");
-        BasicEList<ColorArray> colorArrays = new BasicEList<>();
-        colorArrays.add(colorArray);
-        ColorArray colorArray2 = mock(ColorArray.class);
-        when(colorArray2.getState()).thenReturn(null);
-        when(colorArray2.getCondition()).thenReturn(null);
-        when(colorArray2.getArg()).thenReturn("blue");
-        colorArrays.add(colorArray2);
-        when(widgetMock.getLabelColor()).thenReturn(colorArrays);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("18");
+        when(conditon.getCondition()).thenReturn(">=");
+        Condition conditon2 = mock(Condition.class);
+        when(conditon2.getState()).thenReturn("21");
+        when(conditon2.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        conditions.add(conditon2);
+        ColorArray rule = mock(ColorArray.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("yellow");
+        BasicEList<ColorArray> rules = new BasicEList<>();
+        rules.add(rule);
+        Condition conditon3 = mock(Condition.class);
+        when(conditon3.getState()).thenReturn("21");
+        when(conditon3.getCondition()).thenReturn(">=");
+        Condition conditon4 = mock(Condition.class);
+        when(conditon4.getState()).thenReturn("24");
+        when(conditon4.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions2 = new BasicEList<>();
+        conditions2.add(conditon3);
+        conditions2.add(conditon4);
+        ColorArray rule2 = mock(ColorArray.class);
+        when(rule2.getConditions()).thenReturn(conditions2);
+        when(rule2.getArg()).thenReturn("red");
+        rules.add(rule2);
+        BasicEList<Condition> conditions5 = new BasicEList<>();
+        ColorArray rule3 = mock(ColorArray.class);
+        when(rule3.getConditions()).thenReturn(conditions5);
+        when(rule3.getArg()).thenReturn("blue");
+        rules.add(rule3);
+        when(widgetMock.getLabelColor()).thenReturn(rules);
 
-        when(itemMock.getState()).thenReturn(new DecimalType(21.0));
+        when(itemMock.getState()).thenReturn(new DecimalType(20.9));
 
         String color = uiRegistry.getLabelColor(widgetMock);
+        assertEquals("yellow", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(23.5));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertEquals("red", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertEquals("blue", color);
+
+        conditions5 = null;
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        color = uiRegistry.getLabelColor(widgetMock);
+        assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
+
+        color = uiRegistry.getLabelColor(widgetMock);
         assertEquals("blue", color);
     }
 
     @Test
     public void getValueColor() {
-        ColorArray colorArray = mock(ColorArray.class);
-        when(colorArray.getState()).thenReturn("21");
-        when(colorArray.getCondition()).thenReturn("<");
-        when(colorArray.getArg()).thenReturn("yellow");
-        BasicEList<ColorArray> colorArrays = new BasicEList<>();
-        colorArrays.add(colorArray);
-        ColorArray colorArray2 = mock(ColorArray.class);
-        when(colorArray2.getState()).thenReturn("24");
-        when(colorArray2.getCondition()).thenReturn("<");
-        when(colorArray2.getArg()).thenReturn("red");
-        colorArrays.add(colorArray2);
-        ColorArray colorArray3 = mock(ColorArray.class);
-        when(colorArray3.getState()).thenReturn(null);
-        when(colorArray3.getCondition()).thenReturn(null);
-        when(colorArray3.getArg()).thenReturn("blue");
-        colorArrays.add(colorArray3);
-        when(widgetMock.getValueColor()).thenReturn(colorArrays);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("18");
+        when(conditon.getCondition()).thenReturn(">=");
+        Condition conditon2 = mock(Condition.class);
+        when(conditon2.getState()).thenReturn("21");
+        when(conditon2.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        conditions.add(conditon2);
+        ColorArray rule = mock(ColorArray.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("yellow");
+        BasicEList<ColorArray> rules = new BasicEList<>();
+        rules.add(rule);
+        Condition conditon3 = mock(Condition.class);
+        when(conditon3.getState()).thenReturn("21");
+        when(conditon3.getCondition()).thenReturn(">=");
+        Condition conditon4 = mock(Condition.class);
+        when(conditon4.getState()).thenReturn("24");
+        when(conditon4.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions2 = new BasicEList<>();
+        conditions2.add(conditon3);
+        conditions2.add(conditon4);
+        ColorArray rule2 = mock(ColorArray.class);
+        when(rule2.getConditions()).thenReturn(conditions2);
+        when(rule2.getArg()).thenReturn("red");
+        rules.add(rule2);
+        BasicEList<Condition> conditions5 = new BasicEList<>();
+        ColorArray rule3 = mock(ColorArray.class);
+        when(rule3.getConditions()).thenReturn(conditions5);
+        when(rule3.getArg()).thenReturn("blue");
+        rules.add(rule3);
+        when(widgetMock.getValueColor()).thenReturn(rules);
 
         when(itemMock.getState()).thenReturn(new DecimalType(20.9));
 
@@ -974,7 +1061,24 @@ public class ItemUIRegistryImplTest {
         color = uiRegistry.getValueColor(widgetMock);
         assertEquals("red", color);
 
-        when(itemMock.getState()).thenReturn(new DecimalType(30.0));
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        color = uiRegistry.getValueColor(widgetMock);
+        assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
+
+        color = uiRegistry.getValueColor(widgetMock);
+        assertEquals("blue", color);
+
+        conditions5 = null;
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        color = uiRegistry.getValueColor(widgetMock);
+        assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
 
         color = uiRegistry.getValueColor(widgetMock);
         assertEquals("blue", color);
@@ -982,23 +1086,39 @@ public class ItemUIRegistryImplTest {
 
     @Test
     public void getIconColor() {
-        ColorArray colorArray = mock(ColorArray.class);
-        when(colorArray.getState()).thenReturn("21");
-        when(colorArray.getCondition()).thenReturn("<");
-        when(colorArray.getArg()).thenReturn("yellow");
-        BasicEList<ColorArray> colorArrays = new BasicEList<>();
-        colorArrays.add(colorArray);
-        ColorArray colorArray2 = mock(ColorArray.class);
-        when(colorArray2.getState()).thenReturn("24");
-        when(colorArray2.getCondition()).thenReturn("<");
-        when(colorArray2.getArg()).thenReturn("red");
-        colorArrays.add(colorArray2);
-        ColorArray colorArray3 = mock(ColorArray.class);
-        when(colorArray3.getState()).thenReturn(null);
-        when(colorArray3.getCondition()).thenReturn(null);
-        when(colorArray3.getArg()).thenReturn("blue");
-        colorArrays.add(colorArray3);
-        when(widgetMock.getIconColor()).thenReturn(colorArrays);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("18");
+        when(conditon.getCondition()).thenReturn(">=");
+        Condition conditon2 = mock(Condition.class);
+        when(conditon2.getState()).thenReturn("21");
+        when(conditon2.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        conditions.add(conditon2);
+        ColorArray rule = mock(ColorArray.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("yellow");
+        BasicEList<ColorArray> rules = new BasicEList<>();
+        rules.add(rule);
+        Condition conditon3 = mock(Condition.class);
+        when(conditon3.getState()).thenReturn("21");
+        when(conditon3.getCondition()).thenReturn(">=");
+        Condition conditon4 = mock(Condition.class);
+        when(conditon4.getState()).thenReturn("24");
+        when(conditon4.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions2 = new BasicEList<>();
+        conditions2.add(conditon3);
+        conditions2.add(conditon4);
+        ColorArray rule2 = mock(ColorArray.class);
+        when(rule2.getConditions()).thenReturn(conditions2);
+        when(rule2.getArg()).thenReturn("red");
+        rules.add(rule2);
+        BasicEList<Condition> conditions5 = new BasicEList<>();
+        ColorArray rule3 = mock(ColorArray.class);
+        when(rule3.getConditions()).thenReturn(conditions5);
+        when(rule3.getArg()).thenReturn("blue");
+        rules.add(rule3);
+        when(widgetMock.getIconColor()).thenReturn(rules);
 
         when(itemMock.getState()).thenReturn(new DecimalType(20.9));
 
@@ -1010,9 +1130,170 @@ public class ItemUIRegistryImplTest {
         color = uiRegistry.getIconColor(widgetMock);
         assertEquals("red", color);
 
-        when(itemMock.getState()).thenReturn(new DecimalType(30.0));
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
 
         color = uiRegistry.getIconColor(widgetMock);
         assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
+
+        color = uiRegistry.getIconColor(widgetMock);
+        assertEquals("blue", color);
+
+        conditions5 = null;
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        color = uiRegistry.getIconColor(widgetMock);
+        assertEquals("blue", color);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(17.5));
+
+        color = uiRegistry.getIconColor(widgetMock);
+        assertEquals("blue", color);
+    }
+
+    @Test
+    public void getVisibility() {
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("21");
+        when(conditon.getCondition()).thenReturn(">=");
+        Condition conditon2 = mock(Condition.class);
+        when(conditon2.getState()).thenReturn("24");
+        when(conditon2.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        conditions.add(conditon2);
+        VisibilityRule rule = mock(VisibilityRule.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        BasicEList<VisibilityRule> rules = new BasicEList<>();
+        rules.add(rule);
+        when(widgetMock.getVisibility()).thenReturn(rules);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(20.9));
+
+        assertFalse(uiRegistry.getVisiblity(widgetMock));
+
+        when(itemMock.getState()).thenReturn(new DecimalType(21.0));
+
+        assertTrue(uiRegistry.getVisiblity(widgetMock));
+
+        when(itemMock.getState()).thenReturn(new DecimalType(23.5));
+
+        assertTrue(uiRegistry.getVisiblity(widgetMock));
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        assertFalse(uiRegistry.getVisiblity(widgetMock));
+    }
+
+    @Test
+    public void getCategoryWhenIconSetWithoutRules() {
+        EClass textEClass = mock(EClass.class);
+        when(textEClass.getName()).thenReturn("text");
+        when(textEClass.getInstanceTypeName()).thenReturn("org.openhab.core.model.sitemap.Text");
+        when(widgetMock.eClass()).thenReturn(textEClass);
+        when(widgetMock.getIcon()).thenReturn("temperature");
+        when(widgetMock.getStaticIcon()).thenReturn(null);
+        when(widgetMock.getDynamicIcon()).thenReturn(null);
+
+        String icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("temperature", icon);
+    }
+
+    @Test
+    public void getCategoryWhenIconSetWithRules() {
+        EClass textEClass = mock(EClass.class);
+        when(textEClass.getName()).thenReturn("text");
+        when(textEClass.getInstanceTypeName()).thenReturn("org.openhab.core.model.sitemap.Text");
+        when(widgetMock.eClass()).thenReturn(textEClass);
+        when(widgetMock.getIcon()).thenReturn(null);
+        when(widgetMock.getStaticIcon()).thenReturn(null);
+        Condition conditon = mock(Condition.class);
+        when(conditon.getState()).thenReturn("21");
+        when(conditon.getCondition()).thenReturn(">=");
+        Condition conditon2 = mock(Condition.class);
+        when(conditon2.getState()).thenReturn("24");
+        when(conditon2.getCondition()).thenReturn("<");
+        BasicEList<Condition> conditions = new BasicEList<>();
+        conditions.add(conditon);
+        conditions.add(conditon2);
+        IconRule rule = mock(IconRule.class);
+        when(rule.getConditions()).thenReturn(conditions);
+        when(rule.getArg()).thenReturn("temperature");
+        BasicEList<IconRule> rules = new BasicEList<>();
+        rules.add(rule);
+        BasicEList<Condition> conditions2 = new BasicEList<>();
+        IconRule rule2 = mock(IconRule.class);
+        when(rule2.getConditions()).thenReturn(conditions2);
+        when(rule2.getArg()).thenReturn("humidity");
+        rules.add(rule2);
+        when(widgetMock.getDynamicIcon()).thenReturn(rules);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(20.9));
+
+        String icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("humidity", icon);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(21.0));
+
+        icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("temperature", icon);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(23.5));
+
+        icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("temperature", icon);
+
+        when(itemMock.getState()).thenReturn(new DecimalType(24.0));
+
+        icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("humidity", icon);
+    }
+
+    @Test
+    public void getCategoryWhenStaticIconSet() {
+        EClass textEClass = mock(EClass.class);
+        when(textEClass.getName()).thenReturn("text");
+        when(textEClass.getInstanceTypeName()).thenReturn("org.openhab.core.model.sitemap.Text");
+        when(widgetMock.eClass()).thenReturn(textEClass);
+        when(widgetMock.getIcon()).thenReturn(null);
+        when(widgetMock.getStaticIcon()).thenReturn("temperature");
+        when(widgetMock.getDynamicIcon()).thenReturn(null);
+
+        String icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("temperature", icon);
+    }
+
+    @Test
+    public void getCategoryWhenIconSetOnItem() {
+        EClass textEClass = mock(EClass.class);
+        when(textEClass.getName()).thenReturn("text");
+        when(textEClass.getInstanceTypeName()).thenReturn("org.openhab.core.model.sitemap.Text");
+        when(widgetMock.eClass()).thenReturn(textEClass);
+        when(widgetMock.getIcon()).thenReturn(null);
+        when(widgetMock.getStaticIcon()).thenReturn(null);
+        when(widgetMock.getDynamicIcon()).thenReturn(null);
+
+        when(itemMock.getCategory()).thenReturn("temperature");
+
+        String icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("temperature", icon);
+    }
+
+    @Test
+    public void getCategoryDefaultIcon() {
+        EClass textEClass = mock(EClass.class);
+        when(textEClass.getName()).thenReturn("text");
+        when(textEClass.getInstanceTypeName()).thenReturn("org.openhab.core.model.sitemap.Text");
+        when(widgetMock.eClass()).thenReturn(textEClass);
+        when(widgetMock.getIcon()).thenReturn(null);
+        when(widgetMock.getStaticIcon()).thenReturn(null);
+        when(widgetMock.getDynamicIcon()).thenReturn(null);
+
+        when(itemMock.getCategory()).thenReturn(null);
+
+        String icon = uiRegistry.getCategory(widgetMock);
+        assertEquals("text", icon);
     }
 }


### PR DESCRIPTION
Allow multiple conditions with AND operator in visibility/color/icon rules

Closes #3058

Also allow dynamic icon based on other item states.
Allow dynamic icon even with non OH icon sources.

Example: icon=[item1>0=temperature,==0=material:settings,f7:house]

Related to openhab/openhab-webui#1938

Unit tests added or extended to cover the new features.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>