### PR TITLE
Update Jackson to 2.15.2

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <californium.version>2.7.4</californium.version>
     <cxf.version>3.4.5</cxf.version>
-    <jackson.version>2.14.1</jackson.version>
+    <jackson.version>2.15.2</jackson.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <pax.logging.version>2.2.0</pax.logging.version>
     <pax.web.version>8.0.15</pax.web.version>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -89,18 +89,18 @@
 	</feature>
 
 	<feature name="openhab.tp-jackson" description="FasterXML Jackson bundles" version="${project.version}">
-		<capability>openhab.tp;feature=jackson;version=2.14.1</capability>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.14.1</bundle>
-		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.14.1</bundle>
-		<bundle dependency="true">mvn:org.yaml/snakeyaml/1.33</bundle>
+		<capability>openhab.tp;feature=jackson;version=2.15.2</capability>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.15.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.15.2</bundle>
+		<bundle dependency="true">mvn:org.yaml/snakeyaml/2.1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-asm" description="ASM bundles" version="${project.version}">

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
 	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
-	com.fasterxml.woodstox.woodstox-core;version='[6.4.0,6.4.1)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -104,8 +103,8 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.thing;version='[4.1.0,4.1.1)',\
 	org.openhab.core.transform;version='[4.1.0,4.1.1)',\
 	org.openhab.base-fixes;version='[1.0.0,1.0.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	com.fasterxml.woodstox.woodstox-core;version='[6.5.1,6.5.2)'


### PR DESCRIPTION
Updates Jackson from 2.14.1 to 2.15.2

For release notes, see:

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15

This upgrade addresses:

* CVE-2022-1471