### PR TITLE
Update json-path to 2.8.0

### DIFF
--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.4.0</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.aries.jax.rs</groupId>

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -13,10 +13,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 # done
 #
 -runbundles: \
-	com.jayway.jsonpath.json-path;version='[2.4.0,2.4.1)',\
-	net.minidev.accessors-smart;version='[1.2.0,1.2.1)',\
-	net.minidev.json-smart;version='[2.3.0,2.3.1)',\
-	org.objectweb.asm;version='[5.0.4,5.0.5)',\
 	org.osgi.service.event;version='[1.4.0,1.4.1)',\
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.eclipse.equinox.event;version='[1.4.300,1.4.301)',\
@@ -105,4 +101,7 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.cxf.cxf-rt-rs-sse;version='[3.6.1,3.6.2)',\
 	org.apache.cxf.cxf-rt-security;version='[3.6.1,3.6.2)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.6.1,3.6.2)',\
-	org.apache.ws.xmlschema.core;version='[2.3.0,2.3.1)'
+	org.apache.ws.xmlschema.core;version='[2.3.0,2.3.1)',\
+	json-path;version='[2.8.0,2.8.1)',\
+	net.minidev.accessors-smart;version='[2.4.9,2.4.10)',\
+	net.minidev.json-smart;version='[2.4.10,2.4.11)'


### PR DESCRIPTION
Updates json-path from 2.4.0 to 2.8.0

This addresses:

* CVE-2021-27568
* CVE-2021-31684
* CVE-2023-1370