### PR TITLE
Suppress SseItemStates warnings during startup

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -32,6 +32,7 @@ import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.service.StartLevelService;
 import org.openhab.core.transform.TransformationException;
 import org.openhab.core.transform.TransformationHelper;
 import org.openhab.core.types.State;
@@ -62,13 +63,15 @@ public class SseItemStatesEventBuilder {
     private final BundleContext bundleContext;
     private final ItemRegistry itemRegistry;
     private final LocaleService localeService;
+    private final StartLevelService startLevelService;
 
     @Activate
     public SseItemStatesEventBuilder(final BundleContext bundleContext, final @Reference ItemRegistry itemRegistry,
-            final @Reference LocaleService localeService) {
+            final @Reference LocaleService localeService, final @Reference StartLevelService startLevelService) {
         this.bundleContext = bundleContext;
         this.itemRegistry = itemRegistry;
         this.localeService = localeService;
+        this.startLevelService = startLevelService;
     }
 
     public @Nullable OutboundSseEvent buildEvent(Builder eventBuilder, Set<String> itemNames) {
@@ -86,7 +89,9 @@ public class SseItemStatesEventBuilder {
                 }
                 payload.put(itemName, stateDto);
             } catch (ItemNotFoundException e) {
-                logger.warn("Attempting to send a state update of an item which doesn't exist: {}", itemName);
+                if (startLevelService.getStartLevel() >= StartLevelService.STARTLEVEL_MODEL) {
+                    logger.warn("Attempting to send a state update of an item which doesn't exist: {}", itemName);
+                }
             }
         }
 


### PR DESCRIPTION
During openhab startup the following warnings were logged:

```
09:35:16.934 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Power_Load_Display
09:35:16.935 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Power_From_Solar_Display
09:35:16.937 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Power_From_Grid
09:35:16.938 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Power_From_Grid_Display
09:35:16.939 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Weather_Current_Iconid
09:35:16.940 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Outdoor_Temperature
09:35:16.940 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: UV_Index_Color
09:35:16.941 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: UV_Index
09:35:16.941 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: UV_Protection
09:35:16.942 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Wind_Direction_Icon
09:35:16.942 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: Wind_Speed
```

This PR suppresses these warnings when items weren't loaded yet, so the startup process is not littered with useless warnings.