### PR TITLE
Fix linuxsysfs itest failing when serial device is connected

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -67,10 +67,11 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
 
     private static final String SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT = "/sys/class/tty";
     private static final String DEV_DIRECTORY_DEFAULT = "/dev";
-    private static final String DEV_SERIAL_BY_ID_DIRECTORY = DEV_DIRECTORY_DEFAULT + "/serial/by-id";
+    private static final String SERIAL_BY_ID_DIRECTORY = "/serial/by-id";
 
     private String sysfsTtyDevicesDirectory = SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT;
     private String devDirectory = DEV_DIRECTORY_DEFAULT;
+    private String devSerialByIdDirectory = DEV_DIRECTORY_DEFAULT + SERIAL_BY_ID_DIRECTORY;
 
     private static final String SYSFS_FILENAME_USB_VENDOR_ID = "idVendor";
     private static final String SYSFS_FILENAME_USB_PRODUCT_ID = "idProduct";
@@ -151,7 +152,7 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
         }
 
         // optionally compute links and their corresponding SerialInfo :
-        Path devSerialDir = Path.of(DEV_SERIAL_BY_ID_DIRECTORY);
+        Path devSerialDir = Path.of(devSerialByIdDirectory);
         if (exists(devSerialDir) && isDirectory(devSerialDir) && isReadable(devSerialDir)) {
             // browse serial/by-id directory :
             try (DirectoryStream<Path> directoryStream = newDirectoryStream(devSerialDir)) {
@@ -284,6 +285,7 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
         if (configurationIsChanged) {
             sysfsTtyDevicesDirectory = newSysfsTtyDevicesDirectory;
             devDirectory = newDevDirectory;
+            devSerialByIdDirectory = devDirectory + SERIAL_BY_ID_DIRECTORY;
         }
 
         if (!canPerformScans()) {


### PR DESCRIPTION
This fixes that some linuxsysfs tests always fail on Linux whenever a real serial device is connected. Due to the changes in #3290 the tests would also scan the actual devices causing tests to fail due to unexpected results.