### PR TITLE
[cache] Fix concurrent use of a cache entry

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
@@ -296,7 +296,7 @@ public class LRUMediaCacheEntry<V> {
             }
         }
         // the cache file is now filled, get bytes from it.
-        long maxToRead = Math.min(currentSize, sizeToRead);
+        long maxToRead = Math.min(fileChannelLocal.size(), sizeToRead);
         ByteBuffer byteBufferFromChannelFile = ByteBuffer.allocate((int) maxToRead);
         int byteReadNumber = fileChannelLocal.read(byteBufferFromChannelFile, Integer.valueOf(start).longValue());
         logger.trace("Read {} bytes from the filechannel", byteReadNumber);


### PR DESCRIPTION
Closes #3507
Fix some rare case where the concurrent reads of a cache entry can fail.

Explanation: 
Lines 286 and 288 are executed nearly at the same time. "Nearly" was sufficient to cause error when setting maxToRead and inducing the thread to think that the wanted data cannot be read.