### PR TITLE
Use JUnit TempDir which automatically removes temp dirs

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.*;
 
 import java.io.File;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -26,6 +25,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
 
 /**
@@ -33,6 +33,8 @@ import org.osgi.framework.Bundle;
  */
 @NonNullByDefault
 public class ResourceBundleClassLoaderTest {
+
+    private @TempDir @NonNullByDefault({}) Path tempDir;
 
     static URL createTmpTestPropetiesFile(Path root, String relativeFile) throws Exception {
         Path filePath = Paths.get(relativeFile);
@@ -47,9 +49,8 @@ public class ResourceBundleClassLoaderTest {
 
     @Test
     public void testName() throws Exception {
-        Path tmp = Files.createTempDirectory("tmp");
-        URL hostPropertiesURL = createTmpTestPropetiesFile(tmp, "host/OH-INF/i18n/test.properties");
-        URL fragmentPropertiesURL = createTmpTestPropetiesFile(tmp, "fragment/OH-INF/i18n/test.properties");
+        URL hostPropertiesURL = createTmpTestPropetiesFile(tempDir, "host/OH-INF/i18n/test.properties");
+        URL fragmentPropertiesURL = createTmpTestPropetiesFile(tempDir, "fragment/OH-INF/i18n/test.properties");
 
         Bundle bundleMock = mock(Bundle.class);
         when(bundleMock.findEntries(any(), any(), anyBoolean()))

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
@@ -17,22 +17,20 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.openhab.core.tools.i18n.plugin.DefaultTranslationsGenerationMode.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests {@link GenerateDefaultTranslationsMojo}.
@@ -42,7 +40,7 @@ import org.junit.jupiter.api.Test;
 @NonNullByDefault
 public class GenerateDefaultTranslationsMojoTest {
 
-    public @NonNullByDefault({}) Path tempPath;
+    public @TempDir @NonNullByDefault({}) Path tempPath;
     public @NonNullByDefault({}) Path tempI18nPath;
 
     public static final Path TTS_RESOURCES_PATH = Path.of("src/test/resources/acmetts.bundle");
@@ -95,18 +93,12 @@ public class GenerateDefaultTranslationsMojoTest {
 
     @BeforeEach
     public void before() throws IOException {
-        tempPath = Files.createTempDirectory("i18n-");
         tempI18nPath = tempPath.resolve("OH-INF/i18n");
 
         mojo = new GenerateDefaultTranslationsMojo();
         mojo.setLog(new SystemStreamLog());
         mojo.setOhinfDirectory(tempPath.resolve("OH-INF").toFile());
         mojo.setTargetDirectory(tempI18nPath.toFile());
-    }
-
-    @AfterEach
-    public void afterEach() throws IOException {
-        Files.walk(tempPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
     }
 
     private void assertSameProperties(Path expectedPath, Path actualPath) throws IOException {


### PR DESCRIPTION
The JUnit TempDir annotation allows for using less code and automatically cleaning up temp dirs.