### PR TITLE
Update Swagger to 2.2.15

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -20,7 +20,7 @@
     <californium.version>2.7.4</californium.version>
     <jetty.version>9.4.50.v20221201</jetty.version>
     <pax.web.version>8.0.15</pax.web.version>
-    <swagger.version>2.1.9</swagger.version>
+    <swagger.version>2.2.15</swagger.version>
   </properties>
 
   <dependencies>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -22,7 +22,7 @@
     <jetty.version>9.4.50.v20221201</jetty.version>
     <pax.logging.version>2.2.0</pax.logging.version>
     <pax.web.version>8.0.15</pax.web.version>
-    <swagger.version>2.1.9</swagger.version>
+    <swagger.version>2.2.15</swagger.version>
   </properties>
 
   <dependencyManagement>
@@ -1068,7 +1068,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.27.0-GA</version>
+      <version>3.29.2-GA</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -287,16 +287,16 @@
 	</feature>
 
 	<feature name="openhab.tp-swagger-jaxrs" description="JAX-RS Whiteboard Swagger Support" version="${project.version}">
-		<capability>openhab.tp;feature=swagger-jaxrs;version=2.1.9</capability>
+		<capability>openhab.tp;feature=swagger-jaxrs;version=2.2.15</capability>
 		<feature dependency="true">openhab.tp-jax-rs-whiteboard</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.1.9</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.1.9</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.1.9</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.1.9</bundle>
-		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.1.9</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-annotations/2.2.15</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-core/2.2.15</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-integration/2.2.15</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-jaxrs2/2.2.15</bundle>
+		<bundle dependency="true">mvn:io.swagger.core.v3/swagger-models/2.2.15</bundle>
 		<bundle dependency="true">mvn:jakarta.validation/jakarta.validation-api/2.0.2</bundle>
-		<bundle dependency="true">mvn:org.javassist/javassist/3.27.0-GA</bundle>
+		<bundle dependency="true">mvn:org.javassist/javassist/3.29.2-GA</bundle>
 	</feature>
 
 </features>


### PR DESCRIPTION
Updates Swagger from 2.1.9 to 2.2.15.

This adds OpenAPI v3.1 support.

For more release notes see:

https://github.com/swagger-api/swagger-core/releases