### PR TITLE
Update directory-watcher to 0.18.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -422,7 +422,7 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>io.methvin.directory-watcher</artifactId>
-      <version>0.17.1</version>
+      <version>0.18.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1076,7 +1076,7 @@
     <dependency>
       <groupId>org.openhab.osgiify</groupId>
       <artifactId>io.methvin.directory-watcher</artifactId>
-      <version>0.17.1</version>
+      <version>0.18.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -46,7 +46,7 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.discovery/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.dispatch/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core/${project.version}</bundle>
-		<bundle>mvn:org.openhab.osgiify/io.methvin.directory-watcher/0.17.1</bundle>
+		<bundle>mvn:org.openhab.osgiify/io.methvin.directory-watcher/0.18.0</bundle>
 		<bundle>mvn:net.java.dev.jna/jna/5.12.1</bundle>
 		<bundle>mvn:net.java.dev.jna/jna-platform/5.12.1</bundle>
 		<feature dependency="true">openhab-core-storage-json</feature>

--- a/itests/org.openhab.core.addon.tests/itest.bndrun
+++ b/itests/org.openhab.core.addon.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.core.addon
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -61,4 +60,5 @@ Fragment-Host: org.openhab.core.addon
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -69,4 +68,5 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -64,4 +63,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -30,7 +30,6 @@ Fragment-Host: org.openhab.core.automation
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.automation
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.config.core
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -62,4 +61,5 @@ Fragment-Host: org.openhab.core.config.core
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	javax.jmdns;version='[3.5.8,3.5.9)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -66,4 +65,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -67,4 +66,5 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -38,7 +38,6 @@ Provide-Capability: \
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -75,4 +74,5 @@ Provide-Capability: \
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -55,4 +54,5 @@ Fragment-Host: org.openhab.core.config.dispatch
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -35,7 +35,6 @@ feature.openhab-config: \
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -64,4 +63,5 @@ feature.openhab-config: \
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -16,7 +16,6 @@ Fragment-Host: org.openhab.core.io.net
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	com.sun.xml.bind.jaxb-osgi;version='[2.3.3,2.3.4)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	junit-jupiter-api;version='[5.9.2,5.9.3)',\
@@ -73,4 +72,5 @@ Fragment-Host: org.openhab.core.io.net
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -38,7 +38,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -104,4 +103,5 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.ws.xmlschema.core;version='[2.3.0,2.3.1)',\
 	json-path;version='[2.8.0,2.8.1)',\
 	net.minidev.accessors-smart;version='[2.4.9,2.4.10)',\
-	net.minidev.json-smart;version='[2.4.10,2.4.11)'
+	net.minidev.json-smart;version='[2.4.10,2.4.11)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -50,7 +50,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -114,4 +113,5 @@ Fragment-Host: org.openhab.core.model.item
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
 	uom-lib-common;version='[2.2.0,2.2.1)',\
-	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)'
+	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -54,7 +54,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -118,4 +117,5 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -53,7 +53,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -121,4 +120,6 @@ Fragment-Host: org.openhab.core.model.script
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)',\
+	org.openhab.core.model.rule.runtime;version='[4.1.0,4.1.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -51,7 +51,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.eclipse.xtext.xbase;version='[2.29.0,2.29.1)',\
 	org.eclipse.xtext.xbase.lib;version='[2.29.0,2.29.1)',\
 	org.objectweb.asm;version='[9.4.0,9.4.1)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.4,2.2.5)',\
@@ -123,4 +122,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
 	uom-lib-common;version='[2.2.0,2.2.1)',\
-	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)'
+	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)',\
+	org.openhab.core.model.rule.runtime;version='[4.1.0,4.1.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core.storage.json
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -60,4 +59,5 @@ Fragment-Host: org.openhab.core.storage.json
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -28,7 +28,6 @@ Fragment-Host: org.openhab.core
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -59,4 +58,5 @@ Fragment-Host: org.openhab.core
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.core.thing
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -68,4 +67,5 @@ Fragment-Host: org.openhab.core.thing
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -32,7 +32,6 @@ Fragment-Host: org.openhab.core.voice
 	ch.qos.logback.core;version='[1.2.11,1.2.12)',\
 	biz.aQute.tester.junit-platform;version='[6.4.0,6.4.1)',\
 	com.google.gson;version='[2.9.1,2.9.2)',\
-	io.methvin.directory-watcher;version='[0.17.1,0.17.2)',\
 	com.sun.jna;version='[5.12.1,5.12.2)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
@@ -73,4 +72,5 @@ Fragment-Host: org.openhab.core.voice
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
 	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
-	uom-lib-common;version='[2.2.0,2.2.1)'
+	uom-lib-common;version='[2.2.0,2.2.1)',\
+	io.methvin.directory-watcher;version='[0.18.0,0.18.1)'


### PR DESCRIPTION
Updates the directory-watcher from 0.17.1 to 0.18.0.

This version has some bug fixes/improvements, see:

https://github.com/gmethvin/directory-watcher/compare/v0.17.1...v0.18.0

---

Depends on https://github.com/openhab/openhab-osgiify/pull/42