### PR TITLE
Fix countries and connection AddonInfo issues

### DIFF
--- a/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
+++ b/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
@@ -144,7 +144,8 @@ public class EclipseAddonService implements AddonService {
         if (addonInfo != null) {
             // only enrich if this add-on is installed, otherwise wrong data might be added
             addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
-                    .withCountries(addonInfo.getCountries()).withLink(getDefaultDocumentationLink(type, name))
+                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+                    .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {
             addon = addon.withLabel(name).withLink(getDefaultDocumentationLink(type, name));

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -177,6 +177,6 @@ public class JsonAddonService extends AbstractRemoteAddonService {
                 .withCompatible(compatible).withMaturity(addonEntry.maturity).withProperties(properties)
                 .withLink(addonEntry.link).withImageLink(addonEntry.imageUrl)
                 .withConfigDescriptionURI(addonEntry.configDescriptionURI).withLoggerPackages(addonEntry.loggerPackages)
-                .build();
+                .withConnection(addonEntry.connection).withCountries(addonEntry.countries).build();
     }
 }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
@@ -41,4 +41,6 @@ public class AddonEntryDTO {
     public String url = "";
     @SerializedName("logger_packages")
     public List<String> loggerPackages = List.of();
+    public String connection = "";
+    public List<String> countries = List.of();
 }

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -135,6 +135,10 @@ public class AddonInfo implements Identifiable<String> {
         return sourceBundle;
     }
 
+    public @Nullable String getConnection() {
+        return connection;
+    }
+
     public List<String> getCountries() {
         return countries;
     }
@@ -192,7 +196,7 @@ public class AddonInfo implements Identifiable<String> {
         }
 
         public Builder withCountries(@Nullable String countries) {
-            this.countries = Arrays.asList(Objects.requireNonNullElse(countries, "").split(","));
+            this.countries = countries == null || countries.isBlank() ? List.of() : Arrays.asList(countries.split(","));
             return this;
         }
 

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
@@ -154,6 +154,7 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
         String uid = ADDON_ID_PREFIX + addonInfo.getUID();
         return Addon.create(uid).withId(addonInfo.getId()).withType(addonInfo.getType()).withInstalled(true)
                 .withVersion(bundle.getVersion().toString()).withLabel(addonInfo.getName())
+                .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                 .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI())
                 .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()))
                 .withContentType(ADDONS_CONTENT_TYPE).build();

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -136,7 +136,8 @@ public class KarafAddonService implements AddonService {
         if (isInstalled && addonInfo != null) {
             // only enrich if this add-on is installed, otherwise wrong data might be added
             addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
-                    .withCountries(addonInfo.getCountries()).withLink(getDefaultDocumentationLink(type, name))
+                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+                    .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {
             addon = addon.withLabel(feature.getDescription()).withLink(getDefaultDocumentationLink(type, name));


### PR DESCRIPTION
Fixes the following:

* connection and countries details missing for some AddonServices
* missing connection getter on AddonInfo
* countries lists has empty String when when countries info is missing

Related to #3795