### PR TITLE
[voice] Add dialog group and location

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -29,78 +29,10 @@ import org.openhab.core.voice.text.HumanLanguageInterpreter;
  * @author Miguel Álvarez - Initial contribution
  */
 @NonNullByDefault
-public class DialogContext {
-    private final @Nullable KSService ks;
-    private final @Nullable String keyword;
-    private final STTService stt;
-    private final TTSService tts;
-    private final @Nullable Voice voice;
-    private final List<HumanLanguageInterpreter> hlis;
-    private final AudioSource source;
-    private final AudioSink sink;
-    private final Locale locale;
-    private final @Nullable String listeningItem;
-    private final @Nullable String listeningMelody;
-
-    public DialogContext(@Nullable KSService ks, @Nullable String keyword, STTService stt, TTSService tts,
-            @Nullable Voice voice, List<HumanLanguageInterpreter> hlis, AudioSource source, AudioSink sink,
-            Locale locale, @Nullable String listeningItem, @Nullable String listeningMelody) {
-        this.ks = ks;
-        this.keyword = keyword;
-        this.stt = stt;
-        this.tts = tts;
-        this.voice = voice;
-        this.hlis = hlis;
-        this.source = source;
-        this.sink = sink;
-        this.locale = locale;
-        this.listeningItem = listeningItem;
-        this.listeningMelody = listeningMelody;
-    }
-
-    public @Nullable KSService ks() {
-        return ks;
-    }
-
-    public @Nullable String keyword() {
-        return keyword;
-    }
-
-    public STTService stt() {
-        return stt;
-    }
-
-    public TTSService tts() {
-        return tts;
-    }
-
-    public @Nullable Voice voice() {
-        return voice;
-    }
-
-    public List<HumanLanguageInterpreter> hlis() {
-        return hlis;
-    }
-
-    public AudioSource source() {
-        return source;
-    }
-
-    public AudioSink sink() {
-        return sink;
-    }
-
-    public Locale locale() {
-        return locale;
-    }
-
-    public @Nullable String listeningItem() {
-        return listeningItem;
-    }
-
-    public @Nullable String listeningMelody() {
-        return listeningMelody;
-    }
+public record DialogContext(@Nullable KSService ks, @Nullable String keyword, STTService stt, TTSService tts,
+        @Nullable Voice voice, List<HumanLanguageInterpreter> hlis, AudioSource source, AudioSink sink, Locale locale,
+        String dialogGroup, @Nullable String locationItem, @Nullable String listeningItem,
+        @Nullable String listeningMelody) {
 
     /**
      * Builder for {@link DialogContext}
@@ -116,6 +48,8 @@ public class DialogContext {
         private @Nullable Voice voice;
         private List<HumanLanguageInterpreter> hlis = List.of();
         // options
+        private String dialogGroup = "default";
+        private @Nullable String locationItem;
         private @Nullable String listeningItem;
         private @Nullable String listeningMelody;
         private String keyword;
@@ -189,6 +123,20 @@ public class DialogContext {
             return this;
         }
 
+        public Builder withDialogGroup(@Nullable String dialogGroup) {
+            if (dialogGroup != null) {
+                this.dialogGroup = dialogGroup;
+            }
+            return this;
+        }
+
+        public Builder withLocationItem(@Nullable String locationItem) {
+            if (locationItem != null) {
+                this.locationItem = locationItem;
+            }
+            return this;
+        }
+
         public Builder withListeningItem(@Nullable String listeningItem) {
             if (listeningItem != null) {
                 this.listeningItem = listeningItem;
@@ -244,7 +192,7 @@ public class DialogContext {
                 throw new IllegalStateException("Cannot build dialog context: " + String.join(", ", errors) + ".");
             } else {
                 return new DialogContext(ksService, keyword, sttService, ttsService, voice, hliServices, audioSource,
-                        audioSink, locale, listeningItem, listeningMelody);
+                        audioSink, locale, dialogGroup, locationItem, listeningItem, listeningMelody);
             }
         }
     }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
@@ -66,6 +66,14 @@ public class DialogRegistration {
      */
     public @Nullable String listeningItem;
     /**
+     * Linked location item
+     */
+    public @Nullable String locationItem;
+    /**
+     * Dialog group name
+     */
+    public @Nullable String dialogGroup;
+    /**
      * Custom listening melody
      */
     public @Nullable String listeningMelody;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -17,6 +17,7 @@ import java.text.ParseException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -69,13 +70,13 @@ import org.slf4j.LoggerFactory;
  * @author Miguel Álvarez - Close audio streams + use RecognitionStartEvent
  * @author Miguel Álvarez - Use dialog context
  * @author Miguel Álvarez - Add sounds
+ * @author Miguel Álvarez - Add dialog groups
  *
  */
 @NonNullByDefault
 public class DialogProcessor implements KSListener, STTListener {
-
     private final Logger logger = LoggerFactory.getLogger(DialogProcessor.class);
-
+    private final WeakHashMap<String, DialogContext> activeDialogGroups;
     public final DialogContext dialogContext;
     private @Nullable List<ToneSynthesizer.Tone> listeningMelody;
     private final EventPublisher eventPublisher;
@@ -105,11 +106,12 @@ public class DialogProcessor implements KSListener, STTListener {
     private @Nullable ToneSynthesizer toneSynthesizer;
 
     public DialogProcessor(DialogContext context, DialogEventListener eventListener, EventPublisher eventPublisher,
-            TranslationProvider i18nProvider, Bundle bundle) {
+            WeakHashMap<String, DialogContext> activeDialogGroups, TranslationProvider i18nProvider, Bundle bundle) {
         this.dialogContext = context;
         this.eventListener = eventListener;
         this.eventPublisher = eventPublisher;
         this.i18nProvider = i18nProvider;
+        this.activeDialogGroups = activeDialogGroups;
         this.bundle = bundle;
         var ks = context.ks();
         this.ksFormat = ks != null
@@ -182,7 +184,15 @@ public class DialogProcessor implements KSListener, STTListener {
      * Starts a single dialog
      */
     public void startSimpleDialog() {
-        abortSTT();
+        synchronized (activeDialogGroups) {
+            if (!activeDialogGroups.containsKey(dialogContext.dialogGroup())) {
+                logger.debug("Acquiring dialog group '{}'", dialogContext.dialogGroup());
+                activeDialogGroups.put(dialogContext.dialogGroup(), dialogContext);
+            } else {
+                logger.warn("Ignoring keyword spotting event, dialog group '{}' running", dialogContext.dialogGroup());
+                return;
+            }
+        }
         closeStreamSTT();
         isSTTServerAborting = false;
         AudioFormat fmt = sttFormat;
@@ -196,6 +206,7 @@ public class DialogProcessor implements KSListener, STTListener {
             AudioStream stream = dialogContext.source().getInputStream(fmt);
             streamSTT = stream;
             sttServiceHandle = dialogContext.stt().recognize(this, stream, dialogContext.locale(), new HashSet<>());
+            return;
         } catch (AudioException e) {
             logger.warn("Error creating the audio stream: {}", e.getMessage());
         } catch (STTException e) {
@@ -207,6 +218,11 @@ public class DialogProcessor implements KSListener, STTListener {
             } else if (text != null) {
                 say(text.replace("{0}", ""));
             }
+        }
+        // In case of error release dialog group
+        synchronized (activeDialogGroups) {
+            logger.debug("Releasing dialog group '{}' due to errors", dialogContext.dialogGroup());
+            activeDialogGroups.remove(dialogContext.dialogGroup());
         }
     }
 
@@ -264,6 +280,10 @@ public class DialogProcessor implements KSListener, STTListener {
             sttServiceHandle = null;
         }
         isSTTServerAborting = true;
+        synchronized (activeDialogGroups) {
+            logger.debug("Releasing dialog group '{}'", dialogContext.dialogGroup());
+            activeDialogGroups.remove(dialogContext.dialogGroup());
+        }
     }
 
     private void closeStreamSTT() {
@@ -292,20 +312,18 @@ public class DialogProcessor implements KSListener, STTListener {
 
     @Override
     public void ksEventReceived(KSEvent ksEvent) {
-        if (!processing) {
-            isSTTServerAborting = false;
-            if (ksEvent instanceof KSpottedEvent) {
-                logger.debug("KSpottedEvent event received");
-                try {
-                    startSimpleDialog();
-                } catch (IllegalStateException e) {
-                    logger.warn("{}", e.getMessage());
-                }
-            } else if (ksEvent instanceof KSErrorEvent kse) {
-                logger.debug("KSErrorEvent event received");
-                String text = i18nProvider.getText(bundle, "error.ks-error", null, dialogContext.locale());
-                say(text == null ? kse.getMessage() : text.replace("{0}", kse.getMessage()));
+        isSTTServerAborting = false;
+        if (ksEvent instanceof KSpottedEvent) {
+            logger.debug("KSpottedEvent event received");
+            try {
+                startSimpleDialog();
+            } catch (IllegalStateException e) {
+                logger.warn("{}", e.getMessage());
             }
+        } else if (ksEvent instanceof KSErrorEvent kse) {
+            logger.debug("KSErrorEvent event received");
+            String text = i18nProvider.getText(bundle, "error.ks-error", null, dialogContext.locale());
+            say(text == null ? kse.getMessage() : text.replace("{0}", kse.getMessage()));
         }
     }
 
@@ -322,7 +340,7 @@ public class DialogProcessor implements KSListener, STTListener {
                 String error = null;
                 for (HumanLanguageInterpreter interpreter : dialogContext.hlis()) {
                     try {
-                        answer = interpreter.interpret(dialogContext.locale(), question);
+                        answer = interpreter.interpret(dialogContext.locale(), question, dialogContext);
                         logger.debug("Interpretation result: {}", answer);
                         error = null;
                         break;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.voice.DialogContext;
 
 /**
  * This is the interface that a human language text interpreter has to implement.
@@ -49,6 +50,19 @@ public interface HumanLanguageInterpreter {
      * @return a human language response
      */
     String interpret(Locale locale, String text) throws InterpretationException;
+
+    /**
+     * Interprets a human language text fragment of a given {@link Locale} with optional access to the context of a
+     * dialog execution.
+     *
+     * @param locale language of the text (given by a {@link Locale})
+     * @param text the text to interpret
+     * @return a human language response
+     */
+    default String interpret(Locale locale, String text, @Nullable DialogContext dialogContext)
+            throws InterpretationException {
+        return interpret(locale, text);
+    }
 
     /**
      * Gets the grammar of all commands of a given {@link Locale} of the interpreter

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
@@ -15,6 +15,8 @@ package org.openhab.core.voice.text;
 import java.util.ResourceBundle;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.voice.DialogContext;
 
 /**
  * Represents an expression plus action code that will be executed after successful parsing. This class is immutable and
@@ -43,12 +45,13 @@ public abstract class Rule {
      * @param node the resulting AST node of the parse run. To be used as input.
      * @return
      */
-    public abstract InterpretationResult interpretAST(ResourceBundle language, ASTNode node);
+    public abstract InterpretationResult interpretAST(ResourceBundle language, ASTNode node,
+            @Nullable DialogContext dialogContext);
 
-    InterpretationResult execute(ResourceBundle language, TokenList list) {
+    InterpretationResult execute(ResourceBundle language, TokenList list, @Nullable DialogContext dialogContext) {
         ASTNode node = expression.parse(language, list);
         if (node.isSuccess() && node.getRemainingTokens().eof()) {
-            return interpretAST(language, node);
+            return interpretAST(language, node, dialogContext);
         }
         return InterpretationResult.SYNTAX_ERROR;
     }


### PR DESCRIPTION
I would like to merge this minor improvement into the voice bundle, it introduces two new configurations into the dialog context, the dialogGroup which defaults to "default" and the locationItem with defaults to null.

The dialogGroup is used to discard spot events raised at same time in different dialog executions, so you can have multiple near speakers and not "awake" them at the same time. Also fixes a race error that happened when a KS service sent two consecutive spot events.

The locationItem, is meant to optionally contain the name of a "Location" group item, it is propagated to the StandarInterpreter (to its base class to be correct) so it can reduce label collisions based on this location context.