### PR TITLE
Inject SCRIPT_CONTEXT into the execution context

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -133,6 +133,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         final Map<String, Object> contextNew = new HashMap<>(context);
         contextNew.put("ruleUID", this.ruleUID);
         executionContext.setAttribute("ctx", contextNew, ScriptContext.ENGINE_SCOPE);
+        executionContext.setAttribute("SCRIPT_CONTEXT", contextNew, ScriptContext.ENGINE_SCOPE);
 
         // Add the rule's UID to the global namespace.
         executionContext.setAttribute("ruleUID", this.ruleUID, ScriptContext.ENGINE_SCOPE);


### PR DESCRIPTION
Currently `ctx` is only accessible as a top-level local variable in JRuby. Because the helper library is loaded in a separate `eval` invocation, it doesn't have access to `ctx`. By injecting an uppercase attribute name, it is treated as a global constant which is accessible by the helper library.