### PR TITLE
[sitemap mainUI] fix trailing space in state string

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -89,7 +89,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
     private static final Pattern VISIBILITY_PATTERN = Pattern
             .compile("(?<item>[A-Za-z]\\w*)\\s*(?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>.+)");
     private static final Pattern COLOR_PATTERN = Pattern.compile(
-            "((?<item>[A-Za-z]\\w*)?\\s*((?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>[^=]+))?\\s*=)?\\s*(?<arg>\\S+)");
+            "((?<item>[A-Za-z]\\w*)?\\s*((?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>[^=]*[^= ]+))?\\s*=)?\\s*(?<arg>\\S+)");
 
     private Map<String, Sitemap> sitemaps = new HashMap<>();
     private @Nullable UIComponentRegistryFactory componentRegistryFactory;


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/2082

https://github.com/openhab/openhab-core/pull/3769 fixes an issue with blanks in visibility or color command arguments. It did overlook trailing blanks in color arguments and included them in the argument.
This PR fixes this issue.