### PR TITLE
Upgrade hivemq-mqtt-client to 1.3.3, Netty to 4.1.99.Final

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -234,7 +234,7 @@
     <dependency>
       <groupId>com.hivemq</groupId>
       <artifactId>hivemq-mqtt-client</artifactId>
-      <version>1.2.2</version>
+      <version>1.3.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -517,7 +517,7 @@
     <dependency>
       <groupId>com.hivemq</groupId>
       <artifactId>hivemq-mqtt-client</artifactId>
-      <version>1.2.2</version>
+      <version>1.3.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -59,14 +59,14 @@
 	</feature>
 
 	<feature name="openhab.tp-hivemqclient" description="MQTT Client" version="${project.version}">
-		<capability>openhab.tp;feature=hivemqclient;version=1.2.2</capability>
+		<capability>openhab.tp;feature=hivemqclient;version=1.3.3</capability>
 		<feature dependency="true">openhab.tp-netty</feature>
 		<bundle dependency="true">mvn:org.jctools/jctools-core/2.1.2</bundle>
-		<bundle dependency="true">mvn:io.reactivex.rxjava2/rxjava/2.2.19</bundle>
-		<bundle dependency="true">mvn:org.reactivestreams/reactive-streams/1.0.3</bundle>
+		<bundle dependency="true">mvn:io.reactivex.rxjava2/rxjava/2.2.21</bundle>
+		<bundle dependency="true">mvn:org.reactivestreams/reactive-streams/1.0.4</bundle>
 		<bundle dependency="true">mvn:org.openhab.osgiify/com.google.dagger/2.27</bundle>
-		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
-		<bundle>mvn:com.hivemq/hivemq-mqtt-client/1.2.2</bundle>
+		<bundle dependency="true">mvn:jakarta.inject/jakarta.inject-api/1.0.5</bundle>
+		<bundle>mvn:com.hivemq/hivemq-mqtt-client/1.3.3</bundle>
 	</feature>
 
 	<feature name="openhab.tp-httpclient" version="${project.version}">
@@ -135,23 +135,23 @@
 	</feature>
 
 	<feature name="openhab.tp-netty" description="Netty bundles" version="${project.version}">
-		<capability>openhab.tp;feature=netty;version=4.1.92.Final</capability>
-		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-common/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.92.Final</bundle>
-		<bundle dependency="true">mvn:io.netty/netty-tcnative-classes/2.0.60.Final</bundle>
+		<capability>openhab.tp;feature=netty;version=4.1.99.Final</capability>
+		<bundle dependency="true">mvn:io.netty/netty-buffer/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-common/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-http2/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-mqtt/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-codec-socks/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-handler-proxy/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-resolver/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-epoll/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-kqueue/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-native-unix-common/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-transport-classes-epoll/4.1.99.Final</bundle>
+		<bundle dependency="true">mvn:io.netty/netty-tcnative-classes/2.0.61.Final</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jaxb" description="JAXB bundles" version="${project.version}">


### PR DESCRIPTION
Upgrades:

* hivemq-mqtt-client from 1.2.2 to 1.3.3
* Netty from 4.1.92.Final to 4.1.99.Final

For all fixes and improvements of these upgrades, see:

* https://github.com/hivemq/hivemq-mqtt-client/releases/
* https://netty.io/news/index.html