### PR TITLE
Upgrade CXF to 3.6.2

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <californium.version>2.7.4</californium.version>
-    <cxf.version>3.6.1</cxf.version>
+    <cxf.version>3.6.2</cxf.version>
     <jackson.version>2.15.2</jackson.version>
     <jetty.version>9.4.52.v20230823</jetty.version>
     <pax.logging.version>2.2.3</pax.logging.version>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -16,7 +16,7 @@
   <name>openHAB Core :: BOM :: Test</name>
 
   <properties>
-    <cxf.version>3.6.1</cxf.version>
+    <cxf.version>3.6.2</cxf.version>
     <junit.version>5.9.2</junit.version>
     <mockito.version>4.11.0</mockito.version>
   </properties>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -112,21 +112,21 @@
 	</feature>
 
 	<feature name="openhab.tp-cxf" description="Apache CXF" version="${project.version}">
-		<capability>openhab.tp;feature=cxf;version=3.6.1</capability>
+		<capability>openhab.tp;feature=cxf;version=3.6.2</capability>
 		<feature dependency="true">openhab.tp-jaxws</feature>
 		<bundle dependency="true">mvn:com.fasterxml.woodstox/woodstox-core/6.5.1</bundle>
 		<bundle dependency="true">mvn:jakarta.jws/jakarta.jws-api/2.1.0</bundle>
 		<bundle dependency="true">mvn:jakarta.xml.ws/jakarta.xml.ws-api/2.3.3</bundle>
 		<bundle dependency="true">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
 		<bundle dependency="true">mvn:org.apache.aries.spec/org.apache.aries.javax.jax.rs-api/1.0.4</bundle>
-		<bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/2.3.0</bundle>
+		<bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/2.3.1</bundle>
 		<bundle dependency="true">mvn:org.codehaus.woodstox/stax2-api/4.2.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-core/3.6.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/3.6.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-rt-rs-client/3.6.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-rt-rs-sse/3.6.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-rt-security/3.6.1</bundle>
-		<bundle>mvn:org.apache.cxf/cxf-rt-transports-http/3.6.1</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-core/3.6.2</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/3.6.2</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-rt-rs-client/3.6.2</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-rt-rs-sse/3.6.2</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-rt-security/3.6.2</bundle>
+		<bundle>mvn:org.apache.cxf/cxf-rt-transports-http/3.6.2</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jbbp" description="Java Binary Block Parser library" version="${project.version}">

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -68,13 +68,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	tech.units.indriya;version='[2.2.0,2.2.1)',\
 	uom-lib-common;version='[2.2.0,2.2.1)',\
 	com.fasterxml.woodstox.woodstox-core;version='[6.5.1,6.5.2)',\
-	org.apache.cxf.cxf-core;version='[3.6.1,3.6.2)',\
-	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.6.1,3.6.2)',\
-	org.apache.cxf.cxf-rt-rs-client;version='[3.6.1,3.6.2)',\
-	org.apache.cxf.cxf-rt-rs-sse;version='[3.6.1,3.6.2)',\
-	org.apache.cxf.cxf-rt-security;version='[3.6.1,3.6.2)',\
-	org.apache.cxf.cxf-rt-transports-http;version='[3.6.1,3.6.2)',\
-	org.apache.ws.xmlschema.core;version='[2.3.0,2.3.1)',\
 	json-path;version='[2.8.0,2.8.1)',\
 	net.minidev.accessors-smart;version='[2.4.9,2.4.10)',\
 	net.minidev.json-smart;version='[2.4.10,2.4.11)',\
@@ -104,4 +97,11 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.osgi.service.event;version='[1.4.1,1.4.2)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
-	org.objectweb.asm;version='[9.5.0,9.5.1)'
+	org.objectweb.asm;version='[9.5.0,9.5.1)',\
+	org.apache.cxf.cxf-core;version='[3.6.2,3.6.3)',\
+	org.apache.cxf.cxf-rt-frontend-jaxrs;version='[3.6.2,3.6.3)',\
+	org.apache.cxf.cxf-rt-rs-client;version='[3.6.2,3.6.3)',\
+	org.apache.cxf.cxf-rt-rs-sse;version='[3.6.2,3.6.3)',\
+	org.apache.cxf.cxf-rt-security;version='[3.6.2,3.6.3)',\
+	org.apache.cxf.cxf-rt-transports-http;version='[3.6.2,3.6.3)',\
+	org.apache.ws.xmlschema.core;version='[2.3.1,2.3.2)'


### PR DESCRIPTION
Upgrades CXF from 3.6.1 to 3.6.2.

For release notes, see:

https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12310511&version=12353311

It has a fix to address OOM issues when using HTTP clients:

https://issues.apache.org/jira/browse/CXF-8885