### PR TITLE
Remove unused javax.inject annotations

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.security.RolesAllowed;
-import javax.inject.Singleton;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -92,7 +91,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Path(SseResource.PATH_EVENTS)
 @RolesAllowed({ Role.USER, Role.ADMIN })
 @Tag(name = SseResource.PATH_EVENTS)
-@Singleton
 @NonNullByDefault
 public class SseResource implements RESTResource, SsePublisher {
 

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
@@ -36,7 +36,7 @@ import org.openhab.core.auth.UserRegistry;
  */
 public class ManagedUserBackingEngine implements BackingEngine {
 
-    UserRegistry userRegistry;
+    private final UserRegistry userRegistry;
 
     public ManagedUserBackingEngine(UserRegistry userRegistry) {
         this.userRegistry = userRegistry;

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
@@ -14,8 +14,6 @@ package org.openhab.core.karaf.internal.jaas;
 
 import java.util.Map;
 
-import javax.inject.Singleton;
-
 import org.apache.karaf.jaas.modules.BackingEngine;
 import org.apache.karaf.jaas.modules.BackingEngineFactory;
 import org.openhab.core.auth.UserRegistry;
@@ -28,11 +26,10 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Yannick Schaus - initial contribution
  */
-@Singleton
 @Component(service = BackingEngineFactory.class)
 public class ManagedUserBackingEngineFactory implements BackingEngineFactory {
 
-    UserRegistry userRegistry;
+    private final UserRegistry userRegistry;
 
     @Activate
     public ManagedUserBackingEngineFactory(@Reference UserRegistry userRegistry) {

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
@@ -15,7 +15,6 @@ package org.openhab.core.karaf.internal.jaas;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Singleton;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 
@@ -30,7 +29,6 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Yannick Schaus - initial contribution
  */
-@Singleton
 @Component(service = JaasRealm.class)
 @Service
 public class ManagedUserRealm implements JaasRealm {


### PR DESCRIPTION
AFAIK these annotations are not used when using declarative services.

I stumbled upon these annotations when feature validation failed while creating #3817. Xtext now uses Guice 7 which is using jakarta.inject imports.

Only si.uom:si-units:2.1 still imports javax.inject but it will also switch to jakarta.inject when 2.2 gets released.