### PR TITLE
Upgrade JUnit to 5.10.0

### DIFF
--- a/bom/test-index/pom.xml
+++ b/bom/test-index/pom.xml
@@ -19,12 +19,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>1.9.2</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>biz.aQute.bnd</groupId>

--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <cxf.version>3.6.2</cxf.version>
-    <junit.version>5.9.2</junit.version>
+    <junit.version>5.10.0</junit.version>
     <mockito.version>4.11.0</mockito.version>
   </properties>
 

--- a/itests/org.openhab.core.addon.tests/itest.bndrun
+++ b/itests/org.openhab.core.addon.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.addon
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -28,11 +27,6 @@ Fragment-Host: org.openhab.core.addon
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.addon;version='[4.1.0,4.1.1)',\
 	org.openhab.core.addon.tests;version='[4.1.0,4.1.1)',\
@@ -67,4 +61,10 @@ Fragment-Host: org.openhab.core.addon
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
+++ b/itests/org.openhab.core.auth.oauth2client.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -23,11 +22,6 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -75,4 +69,10 @@ Fragment-Host: org.openhab.core.auth.oauth2client
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -26,11 +25,6 @@ Fragment-Host: org.openhab.core.automation
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -26,11 +25,6 @@ Fragment-Host: org.openhab.core.automation
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -26,11 +25,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.automation;version='[4.1.0,4.1.1)',\
 	org.openhab.core.automation.module.script;version='[4.1.0,4.1.1)',\
@@ -70,4 +64,10 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -26,11 +25,6 @@ Fragment-Host: org.openhab.core.automation
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.automation
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -26,11 +25,6 @@ Fragment-Host: org.openhab.core.automation
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.automation
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.core.tests/itest.bndrun
@@ -12,7 +12,6 @@ Fragment-Host: org.openhab.core.config.core
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -25,11 +24,6 @@ Fragment-Host: org.openhab.core.config.core
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -68,4 +62,10 @@ Fragment-Host: org.openhab.core.config.core
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -25,11 +24,6 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -12,7 +12,6 @@ Fragment-Host: org.openhab.core.config.discovery
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -25,11 +24,6 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -72,4 +66,10 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -24,11 +23,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -21,7 +21,6 @@ Provide-Capability: \
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -34,11 +33,6 @@ Provide-Capability: \
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
@@ -81,4 +75,10 @@ Provide-Capability: \
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.dispatch.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -23,11 +22,6 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.dispatch;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.dispatch.tests;version='[4.1.0,4.1.1)',\
@@ -61,4 +55,10 @@ Fragment-Host: org.openhab.core.config.dispatch
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -16,7 +16,6 @@ feature.openhab-config: \
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -31,11 +30,6 @@ feature.openhab-config: \
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.ephemeris;version='[4.1.0,4.1.1)',\
@@ -70,4 +64,10 @@ feature.openhab-config: \
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.io.net.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.net.tests/itest.bndrun
@@ -12,11 +12,6 @@ Fragment-Host: org.openhab.core.io.net
 -runbundles: \
 	jakarta.inject.jakarta.inject-api;version='[2.0.0,2.0.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
@@ -24,7 +19,6 @@ Fragment-Host: org.openhab.core.io.net
 	org.glassfish.hk2.external.javax.inject;version='[2.4.0,2.4.1)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	si-units;version='[2.1.0,2.1.1)',\
@@ -73,4 +67,10 @@ Fragment-Host: org.openhab.core.io.net
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -16,7 +16,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.osgi.service.jaxrs;version='[1.0.0,1.0.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -32,12 +31,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-jupiter-params;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -104,4 +97,11 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.apache.cxf.cxf-rt-security;version='[3.6.2,3.6.3)',\
 	org.apache.cxf.cxf-rt-transports-http;version='[3.6.2,3.6.3)',\
 	org.apache.ws.xmlschema.core;version='[2.3.1,2.3.2)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-jupiter-params;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -17,7 +17,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -32,11 +31,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.audio;version='[4.1.0,4.1.1)',\
 	org.openhab.core.automation;version='[4.1.0,4.1.1)',\
@@ -120,4 +114,10 @@ Fragment-Host: org.openhab.core.model.item
 	org.eclipse.xtext.xbase.lib;version='[2.32.0,2.32.1)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
 	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.1.0,4.1.1)'
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.1.0,4.1.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -21,7 +21,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -37,11 +36,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.audio;version='[4.1.0,4.1.1)',\
 	org.openhab.core.automation;version='[4.1.0,4.1.1)',\
@@ -124,4 +118,10 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.eclipse.xtext.xbase.lib;version='[2.32.0,2.32.1)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
 	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.1.0,4.1.1)'
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.1.0,4.1.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -20,7 +20,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -36,11 +35,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -127,4 +121,10 @@ Fragment-Host: org.openhab.core.model.script
 	org.eclipse.xtext.xbase.lib;version='[2.32.0,2.32.1)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
 	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.1.0,4.1.1)'
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.1.0,4.1.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -18,7 +18,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	com.google.guava.failureaccess;version='[1.0.1,1.0.2)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	jollyday;version='[0.5.10,0.5.11)',\
@@ -33,12 +32,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-jupiter-params;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -129,4 +122,11 @@ Fragment-Host: org.openhab.core.model.thing
 	org.eclipse.xtext.xbase.lib;version='[2.32.0,2.32.1)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
 	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
-	org.openhab.core.model.sitemap.runtime;version='[4.1.0,4.1.1)'
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-jupiter-params;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.1.0,4.1.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core.storage.json
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -24,11 +23,6 @@ Fragment-Host: org.openhab.core.storage.json
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.io.console;version='[4.1.0,4.1.1)',\
@@ -66,4 +60,10 @@ Fragment-Host: org.openhab.core.storage.json
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.tests/itest.bndrun
@@ -11,7 +11,6 @@ Fragment-Host: org.openhab.core
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -23,11 +22,6 @@ Fragment-Host: org.openhab.core
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -65,4 +59,10 @@ Fragment-Host: org.openhab.core
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.thing
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -28,11 +27,6 @@ Fragment-Host: org.openhab.core.thing
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	net.bytebuddy.byte-buddy;version='[1.12.19,1.12.20)',\
 	net.bytebuddy.byte-buddy-agent;version='[1.12.19,1.12.20)',\
 	org.mockito.junit-jupiter;version='[4.11.0,4.11.1)',\
@@ -74,4 +68,10 @@ Fragment-Host: org.openhab.core.thing
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -15,7 +15,6 @@ Fragment-Host: org.openhab.core.voice
 -runbundles: \
 	org.apache.servicemix.specs.annotation-api-1.3;version='[1.3.0,1.3.1)',\
 	org.hamcrest;version='[2.2.0,2.2.1)',\
-	org.opentest4j;version='[1.2.0,1.2.1)',\
 	jakarta.xml.bind-api;version='[2.3.3,2.3.4)',\
 	org.apache.servicemix.specs.activation-api-1.2.1;version='[1.2.1,1.2.2)',\
 	org.glassfish.hk2.osgi-resource-locator;version='[1.0.3,1.0.4)',\
@@ -28,12 +27,6 @@ Fragment-Host: org.openhab.core.voice
 	org.apache.felix.http.servlet-api;version='[1.2.0,1.2.1)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	xstream;version='[1.4.20,1.4.21)',\
-	junit-jupiter-api;version='[5.9.2,5.9.3)',\
-	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
-	junit-jupiter-params;version='[5.9.2,5.9.3)',\
-	junit-platform-commons;version='[1.9.2,1.9.3)',\
-	junit-platform-engine;version='[1.9.2,1.9.3)',\
-	junit-platform-launcher;version='[1.9.2,1.9.3)',\
 	org.openhab.core;version='[4.1.0,4.1.1)',\
 	org.openhab.core.audio;version='[4.1.0,4.1.1)',\
 	org.openhab.core.config.core;version='[4.1.0,4.1.1)',\
@@ -79,4 +72,11 @@ Fragment-Host: org.openhab.core.voice
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\
 	com.google.gson;version='[2.10.1,2.10.2)',\
 	org.objectweb.asm;version='[9.5.0,9.5.1)',\
-	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)'
+	biz.aQute.tester.junit-platform;version='[7.0.0,7.0.1)',\
+	junit-jupiter-api;version='[5.10.0,5.10.1)',\
+	junit-jupiter-engine;version='[5.10.0,5.10.1)',\
+	junit-jupiter-params;version='[5.10.0,5.10.1)',\
+	junit-platform-commons;version='[1.10.0,1.10.1)',\
+	junit-platform-engine;version='[1.10.0,1.10.1)',\
+	junit-platform-launcher;version='[1.10.0,1.10.1)',\
+	org.opentest4j;version='[1.3.0,1.3.1)'


### PR DESCRIPTION
Upgrades JUnit from 5.9.2 to 5.10.0.

For release notes, see:

https://junit.org/junit5/docs/5.10.0/release-notes/#release-notes-5.10.0