### PR TITLE
Fixes source filter not working for `GenericEventTrigger`

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandler.java
@@ -74,9 +74,9 @@ public class GenericEventTriggerHandler extends BaseTriggerModuleHandler impleme
             topicFilter = null;
         }
         if (module.getConfiguration().get(CFG_TYPES) != null) {
-            this.types = Set.of(((String) module.getConfiguration().get(CFG_TYPES)).split(","));
+            types = Set.of(((String) module.getConfiguration().get(CFG_TYPES)).split(","));
         } else {
-            this.types = Set.of();
+            types = Set.of();
         }
         String payload = (String) module.getConfiguration().get(CFG_PAYLOAD);
         if (!payload.isBlank()) {
@@ -104,11 +104,8 @@ public class GenericEventTriggerHandler extends BaseTriggerModuleHandler impleme
     public void receive(Event event) {
         ModuleHandlerCallback callback = this.callback;
         if (callback != null) {
-            logger.trace("Received Event: Source: {} Topic: {} Type: {}  Payload: {}", event.getSource(),
-                    event.getTopic(), event.getType(), event.getPayload());
-            if (!event.getTopic().contains(source)) {
-                return;
-            }
+            logger.trace("Received Event: Topic: {} Type: {} Source: {} Payload: {}", event.getTopic(), event.getType(),
+                    event.getSource(), event.getPayload());
             Map<String, Object> values = new HashMap<>();
             values.put("event", event);
 


### PR DESCRIPTION
While reviewing https://github.com/openhab/openhab-js/pull/300, I noticed that filtering by source `org.openhab.core.expire` was not possible.

This was because the specified source was checked against the event topic, which makes no sense at all given that different schemes. Source filtering is done inside the `apply` method.

In case you need some code to reproduce the described issue, just let me know.