### PR TITLE
Fix missing ALPN bundles

### DIFF
--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -74,6 +74,7 @@
 		<feature dependency="true">pax-web-jetty-extras</feature>
 		<feature dependency="true">pax-web-jetty-http2</feature>
 		<feature dependency="true">pax-web-jetty-http2-extras</feature>
+		<feature dependency="true">pax-web-jetty-http2-jdk9</feature>
 		<feature dependency="true">pax-web-jetty-websockets</feature>
 	</feature>
 


### PR DESCRIPTION
The pax-web-jetty-http2-jdk9 feature should not have been removed in #3814.

See: https://community.openhab.org/t/openhab-4-1-milestone-discussion/149502/42