### PR TITLE
Use 'uid' instead of 'UID' as method parameters

### DIFF
--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
@@ -60,8 +60,8 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @Nullable ModuleType getModuleType(String UID, @Nullable Locale locale) {
-        switch (UID) {
+    public @Nullable ModuleType getModuleType(String uid, @Nullable Locale locale) {
+        switch (uid) {
             case PlayActionHandler.TYPE_ID:
                 return getPlayActionType(locale);
             case SayActionHandler.TYPE_ID:

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
@@ -57,8 +57,8 @@ public class ScriptedCustomModuleTypeProvider implements ModuleTypeProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
-        return (T) modulesTypes.get(UID);
+    public <T extends ModuleType> T getModuleType(String uid, @Nullable Locale locale) {
+        return (T) modulesTypes.get(uid);
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
@@ -67,10 +67,10 @@ public class ScriptedAutomationManager {
         this.scriptedPrivateModuleHandlerFactory = scriptedPrivateModuleHandlerFactory;
     }
 
-    public void removeModuleType(String UID) {
-        if (modules.remove(UID)) {
-            scriptedCustomModuleTypeProvider.removeModuleType(UID);
-            removeHandler(UID);
+    public void removeModuleType(String uid) {
+        if (modules.remove(uid)) {
+            scriptedCustomModuleTypeProvider.removeModuleType(uid);
+            removeHandler(uid);
         }
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -68,12 +68,12 @@ public class ScriptModuleTypeProvider extends AbstractProvider<ModuleType> imple
 
     @SuppressWarnings("unchecked")
     @Override
-    public @Nullable ModuleType getModuleType(String UID, @Nullable Locale locale) {
+    public @Nullable ModuleType getModuleType(String uid, @Nullable Locale locale) {
         if (parameterOptions.isEmpty()) {
             return null;
-        } else if (ScriptActionHandler.TYPE_ID.equals(UID)) {
+        } else if (ScriptActionHandler.TYPE_ID.equals(uid)) {
             return getScriptActionType(locale);
-        } else if (ScriptConditionHandler.TYPE_ID.equals(UID)) {
+        } else if (ScriptConditionHandler.TYPE_ID.equals(uid)) {
             return getScriptConditionType(locale);
         } else {
             return null;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ActionImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ActionImpl.java
@@ -37,16 +37,16 @@ public class ActionImpl extends ModuleImpl implements Action {
     /**
      * Constructor of Action object.
      *
-     * @param UID action unique id.
+     * @param uid action unique id.
      * @param typeUID module type unique id.
      * @param configuration map of configuration values.
      * @param label the label
      * @param description description
      * @param inputs set of connections to other modules (triggers and other actions).
      */
-    public ActionImpl(String UID, String typeUID, @Nullable Configuration configuration, @Nullable String label,
+    public ActionImpl(String uid, String typeUID, @Nullable Configuration configuration, @Nullable String label,
             @Nullable String description, @Nullable Map<String, String> inputs) {
-        super(UID, typeUID, configuration, label, description);
+        super(uid, typeUID, configuration, label, description);
         this.inputs = inputs == null ? Map.of() : Map.copyOf(inputs);
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
@@ -136,9 +136,9 @@ public class CommandlineModuleTypeProvider extends AbstractCommandProvider<Modul
 
     @SuppressWarnings("unchecked")
     @Override
-    public @Nullable ModuleType getModuleType(String UID, @Nullable Locale locale) {
+    public @Nullable ModuleType getModuleType(String uid, @Nullable Locale locale) {
         synchronized (providedObjectsHolder) {
-            return providedObjectsHolder.get(UID);
+            return providedObjectsHolder.get(uid);
         }
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
@@ -130,9 +130,9 @@ public class CommandlineTemplateProvider extends AbstractCommandProvider<RuleTem
     }
 
     @Override
-    public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
+    public @Nullable RuleTemplate getTemplate(String uid, @Nullable Locale locale) {
         synchronized (providerPortfolio) {
-            return providedObjectsHolder.get(UID);
+            return providedObjectsHolder.get(uid);
         }
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
@@ -98,8 +98,8 @@ public class AnnotatedActionModuleTypeProvider extends BaseModuleHandlerFactory 
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
-        return (T) localizeModuleType(UID, locale);
+    public <T extends ModuleType> T getModuleType(String uid, @Nullable Locale locale) {
+        return (T) localizeModuleType(uid, locale);
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
@@ -114,8 +114,8 @@ public class ModuleTypeResourceBundleProvider extends AbstractResourceBundleProv
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
-        return (T) getPerLocale(providedObjectsHolder.get(UID), locale);
+    public <T extends ModuleType> T getModuleType(String uid, @Nullable Locale locale) {
+        return (T) getPerLocale(providedObjectsHolder.get(uid), locale);
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
@@ -131,8 +131,8 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
      * @see TemplateProvider#getTemplate(java.lang.String, java.util.Locale)
      */
     @Override
-    public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
-        return getPerLocale(providedObjectsHolder.get(UID), locale);
+    public @Nullable RuleTemplate getTemplate(String uid, @Nullable Locale locale) {
+        return getPerLocale(providedObjectsHolder.get(uid), locale);
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
@@ -47,8 +47,8 @@ public abstract class ModuleTypeFileProvider extends AbstractFileProvider<Module
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
-        return (T) providedObjectsHolder.get(UID);
+    public <T extends ModuleType> @Nullable T getModuleType(String uid, @Nullable Locale locale) {
+        return (T) providedObjectsHolder.get(uid);
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
@@ -47,8 +47,8 @@ public abstract class TemplateFileProvider extends AbstractFileProvider<RuleTemp
     }
 
     @Override
-    public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
-        return providedObjectsHolder.get(UID);
+    public @Nullable RuleTemplate getTemplate(String uid, @Nullable Locale locale) {
+        return providedObjectsHolder.get(uid);
     }
 
     @Override

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
@@ -147,8 +147,8 @@ public class AnnotationActionModuleTypeHelper {
         return outputs;
     }
 
-    public @Nullable ActionType buildModuleType(String UID, Map<String, Set<ModuleInformation>> moduleInformation) {
-        Set<ModuleInformation> mis = moduleInformation.get(UID);
+    public @Nullable ActionType buildModuleType(String uid, Map<String, Set<ModuleInformation>> moduleInformation) {
+        Set<ModuleInformation> mis = moduleInformation.get(uid);
         List<ConfigDescriptionParameter> configDescriptions = new ArrayList<>();
 
         if (mis != null && !mis.isEmpty()) {
@@ -158,7 +158,7 @@ public class AnnotationActionModuleTypeHelper {
             if (mi.getConfigName() != null && mi.getThingUID() != null) {
                 logger.error(
                         "ModuleType with UID {} has thingUID ({}) and multi-service ({}) property set, ignoring it.",
-                        UID, mi.getConfigName(), mi.getThingUID());
+                        uid, mi.getConfigName(), mi.getThingUID());
                 return null;
             } else if (mi.getConfigName() != null) {
                 kind = ActionModuleKind.SERVICE;
@@ -170,7 +170,7 @@ public class AnnotationActionModuleTypeHelper {
             if (configParam != null) {
                 configDescriptions.add(configParam);
             }
-            return new ActionType(UID, configDescriptions, mi.getLabel(), mi.getDescription(), mi.getTags(),
+            return new ActionType(uid, configDescriptions, mi.getLabel(), mi.getDescription(), mi.getTags(),
                     mi.getVisibility(), mi.getInputs(), mi.getOutputs());
         }
         return null;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
@@ -109,11 +109,11 @@ public class RuleTemplate implements Template {
      * @param configDescriptions describing meta-data for the configuration of the future {@link Rule} instances.
      * @param visibility the {@link RuleTemplate}'s visibility.
      */
-    public RuleTemplate(@Nullable String UID, @Nullable String label, @Nullable String description,
+    public RuleTemplate(@Nullable String uid, @Nullable String label, @Nullable String description,
             @Nullable Set<String> tags, @Nullable List<Trigger> triggers, @Nullable List<Condition> conditions,
             @Nullable List<Action> actions, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable Visibility visibility) {
-        this.uid = UID == null ? UUID.randomUUID().toString() : UID;
+        this.uid = uid == null ? UUID.randomUUID().toString() : uid;
         this.label = label;
         this.description = description;
         this.triggers = triggers == null ? List.of() : Collections.unmodifiableList(triggers);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
@@ -34,14 +34,14 @@ public interface TemplateProvider<E extends Template> extends Provider<E> {
      * Gets the localized Templates defined by this provider. When the localization is not specified or it is not
      * supported a Template localized with default locale is returned.
      *
-     * @param UID unique identifier of the desired Template.
+     * @param uid unique identifier of the desired Template.
      * @param locale specifies the desired {@link Locale} to be used for localization of the returned element. If
      *            localization resources for this locale are not available or the passed locale is {@code null} the
      *            element is returned with the default localization.
      * @return the desired localized Template.
      */
     @Nullable
-    E getTemplate(String UID, @Nullable Locale locale);
+    E getTemplate(String uid, @Nullable Locale locale);
 
     /**
      * Gets the localized Templates defined by this provider. When localization is not specified or it is not supported

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
@@ -102,8 +102,8 @@ public class AnnotatedThingActionModuleTypeProvider extends BaseModuleHandlerFac
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ModuleType> T getModuleType(String UID, @Nullable Locale locale) {
-        return (T) localizeModuleType(UID, locale);
+    public <T extends ModuleType> T getModuleType(String uid, @Nullable Locale locale) {
+        return (T) localizeModuleType(uid, locale);
     }
 
     @SuppressWarnings("unchecked")

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ActionType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ActionType.java
@@ -52,22 +52,22 @@ public class ActionType extends ModuleType {
      * Creates an instance of {@link ActionType} with base properties - UID, a {@link List} of configuration
      * descriptions and a {@link List} of {@link Input} definitions.
      *
-     * @param UID the {@link ActionType}'s identifier, or {@code null} if a random identifier should be
+     * @param uid the {@link ActionType}'s identifier, or {@code null} if a random identifier should be
      *            generated.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Action} instances.
      * @param inputs a {@link List} with {@link Input} meta-information descriptions of the future
      *            {@link Action} instances.
      */
-    public ActionType(@Nullable String UID, @Nullable List<ConfigDescriptionParameter> configDescriptions,
+    public ActionType(@Nullable String uid, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable List<Input> inputs) {
-        this(UID, configDescriptions, inputs, null);
+        this(uid, configDescriptions, inputs, null);
     }
 
     /**
      * Creates an instance of the {@link ActionType} with UID, a {@link List} of configuration descriptions,
      * a {@link List} of {@link Input} definitions and a {@link List} of {@link Output} descriptions.
      *
-     * @param UID the {@link ActionType}'s identifier, or {@code null} if a random identifier should be
+     * @param uid the {@link ActionType}'s identifier, or {@code null} if a random identifier should be
      *            generated.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Action} instances.
      * @param inputs a {@link List} with {@link Input} meta-information descriptions of the future
@@ -75,9 +75,9 @@ public class ActionType extends ModuleType {
      * @param outputs a {@link List} with {@link Output} meta-information descriptions of the future
      *            {@link Action} instances.
      */
-    public ActionType(@Nullable String UID, @Nullable List<ConfigDescriptionParameter> configDescriptions,
+    public ActionType(@Nullable String uid, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable List<Input> inputs, @Nullable List<Output> outputs) {
-        this(UID, configDescriptions, null, null, null, null, inputs, outputs);
+        this(uid, configDescriptions, null, null, null, null, inputs, outputs);
     }
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeTriggerType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeTriggerType.java
@@ -57,7 +57,7 @@ public class CompositeTriggerType extends TriggerType {
      * Creates an instance of {@code CompositeTriggerType} with ordered set of {@link Trigger} modules. It initializes
      * all properties of the {@code CompositeTriggerType}.
      *
-     * @param UID the {@link TriggerType}'s identifier, or {@code null} if a random identifier should be
+     * @param uid the {@link TriggerType}'s identifier, or {@code null} if a random identifier should be
      *            generated.
      * @param configDescriptions describing meta-data for the configuration of the future {@link Trigger} instances.
      * @param label a short and accurate, human-readable label of the {@link TriggerType}.
@@ -71,10 +71,10 @@ public class CompositeTriggerType extends TriggerType {
      *            {@link Trigger} instances.
      * @param children is a {@link List} of {@link Trigger} modules.
      */
-    public CompositeTriggerType(@Nullable String UID, @Nullable List<ConfigDescriptionParameter> configDescriptions,
+    public CompositeTriggerType(@Nullable String uid, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable String label, @Nullable String description, @Nullable Set<String> tags,
             @Nullable Visibility visibility, @Nullable List<Output> outputs, @Nullable List<Trigger> children) {
-        super(UID, configDescriptions, label, description, tags, visibility, outputs);
+        super(uid, configDescriptions, label, description, tags, visibility, outputs);
         this.children = children != null ? Collections.unmodifiableList(children) : List.of();
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
@@ -34,12 +34,12 @@ public interface ModuleTypeProvider extends Provider<ModuleType> {
      * Gets the localized {@link ModuleType} defined by this provider. When the localization is not specified
      * or it is not supported a {@link ModuleType} with default locale is returned.
      *
-     * @param UID unique identifier of the {@link ModuleType}.
+     * @param uid unique identifier of the {@link ModuleType}.
      * @param locale defines localization of label and description of the {@link ModuleType} or null.
      * @param <T> the type of the required object.
      * @return localized module type.
      */
-    <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale);
+    <T extends ModuleType> @Nullable T getModuleType(String uid, @Nullable Locale locale);
 
     /**
      * Gets the localized {@link ModuleType}s defined by this provider. When localization is not specified or

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
@@ -36,10 +36,10 @@ public abstract class AbstractThingDTO {
     public AbstractThingDTO() {
     }
 
-    protected AbstractThingDTO(String thingTypeUID, String UID, String label, String bridgeUID,
+    protected AbstractThingDTO(String thingTypeUID, String uid, String label, String bridgeUID,
             Map<String, Object> configuration, Map<String, String> properties, String location) {
         this.thingTypeUID = thingTypeUID;
-        this.UID = UID;
+        this.UID = uid;
         this.label = label;
         this.bridgeUID = bridgeUID;
         this.configuration = configuration;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelTypeDTO.java
@@ -44,11 +44,11 @@ public class ChannelTypeDTO {
     public ChannelTypeDTO() {
     }
 
-    public ChannelTypeDTO(String UID, String label, String description, String category, String itemType,
+    public ChannelTypeDTO(String uid, String label, String description, String category, String itemType,
             ChannelKind kind, List<ConfigDescriptionParameterDTO> parameters,
             List<ConfigDescriptionParameterGroupDTO> parameterGroups, StateDescription stateDescription,
             Set<String> tags, boolean advanced, CommandDescription commandDescription) {
-        this.UID = UID;
+        this.UID = uid;
         this.label = label;
         this.description = description;
         this.category = category;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTO.java
@@ -33,9 +33,9 @@ public class StrippedThingTypeDTO {
     public StrippedThingTypeDTO() {
     }
 
-    public StrippedThingTypeDTO(String UID, String label, String description, String category, boolean listed,
+    public StrippedThingTypeDTO(String uid, String label, String description, String category, boolean listed,
             List<String> supportedBridgeTypeUIDs, boolean bridge) {
-        this.UID = UID;
+        this.UID = uid;
         this.label = label;
         this.description = description;
         this.category = category;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
@@ -31,9 +31,9 @@ public class ThingDTO extends AbstractThingDTO {
     public ThingDTO() {
     }
 
-    protected ThingDTO(String thingTypeUID, String UID, String label, String bridgeUID, List<ChannelDTO> channels,
+    protected ThingDTO(String thingTypeUID, String uid, String label, String bridgeUID, List<ChannelDTO> channels,
             Map<String, Object> configuration, Map<String, String> properties, String location) {
-        super(thingTypeUID, UID, label, bridgeUID, configuration, properties, location);
+        super(thingTypeUID, uid, label, bridgeUID, configuration, properties, location);
         this.channels = channels;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingTypeDTO.java
@@ -38,12 +38,12 @@ public class ThingTypeDTO extends StrippedThingTypeDTO {
     public ThingTypeDTO() {
     }
 
-    public ThingTypeDTO(String UID, String label, String description, String category, boolean listed,
+    public ThingTypeDTO(String uid, String label, String description, String category, boolean listed,
             List<ConfigDescriptionParameterDTO> configParameters, List<ChannelDefinitionDTO> channels,
             List<ChannelGroupDefinitionDTO> channelGroups, List<String> supportedBridgeTypeUIDs,
             Map<String, String> properties, boolean bridge, List<ConfigDescriptionParameterGroupDTO> parameterGroups,
             List<String> extensibleChannelTypeIds) {
-        this.UID = UID;
+        this.UID = uid;
         this.label = label;
         this.description = description;
         this.category = category;

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -785,8 +785,8 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
         RuleTemplateProvider templateProvider = new RuleTemplateProvider() {
             @Override
-            public @Nullable RuleTemplate getTemplate(String UID, @Nullable Locale locale) {
-                if (UID.equals(templateUID)) {
+            public @Nullable RuleTemplate getTemplate(String uid, @Nullable Locale locale) {
+                if (uid.equals(templateUID)) {
                     return template;
                 } else {
                     return null;
@@ -827,10 +827,10 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
             }
 
             @Override
-            public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
-                if (UID.equals(triggerTypeUID)) {
+            public <T extends ModuleType> @Nullable T getModuleType(String uid, @Nullable Locale locale) {
+                if (uid.equals(triggerTypeUID)) {
                     return (T) triggerType;
-                } else if (UID.equals(actionTypeUID)) {
+                } else if (uid.equals(actionTypeUID)) {
                     return (T) actionType;
                 } else {
                     return null;

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
@@ -98,7 +98,7 @@ public class TestModuleTypeProvider implements ModuleTypeProvider {
     }
 
     @Override
-    public <T extends ModuleType> @Nullable T getModuleType(String UID, @Nullable Locale locale) {
+    public <T extends ModuleType> @Nullable T getModuleType(String uid, @Nullable Locale locale) {
         return null;
     }
 


### PR DESCRIPTION
Using 'UID' is confusing as method parameter because it can be mistaken for some kind of constant while reading code.

Some were already updated in #3836.