### PR TITLE
[modbus] reduce log level when modbus slave returns DEVICE_BUSY exception

### DIFF
--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -285,6 +285,12 @@ public class ModbusManagerImpl implements ModbusManager {
     private static final String MODBUS_POLLER_THREAD_POOL_NAME = "modbusManagerPollerThreadPool";
 
     /**
+     * The slave exception code indicating that the device is currently busy processing another
+     * command.
+     */
+    private static final int MODBUS_EXCEPTION_SLAVE_DEVICE_BUSY = 6;
+
+    /**
      * Log message with WARN level if the task queues exceed this limit.
      *
      * If the queues grow too large, it might be an issue with consumer of the ModbusManager.
@@ -662,7 +668,11 @@ public class ModbusManagerImpl implements ModbusManager {
                 } catch (ModbusSlaveException e) {
                     lastError.set(new ModbusSlaveErrorResponseExceptionImpl(e));
                     // Slave returned explicit error response, no reason to re-establish new connection
-                    if (willRetry) {
+                    if (willRetry && e.getType() == MODBUS_EXCEPTION_SLAVE_DEVICE_BUSY) {
+                        logger.info(
+                                "Try {} out of {} failed when executing request ({}). The slave device is busy (exception code {}). Will try again soon. [operation ID {}]",
+                                tryIndex, maxTries, request, e.getType(), operationId);
+                    } else if (willRetry) {
                         logger.warn(
                                 "Try {} out of {} failed when executing request ({}). Will try again soon. Error was: {} {} [operation ID {}]",
                                 tryIndex, maxTries, request, e.getClass().getName(), e.getMessage(), operationId);

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -669,7 +669,7 @@ public class ModbusManagerImpl implements ModbusManager {
                     lastError.set(new ModbusSlaveErrorResponseExceptionImpl(e));
                     // Slave returned explicit error response, no reason to re-establish new connection
                     if (willRetry && e.getType() == MODBUS_EXCEPTION_SLAVE_DEVICE_BUSY) {
-                        logger.info(
+                        logger.debug(
                                 "Try {} out of {} failed when executing request ({}). The slave device is busy (exception code {}). Will try again soon. [operation ID {}]",
                                 tryIndex, maxTries, request, e.getType(), operationId);
                     } else if (willRetry) {


### PR DESCRIPTION
This exception is meant to indicate that the request should be retried shortly, essentially, and at least some of the devices I own seem to be busy bees. Thus my logs receive significant spam of this warning.

Since the exception is transient and retrying it is the expected course of action, I think it makes sense to reduce the log level here slightly and only output an error when the retries get exhausted.