### PR TITLE
Fix UI defined sitemaps

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -13,6 +13,7 @@
 package org.openhab.core.ui.internal.components;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +33,7 @@ import org.openhab.core.model.core.ModelRepositoryChangeListener;
 import org.openhab.core.model.sitemap.SitemapProvider;
 import org.openhab.core.model.sitemap.sitemap.Button;
 import org.openhab.core.model.sitemap.sitemap.ColorArray;
+import org.openhab.core.model.sitemap.sitemap.IconRule;
 import org.openhab.core.model.sitemap.sitemap.LinkableWidget;
 import org.openhab.core.model.sitemap.sitemap.Mapping;
 import org.openhab.core.model.sitemap.sitemap.Sitemap;
@@ -48,6 +50,7 @@ import org.openhab.core.model.sitemap.sitemap.impl.ConditionImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.DefaultImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.FrameImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.GroupImpl;
+import org.openhab.core.model.sitemap.sitemap.impl.IconRuleImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.ImageImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.InputImpl;
 import org.openhab.core.model.sitemap.sitemap.impl.MappingImpl;
@@ -94,10 +97,8 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
     private static final String SITEMAP_PREFIX = "uicomponents_";
     private static final String SITEMAP_SUFFIX = ".sitemap";
 
-    private static final Pattern VISIBILITY_PATTERN = Pattern
-            .compile("(?<item>[A-Za-z]\\w*)\\s*(?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>.+)");
-    private static final Pattern COLOR_PATTERN = Pattern.compile(
-            "((?<item>[A-Za-z]\\w*)?\\s*((?<condition>==|!=|<=|>=|<|>)\\s*(?<sign>\\+|-)?(?<state>[^=]*[^= ]+))?\\s*=)?\\s*(?<arg>\\S+)");
+    private static final Pattern CONDITION_PATTERN = Pattern
+            .compile("(?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>)?\\s*(?<sign>\\+|-)?(?<state>.+)");
 
     private Map<String, Sitemap> sitemaps = new HashMap<>();
     private @Nullable UIComponentRegistryFactory componentRegistryFactory;
@@ -160,7 +161,11 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
         SitemapImpl sitemap = (SitemapImpl) SitemapFactory.eINSTANCE.createSitemap();
         sitemap.setName(SITEMAP_PREFIX + rootComponent.getUID());
-        sitemap.setLabel(rootComponent.getConfig().get("label").toString());
+        Object label = rootComponent.getConfig().get("label");
+        if (label == null) {
+            return sitemap;
+        }
+        sitemap.setLabel(label.toString());
 
         if (rootComponent.getSlots() != null && rootComponent.getSlots().containsKey("widgets")) {
             for (UIComponent component : rootComponent.getSlot("widgets")) {
@@ -298,22 +303,10 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             addLabelColor(widget.getLabelColor(), component);
             addValueColor(widget.getValueColor(), component);
             addIconColor(widget.getIconColor(), component);
+            addIconRules(widget.getIconRules(), component);
         }
 
         return widget;
-    }
-
-    private void setWidgetIconPropertyFromComponentConfig(Widget widget, @Nullable UIComponent component) {
-        if (component == null || component.getConfig() == null) {
-            return;
-        }
-        Object value = component.getConfig().get("staticIcon");
-        if (value == null) {
-            return;
-        }
-        boolean staticIcon = Boolean.valueOf(ConfigUtil.normalizeType(value).toString());
-        setWidgetPropertyFromComponentConfig(widget, component, "icon",
-                staticIcon ? SitemapPackage.WIDGET__STATIC_ICON : SitemapPackage.WIDGET__ICON);
     }
 
     private void setWidgetPropertyFromComponentConfig(Widget widget, @Nullable UIComponent component,
@@ -342,10 +335,28 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
         }
     }
 
+    private void setWidgetIconPropertyFromComponentConfig(Widget widget, @Nullable UIComponent component) {
+        if (component == null || component.getConfig() == null) {
+            return;
+        }
+        Object staticIcon = component.getConfig().get("staticIcon");
+        if (staticIcon != null && Boolean.valueOf(ConfigUtil.normalizeType(staticIcon).toString())) {
+            setWidgetPropertyFromComponentConfig(widget, component, "icon", SitemapPackage.WIDGET__STATIC_ICON);
+            return;
+        }
+
+        Object icon = component.getConfig().get("icon");
+        if (icon == null) {
+            return;
+        }
+        setWidgetPropertyFromComponentConfig(widget, component, "icon", SitemapPackage.WIDGET__ICON);
+    }
+
     private void addWidgetMappings(EList<Mapping> mappings, UIComponent component) {
         if (component.getConfig() != null && component.getConfig().containsKey("mappings")) {
-            if (component.getConfig().get("mappings") instanceof Collection<?>) {
-                for (Object sourceMapping : (Collection<?>) component.getConfig().get("mappings")) {
+            Object sourceMappings = component.getConfig().get("mappings");
+            if (sourceMappings instanceof Collection<?>) {
+                for (Object sourceMapping : (Collection<?>) sourceMappings) {
                     if (sourceMapping instanceof String) {
                         String[] splitMapping = sourceMapping.toString().split("=");
                         String cmd = splitMapping[0].trim();
@@ -364,8 +375,9 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
     private void addWidgetButtons(EList<Button> buttons, UIComponent component) {
         if (component.getConfig() != null && component.getConfig().containsKey("buttons")) {
-            if (component.getConfig().get("buttons") instanceof Collection<?>) {
-                for (Object sourceButton : (Collection<?>) component.getConfig().get("buttons")) {
+            Object sourceButtons = component.getConfig().get("buttons");
+            if (sourceButtons instanceof Collection<?>) {
+                for (Object sourceButton : (Collection<?>) sourceButtons) {
                     if (sourceButton instanceof String) {
                         String[] splitted1 = sourceButton.toString().split(":");
                         int idx = Integer.parseInt(splitted1[0].trim());
@@ -387,22 +399,16 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
     private void addWidgetVisibility(EList<VisibilityRule> visibility, UIComponent component) {
         if (component.getConfig() != null && component.getConfig().containsKey("visibility")) {
-            for (Object sourceVisibility : (Collection<?>) component.getConfig().get("visibility")) {
-                if (sourceVisibility instanceof String) {
-                    Matcher matcher = VISIBILITY_PATTERN.matcher(sourceVisibility.toString());
-                    if (matcher.matches()) {
+            Object sourceVisibilities = component.getConfig().get("visibility");
+            if (sourceVisibilities instanceof Collection<?>) {
+                for (Object sourceVisibility : (Collection<?>) sourceVisibilities) {
+                    if (sourceVisibility instanceof String) {
+                        List<String> conditionsString = getRuleConditions(sourceVisibility.toString(), null);
                         VisibilityRuleImpl visibilityRule = (VisibilityRuleImpl) SitemapFactory.eINSTANCE
                                 .createVisibilityRule();
-                        ConditionImpl condition = (ConditionImpl) SitemapFactory.eINSTANCE.createCondition();
-                        condition.setItem(matcher.group("item"));
-                        condition.setCondition(matcher.group("condition"));
-                        condition.setSign(matcher.group("sign"));
-                        condition.setState(matcher.group("state"));
-                        visibilityRule.eSet(SitemapPackage.VISIBILITY_RULE__CONDITIONS, List.of(condition));
+                        List<ConditionImpl> conditions = getConditions(conditionsString, component, "visibility");
+                        visibilityRule.eSet(SitemapPackage.VISIBILITY_RULE__CONDITIONS, conditions);
                         visibility.add(visibilityRule);
-                    } else {
-                        logger.warn("Syntax error in visibility rule '{}' for widget {}", sourceVisibility,
-                                component.getType());
                     }
                 }
             }
@@ -423,25 +429,76 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
     private void addColor(EList<ColorArray> color, UIComponent component, String key) {
         if (component.getConfig() != null && component.getConfig().containsKey(key)) {
-            for (Object sourceColor : (Collection<?>) component.getConfig().get(key)) {
-                if (sourceColor instanceof String) {
-                    Matcher matcher = COLOR_PATTERN.matcher(sourceColor.toString());
-                    if (matcher.matches()) {
+            Object sourceColors = component.getConfig().get(key);
+            if (sourceColors instanceof Collection<?>) {
+                for (Object sourceColor : (Collection<?>) sourceColors) {
+                    if (sourceColor instanceof String) {
+                        String argument = getRuleArgument(sourceColor.toString());
+                        List<String> conditionsString = getRuleConditions(sourceColor.toString(), argument);
                         ColorArrayImpl colorArray = (ColorArrayImpl) SitemapFactory.eINSTANCE.createColorArray();
-                        ConditionImpl condition = (ConditionImpl) SitemapFactory.eINSTANCE.createCondition();
-                        condition.setItem(matcher.group("item"));
-                        condition.setCondition(matcher.group("condition"));
-                        condition.setSign(matcher.group("sign"));
-                        condition.setState(matcher.group("state"));
-                        colorArray.eSet(SitemapPackage.COLOR_ARRAY__CONDITIONS, List.of(condition));
+                        colorArray.eSet(SitemapPackage.COLOR_ARRAY__ARG, argument);
+                        List<ConditionImpl> conditions = getConditions(conditionsString, component, key);
+                        colorArray.eSet(SitemapPackage.COLOR_ARRAY__CONDITIONS, conditions);
                         color.add(colorArray);
-                    } else {
-                        logger.warn("Syntax error in {} rule '{}' for widget {}", key, sourceColor,
-                                component.getType());
                     }
                 }
             }
         }
+    }
+
+    private void addIconRules(EList<IconRule> icon, UIComponent component) {
+        if (component.getConfig() != null && component.getConfig().containsKey("iconrules")) {
+            Object sourceIcons = component.getConfig().get("iconrules");
+            if (sourceIcons instanceof Collection<?>) {
+                for (Object sourceIcon : (Collection<?>) sourceIcons) {
+                    if (sourceIcon instanceof String) {
+                        String argument = getRuleArgument(sourceIcon.toString());
+                        List<String> conditionsString = getRuleConditions(sourceIcon.toString(), argument);
+                        IconRuleImpl iconRule = (IconRuleImpl) SitemapFactory.eINSTANCE.createIconRule();
+                        iconRule.eSet(SitemapPackage.ICON_RULE__ARG, argument);
+                        List<ConditionImpl> conditions = getConditions(conditionsString, component, "iconrules");
+                        iconRule.eSet(SitemapPackage.ICON_RULE__CONDITIONS, conditions);
+                        icon.add(iconRule);
+                    }
+                }
+            }
+        }
+    }
+
+    private List<ConditionImpl> getConditions(List<String> conditionsString, UIComponent component, String key) {
+        List<ConditionImpl> conditions = new ArrayList<>();
+        for (String conditionString : conditionsString) {
+            Matcher matcher = CONDITION_PATTERN.matcher(conditionString);
+            if (matcher.matches()) {
+                ConditionImpl condition = (ConditionImpl) SitemapFactory.eINSTANCE.createCondition();
+                condition.setItem(matcher.group("item"));
+                condition.setCondition(matcher.group("condition"));
+                condition.setSign(matcher.group("sign"));
+                condition.setState(matcher.group("state"));
+                conditions.add(condition);
+            } else {
+                logger.warn("Syntax error in {} rule condition '{}' for widget {}", key, conditionString,
+                        component.getType());
+            }
+        }
+        return conditions;
+    }
+
+    private String getRuleArgument(String rule) {
+        int argIndex = rule.lastIndexOf("=") + 1;
+        return rule.substring(argIndex).trim();
+    }
+
+    private List<String> getRuleConditions(String rule, @Nullable String argument) {
+        String conditions = rule;
+        if (argument != null) {
+            conditions = rule.substring(0, rule.lastIndexOf(argument)).trim();
+            if (conditions.endsWith("=")) {
+                conditions = conditions.substring(0, conditions.length() - 1);
+            }
+        }
+        List<String> conditionsList = List.of(conditions.split(" AND "));
+        return conditionsList.stream().map(String::trim).toList();
     }
 
     @Override

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -434,7 +434,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                         String argument = getRuleArgument(sourceColor.toString());
                         List<String> conditionsString = getRuleConditions(sourceColor.toString(), argument);
                         ColorArrayImpl colorArray = (ColorArrayImpl) SitemapFactory.eINSTANCE.createColorArray();
-                        colorArray.eSet(SitemapPackage.COLOR_ARRAY__ARG, argument);
+                        colorArray.setArg(argument);
                         List<ConditionImpl> conditions = getConditions(conditionsString, component, key);
                         colorArray.eSet(SitemapPackage.COLOR_ARRAY__CONDITIONS, conditions);
                         color.add(colorArray);
@@ -453,7 +453,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                         String argument = getRuleArgument(sourceIcon.toString());
                         List<String> conditionsString = getRuleConditions(sourceIcon.toString(), argument);
                         IconRuleImpl iconRule = (IconRuleImpl) SitemapFactory.eINSTANCE.createIconRule();
-                        iconRule.eSet(SitemapPackage.ICON_RULE__ARG, argument);
+                        iconRule.setArg(argument);
                         List<ConditionImpl> conditions = getConditions(conditionsString, component, "iconrules");
                         iconRule.eSet(SitemapPackage.ICON_RULE__CONDITIONS, conditions);
                         icon.add(iconRule);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -84,8 +84,7 @@ import org.slf4j.LoggerFactory;
  * @author Laurent Garnier - icon color support for all widgets
  * @author Laurent Garnier - Added support for new element Buttongrid
  * @author Laurent Garnier - Added icon field for mappings
- * @author Mark Herwege - Make UI provided sitemaps compatible with enhanced syntax, no full UI support for enhanced
- *         syntax
+ * @author Mark Herwege - Make UI provided sitemaps compatible with enhanced syntax in conditions
  */
 @NonNullByDefault
 @Component(service = SitemapProvider.class)
@@ -162,10 +161,9 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
         SitemapImpl sitemap = (SitemapImpl) SitemapFactory.eINSTANCE.createSitemap();
         sitemap.setName(SITEMAP_PREFIX + rootComponent.getUID());
         Object label = rootComponent.getConfig().get("label");
-        if (label == null) {
-            return sitemap;
+        if (label != null) {
+            sitemap.setLabel(label.toString());
         }
-        sitemap.setLabel(label.toString());
 
         if (rootComponent.getSlots() != null && rootComponent.getSlots().containsKey("widgets")) {
             for (UIComponent component : rootComponent.getSlot("widgets")) {


### PR DESCRIPTION
Close https://github.com/openhab/openhab-core/issues/3846.

Recent enhancements to the sitemap syntax completely broke UI defined sitemaps.

This PR makes sitemap definitions in the UI work again, and is a quick fix.

However, most of the new syntax will still not work in the UI. This requires a larger refactoring both in core and webui.

EDIT:
With the second commit, AND conditions in visibility, color and icon rules are now allowed.
The JSON config format has not been changed (except for the addition of iconrules) to keep full backward compatibility and avoid major refactoring on the UI side. Logic has been created to correctly interpret the condition text strings.

This logic has one inherent problem. Condition strings will be split on ' AND ' strings in their composing parts. If any of the comparisons contains an ' AND ' string (in capitals, including the blanks before and after), provider will give the wrong result.

I will follow up with a UI PR to introduce icon rules and allow AND conditions.

@lolodomo Could you please have a look.