### PR TITLE
[voice] Support item descriptions in built-in interpreter.

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
@@ -12,11 +12,19 @@
  */
 package org.openhab.core.voice.internal.text;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.library.types.HSBType;
@@ -27,10 +35,13 @@ import org.openhab.core.library.types.PlayPauseType;
 import org.openhab.core.library.types.RewindFastforwardType;
 import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.UpDownType;
+import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
+import org.openhab.core.types.TypeParser;
 import org.openhab.core.voice.text.AbstractRuleBasedInterpreter;
 import org.openhab.core.voice.text.Expression;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
+import org.openhab.core.voice.text.Rule;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
@@ -46,11 +57,13 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 @Component(service = HumanLanguageInterpreter.class)
 public class StandardInterpreter extends AbstractRuleBasedInterpreter {
+    private final ItemRegistry itemRegistry;
 
     @Activate
     public StandardInterpreter(final @Reference EventPublisher eventPublisher,
             final @Reference ItemRegistry itemRegistry, @Reference MetadataRegistry metadataRegistry) {
         super(eventPublisher, itemRegistry, metadataRegistry);
+        this.itemRegistry = itemRegistry;
     }
 
     @Override
@@ -60,264 +73,319 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
     }
 
     @Override
-    public void createRules() {
+    public Set<Locale> getSupportedLocales() {
+        return Set.of(Locale.ENGLISH, Locale.GERMAN, Locale.FRENCH, new Locale("es"));
+    }
+
+    @Override
+    public void createRules(@Nullable Locale locale) {
+
         /****************************** ENGLISH ******************************/
 
-        Expression onOff = alt(cmd("on", OnOffType.ON), cmd("off", OnOffType.OFF));
-        Expression turn = alt("turn", "switch");
-        Expression put = alt("put", "bring");
-        Expression of = opt("of");
-        Expression the = opt("the");
-        Expression to = opt("to");
-        Expression color = alt(cmd("white", HSBType.WHITE), cmd("pink", HSBType.fromRGB(255, 96, 208)),
-                cmd("yellow", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
-                cmd("purple", HSBType.fromRGB(128, 0, 128)), cmd("red", HSBType.RED), cmd("green", HSBType.GREEN),
-                cmd("blue", HSBType.BLUE));
+        if (locale == null || Objects.equals(locale.getLanguage(), Locale.ENGLISH.getLanguage())) {
+            Expression onOff = alt(cmd("on", OnOffType.ON), cmd("off", OnOffType.OFF));
+            Expression turn = alt("turn", "switch");
+            Expression put = alt("put", "bring");
+            Expression of = opt("of");
+            Expression the = opt("the");
+            Expression to = opt("to");
+            Expression color = alt(cmd("white", HSBType.WHITE), cmd("pink", HSBType.fromRGB(255, 96, 208)),
+                    cmd("yellow", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
+                    cmd("purple", HSBType.fromRGB(128, 0, 128)), cmd("red", HSBType.RED), cmd("green", HSBType.GREEN),
+                    cmd("blue", HSBType.BLUE));
+            addRules(Locale.ENGLISH,
 
-        addRules(Locale.ENGLISH,
+                    /* OnOffType */
 
-                /* OnOffType */
+                    itemRule(seq(turn, the), /* item */ onOff),
 
-                itemRule(seq(turn, the), /* item */ onOff),
+                    itemRule(seq(turn, onOff) /* item */),
 
-                itemRule(seq(turn, onOff) /* item */),
+                    /* IncreaseDecreaseType */
 
-                /* IncreaseDecreaseType */
+                    itemRule(seq(cmd(alt("dim", "decrease", "lower", "soften"), IncreaseDecreaseType.DECREASE),
+                            the) /*
+                                  * item
+                                  */),
 
-                itemRule(seq(cmd(alt("dim", "decrease", "lower", "soften"), IncreaseDecreaseType.DECREASE), the) /*
-                                                                                                                  * item
-                                                                                                                  */),
+                    itemRule(seq(cmd(alt("brighten", "increase", "harden", "enhance"), IncreaseDecreaseType.INCREASE),
+                            the) /* item */),
 
-                itemRule(seq(cmd(alt("brighten", "increase", "harden", "enhance"), IncreaseDecreaseType.INCREASE),
-                        the) /* item */),
+                    /* ColorType */
 
-                /* ColorType */
+                    itemRule(seq(opt("set"), the, opt("color"), of, the), /* item */ seq(to, color)),
 
-                itemRule(seq(opt("set"), the, opt("color"), of, the), /* item */ seq(to, color)),
+                    /* UpDownType */
 
-                /* UpDownType */
+                    itemRule(seq(put, the), /* item */ cmd("up", UpDownType.UP)),
 
-                itemRule(seq(put, the), /* item */ cmd("up", UpDownType.UP)),
+                    itemRule(seq(put, the), /* item */ cmd("down", UpDownType.DOWN)),
 
-                itemRule(seq(put, the), /* item */ cmd("down", UpDownType.DOWN)),
+                    /* NextPreviousType */
 
-                /* NextPreviousType */
+                    itemRule("move",
+                            /* item */ seq(opt("to"),
+                                    alt(cmd("next", NextPreviousType.NEXT),
+                                            cmd("previous", NextPreviousType.PREVIOUS)))),
 
-                itemRule("move",
-                        /* item */ seq(opt("to"),
-                                alt(cmd("next", NextPreviousType.NEXT), cmd("previous", NextPreviousType.PREVIOUS)))),
+                    /* PlayPauseType */
 
-                /* PlayPauseType */
+                    itemRule(seq(cmd("play", PlayPauseType.PLAY), the) /* item */),
 
-                itemRule(seq(cmd("play", PlayPauseType.PLAY), the) /* item */),
+                    itemRule(seq(cmd("pause", PlayPauseType.PAUSE), the) /* item */),
 
-                itemRule(seq(cmd("pause", PlayPauseType.PAUSE), the) /* item */),
+                    /* RewindFastForwardType */
 
-                /* RewindFastForwardType */
+                    itemRule(seq(cmd("rewind", RewindFastforwardType.REWIND), the) /* item */),
 
-                itemRule(seq(cmd("rewind", RewindFastforwardType.REWIND), the) /* item */),
+                    itemRule(seq(cmd(seq(opt("fast"), "forward"), RewindFastforwardType.FASTFORWARD), the) /* item */),
 
-                itemRule(seq(cmd(seq(opt("fast"), "forward"), RewindFastforwardType.FASTFORWARD), the) /* item */),
+                    /* StopMoveType */
 
-                /* StopMoveType */
+                    itemRule(seq(cmd("stop", StopMoveType.STOP), the) /* item */),
 
-                itemRule(seq(cmd("stop", StopMoveType.STOP), the) /* item */),
+                    itemRule(seq(cmd(alt("start", "move", "continue"), StopMoveType.MOVE), the) /* item */),
 
-                itemRule(seq(cmd(alt("start", "move", "continue"), StopMoveType.MOVE), the) /* item */),
+                    /* RefreshType */
 
-                /* RefreshType */
+                    itemRule(seq(cmd("refresh", RefreshType.REFRESH), the) /* item */)
 
-                itemRule(seq(cmd("refresh", RefreshType.REFRESH), the) /* item */)
-
-        );
+            );
+            /* Item description commands */
+            addRules(Locale.ENGLISH, createItemDescriptionRules( //
+                    (allowedItemNames, labeledCmd) -> restrictedItemRule(allowedItemNames, //
+                            seq(alt("set", "change"), opt(the)), /* item */ seq(to, labeledCmd)//
+                    ), //
+                    Locale.ENGLISH).toArray(Rule[]::new));
+        }
 
         /****************************** GERMAN ******************************/
 
-        Expression einAnAus = alt(cmd("ein", OnOffType.ON), cmd("an", OnOffType.ON), cmd("aus", OnOffType.OFF));
-        Expression denDieDas = opt(alt("den", "die", "das"));
-        Expression schalte = alt("schalt", "schalte", "mach");
-        Expression pause = alt("pause", "stoppe");
-        Expression mache = alt("mach", "mache", "fahre");
-        Expression spiele = alt("spiele", "spiel", "starte");
-        Expression zu = alt("zu", "zum", "zur");
-        Expression naechste = alt("nächste", "nächstes", "nächster");
-        Expression vorherige = alt("vorherige", "vorheriges", "vorheriger");
-        Expression farbe = alt(cmd("weiß", HSBType.WHITE), cmd("pink", HSBType.fromRGB(255, 96, 208)),
-                cmd("gelb", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
-                cmd("lila", HSBType.fromRGB(128, 0, 128)), cmd("rot", HSBType.RED), cmd("grün", HSBType.GREEN),
-                cmd("blau", HSBType.BLUE));
+        if (locale == null || Objects.equals(locale.getLanguage(), Locale.GERMAN.getLanguage())) {
 
-        addRules(Locale.GERMAN,
+            Expression einAnAus = alt(cmd("ein", OnOffType.ON), cmd("an", OnOffType.ON), cmd("aus", OnOffType.OFF));
+            Expression denDieDas = opt(alt("den", "die", "das"));
+            Expression schalte = alt("schalt", "schalte", "mach");
+            Expression pause = alt("pause", "stoppe");
+            Expression mache = alt("mach", "mache", "fahre");
+            Expression spiele = alt("spiele", "spiel", "starte");
+            Expression zu = alt("zu", "zum", "zur");
+            Expression the = opt("the");
+            Expression naechste = alt("nächste", "nächstes", "nächster");
+            Expression vorherige = alt("vorherige", "vorheriges", "vorheriger");
+            Expression farbe = alt(cmd("weiß", HSBType.WHITE), cmd("pink", HSBType.fromRGB(255, 96, 208)),
+                    cmd("gelb", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
+                    cmd("lila", HSBType.fromRGB(128, 0, 128)), cmd("rot", HSBType.RED), cmd("grün", HSBType.GREEN),
+                    cmd("blau", HSBType.BLUE));
 
-                /* OnOffType */
+            addRules(Locale.GERMAN,
 
-                itemRule(seq(schalte, denDieDas), /* item */ einAnAus),
+                    /* OnOffType */
 
-                /* IncreaseDecreaseType */
+                    itemRule(seq(schalte, denDieDas), /* item */ einAnAus),
 
-                itemRule(seq(cmd(alt("dimme"), IncreaseDecreaseType.DECREASE), denDieDas) /* item */),
+                    /* IncreaseDecreaseType */
 
-                itemRule(seq(schalte, denDieDas),
-                        /* item */ cmd(alt("dunkler", "weniger"), IncreaseDecreaseType.DECREASE)),
+                    itemRule(seq(cmd(alt("dimme"), IncreaseDecreaseType.DECREASE), denDieDas) /* item */),
 
-                itemRule(seq(schalte, denDieDas), /* item */ cmd(alt("heller", "mehr"), IncreaseDecreaseType.INCREASE)),
+                    itemRule(seq(schalte, denDieDas),
+                            /* item */ cmd(alt("dunkler", "weniger"), IncreaseDecreaseType.DECREASE)),
 
-                /* ColorType */
+                    itemRule(seq(schalte, denDieDas),
+                            /* item */ cmd(alt("heller", "mehr"), IncreaseDecreaseType.INCREASE)),
 
-                itemRule(seq(schalte, denDieDas), /* item */ seq(opt("auf"), farbe)),
+                    /* ColorType */
 
-                /* UpDownType */
+                    itemRule(seq(schalte, denDieDas), /* item */ seq(opt("auf"), farbe)),
 
-                itemRule(seq(mache, denDieDas), /* item */ cmd("hoch", UpDownType.UP)),
+                    /* UpDownType */
 
-                itemRule(seq(mache, denDieDas), /* item */ cmd("runter", UpDownType.DOWN)),
+                    itemRule(seq(mache, denDieDas), /* item */ cmd("hoch", UpDownType.UP)),
 
-                /* NextPreviousType */
+                    itemRule(seq(mache, denDieDas), /* item */ cmd("runter", UpDownType.DOWN)),
 
-                itemRule("wechsle",
-                        /* item */ seq(opt(zu),
-                                alt(cmd(naechste, NextPreviousType.NEXT), cmd(vorherige, NextPreviousType.PREVIOUS)))),
+                    /* NextPreviousType */
 
-                /* PlayPauseType */
+                    itemRule("wechsle",
+                            /* item */ seq(opt(zu),
+                                    alt(cmd(naechste, NextPreviousType.NEXT),
+                                            cmd(vorherige, NextPreviousType.PREVIOUS)))),
 
-                itemRule(seq(cmd(spiele, PlayPauseType.PLAY), the) /* item */),
+                    /* PlayPauseType */
 
-                itemRule(seq(cmd(pause, PlayPauseType.PAUSE), the) /* item */)
+                    itemRule(seq(cmd(spiele, PlayPauseType.PLAY), the) /* item */),
 
-        );
+                    itemRule(seq(cmd(pause, PlayPauseType.PAUSE), the) /* item */)
+
+            );
+
+            /* Item description commands */
+
+            addRules(Locale.GERMAN, createItemDescriptionRules( //
+                    (allowedItemNames, labeledCmd) -> restrictedItemRule(allowedItemNames, //
+                            seq(schalte, denDieDas), /* item */ seq(opt("auf"), labeledCmd)//
+                    ), //
+                    Locale.GERMAN).toArray(Rule[]::new));
+
+        }
 
         /****************************** FRENCH ******************************/
 
-        Expression allume = alt("allume", "démarre", "active");
-        Expression eteins = alt("éteins", "stoppe", "désactive", "coupe");
-        Expression lela = opt(alt("le", "la", "les", "l"));
-        Expression poursurdude = opt(alt("pour", "sur", "du", "de"));
-        Expression couleur = alt(cmd("blanc", HSBType.WHITE), cmd("rose", HSBType.fromRGB(255, 96, 208)),
-                cmd("jaune", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
-                cmd("violet", HSBType.fromRGB(128, 0, 128)), cmd("rouge", HSBType.RED), cmd("vert", HSBType.GREEN),
-                cmd("bleu", HSBType.BLUE));
+        if (locale == null || Objects.equals(locale.getLanguage(), Locale.FRENCH.getLanguage())) {
+            Expression allume = alt("allume", "démarre", "active");
+            Expression eteins = alt("éteins", "stoppe", "désactive", "coupe");
+            Expression lela = opt(alt("le", "la", "les", "l"));
+            Expression poursurdude = opt(alt("pour", "sur", "du", "de"));
+            Expression couleur = alt(cmd("blanc", HSBType.WHITE), cmd("rose", HSBType.fromRGB(255, 96, 208)),
+                    cmd("jaune", HSBType.fromRGB(255, 224, 32)), cmd("orange", HSBType.fromRGB(255, 160, 16)),
+                    cmd("violet", HSBType.fromRGB(128, 0, 128)), cmd("rouge", HSBType.RED), cmd("vert", HSBType.GREEN),
+                    cmd("bleu", HSBType.BLUE));
 
-        addRules(Locale.FRENCH,
+            addRules(Locale.FRENCH,
 
-                /* OnOffType */
+                    /* OnOffType */
 
-                itemRule(seq(cmd(allume, OnOffType.ON), lela) /* item */),
-                itemRule(seq(cmd(eteins, OnOffType.OFF), lela) /* item */),
+                    itemRule(seq(cmd(allume, OnOffType.ON), lela) /* item */),
+                    itemRule(seq(cmd(eteins, OnOffType.OFF), lela) /* item */),
 
-                /* IncreaseDecreaseType */
+                    /* IncreaseDecreaseType */
 
-                itemRule(seq(cmd("augmente", IncreaseDecreaseType.INCREASE), lela) /* item */),
-                itemRule(seq(cmd("diminue", IncreaseDecreaseType.DECREASE), lela) /* item */),
+                    itemRule(seq(cmd("augmente", IncreaseDecreaseType.INCREASE), lela) /* item */),
+                    itemRule(seq(cmd("diminue", IncreaseDecreaseType.DECREASE), lela) /* item */),
 
-                itemRule(seq(cmd("plus", IncreaseDecreaseType.INCREASE), "de") /* item */),
-                itemRule(seq(cmd("moins", IncreaseDecreaseType.DECREASE), "de") /* item */),
+                    itemRule(seq(cmd("plus", IncreaseDecreaseType.INCREASE), "de") /* item */),
+                    itemRule(seq(cmd("moins", IncreaseDecreaseType.DECREASE), "de") /* item */),
 
-                /* ColorType */
+                    /* ColorType */
 
-                itemRule(seq("couleur", couleur, opt("pour"), lela) /* item */),
+                    itemRule(seq("couleur", couleur, opt("pour"), lela) /* item */),
 
-                /* PlayPauseType */
+                    /* PlayPauseType */
 
-                itemRule(seq(cmd("reprise", PlayPauseType.PLAY), "lecture", poursurdude, lela) /* item */),
-                itemRule(seq(cmd("pause", PlayPauseType.PAUSE), "lecture", poursurdude, lela) /* item */),
+                    itemRule(seq(cmd("reprise", PlayPauseType.PLAY), "lecture", poursurdude, lela) /* item */),
+                    itemRule(seq(cmd("pause", PlayPauseType.PAUSE), "lecture", poursurdude, lela) /* item */),
 
-                /* NextPreviousType */
+                    /* NextPreviousType */
 
-                itemRule(
-                        seq(alt("plage", "piste"),
-                                alt(cmd("suivante", NextPreviousType.NEXT),
-                                        cmd("précédente", NextPreviousType.PREVIOUS)),
-                                poursurdude, lela) /* item */),
+                    itemRule(seq(alt("plage", "piste"),
+                            alt(cmd("suivante", NextPreviousType.NEXT), cmd("précédente", NextPreviousType.PREVIOUS)),
+                            poursurdude, lela) /* item */),
 
-                /* UpDownType */
+                    /* UpDownType */
 
-                itemRule(seq(cmd("monte", UpDownType.UP), lela) /* item */),
-                itemRule(seq(cmd("descends", UpDownType.DOWN), lela) /* item */),
+                    itemRule(seq(cmd("monte", UpDownType.UP), lela) /* item */),
+                    itemRule(seq(cmd("descends", UpDownType.DOWN), lela) /* item */),
 
-                /* StopMoveType */
+                    /* StopMoveType */
 
-                itemRule(seq(cmd("arrête", StopMoveType.STOP), lela) /* item */),
-                itemRule(seq(cmd(alt("bouge", "déplace"), StopMoveType.MOVE), lela) /* item */),
+                    itemRule(seq(cmd("arrête", StopMoveType.STOP), lela) /* item */),
+                    itemRule(seq(cmd(alt("bouge", "déplace"), StopMoveType.MOVE), lela) /* item */),
 
-                /* RefreshType */
+                    /* RefreshType */
 
-                itemRule(seq(cmd("rafraîchis", RefreshType.REFRESH), lela) /* item */)
+                    itemRule(seq(cmd("rafraîchis", RefreshType.REFRESH), lela) /* item */)
 
-        );
+            );
+
+            /* Item description commands */
+
+            addRules(Locale.FRENCH, createItemDescriptionRules( //
+                    (allowedItemNames, labeledCmd) -> restrictedItemRule(allowedItemNames, //
+                            seq("mets", lela), /* item */ seq(poursurdude, lela, labeledCmd)//
+                    ), //
+                    Locale.FRENCH).toArray(Rule[]::new));
+        }
 
         /****************************** SPANISH ******************************/
 
-        Expression encenderApagar = alt(cmd(alt("enciende", "encender"), OnOffType.ON),
-                cmd(alt("apaga", "apagar"), OnOffType.OFF));
-        Expression cambia = alt("cambia", "cambiar");
-        Expression poner = alt("pon", "poner");
-        Expression de = opt("de");
-        Expression articulo = opt(alt("el", "la"));
-        Expression nombreColor = alt(cmd("blanco", HSBType.WHITE), cmd("rosa", HSBType.fromRGB(255, 96, 208)),
-                cmd("amarillo", HSBType.fromRGB(255, 224, 32)), cmd("naranja", HSBType.fromRGB(255, 160, 16)),
-                cmd("púrpura", HSBType.fromRGB(128, 0, 128)), cmd("rojo", HSBType.RED), cmd("verde", HSBType.GREEN),
-                cmd("azul", HSBType.BLUE));
+        Locale localeES = new Locale("es");
+        if (locale == null || Objects.equals(locale.getLanguage(), localeES.getLanguage())) {
+            Expression encenderApagar = alt(cmd(alt("enciende", "encender"), OnOffType.ON),
+                    cmd(alt("apaga", "apagar"), OnOffType.OFF));
+            Expression cambiar = alt("cambia", "cambiar");
+            Expression poner = alt("pon", "poner");
+            Expression preposicion = opt(alt("a", "de", "en"));
+            Expression articulo = opt(alt("el", "la", "los", "las"));
+            Expression nombreColor = alt(cmd("blanco", HSBType.WHITE), cmd("rosa", HSBType.fromRGB(255, 96, 208)),
+                    cmd("amarillo", HSBType.fromRGB(255, 224, 32)), cmd("naranja", HSBType.fromRGB(255, 160, 16)),
+                    cmd("púrpura", HSBType.fromRGB(128, 0, 128)), cmd("rojo", HSBType.RED), cmd("verde", HSBType.GREEN),
+                    cmd("azul", HSBType.BLUE));
 
-        addRules(new Locale("es"),
+            addRules(localeES,
 
-                /* OnOffType */
+                    /* OnOffType */
 
-                itemRule(seq(encenderApagar, articulo)/* item */),
+                    itemRule(seq(encenderApagar, articulo)/* item */),
 
-                /* IncreaseDecreaseType */
+                    /* IncreaseDecreaseType */
 
-                itemRule(seq(cmd(alt("baja", "suaviza", "bajar", "suavizar"), IncreaseDecreaseType.DECREASE),
-                        articulo) /*
-                                   * item
-                                   */),
+                    itemRule(seq(cmd(alt("baja", "suaviza", "bajar", "suavizar"), IncreaseDecreaseType.DECREASE),
+                            articulo) /*
+                                       * item
+                                       */),
 
-                itemRule(seq(cmd(alt("sube", "aumenta", "subir", "aumentar"), IncreaseDecreaseType.INCREASE),
-                        articulo) /* item */),
+                    itemRule(seq(cmd(alt("sube", "aumenta", "subir", "aumentar"), IncreaseDecreaseType.INCREASE),
+                            articulo) /* item */),
 
-                /* ColorType */
+                    /* ColorType */
 
-                itemRule(seq(cambia, articulo, opt("color"), de, articulo), /* item */ seq(opt("a"), nombreColor)),
+                    itemRule(seq(cambiar, articulo, opt("color"), preposicion, articulo),
+                            /* item */ seq(opt("a"), nombreColor)),
 
-                /* UpDownType */
+                    /* UpDownType */
 
-                itemRule(seq(poner, articulo), /* item */ cmd("arriba", UpDownType.UP)),
+                    itemRule(seq(poner, articulo), /* item */ cmd("arriba", UpDownType.UP)),
 
-                itemRule(seq(poner, articulo), /* item */ cmd("abajo", UpDownType.DOWN)),
+                    itemRule(seq(poner, articulo), /* item */ cmd("abajo", UpDownType.DOWN)),
 
-                /* NextPreviousType */
+                    /* NextPreviousType */
 
-                itemRule(alt("cambiar", "cambia"),
-                        /* item */ seq(opt("a"),
-                                alt(cmd("siguiente", NextPreviousType.NEXT),
-                                        cmd("anterior", NextPreviousType.PREVIOUS)))),
+                    itemRule(cambiar,
+                            /* item */ seq(opt("a"),
+                                    alt(cmd("siguiente", NextPreviousType.NEXT),
+                                            cmd("anterior", NextPreviousType.PREVIOUS)))),
 
-                /* PlayPauseType */
+                    /* PlayPauseType */
 
-                itemRule(seq(cmd(alt("continuar", "continua", "reanudar", "reanuda", "play"), PlayPauseType.PLAY),
-                        articulo) /*
-                                   * item
-                                   */),
+                    itemRule(seq(cmd(alt("continuar", "continúa", "reanudar", "reanuda", "play"), PlayPauseType.PLAY),
+                            alt(articulo, "en")) /*
+                                                  * item
+                                                  */),
 
-                itemRule(seq(cmd(alt("pausa", "pausar"), PlayPauseType.PAUSE), articulo) /* item */),
+                    itemRule(seq(cmd(alt("pausa", "pausar", "detén", "detener"), PlayPauseType.PAUSE),
+                            alt(articulo, "en")) /*
+                                                  * item
+                                                  */),
 
-                /* RewindFastForwardType */
+                    /* RewindFastForwardType */
 
-                itemRule(seq(cmd(alt("rebobina", "rebobinar"), RewindFastforwardType.REWIND), articulo) /* item */),
+                    itemRule(seq(cmd(alt("rebobina", "rebobinar"), RewindFastforwardType.REWIND),
+                            alt(articulo, "en")) /* item */),
 
-                itemRule(seq(cmd(alt("avanza", "avanzar"), RewindFastforwardType.FASTFORWARD), articulo) /* item */),
+                    itemRule(seq(cmd(alt("avanza", "avanzar"), RewindFastforwardType.FASTFORWARD),
+                            alt(articulo, "en")) /* item */),
 
-                /* StopMoveType */
+                    /* StopMoveType */
 
-                itemRule(seq(cmd(alt("para", "parar", "stop"), StopMoveType.STOP), articulo) /* item */),
+                    itemRule(seq(cmd(alt("para", "parar", "stop"), StopMoveType.STOP), articulo) /* item */),
 
-                itemRule(seq(cmd(alt("mueve", "mover"), StopMoveType.MOVE), articulo) /* item */),
+                    itemRule(seq(cmd(alt("mueve", "mover"), StopMoveType.MOVE), articulo) /* item */),
 
-                /* RefreshType */
+                    /* RefreshType */
 
-                itemRule(seq(cmd(alt("recarga", "refresca", "recargar", "refrescar"), RefreshType.REFRESH),
-                        articulo) /* item */)
+                    itemRule(seq(cmd(alt("recarga", "refresca", "recargar", "refrescar"), RefreshType.REFRESH),
+                            articulo) /* item */)
 
-        );
+            );
+
+            /* Item description commands */
+
+            addRules(localeES, createItemDescriptionRules( //
+                    (allowedItemNames, labeledCmd) -> restrictedItemRule(allowedItemNames, //
+                            seq(alt(cambiar, poner), opt(articulo)), /* item */ seq(preposicion, labeledCmd)//
+                    ), //
+                    localeES).toArray(Rule[]::new));
+        }
     }
 
     @Override
@@ -328,5 +396,84 @@ public class StandardInterpreter extends AbstractRuleBasedInterpreter {
     @Override
     public String getLabel(@Nullable Locale locale) {
         return "Built-in Interpreter";
+    }
+
+    private List<Rule> createItemDescriptionRules(CreateItemDescriptionRule creator, @Nullable Locale locale) {
+        // Map different item state/command labels with theirs values by item
+        HashMap<String, HashMap<Item, String>> options = new HashMap<>();
+        for (var item : itemRegistry.getItems()) {
+            var stateDesc = item.getStateDescription(locale);
+            if (stateDesc != null) {
+                stateDesc.getOptions().forEach(op -> {
+                    var label = op.getLabel();
+                    if (label == null || label.isBlank()) {
+                        label = op.getValue();
+                    }
+                    var optionValueByItem = options.getOrDefault(label, new HashMap<>());
+                    optionValueByItem.put(item, op.getValue());
+                    options.put(label, optionValueByItem);
+                });
+            }
+            var commandDesc = item.getCommandDescription(locale);
+            if (commandDesc != null) {
+                commandDesc.getCommandOptions().forEach(op -> {
+                    var label = op.getLabel();
+                    if (label == null || label.isBlank()) {
+                        label = op.getCommand();
+                    }
+                    var optionValueByItem = options.getOrDefault(label, new HashMap<>());
+                    optionValueByItem.put(item, op.getCommand());
+                    options.put(label, optionValueByItem);
+                });
+            }
+        }
+        // create rules
+        return options.entrySet().stream() //
+                .map(entry -> {
+                    String label = entry.getKey();
+                    Map<Item, String> commandByItem = entry.getValue();
+                    List<String> itemNames = commandByItem.keySet().stream().map(Item::getName).toList();
+                    String[] labelParts = Arrays.stream(label.split("\\s")).filter(p -> !p.isBlank())
+                            .toArray(String[]::new);
+                    Expression labeledCmd = cmd(seq((Object[]) labelParts),
+                            new ItemStateCommandSupplier(label, commandByItem));
+                    return creator.itemDescriptionRule(itemNames, labeledCmd);
+                }) //
+                .collect(Collectors.toList());
+    }
+
+    private interface CreateItemDescriptionRule {
+        Rule itemDescriptionRule(List<String> allowedItemNames, Expression labeledCmd);
+    }
+
+    private record ItemStateCommandSupplier(String label,
+            Map<Item, String> commandByItem) implements ItemCommandSupplier {
+        @Override
+        public @Nullable Command getItemCommand(Item item) {
+            String textCommand = commandByItem.get(item);
+            if (textCommand == null) {
+                return null;
+            }
+            return TypeParser.parseCommand(item.getAcceptedCommandTypes(), textCommand);
+        }
+
+        @Override
+        public String getCommandLabel() {
+            return label;
+        }
+
+        @Override
+        public List<Class<? extends Command>> getCommandClasses(@Nullable Item item) {
+            if (item == null) {
+                return commandByItem.keySet().stream()//
+                        .flatMap(i -> i.getAcceptedCommandTypes().stream())//
+                        .distinct()//
+                        .collect(Collectors.toList());
+            } else if (commandByItem.containsKey(item)) {
+                return item.getAcceptedCommandTypes();
+            } else {
+                return List.of();
+            }
+        }
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -14,7 +14,6 @@ package org.openhab.core.voice.text;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +24,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.registry.RegistryChangeListener;
@@ -140,9 +140,9 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     }
 
     /**
-     * Called whenever the rules are to be (re)generated and added by {@link addRules}
+     * Called whenever the rules are to be (re)generated and added by {@link #addRules}
      */
-    protected abstract void createRules();
+    protected abstract void createRules(@Nullable Locale locale);
 
     @Override
     public String interpret(Locale locale, String text) throws InterpretationException {
@@ -165,8 +165,9 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         InterpretationResult result;
 
         InterpretationResult lastResult = null;
+        String locationItem = dialogContext != null ? dialogContext.locationItem() : null;
         for (Rule rule : rules) {
-            if ((result = rule.execute(language, tokens, dialogContext)).isSuccess()) {
+            if ((result = rule.execute(language, tokens, locationItem)).isSuccess()) {
                 return result.getResponse();
             } else {
                 if (!InterpretationResult.SYNTAX_ERROR.equals(result)) {
@@ -264,7 +265,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     /**
      * Creates an item name placeholder expression. This expression is greedy: Only use it, if there are no other
      * expressions following this one.
-     * It's safer to use {@link thingRule} instead.
+     * It's safer to use {@link #itemRule} instead.
      *
      * @return Expression that represents a name of an item.
      */
@@ -275,7 +276,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     /**
      * Creates an item name placeholder expression. This expression is greedy: Only use it, if you are able to pass in
      * all possible stop tokens as excludes.
-     * It's safer to use {@link thingRule} instead.
+     * It's safer to use {@link #itemRule} instead.
      *
      * @param stopper Stop expression that, if matching, will stop this expression from consuming further tokens.
      * @return Expression that represents a name of an item.
@@ -284,11 +285,11 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         return tag(NAME, star(new ExpressionIdentifier(this, stopper)));
     }
 
-    private Map<Locale, List<Rule>> getLanguageRules() {
-        if (languageRules.isEmpty()) {
-            createRules();
+    private @Nullable List<@NonNull Rule> getLanguageRules(@Nullable Locale locale) {
+        if (!languageRules.containsKey(locale)) {
+            createRules(locale);
         }
-        return languageRules;
+        return languageRules.get(locale);
     }
 
     /**
@@ -299,15 +300,13 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return Rules in descending match priority order.
      */
     public Rule[] getRules(Locale locale) {
-        Map<Locale, List<Rule>> languageRules = getLanguageRules();
         List<Rule> rules = new ArrayList<>();
         Set<List<Rule>> ruleSets = new HashSet<>();
-        List<Rule> ruleSet = languageRules.get(locale);
+        List<Rule> ruleSet = getLanguageRules(locale);
         if (ruleSet != null) {
             ruleSets.add(ruleSet);
             rules.addAll(ruleSet);
         }
-
         String language = locale.getLanguage();
         for (Entry<Locale, List<Rule>> entry : languageRules.entrySet()) {
             Locale ruleLocale = entry.getKey();
@@ -323,7 +322,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     }
 
     /**
-     * Adds {@link Locale} specific rules to this interpreter. To be called from within {@link createRules}.
+     * Adds {@link Locale} specific rules to this interpreter. To be called from within {@link #createRules}.
      *
      * @param locale Locale of the rules.
      * @param rules Rules to add.
@@ -343,7 +342,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * item
      * name expression.
      *
-     * @param headExpression The head expression that should contain at least one {@link cmd} generated expression. The
+     * @param headExpression The head expression that should contain at least one {@link #cmd} generated expression. The
      *            corresponding {@link Command} will in case of a match be sent to the matching {@link Item}.
      * @return The created rule.
      */
@@ -354,7 +353,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     /**
      * Creates an item rule on base of a head and a tail expression, where the middle part of the new rule's expression
      * will consist of an item
-     * name expression. Either the head expression or the tail expression should contain at least one {@link cmd}
+     * name expression. Either the head expression or the tail expression should contain at least one {@link #cmd}
      * generated expression.
      *
      * @param headExpression The head expression.
@@ -362,27 +361,44 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return The created rule.
      */
     protected Rule itemRule(Object headExpression, @Nullable Object tailExpression) {
+        return restrictedItemRule(List.of(), headExpression, tailExpression);
+    }
+
+    /**
+     * Creates an item rule on base of a head and a tail expression, where the middle part of the new rule's ex ression
+     * will consist of an item
+     * name expression. Either the head expression or the tail expression should contain at least one {@link #cmd}
+     * generated expression.
+     * Rule will be restricted to the provided item names if any.
+     *
+     * @param allowedItemNames List of allowed item names, empty for disabled.
+     * @param headExpression The head expression.
+     * @param tailExpression The tail expression.
+     * @return The created rule.
+     */
+    protected Rule restrictedItemRule(List<String> allowedItemNames, Object headExpression,
+            @Nullable Object tailExpression) {
         Expression tail = exp(tailExpression);
         Expression expression = tail == null ? seq(headExpression, name()) : seq(headExpression, name(tail), tail);
-        return new Rule(expression) {
+        return new Rule(expression, allowedItemNames) {
             @Override
             public InterpretationResult interpretAST(ResourceBundle language, ASTNode node,
-                    @Nullable DialogContext dialogContext) {
+                    InterpretationContext context) {
                 String[] name = node.findValueAsStringArray(NAME);
                 ASTNode cmdNode = node.findNode(CMD);
                 Object tag = cmdNode.getTag();
                 Object value = cmdNode.getValue();
-                Command command;
-                if (tag instanceof Command command1) {
-                    command = command1;
+                ItemCommandSupplier commandSupplier;
+                if (tag instanceof ItemCommandSupplier supplier) {
+                    commandSupplier = supplier;
                 } else if (value instanceof Number number) {
-                    command = new DecimalType(number.longValue());
+                    commandSupplier = new SingleCommandSupplier(new DecimalType(number.longValue()));
                 } else {
-                    command = new StringType(cmdNode.getValueAsString());
+                    commandSupplier = new SingleCommandSupplier(new StringType(cmdNode.getValueAsString()));
                 }
                 if (name != null) {
                     try {
-                        return new InterpretationResult(true, executeSingle(language, name, command, dialogContext));
+                        return new InterpretationResult(true, executeSingle(language, name, commandSupplier, context));
                     } catch (InterpretationException ex) {
                         return new InterpretationResult(ex);
                     }
@@ -393,8 +409,9 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     }
 
     /**
-     * Converts an object to an expression. Objects that are already instances of {@link Expression} are just returned.
-     * All others are converted to {@link match} expressions.
+     * Converts an object to an expression.
+     * Objects that are already instances of {@link Expression} are just returned.
+     * All others are converted to {@link Expression}.
      *
      * @param obj the object that's to be converted
      * @return resulting expression
@@ -408,9 +425,9 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     }
 
     /**
-     * Converts all parameters to an expression array. Objects that are already instances of {@link Expression} are not
-     * touched.
-     * All others are converted to {@link match} expressions.
+     * Converts all parameters to an expression array.
+     * Objects that are already instances of {@link Expression} are not touched.
+     * All others are converted to {@link Expression}.
      *
      * @param objects the objects that are to be converted
      * @return resulting expression array
@@ -468,7 +485,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected Expression cmd(Object expression) {
-        return cmd(expression, null);
+        return cmd(expression, (Command) null);
     }
 
     /**
@@ -479,6 +496,17 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected Expression cmd(Object expression, @Nullable Command command) {
+        return tag(CMD, expression, command != null ? new SingleCommandSupplier(command) : null);
+    }
+
+    /**
+     * Adds command resolver to the resulting AST tree, if the expression matches.
+     *
+     * @param expression the expression that has to match
+     * @param command the command that should be added
+     * @return resulting expression
+     */
+    protected Expression cmd(Object expression, AbstractRuleBasedInterpreter.@Nullable ItemCommandSupplier command) {
         return tag(CMD, expression, command);
     }
 
@@ -548,17 +576,17 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @param labelFragments label fragments that are used to match an item's label.
      *            For a positive match, the item's label has to contain every fragment - independently of their order.
      *            They are treated case insensitive.
-     * @param command command that should be executed
+     * @param commandSupplier supplies the command to be executed.
      * @return response text
      * @throws InterpretationException in case that there is no or more than on item matching the fragments
      */
-    protected String executeSingle(ResourceBundle language, String[] labelFragments, Command command,
-            @Nullable DialogContext dialogContext) throws InterpretationException {
-        List<Item> items = getMatchingItems(language, labelFragments, command.getClass(), dialogContext);
+    protected String executeSingle(ResourceBundle language, String[] labelFragments,
+            ItemCommandSupplier commandSupplier, Rule.InterpretationContext context) throws InterpretationException {
+        List<Item> items = getMatchingItems(language, labelFragments, commandSupplier, context);
         if (items.isEmpty()) {
-            if (!getMatchingItems(language, labelFragments, null, dialogContext).isEmpty()) {
+            if (!getMatchingItems(language, labelFragments, null, context).isEmpty()) {
                 throw new InterpretationException(
-                        language.getString(COMMAND_NOT_ACCEPTED).replace("<cmd>", command.toString()));
+                        language.getString(COMMAND_NOT_ACCEPTED).replace("<cmd>", commandSupplier.getCommandLabel()));
             } else {
                 throw new InterpretationException(language.getString(NO_OBJECTS));
             }
@@ -566,6 +594,12 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             throw new InterpretationException(language.getString(MULTIPLE_OBJECTS));
         } else {
             Item item = items.get(0);
+            Command command = commandSupplier.getItemCommand(item);
+            if (command == null) {
+                // should never happen
+                logger.warn("Failed resolving item command");
+                return language.getString(ERROR);
+            }
             if (command instanceof State newState) {
                 try {
                     State oldState = item.getStateAs(newState.getClass());
@@ -605,18 +639,22 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @param labelFragments label fragments that are used to match an item's label.
      *            For a positive match, the item's label has to contain every fragment - independently of their order.
      *            They are treated case-insensitive.
-     * @param commandType optional command type that all items have to support.
-     *            Provide {null} if there is no need for a certain command to be supported.
+     * @param commandSupplier optional command supplier to access the command types an item have to support.
+     *            Provide {null} if there is no need for a certain command type to be supported.
      * @return All matching items from the item registry.
      */
     protected List<Item> getMatchingItems(ResourceBundle language, String[] labelFragments,
-            @Nullable Class<?> commandType, @Nullable DialogContext dialogContext) {
+            @Nullable ItemCommandSupplier commandSupplier, Rule.InterpretationContext context) {
         Map<Item, ItemInterpretationMetadata> itemsData = new HashMap<>();
         Map<Item, ItemInterpretationMetadata> exactMatchItemsData = new HashMap<>();
         Map<Item, ItemInterpretationMetadata> map = getItemTokens(language.getLocale());
         for (Entry<Item, ItemInterpretationMetadata> entry : map.entrySet()) {
             Item item = entry.getKey();
             ItemInterpretationMetadata interpretationMetadata = entry.getValue();
+            if (!context.allowedItems().isEmpty() && !context.allowedItems().contains(item.getName())) {
+                logger.trace("Item {} discarded, not allowed for this rule", item.getName());
+                continue;
+            }
             for (List<List<String>> itemLabelFragmentsPath : interpretationMetadata.pathToItem) {
                 boolean exactMatch = false;
                 logger.trace("Checking tokens {} against the item tokens {}", labelFragments, itemLabelFragmentsPath);
@@ -635,7 +673,11 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
                 logger.trace("Matched: {}", allMatched);
                 logger.trace("Exact match: {}", exactMatch);
                 if (allMatched) {
-                    if (commandType == null || item.getAcceptedCommandTypes().contains(commandType)) {
+                    List<Class<? extends Command>> commandTypes = commandSupplier != null
+                            ? commandSupplier.getCommandClasses(null)
+                            : List.of();
+                    if (commandSupplier == null
+                            || commandTypes.stream().anyMatch(item.getAcceptedCommandTypes()::contains)) {
                         insertDiscardingMembers(itemsData, item, interpretationMetadata);
                         if (exactMatch) {
                             insertDiscardingMembers(exactMatchItemsData, item, interpretationMetadata);
@@ -645,14 +687,20 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             }
         }
         if (logger.isDebugEnabled()) {
-            String typeDetails = commandType != null ? " that accept " + commandType.getSimpleName() : "";
+            List<Class<? extends Command>> commandTypes = commandSupplier != null
+                    ? commandSupplier.getCommandClasses(null)
+                    : List.of();
+            String typeDetails = !commandTypes.isEmpty()
+                    ? " that accept " + commandTypes.stream().map(Class::getSimpleName).distinct()
+                            .collect(Collectors.joining(" or "))
+                    : "";
             logger.debug("Partial matched items against {}{}: {}", labelFragments, typeDetails,
                     itemsData.keySet().stream().map(Item::getName).collect(Collectors.joining(", ")));
             logger.debug("Exact matched items against {}{}: {}", labelFragments, typeDetails,
                     exactMatchItemsData.keySet().stream().map(Item::getName).collect(Collectors.joining(", ")));
         }
         @Nullable
-        String locationContext = dialogContext != null ? dialogContext.locationItem() : null;
+        String locationContext = context.locationItem();
         if (locationContext != null && itemsData.size() > 1) {
             logger.debug("Filtering {} matched items based on location '{}'", itemsData.size(), locationContext);
             Item matchByLocation = filterMatchedItemsByLocation(itemsData, locationContext);
@@ -722,11 +770,6 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             }
         }
         return parts;
-    }
-
-    @Override
-    public Set<Locale> getSupportedLocales() {
-        return Collections.unmodifiableSet(getLanguageRules().keySet());
     }
 
     @Override
@@ -970,6 +1013,32 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         final List<String> locationParentNames = new ArrayList<>();
 
         ItemInterpretationMetadata() {
+        }
+    }
+
+    protected interface ItemCommandSupplier {
+        @Nullable
+        Command getItemCommand(Item item);
+
+        String getCommandLabel();
+
+        List<Class<? extends Command>> getCommandClasses(@Nullable Item item);
+    }
+
+    private record SingleCommandSupplier(Command command) implements ItemCommandSupplier {
+        @Override
+        public @Nullable Command getItemCommand(Item ignored) {
+            return command;
+        }
+
+        @Override
+        public String getCommandLabel() {
+            return command.toFullString();
+        }
+
+        @Override
+        public List<Class<? extends Command>> getCommandClasses(@Nullable Item ignored) {
+            return List.of(command.getClass());
         }
     }
 }

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,8 +40,12 @@ import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
 import org.openhab.core.items.MetadataRegistry;
 import org.openhab.core.items.events.ItemEventFactory;
+import org.openhab.core.library.items.DimmerItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.CommandOption;
 import org.openhab.core.voice.DialogContext;
 import org.openhab.core.voice.STTService;
 import org.openhab.core.voice.TTSService;
@@ -142,5 +147,45 @@ public class StandardInterpreterTest {
         assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "turn off bedroom pc"));
         verify(eventPublisherMock, times(1))
                 .post(ItemEventFactory.createCommandEvent(computerItem.getName(), OnOffType.OFF));
+    }
+
+    @Test
+    public void allowUseItemDescription() throws InterpretationException {
+        var cmdDescription = new CommandDescription() {
+            @Override
+            public List<CommandOption> getCommandOptions() {
+                return List.of(new CommandOption("10", "low"), new CommandOption("50", "medium"),
+                        new CommandOption("90", "high"), new CommandOption("100", "high two"));
+            }
+        };
+        var brightness = new DimmerItem("brightness") {
+            @Override
+            public @Nullable CommandDescription getCommandDescription() {
+                return cmdDescription;
+            }
+
+            @Override
+            public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
+                return getCommandDescription();
+            }
+        };
+        brightness.setLabel("Brightness");
+        List<Item> items = List.of(brightness);
+        when(itemRegistryMock.getItems()).thenReturn(items);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set the brightness to low"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(10)));
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness to medium"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(50)));
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness high"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(90)));
+        reset(eventPublisherMock);
+        assertEquals(OK_RESPONSE, standardInterpreter.interpret(Locale.ENGLISH, "set brightness high two"));
+        verify(eventPublisherMock, times(1))
+                .post(ItemEventFactory.createCommandEvent(brightness.getName(), new PercentType(100)));
     }
 }


### PR DESCRIPTION
Hello OpenHAB's maintainers, I would like to merge the following changes in the voice bundle.

It enables support in the standard interpreter to use the item StateDescription/CommandDescription labels to update them in the current available languages.

As an example: 
If you have a dimmer item labeled as `Brightness` with command description `50=normal`, the command `set brightness to normal` will be handled and send a PercentageType command with value 50 to the item.

French and German command needs to be reviewed, I made them by coping the color command or using a translator.  

It introduces a minor behavior change, if the language (a locale instance) is provided only the rules for that language are loaded. I think it's the correct thing to do in order to avoid register rules you are not going to use, but I can revert that part if you think it can have any side effect.

Tested in the 4.1.0.M2, seems to work great.