### PR TITLE
Small code cleanup

### DIFF
--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
@@ -273,7 +273,7 @@ public class AudioManagerTest {
 
     /**
      *
-     * @param param - either default source or default sink
+     * @param param either default source or default sink
      */
     private void assertAddedParameterOption(String param, Locale locale) {
         String id = "";

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
@@ -59,7 +59,7 @@ public interface ModuleHandlerCallback {
      *
      * @param ruleUID UID of the {@link Rule}
      * @return {@link RuleStatusInfo} object containing status of the looking {@link Rule} or null when a rule with
-     *         specified UID does not exists.
+     *         specified UID does not exist.
      */
     @Nullable
     RuleStatusInfo getStatusInfo(String ruleUID);
@@ -69,7 +69,7 @@ public interface ModuleHandlerCallback {
      *
      * @param ruleUID UID of the {@link Rule}
      * @return {@link RuleStatus} object containing status of the looking {@link Rule} or null when a rule with
-     *         specified UID does not exists.
+     *         specified UID does not exist.
      */
     @Nullable
     RuleStatus getStatus(String ruleUID);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
@@ -63,7 +63,7 @@ public interface RuleManager {
      *
      * @param ruleUID UID of the {@link Rule}
      * @return {@link RuleStatusInfo} object containing status of the looking {@link Rule} or null when a rule with
-     *         specified UID does not exists.
+     *         specified UID does not exist.
      */
     @Nullable
     RuleStatusInfo getStatusInfo(String ruleUID);
@@ -73,7 +73,7 @@ public interface RuleManager {
      *
      * @param ruleUID UID of the {@link Rule}
      * @return {@link RuleStatus} object containing status of the looking {@link Rule} or null when a rule with
-     *         specified UID does not exists.
+     *         specified UID does not exist.
      */
     @Nullable
     RuleStatus getStatus(String ruleUID);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1164,7 +1164,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     /**
-     * This method evaluates actions of the {@link Rule} and set their {@link Output}s when they exists.
+     * This method evaluates actions of the {@link Rule} and set their {@link Output}s when they exist.
      *
      * @param rule executed rule.
      */
@@ -1207,7 +1207,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * This method gets rule's status object.
      *
      * @param rUID rule's UID
-     * @return status of the rule or null when such rule does not exists.
+     * @return status of the rule or null when such rule does not exist.
      */
     protected @Nullable RuleStatus getRuleStatus(String rUID) {
         RuleStatusInfo info = getStatusInfo(rUID);

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -73,11 +73,11 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
     /**
      * Is called for each instance of the first argument's type contained in a resource.
      * 
-     * @param ruleModel - the model to create one or more JvmDeclaredTypes from.
-     * @param acceptor - each created JvmDeclaredType without a container should be passed to the acceptor in order get attached to the
+     * @param ruleModel the model to create one or more JvmDeclaredTypes from.
+     * @param acceptor each created JvmDeclaredType without a container should be passed to the acceptor in order get attached to the
      *                   current resource.
-     * @param isPreIndexingPhase - whether the method is called in a pre linking phase, i.e. when the global index isn't fully updated. You
-     *        must not rely on linking using the index if iPrelinkingPhase is <code>true</code>
+     * @param isPreIndexingPhase whether the method is called in a pre linking phase, i.e. when the global index isn't fully updated. You
+     *        must not rely on linking using the index if isPreIndexingPhase is <code>true</code>
      */
     def dispatch void infer(RuleModel ruleModel, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
         val className = ruleModel.eResource.URI.lastSegment.split("\\.").head.toFirstUpper + "Rules"

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -98,11 +98,11 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     /**
      * Is called for each instance of the first argument's type contained in a resource.
      * 
-     * @param script - the model to create one or more JvmDeclaredTypes from.
-     * @param acceptor - each created JvmDeclaredType without a container should be passed to the acceptor in order get attached to the
+     * @param script the model to create one or more JvmDeclaredTypes from.
+     * @param acceptor each created JvmDeclaredType without a container should be passed to the acceptor in order get attached to the
      *                   current resource.
-     * @param isPreIndexingPhase - whether the method is called in a pre linking phase, i.e. when the global index isn't fully updated. You
-     *        must not rely on linking using the index if iPrelinkingPhase is <code>true</code>
+     * @param isPreIndexingPhase whether the method is called in a pre linking phase, i.e. when the global index isn't fully updated. You
+     *        must not rely on linking using the index if isPreIndexingPhase is <code>true</code>
      */
     def dispatch void infer(Script script, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
         val className = script.eResource.URI.lastSegment.split("\\.").head.toFirstUpper + "Script"

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagRegistry.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagRegistry.java
@@ -42,7 +42,7 @@ public interface SemanticTagRegistry extends Registry<SemanticTag, String> {
      * Checks if a tag with a given id can be added to the registry.
      *
      * To be added, no tag with this id must already exist in the registry, the tag name extracted from this id
-     * must have a valid syntax, the parent tag extracted from this id must already exists in the registry and
+     * must have a valid syntax, the parent tag extracted from this id must already exist in the registry and
      * should be either a default semantic tag or a managed semantic tag, and no tag with a same name must already
      * exist in the registry.
      *

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
@@ -96,7 +96,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
                 throw new IllegalStateException("Thing with UID " + thingUID + " has no handler attached.");
             }
         } else {
-            throw new IllegalArgumentException("Thing with UID " + thingUID + " does not exists.");
+            throw new IllegalArgumentException("Thing with UID " + thingUID + " does not exist.");
         }
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
@@ -118,7 +118,7 @@ public abstract class AbstractManagedProvider<@NonNull E extends Identifiable<K>
                 return oldElement;
             }
         } else {
-            logger.warn("Could not update element with key {} in {}, because it does not exists.", key,
+            logger.warn("Could not update element with key {} in {}, because it does not exist.", key,
                     this.getClass().getSimpleName());
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -115,7 +115,7 @@ public class WatchServiceImpl implements WatchService, DirectoryChangeListener {
             closeWatcherAndUnregister();
 
             if (!Files.exists(basePath)) {
-                logger.info("Watch directory '{}' does not exists. Trying to create it.", basePath);
+                logger.info("Watch directory '{}' does not exist. Trying to create it.", basePath);
                 Files.createDirectories(basePath);
             }
 


### PR DESCRIPTION
* Removes hyphens from JavaDoc parameters
* Fixes a few 'exists' grammar mistakes