### PR TITLE
Do not leak running pools from the internal collection

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -74,7 +73,7 @@ public class ThreadPoolManager {
     protected static final long THREAD_TIMEOUT = 65L;
     protected static final long THREAD_MONITOR_SLEEP = 60000;
 
-    protected static Map<String, ExecutorService> pools = new WeakHashMap<>();
+    protected static Map<String, ExecutorService> pools = new ConcurrentHashMap<>();
 
     private static Map<String, Integer> configs = new ConcurrentHashMap<>();
 
@@ -124,23 +123,17 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ScheduledExecutorService getScheduledPool(String poolName) {
-        ExecutorService pool = pools.get(poolName);
-        if (pool == null) {
-            synchronized (pools) {
-                // do a double check if it is still null or if another thread might have created it meanwhile
-                pool = pools.get(poolName);
-                if (pool == null) {
-                    int cfg = getConfig(poolName);
-                    pool = new WrappedScheduledExecutorService(cfg,
-                            new NamedThreadFactory(poolName, true, Thread.NORM_PRIORITY));
-                    ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
-                    ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
-                    ((ScheduledThreadPoolExecutor) pool).setRemoveOnCancelPolicy(true);
-                    pools.put(poolName, pool);
-                    LOGGER.debug("Created scheduled thread pool '{}' of size {}", poolName, cfg);
-                }
-            }
-        }
+        ExecutorService pool = pools.computeIfAbsent(poolName, (name) -> {
+            int cfg = getConfig(name);
+            ScheduledThreadPoolExecutor executor = new WrappedScheduledExecutorService(cfg,
+                    new NamedThreadFactory(name, true, Thread.NORM_PRIORITY));
+            executor.setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
+            executor.allowCoreThreadTimeOut(true);
+            executor.setRemoveOnCancelPolicy(true);
+            LOGGER.debug("Created scheduled thread pool '{}' of size {}", name, cfg);
+            return executor;
+        });
+
         if (pool instanceof ScheduledExecutorService service) {
             return new UnstoppableScheduledExecutorService(poolName, service);
         } else {
@@ -156,21 +149,15 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ExecutorService getPool(String poolName) {
-        ExecutorService pool = pools.get(poolName);
-        if (pool == null) {
-            synchronized (pools) {
-                // do a double check if it is still null or if another thread might have created it meanwhile
-                pool = pools.get(poolName);
-                if (pool == null) {
-                    int cfg = getConfig(poolName);
-                    pool = QueueingThreadPoolExecutor.createInstance(poolName, cfg);
-                    ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
-                    ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
-                    pools.put(poolName, pool);
-                    LOGGER.debug("Created thread pool '{}' with size {}", poolName, cfg);
-                }
-            }
-        }
+        ExecutorService pool = pools.computeIfAbsent(poolName, (name) -> {
+            int cfg = getConfig(name);
+            ThreadPoolExecutor executor = QueueingThreadPoolExecutor.createInstance(name, cfg);
+            executor.setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
+            executor.allowCoreThreadTimeOut(true);
+            LOGGER.debug("Created thread pool '{}' with size {}", name, cfg);
+            return executor;
+        });
+
         return new UnstoppableExecutorService<>(poolName, pool);
     }
 
@@ -179,9 +166,9 @@ public class ThreadPoolManager {
         return (ThreadPoolExecutor) ret.getDelegate();
     }
 
-    static ThreadPoolExecutor getScheduledPoolUnwrapped(String poolName) {
+    static ScheduledThreadPoolExecutor getScheduledPoolUnwrapped(String poolName) {
         UnstoppableExecutorService<?> ret = (UnstoppableScheduledExecutorService) getScheduledPool(poolName);
-        return (ThreadPoolExecutor) ret.getDelegate();
+        return (ScheduledThreadPoolExecutor) ret.getDelegate();
     }
 
     protected static int getConfig(String poolName) {


### PR DESCRIPTION
# Context

In theory the `ThreadPoolManager` could leak running thread pools an create new ones.
I have not seen this in the wild, but it could happen.

The `ThreadPoolManager` did use a `WeakHashMap<String, ExecutorService>` to store the running pools.
It holds a weak reference to the `String` and a strong to the `ExecutorService`.
As soon as the `String` gets collected by the GC, the strong reference to the `ExecutorService` is dopped.

This is a example of problematic code, this could create two pools when GC did clear the `WeakReferences` between the two calls to `ThreadPoolManager.getScheduledPoolUnwrapped`:
```
ThreadPoolManager.getScheduledPoolUnwrapped("test" + 1);
System.gc();
ThreadPoolManager.getScheduledPoolUnwrapped("test" + 1);
```

Beside this, there are [other issues like accessing](http://dowbecki.com/WeakHashMap-is-not-thread-safe/) the `WeakHashMap` outside a synchronized block.
This double check logic used is in my mind only safe for immutable objects...

# Description
This PR will replace the `WeakHashMap` with a `ConcurrentHashMap` to fix the issues above.