### PR TITLE
Add JavaDoc build badge and reconfigure plugin to indicate JavaDoc warnings/errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GitHub Actions Build Status](https://github.com/openhab/openhab-core/actions/workflows/ci-build.yml/badge.svg?branch=main)](https://github.com/openhab/openhab-core/actions/workflows/ci-build.yml)
 [![Jenkins Build Status](https://ci.openhab.org/job/openHAB-Core/badge/icon)](https://ci.openhab.org/job/openHAB-Core/)
+[![JavaDoc Build Status](https://ci.openhab.org/view/Documentation/job/openHAB-JavaDoc/badge/icon?subject=javadoc)](https://ci.openhab.org/view/Documentation/job/openHAB-JavaDoc/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
 [![Crowdin](https://badges.crowdin.net/openhab-core/localized.svg)](https://crowdin.com/project/openhab-core)
 

--- a/pom.xml
+++ b/pom.xml
@@ -326,10 +326,12 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.6.2</version>
           <configuration>
-            <failOnError>!${quality.skip}</failOnError>
+            <failOnError>true</failOnError>
+            <failOnWarnings>true</failOnWarnings>
             <doclint>none</doclint>
+            <legacyMode>true</legacyMode>
             <excludePackageNames>*.internal,*.internal.*</excludePackageNames>
             <!-- The search function is broken without the workaround below -->
             <!-- See: https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url -->

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -39,6 +39,11 @@
       <version>1.5.0</version>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>


### PR DESCRIPTION
* Add JavaDoc build badge
* Add dependency to upgradetool to fix remaining JavaDoc error
* Fail JavaDoc build on JavaDoc warnings/errors
* Upgrade maven-javadoc-plugin to fix it failures even if there are no warnings/errors
* Enable legacyMode to workaround JPMS issues in newer maven-javadoc-plugin versions