### PR TITLE
[Sitemap] Change syntax for Buttongrid sitemap element

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
@@ -17,10 +17,12 @@ package org.openhab.core.io.rest.sitemap.internal;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Laurent Garnier - New fields position and icon
+ * @author Laurent Garnier - Replace field position by fields row and column
  */
 public class MappingDTO {
 
-    public Integer position;
+    public Integer row;
+    public Integer column;
     public String command;
     public String label;
     public String icon;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -625,10 +625,10 @@ public class SitemapResource
             bean.step = setpointWidget.getStep();
         }
         if (widget instanceof Buttongrid buttonGridWidget) {
-            bean.columns = buttonGridWidget.getColumns();
             for (Button button : buttonGridWidget.getButtons()) {
                 MappingDTO mappingBean = new MappingDTO();
-                mappingBean.position = button.getPosition();
+                mappingBean.row = button.getRow();
+                mappingBean.column = button.getColumn();
                 mappingBean.command = button.getCmd();
                 mappingBean.label = button.getLabel();
                 mappingBean.icon = button.getIcon();

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -27,6 +27,7 @@ import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
  * @author Mark herwege - New fields pattern, unit
  * @author Laurent Garnier - New field columns
  * @author Danny Baumann - New field labelSource
+ * @author Laurent Garnier - Remove field columns
  */
 public class WidgetDTO {
 
@@ -68,7 +69,6 @@ public class WidgetDTO {
     public String yAxisDecimalPattern;
     public Boolean legend;
     public Boolean forceAsItem;
-    public Integer columns;
     public String state;
 
     public EnrichedItemDTO item;

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -182,7 +182,6 @@ Buttongrid:
     (('icon=' icon=Icon) |
         ('icon=[' (IconRules+=IconRule (',' IconRules+=IconRule)*) ']') |
         ('staticIcon=' staticIcon=Icon))? &
-    ('columns=' columns=INT) &
     ('buttons=[' buttons+=Button (',' buttons+=Button)* ']') &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)*) ']')? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)*) ']')? &
@@ -201,7 +200,7 @@ Default:
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)*) ']')?);
 
 Button:
-    position=INT ':' cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;
+    row=INT ':' column=INT ':' cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;
 
 Mapping:
     cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -269,7 +269,6 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 ButtongridImpl buttongridWidget = (ButtongridImpl) SitemapFactory.eINSTANCE.createButtongrid();
                 addWidgetButtons(buttongridWidget.getButtons(), component);
                 widget = buttongridWidget;
-                setWidgetPropertyFromComponentConfig(widget, component, "columns", SitemapPackage.BUTTONGRID__COLUMNS);
                 break;
             case "Default":
                 DefaultImpl defaultWidget = (DefaultImpl) SitemapFactory.eINSTANCE.createDefault();
@@ -378,13 +377,16 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 for (Object sourceButton : (Collection<?>) sourceButtons) {
                     if (sourceButton instanceof String) {
                         String[] splitted1 = sourceButton.toString().split(":");
-                        int idx = Integer.parseInt(splitted1[0].trim());
-                        String[] splitted2 = splitted1[1].trim().split("=");
-                        String cmd = splitted2[0].trim();
-                        String label = splitted2[1].trim();
-                        String icon = splitted2.length < 3 ? null : splitted2[2].trim();
+                        String[] splitted2 = splitted1[0].split(",");
+                        int row = Integer.parseInt(splitted2[0].trim());
+                        int column = Integer.parseInt(splitted2[1].trim());
+                        String[] splitted3 = splitted1[1].trim().split("=");
+                        String cmd = splitted3[0].trim();
+                        String label = splitted3[1].trim();
+                        String icon = splitted3.length < 3 ? null : splitted3[2].trim();
                         ButtonImpl button = (ButtonImpl) SitemapFactory.eINSTANCE.createButton();
-                        button.setPosition(idx);
+                        button.setRow(row);
+                        button.setColumn(column);
                         button.setCmd(cmd);
                         button.setLabel(label);
                         button.setIcon(icon);


### PR DESCRIPTION
Follow-up #3810

Location in the grid is now defined by a row number and a column number.

Signed-off-by: Laurent Garnier <lg.hc@ree.fr>