### PR TITLE
Fix addon name localisation before installation

### DIFF
--- a/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
+++ b/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
@@ -142,9 +142,12 @@ public class EclipseAddonService implements AddonService {
         AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid, locale);
 
         if (addonInfo != null) {
-            // only enrich if this add-on is installed, otherwise wrong data might be added
-            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
-                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+            if (addonInfo.isMasterAddonInfo()) {
+                addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription());
+            } else {
+                addon = addon.withLabel(name);
+            }
+            addon = addon.withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                     .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -33,8 +33,6 @@ import org.openhab.core.common.registry.Identifiable;
 @NonNullByDefault
 public class AddonInfo implements Identifiable<String> {
 
-    public static final String NA = "n/a";
-
     private static final Set<String> SUPPORTED_ADDON_TYPES = Set.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
 
@@ -50,10 +48,13 @@ public class AddonInfo implements Identifiable<String> {
     private @Nullable String sourceBundle;
     private @Nullable List<AddonDiscoveryMethod> discoveryMethods;
 
+    private boolean masterAddonInfo = true;
+
     private AddonInfo(String id, String type, @Nullable String uid, String name, String description,
             @Nullable String connection, List<String> countries, @Nullable String configDescriptionURI,
             @Nullable String serviceId, @Nullable String sourceBundle,
-            @Nullable List<AddonDiscoveryMethod> discoveryMethods) throws IllegalArgumentException {
+            @Nullable List<AddonDiscoveryMethod> discoveryMethods, boolean isMasterAddonInfo)
+            throws IllegalArgumentException {
         // mandatory fields
         if (id.isBlank()) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
@@ -81,6 +82,8 @@ public class AddonInfo implements Identifiable<String> {
         this.serviceId = Objects.requireNonNullElse(serviceId, type + "." + id);
         this.sourceBundle = sourceBundle;
         this.discoveryMethods = discoveryMethods;
+
+        this.masterAddonInfo = isMasterAddonInfo;
     }
 
     /**
@@ -155,6 +158,10 @@ public class AddonInfo implements Identifiable<String> {
         return discoveryMethods != null ? discoveryMethods : List.of();
     }
 
+    public boolean isMasterAddonInfo() {
+        return masterAddonInfo;
+    }
+
     public static Builder builder(String id, String type) {
         return new Builder(id, type);
     }
@@ -177,6 +184,8 @@ public class AddonInfo implements Identifiable<String> {
         private @Nullable String sourceBundle;
         private @Nullable List<AddonDiscoveryMethod> discoveryMethods;
 
+        private boolean masterAddonInfo = true;
+
         private Builder(String id, String type) {
             this.id = id;
             this.type = type;
@@ -194,6 +203,7 @@ public class AddonInfo implements Identifiable<String> {
             this.serviceId = addonInfo.serviceId;
             this.sourceBundle = addonInfo.sourceBundle;
             this.discoveryMethods = addonInfo.discoveryMethods;
+            this.masterAddonInfo = addonInfo.masterAddonInfo;
         }
 
         public Builder withUID(@Nullable String uid) {
@@ -246,6 +256,11 @@ public class AddonInfo implements Identifiable<String> {
             return this;
         }
 
+        public Builder isMasterAddonInfo(boolean masterAddonInfo) {
+            this.masterAddonInfo = masterAddonInfo;
+            return this;
+        }
+
         /**
          * Build an {@link AddonInfo} from this builder
          *
@@ -254,7 +269,7 @@ public class AddonInfo implements Identifiable<String> {
          */
         public AddonInfo build() throws IllegalArgumentException {
             return new AddonInfo(id, type, uid, name, description, connection, countries, configDescriptionURI,
-                    serviceId, sourceBundle, discoveryMethods);
+                    serviceId, sourceBundle, discoveryMethods, masterAddonInfo);
         }
     }
 }

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -108,6 +108,9 @@ public class AddonInfoRegistry {
             builder.withName(b.getName());
             builder.withDescription(b.getDescription());
         }
+        if (!(a.isMasterAddonInfo() || b.isMasterAddonInfo())) {
+            builder.isMasterAddonInfo(false);
+        }
         if (a.getConnection() == null && b.getConnection() != null) {
             builder.withConnection(b.getConnection());
         }

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -28,6 +28,8 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link AddonInfoRegistry} provides access to {@link AddonInfo} objects.
@@ -39,6 +41,8 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 @Component(immediate = true, service = AddonInfoRegistry.class)
 @NonNullByDefault
 public class AddonInfoRegistry {
+
+    private final Logger logger = LoggerFactory.getLogger(AddonInfoRegistry.class);
 
     private final Collection<AddonInfoProvider> addonInfoProviders = new CopyOnWriteArrayList<>();
 
@@ -85,7 +89,7 @@ public class AddonInfoRegistry {
      * <p>
      * If the first object has a non-null field value the result object takes the first value, or if the second object
      * has a non-null field value the result object takes the second value. Otherwise the field remains null.
-     * 
+     *
      * @param a the first {@link AddonInfo} (could be null)
      * @param b the second {@link AddonInfo} (could be null)
      * @return a new {@link AddonInfo} containing the combined field values (could be null)
@@ -97,15 +101,12 @@ public class AddonInfoRegistry {
             return a;
         }
         AddonInfo.Builder builder = AddonInfo.builder(a);
-        if (AddonInfo.NA.equals(a.getName())) {
-            builder.withName(b.getName());
-        } else if (AddonInfo.NA.equals(b.getName())) {
+        if (a.isMasterAddonInfo()) {
             builder.withName(a.getName());
-        }
-        if (AddonInfo.NA.equals(a.getDescription())) {
-            builder.withDescription(b.getDescription());
-        } else if (AddonInfo.NA.equals(b.getDescription())) {
             builder.withDescription(a.getDescription());
+        } else {
+            builder.withName(b.getName());
+            builder.withDescription(b.getDescription());
         }
         if (a.getConnection() == null && b.getConnection() != null) {
             builder.withConnection(b.getConnection());

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
@@ -95,7 +95,7 @@ public class AddonInfoAddonsXmlProvider implements AddonInfoProvider {
                 String xml = Files.readString(f.toPath());
                 if (xml != null && !xml.isBlank()) {
                     addonInfos.addAll(reader.readFromXML(xml).getAddons().stream()
-                            .map(a -> AddonInfo.builder(a).withName(AddonInfo.NA).withDescription(AddonInfo.NA).build())
+                            .map(a -> AddonInfo.builder(a).isMasterAddonInfo(false).build())
                             .collect(Collectors.toSet()));
                 } else {
                     logger.warn("File '{}' contents are null or empty", f.getName());

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -134,8 +134,12 @@ public class KarafAddonService implements AddonService {
         AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid, locale);
 
         if (addonInfo != null) {
-            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
-                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+            if (addonInfo.isMasterAddonInfo()) {
+                addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription());
+            } else {
+                addon = addon.withLabel(feature.getDescription());
+            }
+            addon = addon.withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                     .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/2204
Replaces https://github.com/openhab/openhab-core/pull/3905

The issue is that no addon info is available for distribution addons before installation. The only thing available is the feature description and the addon endpoint gets it from the addon data, not the addonInfo data. So a merge of addonInfo is not even happening.
This change introduces a flag in AddonInfo indicating if it is the master info or not. When the info is coming from the addon repository scan, it is flagged to not be the master data and name and description will be ignored (because localization info is not available). Addon services will check if the addon info is master info, and only then update name and description.