### PR TITLE
UpnpAddonFinder execute M-SEARCH ST: ssdp:all

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
@@ -85,6 +85,7 @@ public class UpnpAddonFinder extends BaseAddonFinder implements RegistryListener
             remoteDeviceAdded(registry, device);
         }
         registry.addListener(this);
+        upnpService.getControlPoint().search();
     }
 
     @Deactivate


### PR DESCRIPTION
Potentially fixes https://github.com/openhab/openhab-addons/issues/16036

In the above-mentioned issue, it has been reported that the UPnpAddonFinder may not be finding computers which are running the deconz application. Whereas by contrast the deconz binding's bridge discovery (based on UpnpDiscoveryParticipant) does find the respective computer.

A potential reason could be that `UpnpAddonFinder` issues a root device search (`M-SEARCH ST: upnp:rootdevice`) and perhaps the deconz application has a bug whereby it does not respond to root device searches.

On the other hand the `UpnpDiscoveryService` issues both a root device search plus also a 'catch-all' search (`M-SEARCH ST: ssdp:all`) so perhaps the deconz application does respond to the latter search but not the former.

Notes:
1. this is currently a hypothesis only, subject to user testing and confirmation.
2. if this hypothesis is proven, it confirms that the deconz application is buggy.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
