### PR TITLE
Make logger for jar file add-ons configurable in UI

### DIFF
--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
@@ -157,7 +157,7 @@ public class JarFileAddonService extends BundleTracker<Bundle> implements AddonS
                 .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                 .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI())
                 .withDescription(Objects.requireNonNullElse(addonInfo.getDescription(), bundle.getSymbolicName()))
-                .withContentType(ADDONS_CONTENT_TYPE).build();
+                .withContentType(ADDONS_CONTENT_TYPE).withLoggerPackages(List.of(bundle.getSymbolicName())).build();
     }
 
     @Override


### PR DESCRIPTION
Add-ons provided as jar files in the addons in the add-on folder did not have any information about loggers, so the logger could not be set through the UI.
As jar files are often provided to test new add-on functionality, the ability to set logging in the UI is relevant.
This PR adds the symbolic name as the name for the logger, which should be the main logger for most of the jar file provided add-ons.
