### PR TITLE
Extend OnOffType so it can be used as drop-in-replacement for Number types

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OnOffType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OnOffType.java
@@ -60,6 +60,34 @@ public enum OnOffType implements PrimitiveType, State, Command {
         return super.toString();
     }
 
+    public boolean booleanValue() {
+        return this == ON;
+    }
+
+    public byte byteValue() {
+        return (byte) (this == ON ? 1 : 0);
+    }
+
+    public double doubleValue() {
+        return this == ON ? 1.0 : 0.0;
+    }
+
+    public float floatValue() {
+        return this == ON ? 1.0f : 0.0f;
+    }
+
+    public int intValue() {
+        return this == ON ? 1 : 0;
+    }
+
+    public long longValue() {
+        return this == ON ? 1L : 0L;
+    }
+
+    public short shortValue() {
+        return (short) (this == ON ? 1 : 0);
+    }
+
     @Override
     public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == DecimalType.class) {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
@@ -48,4 +48,46 @@ public class OnOffTypeTest {
         assertNull(OnOffType.ON.as(PointType.class));
         assertNull(OnOffType.OFF.as(PointType.class));
     }
+
+    @Test
+    public void testBooleanValue() {
+        assertEquals(true, OnOffType.ON.booleanValue());
+        assertEquals(false, OnOffType.OFF.booleanValue());
+    }
+
+    @Test
+    public void testByteValue() {
+        assertEquals((byte) 1, OnOffType.ON.byteValue());
+        assertEquals((byte) 0, OnOffType.OFF.byteValue());
+    }
+
+    @Test
+    public void testDoubleValue() {
+        assertEquals(1.0, OnOffType.ON.doubleValue());
+        assertEquals(0.0, OnOffType.OFF.doubleValue());
+    }
+
+    @Test
+    public void testFloatValue() {
+        assertEquals(1.0f, OnOffType.ON.floatValue());
+        assertEquals(0.0f, OnOffType.OFF.floatValue());
+    }
+
+    @Test
+    public void testIntValue() {
+        assertEquals(1, OnOffType.ON.intValue());
+        assertEquals(0, OnOffType.OFF.intValue());
+    }
+
+    @Test
+    public void testLongValue() {
+        assertEquals((long) 1, OnOffType.ON.longValue());
+        assertEquals((long) 0, OnOffType.OFF.longValue());
+    }
+
+    @Test
+    public void testShortValue() {
+        assertEquals((short) 1, OnOffType.ON.shortValue());
+        assertEquals((short) 0, OnOffType.OFF.shortValue());
+    }
 }


### PR DESCRIPTION
I have added the methods of java class `Number` to `OnOffType`. This allows items of this class to be used as drop-on-replacement for numeric types in scripted rules:

```
    if (ir.getItem("someItem").getState().intValue() > 0) { .... }
```

Additionally, I have added a method `booleanValue()`, which allows this state to be used without importing OnOffType first.
