### PR TITLE
[Voice] Fix match question and allow force command

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @Component(service = HumanLanguageInterpreter.class)
 public class StandardInterpreter extends AbstractRuleBasedInterpreter {
-    public static final String VOICE_SYSTEM_NAMESPACE = "voice-system";
+    public static final String VOICE_SYSTEM_NAMESPACE = "voiceSystem";
     private Logger logger = LoggerFactory.getLogger(StandardInterpreter.class);
     private final ItemRegistry itemRegistry;
     private final MetadataRegistry metadataRegistry;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -1074,7 +1074,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      *
      * @param item will be the target of the rule.
      * @param ruleText the text to parse into a {@link Rule}
-     * @param metadata voice-system metadata.
+     * @param metadata voiceSystem metadata.
      * @return The created rule.
      */
     protected List<Rule> parseItemCustomRules(Locale locale, Item item, String ruleText, Metadata metadata) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
@@ -28,6 +28,7 @@ public abstract class Rule {
 
     private final Expression expression;
     private final AbstractRuleBasedInterpreter.ItemFilter itemFilter;
+    private final boolean isForced;
     private final boolean isSilent;
 
     /**
@@ -37,10 +38,12 @@ public abstract class Rule {
      * @param itemFilter Filters allowed items for rule.
      * @param isSilent Rule will emit no response on success.
      */
-    public Rule(Expression expression, AbstractRuleBasedInterpreter.ItemFilter itemFilter, boolean isSilent) {
+    public Rule(Expression expression, AbstractRuleBasedInterpreter.ItemFilter itemFilter, boolean isForced,
+            boolean isSilent) {
         this.expression = expression;
         this.itemFilter = itemFilter;
         this.isSilent = isSilent;
+        this.isForced = isForced;
     }
 
     /**
@@ -57,7 +60,8 @@ public abstract class Rule {
     InterpretationResult execute(ResourceBundle language, TokenList list, @Nullable String locationItem) {
         ASTNode node = expression.parse(language, list);
         if (node.isSuccess() && node.getRemainingTokens().eof()) {
-            return interpretAST(language, node, new InterpretationContext(this.itemFilter, isSilent, locationItem));
+            return interpretAST(language, node,
+                    new InterpretationContext(this.itemFilter, isForced, isSilent, locationItem));
         }
         return InterpretationResult.SYNTAX_ERROR;
     }
@@ -77,7 +81,7 @@ public abstract class Rule {
      * @param itemFilter Restricts rule compatibility to allowed items.
      * @param locationItem Location item to prioritize item matches or null.
      */
-    public record InterpretationContext(AbstractRuleBasedInterpreter.ItemFilter itemFilter, boolean isSilent,
-            @Nullable String locationItem) {
+    public record InterpretationContext(AbstractRuleBasedInterpreter.ItemFilter itemFilter, boolean isForced,
+            boolean isSilent, @Nullable String locationItem) {
     }
 }


### PR DESCRIPTION
Hello, I would like to merge these fixes related to #3897.

It fixes an error introduced in that PR because the "?" should be removed when tokenizing unless when tokenizing the custom rule text, if not, it's imposible to match a question with the current implementation.

Also I have introduced the option to allow a custom rule to send a command no matter the item is already on that state, because if you are going to use the item to trigger a rule "on command received" instead of "on state change" you want the rule to behave that way and send the command always.