### PR TITLE
Additional logging AddonInfo addons.xml

### DIFF
--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
@@ -103,7 +103,7 @@ public class AddonInfoAddonsXmlProvider implements AddonInfoProvider {
             } catch (IOException e) {
                 logger.warn("File '{}' could not be read", f.getName());
             } catch (ConversionException e) {
-                logger.warn("File '{}' has invalid content", f.getName());
+                logger.warn("File '{}' has invalid content: {}", f.getName(), e.getMessage());
             } catch (XStreamException e) {
                 logger.warn("File '{}' could not be deserialized", f.getName());
             } catch (SecurityException e) {


### PR DESCRIPTION
This PR is intended to get more information if reading of addons.xml / openhab-addons.xml is failing.
It indicates in which line the problem is located.

```
22:17:11.743 [WARN ] [ternal.xml.AddonInfoAddonsXmlProvider] - File 'openhab-addons.xml' has invalid content:
---- Debugging information ----
cause-exception     : com.thoughtworks.xstream.mapper.CannotResolveClassException
cause-message       : mdns-service-type
class               : java.util.ArrayList
required-type       : java.util.ArrayList
converter-type      : com.thoughtworks.xstream.converters.collections.CollectionConverter
path                : /addon-info-list/addons/addon[18]/discovery-methods/discovery-method/mdns-service-type
line number         : 238
class[1]            : org.openhab.core.addon.AddonDiscoveryMethod
required-type[1]    : org.openhab.core.addon.AddonDiscoveryMethod
converter-type[1]   : org.openhab.core.addon.internal.xml.AddonDiscoveryMethodConverter
class[2]            : org.openhab.core.config.core.xml.util.NodeList
required-type[2]    : org.openhab.core.config.core.xml.util.NodeList
converter-type[2]   : org.openhab.core.config.core.xml.util.NodeListConverter
class[3]            : org.openhab.core.addon.internal.xml.AddonInfoXmlResult
required-type[3]    : org.openhab.core.addon.internal.xml.AddonInfoXmlResult
converter-type[3]   : org.openhab.core.addon.internal.xml.AddonInfoConverter
class[4]            : org.openhab.core.addon.AddonInfoList
required-type[4]    : org.openhab.core.addon.AddonInfoList
converter-type[4]   : org.openhab.core.addon.internal.xml.AddonInfoListConverter
version             : 1.4.20
-------------------------------
```

@andrewfg do you think this is useful?