### PR TITLE
UPnP add M-SEARCH for root devices

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.core.config.discovery.addon.upnp;
 
-import static org.openhab.core.config.discovery.addon.AddonFinderConstants.*;
+import static org.openhab.core.config.discovery.addon.AddonFinderConstants.SERVICE_NAME_UPNP;
+import static org.openhab.core.config.discovery.addon.AddonFinderConstants.SERVICE_TYPE_UPNP;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jupnp.UpnpService;
+import org.jupnp.model.message.header.RootDeviceHeader;
 import org.jupnp.model.meta.DeviceDetails;
 import org.jupnp.model.meta.LocalDevice;
 import org.jupnp.model.meta.ManufacturerDetails;
@@ -86,6 +88,7 @@ public class UpnpAddonFinder extends BaseAddonFinder implements RegistryListener
         }
         registry.addListener(this);
         upnpService.getControlPoint().search();
+        upnpService.getControlPoint().search(new RootDeviceHeader());
     }
 
     @Deactivate

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.jupnp.UpnpService;
+import org.jupnp.model.message.header.RootDeviceHeader;
 import org.jupnp.model.meta.LocalDevice;
 import org.jupnp.model.meta.RemoteDevice;
 import org.jupnp.model.types.UDN;
@@ -151,6 +152,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
         }
         upnpService.getRegistry().addListener(this);
         upnpService.getControlPoint().search();
+        upnpService.getControlPoint().search(new RootDeviceHeader());
     }
 
     @Override


### PR DESCRIPTION
Following release of OH v4.1M5 some users found that the new Add-on Suggestion Finder was not discovering all UPnP devices on their LAN.

The OH UPnP discovery mechanism currently sends an `M-SEARCH` broadcast with a search target `ST: ssdp:all` header -- yet some devices do not respond to broadcasts with `ST: ssdp:all` and only respond to broadcasts with `ST: upnp:rootdevice`.

This PR adds a `M-SEARCH` broadcast with search target `ST: upnp:rootdevice`.

The functionality of this PR was tested already live via https://github.com/openhab/openhab-addons/pull/16077

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
