### PR TITLE
Provide I18N properties for Unit Settings

### DIFF
--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
@@ -1,18 +1,18 @@
 system.config.i18n.language.label = Language
 system.config.i18n.language.description = The default language that should be used. If not specified, the system default locale is used.
-system.config.i18n.script.label = Script
-system.config.i18n.script.description = The script that should be used.
-system.config.i18n.region.label = Country / Region
-system.config.i18n.region.description = The region that should be used.
-system.config.i18n.variant.label = Variant
-system.config.i18n.variant.description = A variation of the Locale. Any arbitrary value used to indicate a variation of a Locale.
-system.config.i18n.timezone.label = Time Zone
-system.config.i18n.timezone.description = A time zone can be set from the user interface. The underlying system's time zone is the default.
 system.config.i18n.location.label = Location
 system.config.i18n.location.description = The location of this installation.<br>Coordinates as &lt;latitude&gt;,&lt;longitude&gt;[&lt;altitude&gt;]<br>Example: "52.5200066,13.4049540" (Berlin)
 system.config.i18n.measurementSystem.label = Measurement System
 system.config.i18n.measurementSystem.description = The measurement system is used for unit conversion.
 system.config.i18n.measurementSystem.option.SI = Metric
 system.config.i18n.measurementSystem.option.US = Imperial (US)
+system.config.i18n.region.label = Country / Region
+system.config.i18n.region.description = The region that should be used.
+system.config.i18n.script.label = Script
+system.config.i18n.script.description = The script that should be used.
+system.config.i18n.timezone.label = Time Zone
+system.config.i18n.timezone.description = A time zone can be set from the user interface. The underlying system's time zone is the default.
+system.config.i18n.variant.label = Variant
+system.config.i18n.variant.description = A variation of the Locale. Any arbitrary value used to indicate a variation of a Locale.
 
 service.system.i18n.label = Regional Settings

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/network.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/network.properties
@@ -1,10 +1,10 @@
-system.config.network.primaryAddress.label = Primary Address
-system.config.network.primaryAddress.description = A subnet (e.g. 192.168.1.0/24).
 system.config.network.broadcastAddress.label = Broadcast Address
 system.config.network.broadcastAddress.description = A broadcast address (e.g. 192.168.1.255).
-system.config.network.useOnlyOneAddress.label = Single IP Address per Interface
-system.config.network.useOnlyOneAddress.description = Use only one IP address per interface and family.
+system.config.network.primaryAddress.label = Primary Address
+system.config.network.primaryAddress.description = A subnet (e.g. 192.168.1.0/24).
 system.config.network.useIPv6.label = Use IPv6
 system.config.network.useIPv6.description = Use IPv6 Addresses if available.
+system.config.network.useOnlyOneAddress.label = Single IP Address per Interface
+system.config.network.useOnlyOneAddress.description = Use only one IP address per interface and family.
 
 service.system.network.label = Network Settings

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/units.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/units.properties
@@ -1,0 +1,6 @@
+system.config.units.currencyProvider.label = Currency Provider
+system.config.units.currencyProvider.description = The service that is used to provide a set of currencies and their exchange rates.
+system.config.units.fixedBaseCurrency.label = Fixed Base Currency
+system.config.units.fixedBaseCurrency.description = The base currency of this system when the fixed currency provider is used.
+
+service.system.units.label = Unit Settings


### PR DESCRIPTION
Seems missing from #3503.

Generated by:
```shell
mvn i18n:generate-default-translations
```

Then manually moved to new file `units.properties` where I manually added the last line:
```ini
service.system.units.label = Unit Settings
```

I don't know if this is the correct process or if there is a better one.

To make sure the manually added label is correct, I built and tested it with a Danish string provided:

![image](https://github.com/openhab/openhab-core/assets/19519842/0d504e10-429f-4494-9662-4b28cba3470e)
