### PR TITLE
Fix for #3946

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -184,9 +184,11 @@ public class AddonSuggestionService implements AutoCloseable {
     }
 
     private void changed() {
-        List<AddonInfo> candidates = addonInfoProviders.stream().map(p -> p.getAddonInfos(localeProvider.getLocale()))
-                .flatMap(Collection::stream).toList();
-        addonFinders.stream().filter(this::isFinderEnabled).forEach(f -> f.setAddonCandidates(candidates));
+        synchronized (addonInfoProviders) {
+            List<AddonInfo> candidates = addonInfoProviders.stream()
+                    .map(p -> p.getAddonInfos(localeProvider.getLocale())).flatMap(Collection::stream).toList();
+            addonFinders.stream().filter(this::isFinderEnabled).forEach(f -> f.setAddonCandidates(candidates));
+        }
     }
 
     @Deactivate

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -206,12 +206,16 @@ public class AddonSuggestionService implements AutoCloseable {
     @Deactivate
     @Override
     public void close() throws Exception {
-        addonFinders.clear();
-        addonInfoProviders.clear();
+        synchronized (this) {
+            addonFinders.clear();
+            addonInfoProviders.clear();
+        }
     }
 
     public Set<AddonInfo> getSuggestedAddons(@Nullable Locale locale) {
-        return addonFinders.stream().filter(this::isFinderEnabled).map(f -> f.getSuggestedAddons())
-                .flatMap(Collection::stream).collect(Collectors.toSet());
+        synchronized (this) {
+            return addonFinders.stream().filter(this::isFinderEnabled).map(f -> f.getSuggestedAddons())
+                    .flatMap(Collection::stream).collect(Collectors.toSet());
+        }
     }
 }

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -180,12 +180,8 @@ public class AddonSuggestionService implements AutoCloseable {
     }
 
     public void removeAddonFinder(AddonFinder addonFinder) {
-        boolean removed;
         synchronized (addonFinders) {
-            removed = addonFinders.remove(addonFinder);
-        }
-        if (removed) {
-            changed();
+            addonFinders.remove(addonFinder);
         }
     }
 

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -183,12 +183,10 @@ public class AddonSuggestionService implements AutoCloseable {
         }
     }
 
-    private void changed() {
-        synchronized (addonInfoProviders) {
-            List<AddonInfo> candidates = addonInfoProviders.stream()
-                    .map(p -> p.getAddonInfos(localeProvider.getLocale())).flatMap(Collection::stream).toList();
-            addonFinders.stream().filter(this::isFinderEnabled).forEach(f -> f.setAddonCandidates(candidates));
-        }
+    private synchronized void changed() {
+        List<AddonInfo> candidates = addonInfoProviders.stream().map(p -> p.getAddonInfos(localeProvider.getLocale()))
+                .flatMap(Collection::stream).toList();
+        addonFinders.stream().filter(this::isFinderEnabled).forEach(f -> f.setAddonCandidates(candidates));
     }
 
     @Deactivate


### PR DESCRIPTION
Fixes #3946 

@kaikreuzer / @mherwege can you please check this? I am not sure if the fix that I proposed is fully sufficient to synchronize the stream access, if synchronization also needs to be applied in the other methods that access `addonFinders` or `addonInfoProviders` too??

``
    public void addAddonInfoProvider(AddonInfoProvider addonInfoProvider) {
    public void removeAddonInfoProvider(AddonInfoProvider addonInfoProvider) {
    public void addAddonFinder(AddonFinder addonFinder) {
    public void removeAddonFinder(AddonFinder addonFinder) {
```

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>