### PR TITLE
Refactor ThingHandlerService to an OSGi component prototype

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -62,6 +62,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <version>1.5.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.scr</artifactId>
       <version>2.2.6</version>

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -422,14 +422,6 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
         return timestampOfLastScan;
     }
 
-    private boolean getAutoDiscoveryEnabled(Object autoDiscoveryEnabled) {
-        if (autoDiscoveryEnabled instanceof String string) {
-            return Boolean.parseBoolean(string);
-        } else {
-            return Boolean.TRUE.equals(autoDiscoveryEnabled);
-        }
-    }
-
     private String inferKey(DiscoveryResult discoveryResult, String lastSegment) {
         return "discovery." + discoveryResult.getThingUID().getAsString().replace(":", ".") + "." + lastSegment;
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -349,7 +349,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     protected void activate(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
             backgroundDiscoveryEnabled = ConfigParser.valueAsOrElse(
-                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class, false);
+                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                    backgroundDiscoveryEnabled);
         }
         if (backgroundDiscoveryEnabled) {
             startBackgroundDiscovery();
@@ -370,7 +371,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     protected void modified(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
             boolean enabled = ConfigParser.valueAsOrElse(
-                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class, false);
+                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class,
+                    backgroundDiscoveryEnabled);
 
             if (backgroundDiscoveryEnabled && !enabled) {
                 stopBackgroundDiscovery();

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.config.core.ConfigParser;
 import org.openhab.core.i18n.I18nUtil;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TranslationProvider;
@@ -347,10 +348,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      */
     protected void activate(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
-            Object property = configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-            if (property != null) {
-                backgroundDiscoveryEnabled = getAutoDiscoveryEnabled(property);
-            }
+            backgroundDiscoveryEnabled = ConfigParser.valueAsOrElse(
+                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class, false);
         }
         if (backgroundDiscoveryEnabled) {
             startBackgroundDiscovery();
@@ -370,20 +369,17 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      */
     protected void modified(@Nullable Map<String, Object> configProperties) {
         if (configProperties != null) {
-            Object property = configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY);
-            if (property != null) {
-                boolean enabled = getAutoDiscoveryEnabled(property);
+            boolean enabled = ConfigParser.valueAsOrElse(
+                    configProperties.get(DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY), Boolean.class, false);
 
-                if (backgroundDiscoveryEnabled && !enabled) {
-                    stopBackgroundDiscovery();
-                    logger.debug("Background discovery for discovery service '{}' disabled.",
-                            this.getClass().getName());
-                } else if (!backgroundDiscoveryEnabled && enabled) {
-                    startBackgroundDiscovery();
-                    logger.debug("Background discovery for discovery service '{}' enabled.", this.getClass().getName());
-                }
-                backgroundDiscoveryEnabled = enabled;
+            if (backgroundDiscoveryEnabled && !enabled) {
+                stopBackgroundDiscovery();
+                logger.debug("Background discovery for discovery service '{}' disabled.", this.getClass().getName());
+            } else if (!backgroundDiscoveryEnabled && enabled) {
+                startBackgroundDiscovery();
+                logger.debug("Background discovery for discovery service '{}' enabled.", this.getClass().getName());
             }
+            backgroundDiscoveryEnabled = enabled;
         }
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -50,7 +50,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
         this.thingClazz = thingClazz;
     }
 
-    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
+    protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
             int timeout) throws IllegalArgumentException {
         super(supportedThingTypes, timeout);
         this.thingClazz = thingClazz;

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2010-2023 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.discovery;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
+
+/**
+ * The {@link AbstractThingHandlerDiscoveryService} extends the {@link AbstractDiscoveryService} for thing-based
+ * discovery services.
+ *
+ * It handles the injection of the {@link ThingHandler}
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandler> extends AbstractDiscoveryService
+        implements ThingHandlerService {
+
+    private final Class<T> thingClazz;
+    protected @Nullable T thingHandler;
+
+    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
+            int timeout, boolean backgroundDiscoveryEnabledByDefault) throws IllegalArgumentException {
+        super(supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault);
+        this.thingClazz = thingClazz;
+    }
+
+    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
+            int timeout) throws IllegalArgumentException {
+        super(supportedThingTypes, timeout);
+        this.thingClazz = thingClazz;
+    }
+
+    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, int timeout) throws IllegalArgumentException {
+        super(timeout);
+        this.thingClazz = thingClazz;
+    }
+
+    @Override
+    protected abstract void startScan();
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setThingHandler(ThingHandler handler) {
+        if (thingClazz.isAssignableFrom(handler.getClass())) {
+            this.thingHandler = (T) handler;
+        } else {
+            throw new IllegalArgumentException(
+                    "Expected class is " + thingClazz + " but the parameter has class " + handler.getClass());
+        }
+    }
+
+    @Override
+    public @Nullable ThingHandler getThingHandler() {
+        return thingHandler;
+    }
+
+    @Override
+    public void activate(@Nullable Map<String, Object> config) {
+        super.activate(config);
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+}

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -44,7 +44,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
     // initialized when the type is generic, so we have to initialize it with "something"
     protected @NonNullByDefault({}) T thingHandler = (@NonNull T) null;
 
-    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
+    protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
             int timeout, boolean backgroundDiscoveryEnabledByDefault) throws IllegalArgumentException {
         super(supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault);
         this.thingClazz = thingClazz;

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -98,7 +98,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
 
             if (backgroundDiscoveryEnabled && !enabled) {
                 stopBackgroundDiscovery();
-                logger.debug("Background discovery for discovery service '{}' disabled.", this.getClass().getName());
+                logger.debug("Background discovery for discovery service '{}' disabled.", getClass().getName());
             } else if (!backgroundDiscoveryEnabled && enabled) {
                 startBackgroundDiscovery();
                 logger.debug("Background discovery for discovery service '{}' enabled.", this.getClass().getName());

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -101,7 +101,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
                 logger.debug("Background discovery for discovery service '{}' disabled.", getClass().getName());
             } else if (!backgroundDiscoveryEnabled && enabled) {
                 startBackgroundDiscovery();
-                logger.debug("Background discovery for discovery service '{}' enabled.", this.getClass().getName());
+                logger.debug("Background discovery for discovery service '{}' enabled.", getClass().getName());
             }
             backgroundDiscoveryEnabled = enabled;
         }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -56,7 +56,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
         this.thingClazz = thingClazz;
     }
 
-    public AbstractThingHandlerDiscoveryService(Class<T> thingClazz, int timeout) throws IllegalArgumentException {
+    protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, int timeout) throws IllegalArgumentException {
         super(timeout);
         this.thingClazz = thingClazz;
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -116,7 +116,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
     public void initialize() {
         if (backgroundDiscoveryEnabled) {
             startBackgroundDiscovery();
-            logger.debug("Background discovery for discovery service '{}' enabled.", this.getClass().getName());
+            logger.debug("Background discovery for discovery service '{}' enabled.", getClass().getName());
         }
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas Höfer - added config status provider and firmware update handler service registration
  * @author Stefan Bußweiler - API changes due to bridge/thing life cycle refactoring, removed OSGi service registration
  *         for thing handlers
+ * @author Connor Petty - added osgi service registration for thing handler services.
  */
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
@@ -407,6 +408,5 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                 serviceObjs.ungetService(this.serviceInstance);
             }
         }
-
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -163,7 +163,6 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private <T extends ThingHandlerService> void registerThingHandlerService(ThingUID thingUID,
             ThingHandler thingHandler, Class<T> c) {
-
         RegisteredThingHandlerService<T> registeredService;
 
         Component component = c.getAnnotation(Component.class);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -15,9 +15,9 @@ package org.openhab.core.thing.binding;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,8 +34,12 @@ import org.openhab.core.thing.binding.firmware.FirmwareUpdateHandler;
 import org.openhab.core.thing.type.ThingType;
 import org.openhab.core.thing.type.ThingTypeRegistry;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceObjects;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,6 +60,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
+    private static final String THING_HANDER_SERVICE_CANONICAL_NAME = ThingHandlerService.class.getCanonicalName();
+
     protected @NonNullByDefault({}) BundleContext bundleContext;
 
     private final Logger logger = LoggerFactory.getLogger(BaseThingHandlerFactory.class);
@@ -63,7 +69,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
     private final Map<String, ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
     private final Map<String, ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
 
-    private final Map<ThingUID, Set<ServiceRegistration<?>>> thingHandlerServices = new ConcurrentHashMap<>();
+    private final Map<ThingUID, Set<RegisteredThingHandlerService<?>>> thingHandlerServices = new ConcurrentHashMap<>();
 
     private @NonNullByDefault({}) ServiceTracker<ThingTypeRegistry, ThingTypeRegistry> thingTypeRegistryServiceTracker;
     private @NonNullByDefault({}) ServiceTracker<ConfigDescriptionRegistry, ConfigDescriptionRegistry> configDescriptionRegistryServiceTracker;
@@ -143,67 +149,73 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private void registerServices(Thing thing, ThingHandler thingHandler) {
         ThingUID thingUID = thing.getUID();
-        for (Class<?> c : thingHandler.getServices()) {
+        for (Class<? extends ThingHandlerService> c : thingHandler.getServices()) {
+            if (!ThingHandlerService.class.isAssignableFrom(c)) {
+                logger.warn(
+                        "Should register service={} for thingUID={}, but it does not implement the interface ThingHandlerService.",
+                        c.getCanonicalName(), thingUID);
+                continue;
+            }
+            registerThingHandlerService(thingUID, thingHandler, c);
+        }
+    }
+
+    private <T extends ThingHandlerService> void registerThingHandlerService(ThingUID thingUID,
+            ThingHandler thingHandler, Class<T> c) {
+
+        RegisteredThingHandlerService<T> registeredService;
+
+        Component component = c.getAnnotation(Component.class);
+        if (component != null && component.enabled()) {
+            if (component.scope() != ServiceScope.PROTOTYPE) {
+                // then we cannot use it.
+                logger.warn("Could not register service for class={}. Service must have a prototype scope",
+                        c.getCanonicalName());
+                return;
+            }
+            if (component.service().length != 1 || component.service()[0] != c) {
+                logger.warn(
+                        "Could not register service for class={}. ThingHandlerService with @Component must only label itself as a service.",
+                        c.getCanonicalName());
+                return;
+            }
+        }
+
+        ServiceReference<T> serviceRef = bundleContext.getServiceReference(c);
+        if (serviceRef != null) {
+            ServiceObjects<T> serviceObjs = bundleContext.getServiceObjects(serviceRef);
+            registeredService = new RegisteredThingHandlerService<>(serviceObjs);
+        } else {
             try {
-                Object serviceInstance = c.getConstructor().newInstance();
-
-                ThingHandlerService ths = null;
-                if (serviceInstance instanceof ThingHandlerService service) {
-                    ths = service;
-                    ths.setThingHandler(thingHandler);
-                } else {
-                    logger.warn(
-                            "Should register service={} for thingUID={}, but it does not implement the interface ThingHandlerService.",
-                            c.getCanonicalName(), thingUID);
-                    continue;
-                }
-
-                Set<Class<?>> interfaces = getAllInterfaces(c);
-                List<String> serviceNames = new LinkedList<>();
-                interfaces.forEach(i -> {
-                    String className = i.getCanonicalName();
-                    // we only add specific ThingHandlerServices, i.e. those that derive from the ThingHandlerService
-                    // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
-                    // services later, rather than as a generic ThingHandlerService.
-                    if (className != null && !className.equals(ThingHandlerService.class.getCanonicalName())) {
-                        serviceNames.add(className);
-                    }
-                });
-                if (!serviceNames.isEmpty()) {
-                    String[] serviceNamesArray = serviceNames.toArray(new String[serviceNames.size()]);
-                    ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNamesArray,
-                            serviceInstance, null);
-                    if (serviceReg != null) {
-                        Set<ServiceRegistration<?>> serviceRegs = thingHandlerServices.get(thingUID);
-                        if (serviceRegs == null) {
-                            Set<ServiceRegistration<?>> set = new HashSet<>();
-                            set.add(serviceReg);
-                            thingHandlerServices.put(thingUID, set);
-                        } else {
-                            serviceRegs.add(serviceReg);
-                        }
-                        ths.activate();
-                    }
-                }
+                T serviceInstance = c.getConstructor().newInstance();
+                registeredService = new RegisteredThingHandlerService<>(serviceInstance);
             } catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException
                     | InvocationTargetException e) {
                 logger.warn("Could not register service for class={}", c.getCanonicalName(), e);
+                return;
             }
         }
+
+        String[] serviceNames = getAllInterfaces(c).stream()//
+                .map(clazz -> clazz.getCanonicalName())
+                // we only add specific ThingHandlerServices, i.e. those that derive from the
+                // ThingHandlerService
+                // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
+                // services later, rather than as a generic ThingHandlerService.
+                .filter(className -> className != null && !className.equals(THING_HANDER_SERVICE_CANONICAL_NAME))
+                .toArray(String[]::new);
+
+        registeredService.initializeService(thingHandler, serviceNames);
+
+        Objects.requireNonNull(thingHandlerServices.computeIfAbsent(thingUID, uid -> new HashSet<>()))
+                .add(registeredService);
     }
 
     private void unregisterServices(Thing thing) {
         ThingUID thingUID = thing.getUID();
-        Set<ServiceRegistration<?>> serviceRegs = thingHandlerServices.remove(thingUID);
+        Set<RegisteredThingHandlerService<?>> serviceRegs = thingHandlerServices.remove(thingUID);
         if (serviceRegs != null) {
-            serviceRegs.forEach(serviceReg -> {
-                ThingHandlerService ths = (ThingHandlerService) getBundleContext()
-                        .getService(serviceReg.getReference());
-                serviceReg.unregister();
-                if (ths != null) {
-                    ths.deactivate();
-                }
-            });
+            serviceRegs.forEach(RegisteredThingHandlerService::disposeService);
         }
     }
 
@@ -213,7 +225,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
      * @param clazz The class
      * @return A {@link List} of interfaces
      */
-    private Set<Class<?>> getAllInterfaces(Class<?> clazz) {
+    private static Set<Class<?>> getAllInterfaces(Class<?> clazz) {
         Set<Class<?>> interfaces = new HashSet<>();
         for (Class<?> superclazz = clazz; superclazz != null; superclazz = superclazz.getSuperclass()) {
             interfaces.addAll(Arrays.asList(superclazz.getInterfaces()));
@@ -353,5 +365,48 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                     "Config Description Registry has not been properly initialized. Did you forget to call super.activate()?");
         }
         return configDescriptionRegistryServiceTracker.getService();
+    }
+
+    private class RegisteredThingHandlerService<T extends ThingHandlerService> {
+
+        private T serviceInstance;
+
+        private @Nullable ServiceObjects<T> serviceObjects;
+
+        private @Nullable ServiceRegistration<?> serviceRegistration;
+
+        public RegisteredThingHandlerService(T serviceInstance) {
+            this.serviceInstance = serviceInstance;
+        }
+
+        public RegisteredThingHandlerService(ServiceObjects<T> serviceObjs) {
+            this.serviceInstance = serviceObjs.getService();
+            this.serviceObjects = serviceObjs;
+        }
+
+        public void initializeService(ThingHandler handler, String[] serviceNames) {
+            this.serviceInstance.setThingHandler(handler);
+            if (serviceNames.length > 0) {
+                ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNames, serviceInstance, null);
+                if (serviceReg != null) {
+                    this.serviceRegistration = serviceReg;
+                }
+            }
+            this.serviceInstance.initialize();
+        }
+
+        public void disposeService() {
+            ServiceRegistration<?> serviceReg = this.serviceRegistration;
+            if (serviceReg != null) {
+                serviceReg.unregister();
+            }
+            this.serviceInstance.dispose();
+
+            ServiceObjects<T> serviceObjs = this.serviceObjects;
+            if (serviceObjs != null) {
+                serviceObjs.ungetService(this.serviceInstance);
+            }
+        }
+
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -198,7 +198,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         }
 
         String[] serviceNames = getAllInterfaces(c).stream()//
-                .map(clazz -> clazz.getCanonicalName())
+                .map(Class::getCanonicalName)
                 // we only add specific ThingHandlerServices, i.e. those that derive from the
                 // ThingHandlerService
                 // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
@@ -370,7 +370,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     private class RegisteredThingHandlerService<T extends ThingHandlerService> {
 
-        private T serviceInstance;
+        private final T serviceInstance;
 
         private @Nullable ServiceObjects<T> serviceObjects;
 
@@ -397,11 +397,12 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         }
 
         public void disposeService() {
+            this.serviceInstance.dispose();
+
             ServiceRegistration<?> serviceReg = this.serviceRegistration;
             if (serviceReg != null) {
                 serviceReg.unregister();
             }
-            this.serviceInstance.dispose();
 
             ServiceObjects<T> serviceObjs = this.serviceObjects;
             if (serviceObjs != null) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
-    private static final String THING_HANDER_SERVICE_CANONICAL_NAME = ThingHandlerService.class.getCanonicalName();
+    private static final String THING_HANDLER_SERVICE_CANONICAL_NAME = ThingHandlerService.class.getCanonicalName();
 
     protected @NonNullByDefault({}) BundleContext bundleContext;
 
@@ -202,7 +202,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
                 // ThingHandlerService
                 // interface, NOT the ThingHandlerService itself. We do this to register them as specific OSGi
                 // services later, rather than as a generic ThingHandlerService.
-                .filter(className -> className != null && !className.equals(THING_HANDER_SERVICE_CANONICAL_NAME))
+                .filter(className -> className != null && !className.equals(THING_HANDLER_SERVICE_CANONICAL_NAME))
                 .toArray(String[]::new);
 
         registeredService.initializeService(thingHandler, serviceNames);
@@ -385,18 +385,18 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         }
 
         public void initializeService(ThingHandler handler, String[] serviceNames) {
-            this.serviceInstance.setThingHandler(handler);
+            serviceInstance.setThingHandler(handler);
             if (serviceNames.length > 0) {
                 ServiceRegistration<?> serviceReg = bundleContext.registerService(serviceNames, serviceInstance, null);
                 if (serviceReg != null) {
-                    this.serviceRegistration = serviceReg;
+                    serviceRegistration = serviceReg;
                 }
             }
-            this.serviceInstance.initialize();
+            serviceInstance.initialize();
         }
 
         public void disposeService() {
-            this.serviceInstance.dispose();
+            serviceInstance.dispose();
 
             ServiceRegistration<?> serviceReg = this.serviceRegistration;
             if (serviceReg != null) {
@@ -405,7 +405,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
             ServiceObjects<T> serviceObjs = this.serviceObjects;
             if (serviceObjs != null) {
-                serviceObjs.ungetService(this.serviceInstance);
+                serviceObjs.ungetService(serviceInstance);
             }
         }
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -41,13 +41,35 @@ public interface ThingHandlerService {
 
     /**
      * Method that will be called if this service will be activated
+     *
+     * @deprecated please override initialize instead
      */
+    @Deprecated
     default void activate() {
     }
 
     /**
      * Method that will be called if this service will be deactivated
+     *
+     * @deprecated please override dispose instead
      */
+    @Deprecated
     default void deactivate() {
+
     }
+
+    /**
+     * Method that will be called if this service will be initialized
+     */
+    default void initialize() {
+        activate();
+    }
+
+    /**
+     * Method that will be called if this service will be disposed
+     */
+    default void dispose() {
+        deactivate();
+    }
+
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -61,7 +61,8 @@ public interface ThingHandlerService {
      * This method is used by the framework during activation of the service.
      * It is called AFTER the component is fully activated and thing handler has been set.
      *
-     * Implementations should override this method to add additional initialization code.
+     * Implementations should override this method to add additional initialization code. This method should call
+     * <code>super.initialize()</code> to ensure background discovery is properly handled.
      *
      * See {@link #activate(), #{@link #dispose()}
      */
@@ -72,7 +73,8 @@ public interface ThingHandlerService {
      * This method is used by the framework during de-activation of the service.
      * It is called while the component is still activated.
      *
-     * Code depending on an activated service should go here.
+     * Code depending on an activated service should go here. This method should call <code>super.dispose()</code> to
+     * ensure background discovery is properly handled.
      *
      * See {@link #deactivate()}, {@link #initialize()}
      */

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -55,7 +55,6 @@ public interface ThingHandlerService {
      */
     @Deprecated
     default void deactivate() {
-
     }
 
     /**
@@ -71,5 +70,4 @@ public interface ThingHandlerService {
     default void dispose() {
         deactivate();
     }
-
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -40,34 +40,42 @@ public interface ThingHandlerService {
     ThingHandler getThingHandler();
 
     /**
-     * Method that will be called if this service will be activated
+     * This method is used by the framework during activation of the OSGi component.
+     * It is called BEFORE the thing handler is set.
      *
-     * @deprecated please override initialize instead
+     * See {@link #initialize()}, {@link #deactivate()}
      */
-    @Deprecated
     default void activate() {
     }
 
     /**
-     * Method that will be called if this service will be deactivated
+     * This method is used by the framework during de-activation of the OSGi component.
+     * It is NOT guaranteed that the thing handler is still valid.
      *
-     * @deprecated please override dispose instead
+     * See {@link #dispose()}, {@link #activate()}
      */
-    @Deprecated
     default void deactivate() {
     }
 
     /**
-     * Method that will be called if this service will be initialized
+     * This method is used by the framework during activation of the service.
+     * It is called AFTER the component is fully activated and thing handler has been set.
+     *
+     * Implementations should override this method to add additional initialization code.
+     *
+     * See {@link #activate(), #{@link #dispose()}
      */
     default void initialize() {
-        activate();
     }
 
     /**
-     * Method that will be called if this service will be disposed
+     * This method is used by the framework during de-activation of the service.
+     * It is called while the component is still activated.
+     *
+     * Code depending on an activated service should go here.
+     *
+     * See {@link #deactivate()}, {@link #initialize()}
      */
     default void dispose() {
-        deactivate();
     }
 }

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -34,6 +34,7 @@
 		<bundle dependency="true">mvn:tech.units/indriya/2.2</bundle>
 		<bundle dependency="true">mvn:tech.uom.lib/uom-lib-common/2.2</bundle>
 		<bundle dependency="true">mvn:org.apiguardian/apiguardian-api/1.1.2</bundle>
+		<bundle dependency="true">mvn:org.osgi/org.osgi.service.component.annotations/1.5.0</bundle>
 
 		<!-- TODO: Unbundled libraries -->
 		<bundle dependency="true">mvn:com.thoughtworks.xstream/xstream/1.4.20</bundle>

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -71,4 +71,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.config.discovery.mdns
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.config.discovery.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.tests/itest.bndrun
@@ -73,4 +73,5 @@ Fragment-Host: org.openhab.core.config.discovery
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/itest.bndrun
@@ -82,4 +82,5 @@ Provide-Capability: \
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.io.rest.core.tests/itest.bndrun
@@ -105,4 +105,6 @@ Fragment-Host: org.openhab.core.io.rest.core
 	org.openhab.core.semantics;version='[4.2.0,4.2.1)',\
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
-	org.openhab.core.transform;version='[4.2.0,4.2.1)'
+	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -110,7 +110,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.model.item.tests;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.persistence;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.rule;version='[4.2.0,4.2.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.sitemap;version='[4.2.0,4.2.1)',\
@@ -120,4 +119,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.openhab.core.voice;version='[4.2.0,4.2.1)'
+	org.openhab.core.voice;version='[4.2.0,4.2.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -123,4 +123,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.openhab.core.voice;version='[4.2.0,4.2.1)'
+	org.openhab.core.voice;version='[4.2.0,4.2.1)',\
+	org.openhab.core.model.item.runtime;version='[4.2.0,4.2.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -116,7 +116,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.model.item;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.persistence;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.rule;version='[4.2.0,4.2.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script.tests;version='[4.2.0,4.2.1)',\
@@ -127,4 +126,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.openhab.core.voice;version='[4.2.0,4.2.1)'
+	org.openhab.core.voice;version='[4.2.0,4.2.1)',\
+	org.openhab.core.model.item.runtime;version='[4.2.0,4.2.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -116,7 +116,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.model.item.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.persistence;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.rule;version='[4.2.0,4.2.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.script.runtime;version='[4.2.0,4.2.1)',\
 	org.openhab.core.model.sitemap;version='[4.2.0,4.2.1)',\
@@ -129,4 +128,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.openhab.core.voice;version='[4.2.0,4.2.1)'
+	org.openhab.core.voice;version='[4.2.0,4.2.1)',\
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.storage.json.tests/itest.bndrun
+++ b/itests/org.openhab.core.storage.json.tests/itest.bndrun
@@ -67,4 +67,5 @@ Fragment-Host: org.openhab.core.storage.json
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.thing.tests/itest.bndrun
@@ -74,4 +74,5 @@ Fragment-Host: org.openhab.core.thing
 	org.openhab.core.test;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.thing.tests;version='[4.2.0,4.2.1)',\
-	org.openhab.core.transform;version='[4.2.0,4.2.1)'
+	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.voice.tests/itest.bndrun
+++ b/itests/org.openhab.core.voice.tests/itest.bndrun
@@ -79,4 +79,5 @@ Fragment-Host: org.openhab.core.voice
 	org.openhab.core.thing;version='[4.2.0,4.2.1)',\
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
 	org.openhab.core.voice;version='[4.2.0,4.2.1)',\
-	org.openhab.core.voice.tests;version='[4.2.0,4.2.1)'
+	org.openhab.core.voice.tests;version='[4.2.0,4.2.1)',\
+	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)'


### PR DESCRIPTION
Supersedes #1941 

Since Connor is no longer available I decided to pick up the PR and enhance it. A very good example why we should go this way is https://github.com/openhab/openhab-addons/pull/16037. It implements a `TheKeyTranslationProvider.java` just to pass it from the handler factory to the thing handler and then to the `ThinghandlerService` for localization of the discovery results. There is already similar code in the repository. This is only necessary because we can't inject OSGi services directly to the discovery services.

I started with two implementations in openhab-addons (https://github.com/openhab/openhab-addons/pull/16107) and would like to hear comments from @openhab/core-maintainers before I start a bigger refactoring in openhab-addons.