### PR TITLE
Fix duplicate UIDs in remote add-on services

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -131,8 +131,26 @@ public class JsonAddonService extends AbstractRemoteAddonService {
             } catch (IOException e) {
                 return List.of();
             }
-        }).flatMap(List::stream).filter(Objects::nonNull).map(e -> (AddonEntryDTO) e)
-                .filter(e -> showUnstable || "stable".equals(e.maturity)).map(this::fromAddonEntry).toList();
+        }).flatMap(List::stream).filter(Objects::nonNull).map(e -> (AddonEntryDTO) e).filter(this::showAddon)
+                .map(this::fromAddonEntry).toList();
+    }
+
+    /**
+     * Check if the addon UID is present and the entry is eitehr stable or unstable add-ons are requested
+     *
+     * @param addonEntry the add-on entry to check
+     * @return {@code true} if the add-on entry should be processed, {@code false otherwise}
+     */
+    private boolean showAddon(AddonEntryDTO addonEntry) {
+        if (addonEntry.uid.isBlank()) {
+            logger.debug("Skipping {} because the UID is not set", addonEntry);
+            return false;
+        }
+        if (!showUnstable && !"stable".equals(addonEntry.maturity)) {
+            logger.debug("Skipping {} because the the add-on is not stable and showUnstable is disabled.", addonEntry);
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -13,11 +13,9 @@
 package org.openhab.core.addon.marketplace;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openhab.core.addon.marketplace.AbstractRemoteAddonService.CONFIG_REMOTE_ENABLED;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.ALL_ADDON_COUNT;
 import static org.openhab.core.addon.marketplace.test.TestAddonService.COMPATIBLE_ADDON_COUNT;
@@ -31,6 +29,7 @@ import java.io.IOException;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;
@@ -254,6 +253,27 @@ public class AbstractRemoteAddonServiceTest {
         addonService.uninstall(TEST_ADDON);
 
         checkResult(TEST_ADDON, getFullAddonId(TEST_ADDON) + "/failed", false, true);
+    }
+
+    // add-comparisons
+    @Test
+    public void testAddonOrdering() {
+        Addon addon1 = getMockedAddon("4.1.0", false);
+        Addon addon2 = getMockedAddon("4.2.0", true);
+        Addon addon3 = getMockedAddon("4.1.4", false);
+        Addon addon4 = getMockedAddon("4.2.1", true);
+        List<Addon> actual = Stream.of(addon1, addon2, addon3, addon4)
+                .sorted(AbstractRemoteAddonService.BY_COMPATIBLE_AND_VERSION).toList();
+        List<Addon> expected = List.of(addon4, addon2, addon3, addon1);
+
+        assertThat(actual, is(equalTo(expected)));
+    }
+
+    private Addon getMockedAddon(String version, boolean compatible) {
+        Addon addon = mock(Addon.class);
+        when(addon.getVersion()).thenReturn(version);
+        when(addon.getCompatible()).thenReturn(compatible);
+        return addon;
     }
 
     /**


### PR DESCRIPTION
Missing UIDs or multiple versions of the same add-on resulted in duplicate entries for the community marketplace or JSON add-on service. With this fix add-ons with missing UID (i.e. from versions pre-4.0, before UIDs were introduced in the JSON) are now discarded and duplicate UIDs are filtered, with compatible add-ons and - if same compatibility - higher version being preferred. This is mostly a bug-fix, but also necessary for the upcoming multi-version community-marketplace add-ons I'm working on (see #3852). Since it affects users I suggest to also back-port it to `4.1.x`.