### PR TITLE
Remove unnecessary parenthesis from lambdas

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -120,7 +120,7 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
         AudioSink sink = getSink(sinkId);
         if (sink != null) {
             Runnable restoreVolume = handleVolumeCommand(volume, sink);
-            sink.processAndComplete(audioStream).exceptionally((exception) -> {
+            sink.processAndComplete(audioStream).exceptionally(exception -> {
                 logger.warn("Error playing '{}': {}", audioStream, exception.getMessage(), exception);
                 return null;
             }).thenRun(restoreVolume);

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
@@ -43,8 +43,7 @@ public class ConfigurableServiceUtilTest {
         properties.put(SERVICE_PROPERTY_FACTORY_SERVICE, factory);
         properties.put(SERVICE_PROPERTY_LABEL, label);
 
-        ConfigurableService configurableService = ConfigurableServiceUtil
-                .asConfigurableService((key) -> properties.get(key));
+        ConfigurableService configurableService = ConfigurableServiceUtil.asConfigurableService(properties::get);
 
         assertThat(configurableService.annotationType(), is(ConfigurableService.class));
         assertThat(configurableService.category(), is(category));
@@ -57,8 +56,7 @@ public class ConfigurableServiceUtilTest {
     public void asConfigurableServiceUndefinedProperties() {
         Properties properties = new Properties();
 
-        ConfigurableService configurableService = ConfigurableServiceUtil
-                .asConfigurableService((key) -> properties.get(key));
+        ConfigurableService configurableService = ConfigurableServiceUtil.asConfigurableService(properties::get);
 
         assertThat(configurableService.annotationType(), is(ConfigurableService.class));
         assertThat(configurableService.category(), is(emptyString()));

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -296,7 +296,7 @@ public class ConfigurableServiceResource implements RESTResource {
             for (ServiceReference<?> serviceReference : serviceReferences) {
                 String id = getServiceId(serviceReference);
                 ConfigurableService configurableService = ConfigurableServiceUtil
-                        .asConfigurableService((key) -> serviceReference.getProperty(key));
+                        .asConfigurableService(serviceReference::getProperty);
 
                 String defaultLabel = configurableService.label();
                 if (defaultLabel.isEmpty()) { // for multi context services the label can be changed and must be read
@@ -336,7 +336,7 @@ public class ConfigurableServiceResource implements RESTResource {
 
             if (refs != null && refs.length > 0) {
                 ConfigurableService configurableService = ConfigurableServiceUtil
-                        .asConfigurableService((key) -> refs[0].getProperty(key));
+                        .asConfigurableService(key -> refs[0].getProperty(key));
                 configDescriptionURI = configurableService.description_uri();
             }
         } catch (InvalidSyntaxException e) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -665,7 +665,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     protected void removeAudioSink(AudioSink audioSink) {
-        stopDialogs((dialog) -> dialog.dialogContext.sink().getId().equals(audioSink.getId()));
+        stopDialogs(dialog -> dialog.dialogContext.sink().getId().equals(audioSink.getId()));
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -674,7 +674,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
     }
 
     protected void removeAudioSource(AudioSource audioSource) {
-        stopDialogs((dialog) -> dialog.dialogContext.source().getId().equals(audioSource.getId()));
+        stopDialogs(dialog -> dialog.dialogContext.source().getId().equals(audioSource.getId()));
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -685,7 +685,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
 
     protected void removeKSService(KSService ksService) {
         this.ksServices.remove(ksService.getId());
-        stopDialogs((dialog) -> {
+        stopDialogs(dialog -> {
             var ks = dialog.dialogContext.ks();
             return ks != null && ks.getId().equals(ksService.getId());
         });
@@ -699,7 +699,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
 
     protected void removeSTTService(STTService sttService) {
         this.sttServices.remove(sttService.getId());
-        stopDialogs((dialog) -> dialog.dialogContext.stt().getId().equals(sttService.getId()));
+        stopDialogs(dialog -> dialog.dialogContext.stt().getId().equals(sttService.getId()));
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -710,7 +710,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
 
     protected void removeTTSService(TTSService ttsService) {
         this.ttsServices.remove(ttsService.getId());
-        stopDialogs((dialog) -> dialog.dialogContext.tts().getId().equals(ttsService.getId()));
+        stopDialogs(dialog -> dialog.dialogContext.tts().getId().equals(ttsService.getId()));
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -721,7 +721,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
 
     protected void removeHumanLanguageInterpreter(HumanLanguageInterpreter humanLanguageInterpreter) {
         this.humanLanguageInterpreters.remove(humanLanguageInterpreter.getId());
-        stopDialogs((dialog) -> dialog.dialogContext.hlis().stream()
+        stopDialogs(dialog -> dialog.dialogContext.hlis().stream()
                 .anyMatch(hli -> hli.getId().equals(humanLanguageInterpreter.getId())));
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -1002,7 +1002,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
     @Nullable
     private Item filterMatchedItemsByLocation(Map<Item, ItemInterpretationMetadata> itemsData, String locationContext) {
         var itemsFilteredByLocation = itemsData.entrySet().stream()
-                .filter((entry) -> entry.getValue().locationParentNames.contains(locationContext)).toList();
+                .filter(entry -> entry.getValue().locationParentNames.contains(locationContext)).toList();
         if (itemsFilteredByLocation.size() != 1) {
             return null;
         }
@@ -1015,7 +1015,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         String name = item.getName();
         boolean insert = items.keySet().stream().noneMatch(i -> name.startsWith(i.getName()));
         if (insert) {
-            items.keySet().removeIf((matchedItem) -> matchedItem.getName().startsWith(name));
+            items.keySet().removeIf(matchedItem -> matchedItem.getName().startsWith(name));
             items.put(item, interpretationMetadata);
         }
     }
@@ -1244,7 +1244,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
             throw new ParseException("The character '|' can not be used alone", 0);
         }
         Expression expression = seq(tokenText.contains("|") ? alt(Arrays.stream(tokenText.split("\\|"))//
-                .filter((s) -> !s.isBlank()).toArray()) : tokenText);
+                .filter(s -> !s.isBlank()).toArray()) : tokenText);
         if (optional) {
             return opt(expression);
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -123,7 +123,7 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ScheduledExecutorService getScheduledPool(String poolName) {
-        ExecutorService pool = pools.computeIfAbsent(poolName, (name) -> {
+        ExecutorService pool = pools.computeIfAbsent(poolName, name -> {
             int cfg = getConfig(name);
             ScheduledThreadPoolExecutor executor = new WrappedScheduledExecutorService(cfg,
                     new NamedThreadFactory(name, true, Thread.NORM_PRIORITY));
@@ -149,7 +149,7 @@ public class ThreadPoolManager {
      * @return an instance to use
      */
     public static ExecutorService getPool(String poolName) {
-        ExecutorService pool = pools.computeIfAbsent(poolName, (name) -> {
+        ExecutorService pool = pools.computeIfAbsent(poolName, name -> {
             int cfg = getConfig(name);
             ThreadPoolExecutor executor = QueueingThreadPoolExecutor.createInstance(name, cfg);
             executor.setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronAdjuster.java
@@ -277,7 +277,7 @@ public class CronAdjuster implements SchedulerTemporalAdjuster {
                 return CronAdjuster::isLastWorkingDayInMonth;
             } else if (sub.endsWith("W")) {
                 final int n = parseInt(cronExpression, chronoField, sub.substring(0, sub.length() - 1));
-                return (temporal) -> isNearestWorkDay(temporal, n);
+                return temporal -> isNearestWorkDay(temporal, n);
             }
             // fall through, it is a normal expression
         }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheTest.java
@@ -271,7 +271,7 @@ public class LRUMediaCacheTest {
             file2Writer.write("falsedata");
         }
         when(storage.stream())
-                .thenAnswer((invocation) -> Stream.of(new AbstractMap.SimpleImmutableEntry("key1", metadataSample1),
+                .thenAnswer(invocation -> Stream.of(new AbstractMap.SimpleImmutableEntry("key1", metadataSample1),
                         new AbstractMap.SimpleImmutableEntry("key2", metadataSample2)));
 
         // create a LRU cache that will use the above data
@@ -322,7 +322,7 @@ public class LRUMediaCacheTest {
 
         // prepare storage map for stream operation
         when(storage.stream())
-                .thenAnswer((invocation) -> Stream.of(new AbstractMap.SimpleImmutableEntry("key1", metadataSample1),
+                .thenAnswer(invocation -> Stream.of(new AbstractMap.SimpleImmutableEntry("key1", metadataSample1),
                         new AbstractMap.SimpleImmutableEntry("key2", metadataSample2)));
 
         // prepare some files : orphan file
@@ -386,7 +386,7 @@ public class LRUMediaCacheTest {
     public void faultyStreamTest() throws IOException {
         MetadataSample metadata = new MetadataSample("meta1", 42);
 
-        when(supplier.get()).thenAnswer((invocation) -> new LRUMediaCacheEntry<>("key", inputStreamMock, metadata));
+        when(supplier.get()).thenAnswer(invocation -> new LRUMediaCacheEntry<>("key", inputStreamMock, metadata));
         // In this test the stream will return two bytes of data, then an empty stream so signal its end.
         // it will be called twice, so return it twice
         when(inputStreamMock.readNBytes(any(Integer.class))).thenReturn(new byte[2], new byte[0], new byte[2],


### PR DESCRIPTION
These parentheses do not change the meaning of the code and also do not improve the readability.