### PR TITLE
Remove unnecessary boxing

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -428,7 +428,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     private boolean getAutoDiscoveryEnabled(Object autoDiscoveryEnabled) {
         if (autoDiscoveryEnabled instanceof String string) {
-            return Boolean.valueOf(string);
+            return Boolean.parseBoolean(string);
         } else {
             return Boolean.TRUE.equals(autoDiscoveryEnabled);
         }

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -281,7 +281,7 @@ public class HttpUtil {
             String proxyPortString = System.getProperty("http.proxyPort");
             if (proxyPortString != null && !proxyPortString.isBlank()) {
                 try {
-                    proxyParams.proxyPort = Integer.valueOf(proxyPortString);
+                    proxyParams.proxyPort = Integer.parseInt(proxyPortString);
                 } catch (NumberFormatException e) {
                     LOGGER.warn("'{}' is not a valid proxy port - using default port ({}) instead", proxyPortString,
                             proxyParams.proxyPort);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -605,7 +605,7 @@ public class ThingResource implements RESTResource {
             return getThingNotFoundResponse(thingUID);
         }
 
-        thingManager.setEnabled(thingUIDObject, Boolean.valueOf(enabled));
+        thingManager.setEnabled(thingUIDObject, Boolean.parseBoolean(enabled));
 
         // everything went well
         return getThingResponse(Status.OK, thing, locale, null);

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttWillAndTestament.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttWillAndTestament.java
@@ -72,14 +72,14 @@ public class MqttWillAndTestament {
                         break;
                     case 2:
                         if (!"".equals(value)) {
-                            int tmp = Integer.valueOf(value);
+                            int tmp = Integer.parseInt(value);
                             if (tmp >= 0 && tmp <= 2) {
                                 tmpQos = tmp;
                             }
                         }
                         break;
                     case 3:
-                        tmpRetain = Boolean.valueOf(value);
+                        tmpRetain = Boolean.parseBoolean(value);
                         break;
                 }
             }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
@@ -76,7 +76,7 @@ public class SystemHysteresisStateProfile implements StateProfile {
         this.upper = convertedUpperParam;
 
         final Object paramValue = context.getConfiguration().get(INVERTED_PARAM);
-        final boolean inverted = paramValue == null ? false : Boolean.valueOf(paramValue.toString());
+        final boolean inverted = paramValue != null && Boolean.parseBoolean(paramValue.toString());
         this.low = OnOffType.from(inverted);
         this.high = OnOffType.from(!inverted);
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
@@ -83,7 +83,7 @@ public class SystemRangeStateProfile implements StateProfile {
         this.upper = convertedUpperParam;
 
         final Object paramValue = context.getConfiguration().get(INVERTED_PARAM);
-        final boolean inverted = paramValue == null ? false : Boolean.valueOf(paramValue.toString());
+        final boolean inverted = paramValue != null && Boolean.parseBoolean(paramValue.toString());
         this.inRange = OnOffType.from(!inverted);
         this.notInRange = OnOffType.from(inverted);
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
@@ -61,7 +61,7 @@ public class TimestampOffsetProfile implements StateProfile {
         if (offsetParam instanceof Number bd) {
             offset = Duration.ofSeconds(bd.longValue());
         } else if (offsetParam instanceof String s) {
-            offset = Duration.ofSeconds(Long.valueOf(s));
+            offset = Duration.ofSeconds(Long.parseLong(s));
         } else {
             logger.error(
                     "Parameter '{}' is not of type String or Number. Please make sure it is one of both, e.g. 3 or \"-1\".",

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
@@ -73,7 +73,7 @@ public class StateDescriptionConverter extends GenericUnmarshaller<StateDescript
 
     private boolean toBoolean(Map<String, String> attributes, String attribute, boolean defaultValue) {
         String attrValueText = attributes.get(attribute);
-        return attrValueText == null ? defaultValue : Boolean.valueOf(attrValueText);
+        return attrValueText == null ? defaultValue : Boolean.parseBoolean(attrValueText);
     }
 
     private List<StateOption> toListOfChannelState(NodeList nodeList) throws ConversionException {

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
@@ -88,9 +88,9 @@ public abstract class AbstractResourceIconProvider implements IconProvider {
         } else {
             // let's treat all percentage-based categories
             try {
-                Double stateAsDouble = Double.valueOf(iconState);
+                double stateAsDouble = Double.parseDouble(iconState);
                 if (stateAsDouble >= 0 && stateAsDouble <= 100) {
-                    for (int i = stateAsDouble.intValue(); i >= 0; i--) {
+                    for (int i = (int) stateAsDouble; i >= 0; i--) {
                         String resourceWithNumberState = category.toLowerCase() + "-" + i + "."
                                 + format.toString().toLowerCase();
                         if (hasResource(iconSetId, resourceWithNumberState)) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -320,7 +320,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             Object normalizedValue = ConfigUtil.normalizeType(value);
             if (widgetImpl.eGet(feature, false, false) instanceof Integer) {
                 normalizedValue = (normalizedValue instanceof BigDecimal bd) ? bd.intValue()
-                        : Integer.valueOf(normalizedValue.toString());
+                        : Integer.parseInt(normalizedValue.toString());
             } else if (widgetImpl.eGet(feature, false, false) instanceof Boolean
                     && !(normalizedValue instanceof Boolean)) {
                 normalizedValue = Boolean.valueOf(normalizedValue.toString());
@@ -337,7 +337,7 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
             return;
         }
         Object staticIcon = component.getConfig().get("staticIcon");
-        if (staticIcon != null && Boolean.valueOf(ConfigUtil.normalizeType(staticIcon).toString())) {
+        if (staticIcon != null && Boolean.parseBoolean(ConfigUtil.normalizeType(staticIcon).toString())) {
             setWidgetPropertyFromComponentConfig(widget, component, "icon", SitemapPackage.WIDGET__STATIC_ICON);
             return;
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -591,7 +591,7 @@ public class NetUtil implements NetworkAddressService {
             return boolean1;
         }
         if (value instanceof String string) {
-            return Boolean.valueOf(string);
+            return Boolean.parseBoolean(string);
         } else {
             return defaultValue;
         }


### PR DESCRIPTION
Using primitives makes the code faster and consume less memory.