### PR TITLE
[rest] Add `no-cache` directive to cached REST responses

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -188,6 +188,7 @@ public class RuleResource implements RESTResource {
                     .map(rule -> EnrichedRuleDTOMapper.map(rule, ruleManager, managedRuleProvider));
 
             CacheControl cc = new CacheControl();
+            cc.setNoCache(true);
             cc.setMustRevalidate(true);
             cc.setPrivate(true);
             rules = dtoMapper.limitToFields(rules, "uid,templateUID,name,visibility,description,tags,editable");

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -271,6 +271,7 @@ public class ItemResource implements RESTResource {
                     "name,label,type,groupType,function,category,editable,groupNames,link,tags,metadata,commandDescription,stateDescription");
 
             CacheControl cc = new CacheControl();
+            cc.setNoCache(true);
             cc.setMustRevalidate(true);
             cc.setPrivate(true);
             return Response.ok(new Stream2JSONInputStream(itemStream)).lastModified(lastModifiedDate).cacheControl(cc)

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
@@ -133,6 +133,7 @@ public class TagResource implements RESTResource {
         }
 
         CacheControl cc = new CacheControl();
+        cc.setNoCache(true);
         cc.setMustRevalidate(true);
         cc.setPrivate(true);
 
@@ -165,6 +166,7 @@ public class TagResource implements RESTResource {
         }
 
         CacheControl cc = new CacheControl();
+        cc.setNoCache(true);
         cc.setMustRevalidate(true);
         cc.setPrivate(true);
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -328,6 +328,7 @@ public class ThingResource implements RESTResource {
             }
 
             CacheControl cc = new CacheControl();
+            cc.setNoCache(true);
             cc.setMustRevalidate(true);
             cc.setPrivate(true);
             thingStream = dtoMapper.limitToFields(thingStream, "UID,label,bridgeUID,thingTypeUID,location,editable");

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
@@ -168,6 +168,7 @@ public class UIResource implements RESTResource {
             }
 
             CacheControl cc = new CacheControl();
+            cc.setNoCache(true);
             cc.setMustRevalidate(true);
             cc.setPrivate(true);
             return Response.ok(new Stream2JSONInputStream(components)).lastModified(lastModifiedDate).cacheControl(cc)

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
@@ -119,6 +119,7 @@ public class SystemInfoResource implements RESTResource, ConfigurationListener {
         }
 
         CacheControl cc = new CacheControl();
+        cc.setNoCache(true);
         cc.setMustRevalidate(true);
         cc.setPrivate(true);
 


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/2102, where Firefox users reported problems with outdated data in Main UI due to Firefox handling caching different than Chromium.
Also reported on the community, e.g. https://community.openhab.org/t/firefox-oh-4-0-1-issues/148633 and https://community.openhab.org/t/updating-widget-code-not-working/148265.

This forces the browser to revalidate the cache every time it is accessed to ensure the data is always fresh. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#directives.

This is approach is also suggested in the mdn web docs, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#up-to-date_contents_always.

This PR should be backported to 4.1.x.