### PR TITLE
Replace lambdas with method references

### DIFF
--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonDiscoveryMethodConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonDiscoveryMethodConverter.java
@@ -49,11 +49,11 @@ public class AddonDiscoveryMethodConverter extends GenericUnmarshaller<AddonDisc
 
         Object paramObject = nodeIterator.nextList("discovery-parameters", false);
         List<AddonParameter> parameters = !(paramObject instanceof List<?> list) ? null
-                : list.stream().filter(e -> (e instanceof AddonParameter)).map(e -> ((AddonParameter) e)).toList();
+                : list.stream().filter(AddonParameter.class::isInstance).map(e -> ((AddonParameter) e)).toList();
 
         Object matchPropObject = nodeIterator.nextList("match-properties", false);
         List<AddonMatchProperty> matchProperties = !(matchPropObject instanceof List<?> list) ? null
-                : list.stream().filter(e -> (e instanceof AddonMatchProperty)).map(e -> ((AddonMatchProperty) e))
+                : list.stream().filter(AddonMatchProperty.class::isInstance).map(e -> ((AddonMatchProperty) e))
                         .toList();
 
         nodeIterator.assertEndOfType();

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoConverter.java
@@ -111,7 +111,7 @@ public class AddonInfoConverter extends GenericUnmarshaller<AddonInfoXmlResult> 
 
         Object object = nodeIterator.nextList("discovery-methods", false);
         addonInfo.withDiscoveryMethods(!(object instanceof List<?> list) ? null
-                : list.stream().filter(e -> (e instanceof AddonDiscoveryMethod)).map(e -> ((AddonDiscoveryMethod) e))
+                : list.stream().filter(AddonDiscoveryMethod.class::isInstance).map(e -> ((AddonDiscoveryMethod) e))
                         .toList());
 
         nodeIterator.assertEndOfType();

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListConverter.java
@@ -13,6 +13,7 @@
 package org.openhab.core.addon.internal.xml;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -46,8 +47,8 @@ public class AddonInfoListConverter extends GenericUnmarshaller<AddonInfoList> {
 
         Object object = nodeIterator.nextList("addons", false);
         List<AddonInfo> addons = (object instanceof List<?> list)
-                ? list.stream().filter(e -> e != null).filter(e -> (e instanceof AddonInfoXmlResult))
-                        .map(e -> (AddonInfoXmlResult) e).map(r -> r.addonInfo()).toList()
+                ? list.stream().filter(Objects::nonNull).filter(AddonInfoXmlResult.class::isInstance)
+                        .map(e -> (AddonInfoXmlResult) e).map(AddonInfoXmlResult::addonInfo).toList()
                 : null;
 
         nodeIterator.assertEndOfType();

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -102,7 +102,7 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     @Deactivate
     protected synchronized void deactivate() {
-        servedStreams.values().stream().map(streamServed -> streamServed.audioStream()).forEach(this::tryClose);
+        servedStreams.values().stream().map(StreamServed::audioStream).forEach(this::tryClose);
         servedStreams.clear();
     }
 

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
@@ -148,7 +148,7 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
                     options.add(new ParameterOption(fileName, capitalizedSoundName));
                 }
             }
-            options.sort(comparing(o -> o.getLabel()));
+            options.sort(comparing(ParameterOption::getLabel));
         }
         return options;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -78,8 +78,8 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
     }
 
     private Collection<ParameterOption> processTimeZoneParam() {
-        Comparator<TimeZone> byOffset = (t1, t2) -> t1.getRawOffset() - t2.getRawOffset();
-        Comparator<TimeZone> byID = (t1, t2) -> t1.getID().compareTo(t2.getID());
+        Comparator<TimeZone> byOffset = Comparator.comparingInt(TimeZone::getRawOffset);
+        Comparator<TimeZone> byID = Comparator.comparing(TimeZone::getID);
         return ZoneId.getAvailableZoneIds().stream().map(TimeZone::getTimeZone).sorted(byOffset.thenComparing(byID))
                 .map(tz -> new ParameterOption(tz.getID(), getTimeZoneRepresentation(tz))).toList();
     }
@@ -105,7 +105,7 @@ public class I18nConfigOptionsProvider implements ConfigOptionProvider {
                 .map(mapFunction) //
                 .distinct() //
                 .filter(po -> !po.getValue().isEmpty()) //
-                .sorted(Comparator.comparing(a -> a.getLabel())) //
+                .sorted(Comparator.comparing(ParameterOption::getLabel)) //
                 .toList();
     }
 }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
@@ -17,6 +17,7 @@ import java.math.BigDecimal;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
+import org.openhab.core.config.core.ParameterOption;
 import org.openhab.core.config.core.validation.ConfigValidationMessage;
 
 /**
@@ -42,7 +43,8 @@ final class OptionsValidator implements ConfigDescriptionParameterValidator {
             invalid = param.getOptions().stream().map(o -> new BigDecimal(o.getValue()))
                     .noneMatch(v -> v.compareTo(bdValue) == 0);
         } else {
-            invalid = param.getOptions().stream().map(o -> o.getValue()).noneMatch(v -> v.equals(value.toString()));
+            invalid = param.getOptions().stream().map(ParameterOption::getValue)
+                    .noneMatch(v -> v.equals(value.toString()));
         }
 
         if (invalid) {

--- a/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
@@ -45,6 +45,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.addon.AddonDiscoveryMethod;
 import org.openhab.core.addon.AddonInfo;
+import org.openhab.core.addon.AddonMatchProperty;
+import org.openhab.core.addon.AddonParameter;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.discovery.addon.AddonFinder;
 import org.openhab.core.config.discovery.addon.BaseAddonFinder;
@@ -196,9 +198,9 @@ public class IpAddonFinder extends BaseAddonFinder {
                 logger.trace("Checking candidate: {}", candidate.getUID());
 
                 Map<String, String> parameters = method.getParameters().stream()
-                        .collect(Collectors.toMap(property -> property.getName(), property -> property.getValue()));
+                        .collect(Collectors.toMap(AddonParameter::getName, AddonParameter::getValue));
                 Map<String, String> matchProperties = method.getMatchProperties().stream()
-                        .collect(Collectors.toMap(property -> property.getName(), property -> property.getRegex()));
+                        .collect(Collectors.toMap(AddonMatchProperty::getName, AddonMatchProperty::getRegex));
 
                 // parse standard set of parameters
                 String type = Objects.toString(parameters.get("type"), "");

--- a/bundles/org.openhab.core.config.discovery.addon.mdns/src/main/java/org/openhab/core/config/discovery/addon/mdns/MDNSAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.mdns/src/main/java/org/openhab/core/config/discovery/addon/mdns/MDNSAddonFinder.java
@@ -31,6 +31,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.addon.AddonDiscoveryMethod;
 import org.openhab.core.addon.AddonInfo;
+import org.openhab.core.addon.AddonMatchProperty;
+import org.openhab.core.addon.AddonParameter;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.config.discovery.addon.AddonFinder;
 import org.openhab.core.config.discovery.addon.BaseAddonFinder;
@@ -127,7 +129,7 @@ public class MDNSAddonFinder extends BaseAddonFinder implements ServiceListener 
             for (AddonDiscoveryMethod method : candidate.getDiscoveryMethods().stream()
                     .filter(method -> SERVICE_TYPE.equals(method.getServiceType())).toList()) {
                 Map<String, Pattern> matchProperties = method.getMatchProperties().stream()
-                        .collect(Collectors.toMap(property -> property.getName(), property -> property.getPattern()));
+                        .collect(Collectors.toMap(AddonMatchProperty::getName, AddonMatchProperty::getPattern));
 
                 Set<String> matchPropertyKeys = matchProperties.keySet().stream()
                         .filter(property -> (!NAME.equals(property) && !APPLICATION.equals(property)))
@@ -154,7 +156,7 @@ public class MDNSAddonFinder extends BaseAddonFinder implements ServiceListener 
 
     private String getMdnsServiceType(AddonDiscoveryMethod method) {
         String param = method.getParameters().stream().filter(p -> MDNS_SERVICE_TYPE.equals(p.getName()))
-                .map(p -> p.getValue()).findFirst().orElse("");
+                .map(AddonParameter::getValue).findFirst().orElse("");
         return param == null ? "" : param;
     }
 

--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
@@ -39,6 +39,7 @@ import org.jupnp.registry.Registry;
 import org.jupnp.registry.RegistryListener;
 import org.openhab.core.addon.AddonDiscoveryMethod;
 import org.openhab.core.addon.AddonInfo;
+import org.openhab.core.addon.AddonMatchProperty;
 import org.openhab.core.config.discovery.addon.AddonFinder;
 import org.openhab.core.config.discovery.addon.BaseAddonFinder;
 import org.osgi.service.component.annotations.Activate;
@@ -126,7 +127,7 @@ public class UpnpAddonFinder extends BaseAddonFinder implements RegistryListener
             for (AddonDiscoveryMethod method : candidate.getDiscoveryMethods().stream()
                     .filter(method -> SERVICE_TYPE.equals(method.getServiceType())).toList()) {
                 Map<String, Pattern> matchProperties = method.getMatchProperties().stream()
-                        .collect(Collectors.toMap(property -> property.getName(), property -> property.getPattern()));
+                        .collect(Collectors.toMap(AddonMatchProperty::getName, AddonMatchProperty::getPattern));
 
                 Set<String> propertyNames = new HashSet<>(matchProperties.keySet());
                 propertyNames.removeAll(SUPPORTED_PROPERTIES);

--- a/bundles/org.openhab.core.config.discovery.addon.usb/src/main/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.usb/src/main/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinder.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.addon.AddonDiscoveryMethod;
 import org.openhab.core.addon.AddonInfo;
+import org.openhab.core.addon.AddonMatchProperty;
 import org.openhab.core.config.discovery.addon.AddonFinder;
 import org.openhab.core.config.discovery.addon.BaseAddonFinder;
 import org.openhab.core.config.discovery.usbserial.UsbSerialDeviceInformation;
@@ -39,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This is a {@link USBAddonFinder} for finding suggested add-ons related to USB devices.
+ * This is a {@link AddonFinder} for finding suggested add-ons related to USB devices.
  * <p>
  * It supports the following values for the 'match-property' 'name' element:
  * <li>product - match on the product description text
@@ -89,7 +90,7 @@ public class UsbAddonFinder extends BaseAddonFinder implements UsbSerialDiscover
             for (AddonDiscoveryMethod method : candidate.getDiscoveryMethods().stream()
                     .filter(method -> SERVICE_TYPE.equals(method.getServiceType())).toList()) {
                 Map<String, Pattern> matchProperties = method.getMatchProperties().stream()
-                        .collect(Collectors.toMap(property -> property.getName(), property -> property.getPattern()));
+                        .collect(Collectors.toMap(AddonMatchProperty::getName, AddonMatchProperty::getPattern));
 
                 Set<String> propertyNames = new HashSet<>(matchProperties.keySet());
                 propertyNames.removeAll(SUPPORTED_PROPERTIES);

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -482,7 +482,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
                 this.args = null;
             } else {
                 this.args = Arrays.stream(parts[1].replaceAll("\\[|\\]|\"", "").split(","))
-                        .filter(s -> s != null && !s.isBlank()).map(s -> s.trim()).toArray(Object[]::new);
+                        .filter(s -> s != null && !s.isBlank()).map(String::trim).toArray(Object[]::new);
             }
         }
     }

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
@@ -229,12 +229,7 @@ public class ConfigDispatcher {
             File[] files = dir.listFiles();
             // Sort the files by modification time,
             // so that the last modified file is processed last.
-            Arrays.sort(files, new Comparator<File>() {
-                @Override
-                public int compare(File left, File right) {
-                    return Long.compare(left.lastModified(), right.lastModified());
-                }
-            });
+            Arrays.sort(files, Comparator.comparingLong(File::lastModified));
             for (File file : files) {
                 try {
                     internalProcessConfigFile(file);
@@ -440,7 +435,7 @@ public class ConfigDispatcher {
                         .replace(DEFAULT_LIST_STARTING_CHARACTER, "") //
                         .replace(DEFAULT_LIST_ENDING_CHARACTER, "")//
                         .split(DEFAULT_LIST_DELIMITER))//
-                        .map(v -> v.trim())//
+                        .map(String::trim)//
                         .filter(v -> !v.isEmpty())//
                         .toList();
                 return new ParseLineResult(pid, property.trim(), values);
@@ -537,7 +532,7 @@ public class ConfigDispatcher {
          * @return the list of PIDs which where not processed either during #activate or on file deleted event.
          */
         public List<String> getOrphanPIDs() {
-            return processedPIDMapping.entrySet().stream().filter(e -> e.getValue() == null).map(e -> e.getKey())
+            return processedPIDMapping.entrySet().stream().filter(e -> e.getValue() == null).map(Entry::getKey)
                     .toList();
         }
 
@@ -545,8 +540,8 @@ public class ConfigDispatcher {
          * Set the exclusivePID list to the processed PIDs (mapped path is not null).
          */
         public void setCurrentExclusivePIDList() {
-            exclusivePIDs = processedPIDMapping.entrySet().stream().filter(e -> e.getValue() != null)
-                    .map(e -> e.getKey()).toList();
+            exclusivePIDs = processedPIDMapping.entrySet().stream().filter(e -> e.getValue() != null).map(Entry::getKey)
+                    .toList();
         }
 
         public boolean contains(String pid) {

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleter.java
@@ -50,8 +50,8 @@ public class ItemConsoleCommandCompleter implements ConsoleCommandCompleter {
     @SuppressWarnings("unchecked")
     public boolean complete(String[] args, int cursorArgumentIndex, int cursorPosition, List<String> candidates) {
         if (cursorArgumentIndex <= 0) {
-            return new StringsCompleter(itemRegistry.getAll().stream().map(i -> i.getName()).toList(), true)
-                    .complete(args, cursorArgumentIndex, cursorPosition, candidates);
+            return new StringsCompleter(itemRegistry.getAll().stream().map(Item::getName).toList(), true).complete(args,
+                    cursorArgumentIndex, cursorPosition, candidates);
         }
         var localDataTypeGetter = dataTypeGetter;
         if (cursorArgumentIndex == 1 && localDataTypeGetter != null) {

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtension.java
@@ -72,7 +72,7 @@ public class ItemConsoleCommandExtension extends AbstractConsoleCommandExtension
                     default:
                         return false;
                 }
-                return new StringsCompleter(items.stream().map(i -> i.getName()).toList(), true).complete(args,
+                return new StringsCompleter(items.stream().map(Item::getName).toList(), true).complete(args,
                         cursorArgumentIndex, cursorPosition, candidates);
             }
             if (cursorArgumentIndex == 2 && args[0].equals(SUBCMD_RMTAG)) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
@@ -57,7 +57,7 @@ public class MetadataSelectorMatcher {
         } else {
             Set<String> originalNamespaces = Arrays.stream(namespaceSelector.split(",")) //
                     .filter(n -> !metadataRegistry.isInternalNamespace(n)) //
-                    .map(n -> n.trim()) //
+                    .map(String::trim) //
                     .collect(Collectors.toSet());
 
             Set<String> allMetadataNamespaces = metadataRegistry.getAll().stream() //

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -116,7 +116,7 @@ public class ProfileTypeResource implements RESTResource {
             @Nullable String itemType) {
         return profileTypeRegistry.getProfileTypes(locale).stream().filter(matchesChannelUID(channelTypeUID, locale))
                 .filter(matchesItemType(itemType)).sorted(Comparator.comparing(ProfileType::getLabel))
-                .map(profileType -> ProfileTypeDTOMapper.map(profileType));
+                .map(ProfileTypeDTOMapper::map);
     }
 
     private Predicate<ProfileType> matchesChannelUID(@Nullable String channelTypeUID, @Nullable Locale locale) {

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/BitArray.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/BitArray.java
@@ -118,7 +118,7 @@ public class BitArray implements Iterable<Boolean> {
 
     @Override
     public Iterator<Boolean> iterator() {
-        return IntStream.range(0, size()).mapToObj(i -> getBit(i)).iterator();
+        return IntStream.range(0, size()).mapToObj(this::getBit).iterator();
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ValueBuffer.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ValueBuffer.java
@@ -108,7 +108,7 @@ public class ValueBuffer {
      * @throws InvalidMarkException If the mark has not been set
      */
     public ValueBuffer reset() throws InvalidMarkException {
-        int mark = Optional.ofNullable(this.mark.get()).map(i -> i.get()).orElse(-1);
+        int mark = Optional.ofNullable(this.mark.get()).map(AtomicInteger::get).orElse(-1);
         if (mark < 0) {
             throw new InvalidMarkException();
         }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -205,7 +205,7 @@ public class ModbusManagerImpl implements ModbusManager {
                     request.getFunctionCode(), libRequest.getHexMessage(), operationId);
             // Might throw ModbusIOException (I/O error) or ModbusSlaveException (explicit exception response from
             // slave)
-            timer.transaction.timeRunnableWithModbusException(() -> transaction.execute());
+            timer.transaction.timeRunnableWithModbusException(transaction::execute);
             ModbusResponse response = transaction.getResponse();
             logger.trace("Response for read request (FC={}, transaction ID={}): {} [operation ID {}]",
                     response.getFunctionCode(), response.getTransactionID(), response.getHexMessage(), operationId);
@@ -243,7 +243,7 @@ public class ModbusManagerImpl implements ModbusManager {
 
             // Might throw ModbusIOException (I/O error) or ModbusSlaveException (explicit exception response from
             // slave)
-            timer.transaction.timeRunnableWithModbusException(() -> transaction.execute());
+            timer.transaction.timeRunnableWithModbusException(transaction::execute);
             ModbusResponse response = transaction.getResponse();
             logger.trace("Response for write request (FC={}, transaction ID={}): {} [operation ID {}]",
                     response.getFunctionCode(), response.getTransactionID(), response.getHexMessage(), operationId);

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
@@ -50,7 +50,7 @@ public class ModbusSlaveErrorResponseExceptionImpl extends ModbusSlaveErrorRespo
     @Override
     public @Nullable String getMessage() {
         return String.format("Slave responded with error=%d (%s)", rawCode,
-                exceptionCode.map(c -> c.name()).orElse("unknown error code"));
+                exceptionCode.map(Enum::name).orElse("unknown error code"));
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractIndividualMethodsTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractIndividualMethodsTest.java
@@ -105,7 +105,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
                 type);
         final Object expectedNumber;
         if (expectedResult instanceof Class class1 && Exception.class.isAssignableFrom(class1)) {
-            assertThrows((Class<? extends Throwable>) expectedResult, () -> methodUnderTest.get());
+            assertThrows((Class<? extends Throwable>) expectedResult, methodUnderTest::get);
         } else if (expectedResult instanceof Optional<?> optional) {
             assertTrue(optional.isEmpty());
             if (defaultWhenEmptyOptional == null) {
@@ -128,7 +128,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualSInt16(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex, () -> ModbusBitUtilities.extractSInt16(bytes, byteIndex),
-                decimal -> decimal.shortValue());
+                Number::shortValue);
     }
 
     public static Stream<Object[]> filteredTestDataUInt16() {
@@ -140,7 +140,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualUInt16(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex, () -> ModbusBitUtilities.extractUInt16(bytes, byteIndex),
-                decimal -> decimal.intValue());
+                DecimalType::intValue);
     }
 
     public static Stream<Object[]> filteredTestDataSInt32() {
@@ -152,7 +152,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualSInt32(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex, () -> ModbusBitUtilities.extractSInt32(bytes, byteIndex),
-                decimal -> decimal.intValue());
+                DecimalType::intValue);
     }
 
     public static Stream<Object[]> filteredTestDataUInt32() {
@@ -164,7 +164,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualUInt32(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex, () -> ModbusBitUtilities.extractUInt32(bytes, byteIndex),
-                decimal -> decimal.longValue());
+                DecimalType::longValue);
     }
 
     public static Stream<Object[]> filteredTestDataSInt32Swap() {
@@ -176,7 +176,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualSInt32Swap(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex,
-                () -> ModbusBitUtilities.extractSInt32Swap(bytes, byteIndex), decimal -> decimal.intValue());
+                () -> ModbusBitUtilities.extractSInt32Swap(bytes, byteIndex), DecimalType::intValue);
     }
 
     public static Stream<Object[]> filteredTestDataUInt32Swap() {
@@ -188,7 +188,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualUInt32Swap(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex,
-                () -> ModbusBitUtilities.extractUInt32Swap(bytes, byteIndex), decimal -> decimal.longValue());
+                () -> ModbusBitUtilities.extractUInt32Swap(bytes, byteIndex), DecimalType::longValue);
     }
 
     public static Stream<Object[]> filteredTestDataSInt64() {
@@ -200,7 +200,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualSInt64(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex, () -> ModbusBitUtilities.extractSInt64(bytes, byteIndex),
-                decimal -> decimal.longValue());
+                DecimalType::longValue);
     }
 
     public static Stream<Object[]> filteredTestDataUInt64() {
@@ -224,7 +224,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualSInt64Swap(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex,
-                () -> ModbusBitUtilities.extractSInt64Swap(bytes, byteIndex), decimal -> decimal.longValue());
+                () -> ModbusBitUtilities.extractSInt64Swap(bytes, byteIndex), DecimalType::longValue);
     }
 
     public static Stream<Object[]> filteredTestDataUInt64Swap() {
@@ -249,7 +249,7 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualFloat32(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex,
-                () -> ModbusBitUtilities.extractFloat32(bytes, byteIndex), decimal -> decimal.floatValue(), Float.NaN);
+                () -> ModbusBitUtilities.extractFloat32(bytes, byteIndex), DecimalType::floatValue, Float.NaN);
     }
 
     public static Stream<Object[]> filteredTestDataFloat32Swap() {
@@ -261,7 +261,6 @@ public class BitUtilitiesExtractIndividualMethodsTest {
     public void testExtractIndividualFloat32Swap(Object expectedResult, ValueType type, byte[] bytes, int byteIndex)
             throws InstantiationException, IllegalAccessException {
         testIndividual(expectedResult, type, bytes, byteIndex,
-                () -> ModbusBitUtilities.extractFloat32Swap(bytes, byteIndex), decimal -> decimal.floatValue(),
-                Float.NaN);
+                () -> ModbusBitUtilities.extractFloat32Swap(bytes, byteIndex), DecimalType::floatValue, Float.NaN);
     }
 }

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticTagRegistryImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticTagRegistryImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.openhab.core.common.registry.AbstractRegistry;
+import org.openhab.core.common.registry.Identifiable;
 import org.openhab.core.common.registry.Provider;
 import org.openhab.core.semantics.Equipment;
 import org.openhab.core.semantics.Location;
@@ -133,7 +134,7 @@ public class SemanticTagRegistryImpl extends AbstractRegistry<SemanticTag, Strin
 
     @Override
     public List<SemanticTag> getSubTree(SemanticTag tag) {
-        List<String> ids = getAll().stream().map(t -> t.getUID()).filter(uid -> uid.startsWith(tag.getUID() + "_"))
+        List<String> ids = getAll().stream().map(Identifiable::getUID).filter(uid -> uid.startsWith(tag.getUID() + "_"))
                 .toList();
         List<SemanticTag> tags = new ArrayList<>();
         tags.add(tag);

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
@@ -100,7 +100,7 @@ public class JsonStorage<T> implements Storage<T> {
         this.maxBackupFiles = maxBackupFiles;
         this.writeDelay = writeDelay;
         this.maxDeferredPeriod = maxDeferredPeriod;
-        this.typeMigrators = typeMigrators.stream().collect(Collectors.toMap(e -> e.getOldType(), e -> e));
+        this.typeMigrators = typeMigrators.stream().collect(Collectors.toMap(TypeMigrator::getOldType, e -> e));
 
         this.internalMapper = new GsonBuilder() //
                 .registerTypeHierarchyAdapter(Map.class, new OrderingMapSerializer())//

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntryMapDeserializer.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntryMapDeserializer.java
@@ -60,7 +60,7 @@ public class StorageEntryMapDeserializer implements JsonDeserializer<Map<String,
             if (entrySet.size() != 2) {
                 return false;
             }
-            Set<String> keys = entrySet.stream().map(e -> e.getKey()).collect(Collectors.toSet());
+            Set<String> keys = entrySet.stream().map(Entry::getKey).collect(Collectors.toSet());
             if (!keys.contains(JsonStorage.CLASS) || !keys.contains(JsonStorage.VALUE)) {
                 return false;
             }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -172,7 +172,7 @@ public final class ThingStatusInfoI18nLocalizationService {
                 this.args = null;
             } else {
                 this.args = Arrays.stream(parts[1].replaceAll("\\[|\\]|\"", "").split(","))
-                        .filter(s -> s != null && !s.trim().isEmpty()).map(s -> s.trim()).toArray(String[]::new);
+                        .filter(s -> s != null && !s.trim().isEmpty()).map(String::trim).toArray(String[]::new);
             }
         }
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -185,7 +185,7 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             if (forLinkedUID == null) {
                 return Set.of();
             }
-            return forLinkedUID.stream().map(link -> link.getItemName()).collect(Collectors.toSet());
+            return forLinkedUID.stream().map(AbstractLink::getItemName).collect(Collectors.toSet());
         } finally {
             toLinkLock.readLock().unlock();
         }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -153,7 +153,7 @@ public class DefaultChartProvider implements ChartProvider {
         QueryablePersistenceService persistenceService = (service instanceof QueryablePersistenceService qps) ? qps
                 : (QueryablePersistenceService) persistenceServiceRegistry.getAll() //
                         .stream() //
-                        .filter(it -> it instanceof QueryablePersistenceService) //
+                        .filter(QueryablePersistenceService.class::isInstance) //
                         .findFirst() //
                         .orElseThrow(() -> new IllegalArgumentException("No Persistence service found."));
 


### PR DESCRIPTION
Method references are more readable because they refer to class names and usually result in less code.