### PR TITLE
Add network-interface context

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
@@ -13,9 +13,13 @@
 package org.openhab.core.config.core.internal.net;
 
 import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -39,25 +43,55 @@ public class NetworkConfigOptionProvider implements ConfigOptionProvider {
     static final URI CONFIG_URI = URI.create("system:network");
     static final String PARAM_PRIMARY_ADDRESS = "primaryAddress";
     static final String PARAM_BROADCAST_ADDRESS = "broadcastAddress";
+    static final String NETWORK_INTERFACE = "network-interface";
 
     @Override
     public @Nullable Collection<ParameterOption> getParameterOptions(URI uri, String param, @Nullable String context,
             @Nullable Locale locale) {
-        if (!CONFIG_URI.equals(uri)) {
+        if (CONFIG_URI.equals(uri)) {
+            switch (param) {
+                case PARAM_PRIMARY_ADDRESS:
+                    Stream<CidrAddress> ipv4Addresses = NetUtil.getAllInterfaceAddresses().stream()
+                            .filter(a -> a.getAddress() instanceof Inet4Address);
+                    return ipv4Addresses.map(a -> new ParameterOption(a.toString(), a.toString())).toList();
+                case PARAM_BROADCAST_ADDRESS:
+                    List<String> broadcastAddrList = new ArrayList<>(NetUtil.getAllBroadcastAddresses());
+                    broadcastAddrList.add("255.255.255.255");
+                    return broadcastAddrList.stream().distinct().map(a -> new ParameterOption(a, a)).toList();
+                default:
+                    return null;
+            }
+        } else if (NETWORK_INTERFACE.equals(context)) {
+            try {
+                List<ParameterOption> options = new ArrayList<>();
+                Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+                while (networkInterfaces.hasMoreElements()) {
+                    NetworkInterface networkInterface = networkInterfaces.nextElement();
+                    options.add(new ParameterOption(networkInterface.getName(),
+                            getNetworkInterfaceLabel(networkInterface)));
+                }
+                return options;
+            } catch (SocketException e) {
+                return null;
+            }
+        } else {
             return null;
         }
+    }
 
-        switch (param) {
-            case PARAM_PRIMARY_ADDRESS:
-                Stream<CidrAddress> ipv4Addresses = NetUtil.getAllInterfaceAddresses().stream()
-                        .filter(a -> a.getAddress() instanceof Inet4Address);
-                return ipv4Addresses.map(a -> new ParameterOption(a.toString(), a.toString())).toList();
-            case PARAM_BROADCAST_ADDRESS:
-                List<String> broadcastAddrList = new ArrayList<>(NetUtil.getAllBroadcastAddresses());
-                broadcastAddrList.add("255.255.255.255");
-                return broadcastAddrList.stream().distinct().map(a -> new ParameterOption(a, a)).toList();
-            default:
-                return null;
+    private String getNetworkInterfaceLabel(NetworkInterface networkInterface) {
+        Enumeration<InetAddress> inetAddresses = networkInterface.getInetAddresses();
+        String hostName = null;
+        while (inetAddresses.hasMoreElements()) {
+            InetAddress inetAddress = inetAddresses.nextElement();
+            if (inetAddress instanceof Inet4Address) {
+                hostName = inetAddress.getHostName();
+                break;
+            } else if (hostName == null) {
+                hostName = inetAddress.getHostName();
+            }
         }
+        return hostName == null ? networkInterface.getName()
+                : String.format("%s (%s)", networkInterface.getName(), hostName);
     }
 }


### PR DESCRIPTION
This allows for selecting network interface names in configuration parameters.

Just add `<context>network-interface</context>` to your config parameter similar to `<context>serial-port</context>` .

