### PR TITLE
Respond with 404 if add-on is missing in add-on service

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -253,7 +253,7 @@ public class AddonResource implements RESTResource {
     public Response installAddon(final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
-        if (addonService == null) {
+        if (addonService == null || addonService.getAddon(addonId, null) == null) {
             return Response.status(HttpStatus.NOT_FOUND_404).build();
         }
 
@@ -295,7 +295,7 @@ public class AddonResource implements RESTResource {
     public Response uninstallAddon(final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
-        if (addonService == null) {
+        if (addonService == null || addonService.getAddon(addonId, null) == null) {
             return Response.status(HttpStatus.NOT_FOUND_404).build();
         }
         ThreadPoolManager.getPool(THREAD_POOL_NAME).submit(() -> {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -256,6 +256,7 @@ public class AddonResource implements RESTResource {
         if (addonService == null) {
             return Response.status(HttpStatus.NOT_FOUND_404).build();
         }
+
         ThreadPoolManager.getPool(THREAD_POOL_NAME).submit(() -> {
             try {
                 addonService.install(addonId);


### PR DESCRIPTION
Fixes #3987 

We can easily check if the requested service supports the add-on and respond with "NOT_FOUND" when the service is unknown or the add-on is not available from that service.