### PR TITLE
Add the possibility to invert the mute system channel

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -80,6 +80,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             "color-temperature-abs");
     public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_VOLUME = new ChannelTypeUID(BINDING_ID, "volume");
     public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MUTE = new ChannelTypeUID(BINDING_ID, "mute");
+    public static final String SYSTEM_CHANNEL_TYPE_MUTE_CFG_INVERTED = "inverted";
     public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MEDIA_CONTROL = new ChannelTypeUID(BINDING_ID,
             "media-control");
     public static final ChannelTypeUID SYSTEM_CHANNEL_TYPE_UID_MEDIA_TITLE = new ChannelTypeUID(BINDING_ID,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -266,7 +267,8 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
             .state(SYSTEM_CHANNEL_TYPE_UID_MUTE, "Mute", CoreItemFactory.SWITCH)
             .withDescription("Mute audio of the device").withCategory("SoundVolume")
-            .withTags(List.of("Switch", "SoundVolume")).build();
+            .withConfigDescriptionURI(URI.create("channel-type:system:mute")).withTags(List.of("Switch", "SoundVolume"))
+            .build();
 
     /**
      * Media-control: system wide {@link ChannelType} which controls a media player

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/muteChannelType.xml
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/config/muteChannelType.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+	https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="channel-type:system:mute">
+		<parameter name="inverted" type="boolean" required="false">
+			<label>Inverted</label>
+			<description>Inverts the behavior, i.e. ON means the audio is on.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/DefaultSystemChannels.properties
+++ b/bundles/org.openhab.core.thing/src/main/resources/OH-INF/i18n/DefaultSystemChannels.properties
@@ -56,3 +56,5 @@ channel-type.system.electric-voltage.label = Electric Voltage
 channel-type.system.electric-voltage.description = Current electric voltage
 channel-type.system.electrical-energy.label = Electrical Energy
 channel-type.system.electrical-energy.description = Current electrical energy
+channel-type.config.system.mute.inverted.label = Inverted
+channel-type.config.system.mute.inverted.description = Inverts the behavior, i.e. ON means the audio is on.


### PR DESCRIPTION
Very often, the mute feature is counter-intuitive: in the UI, the user rather wants to see whether a speaker/zone/amp is on (active) or off (deactivated).
This PR gives the possibility to invert the "mute" behavior to make the above scenario an option.