### PR TITLE
Fix build number reporting at startup

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
@@ -31,7 +31,7 @@ public final class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext bc) throws Exception {
-        logger.info("Starting openHAB {} (build {})", OpenHAB.getVersion(), OpenHAB.buildString());
+        logger.info("Starting openHAB {} ({})", OpenHAB.getVersion(), OpenHAB.buildString());
     }
 
     @Override


### PR DESCRIPTION
openHAB currently logs during startup something like
```
22:09:04.949 [INFO ] [org.openhab.core.Activator          ] - Starting openHAB 4.2.0 (build Unknown Build No.)
```
The word `build` seems unnecessary here.
- In case of a release build, the `version.properties` file contains `Release Build`
- In case of a snapshot build, the `version.properties` file contains `Build #3814`

In all cases, we hence do not need the word `build` before it.