### PR TITLE
Remove redundant array creation for calling varargs methods

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.automation.internal.commands;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -142,7 +141,7 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
 
     @Override
     public List<String> getUsages() {
-        return Arrays.asList(new String[] {
+        return List.of(
                 buildCommandUsage(LIST_MODULE_TYPES + " [-st] <filter> <language>",
                         "lists all Module Types. If filter is present, lists only matching Module Types."
                                 + " If language is missing, the default language will be used."),
@@ -174,7 +173,7 @@ public class AutomationCommandsPluggable extends AutomationCommands implements C
                         "Enables the Rule, specified by given UID. If enable parameter is missing, "
                                 + "the result of the command will be visualization of enabled/disabled state of the rule, "
                                 + "if its value is \"true\" or \"false\", "
-                                + "the result of the command will be to set enable/disable on the Rule.") });
+                                + "the result of the command will be to set enable/disable on the Rule."));
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusBitUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusBitUtilities.java
@@ -651,7 +651,7 @@ public class ModbusBitUtilities {
                 // big endian byte ordering
                 byte hi = (byte) (shortValue >> 8);
                 byte lo = (byte) shortValue;
-                return new ModbusRegisterArray(new byte[] { hi, lo });
+                return new ModbusRegisterArray(hi, lo);
             }
             case INT32:
             case UINT32: {
@@ -661,7 +661,7 @@ public class ModbusBitUtilities {
                 byte lo1 = (byte) (intValue >> 16);
                 byte hi2 = (byte) (intValue >> 8);
                 byte lo2 = (byte) intValue;
-                return new ModbusRegisterArray(new byte[] { hi1, lo1, hi2, lo2 });
+                return new ModbusRegisterArray(hi1, lo1, hi2, lo2);
             }
             case INT32_SWAP:
             case UINT32_SWAP: {
@@ -672,7 +672,7 @@ public class ModbusBitUtilities {
                 byte hi2 = (byte) (intValue >> 8);
                 byte lo2 = (byte) intValue;
                 // Swapped order of registers
-                return new ModbusRegisterArray(new byte[] { hi2, lo2, hi1, lo1 });
+                return new ModbusRegisterArray(hi2, lo2, hi1, lo1);
             }
             case FLOAT32: {
                 float floatValue = numericCommand.floatValue();
@@ -682,7 +682,7 @@ public class ModbusBitUtilities {
                 byte lo1 = (byte) (intBits >> 16);
                 byte hi2 = (byte) (intBits >> 8);
                 byte lo2 = (byte) intBits;
-                return new ModbusRegisterArray(new byte[] { hi1, lo1, hi2, lo2 });
+                return new ModbusRegisterArray(hi1, lo1, hi2, lo2);
             }
             case FLOAT32_SWAP: {
                 float floatValue = numericCommand.floatValue();
@@ -693,7 +693,7 @@ public class ModbusBitUtilities {
                 byte hi2 = (byte) (intBits >> 8);
                 byte lo2 = (byte) intBits;
                 // Swapped order of registers
-                return new ModbusRegisterArray(new byte[] { hi2, lo2, hi1, lo1 });
+                return new ModbusRegisterArray(hi2, lo2, hi1, lo1);
             }
             case INT64:
             case UINT64: {
@@ -707,7 +707,7 @@ public class ModbusBitUtilities {
                 byte lo3 = (byte) (longValue >> 16);
                 byte hi4 = (byte) (longValue >> 8);
                 byte lo4 = (byte) longValue;
-                return new ModbusRegisterArray(new byte[] { hi1, lo1, hi2, lo2, hi3, lo3, hi4, lo4 });
+                return new ModbusRegisterArray(hi1, lo1, hi2, lo2, hi3, lo3, hi4, lo4);
             }
             case INT64_SWAP:
             case UINT64_SWAP: {
@@ -722,7 +722,7 @@ public class ModbusBitUtilities {
                 byte hi4 = (byte) (longValue >> 8);
                 byte lo4 = (byte) longValue;
                 // Swapped order of registers
-                return new ModbusRegisterArray(new byte[] { hi4, lo4, hi3, lo3, hi2, lo2, hi1, lo1 });
+                return new ModbusRegisterArray(hi4, lo4, hi3, lo3, hi2, lo2, hi1, lo1);
             }
             default:
                 throw new IllegalArgumentException(

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
@@ -183,7 +183,7 @@ final class ProgressCallbackImpl implements ProgressCallback {
 
     void failedInternal(String errorMessageKey) {
         this.state = InternalState.FINISHED;
-        String errorMessage = getMessage(ProgressCallbackImpl.class, errorMessageKey, new Object[] {});
+        String errorMessage = getMessage(ProgressCallbackImpl.class, errorMessageKey);
         postResultInfoEvent(FirmwareUpdateResult.ERROR, errorMessage);
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
@@ -81,7 +81,7 @@ public class StateUtil {
         states.add(RewindFastforwardType.REWIND);
         states.add(RewindFastforwardType.FASTFORWARD);
 
-        StringListType stringList = new StringListType(new String[] { "foo", "bar" });
+        StringListType stringList = new StringListType("foo", "bar");
         states.add(stringList);
 
         StringType string = new StringType("foo");


### PR DESCRIPTION
These array creations are unnecessary because arrays are created automatically for methods using varargs.