### PR TITLE
Use isEmpty instead of 0 comparisons

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -518,7 +518,7 @@ public class PersistenceResource implements RESTResource {
     private Response deletePersistenceItemData(@Nullable String serviceId, String itemName, @Nullable String timeBegin,
             @Nullable String timeEnd) {
         // For deleting, we must specify a service id - don't use the default service
-        if (serviceId == null || serviceId.length() == 0) {
+        if (serviceId == null || serviceId.isEmpty()) {
             logger.debug("Persistence service must be specified for delete operations.");
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST,
                     "Persistence service must be specified for delete operations.");
@@ -598,7 +598,7 @@ public class PersistenceResource implements RESTResource {
         }
 
         ZonedDateTime dateTime = null;
-        if (time != null && time.length() != 0) {
+        if (time != null && !time.isEmpty()) {
             dateTime = convertTime(time);
         }
         if (dateTime == null || dateTime.toEpochSecond() == 0) {

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
@@ -92,7 +92,7 @@ public final class WriteRequestJsonUtilities {
      */
     public static Collection<ModbusWriteRequestBlueprint> fromJson(int unitId, String jsonString) {
         JsonArray jsonArray = JsonParser.parseString(jsonString).getAsJsonArray();
-        if (jsonArray.size() == 0) {
+        if (jsonArray.isEmpty()) {
             return new LinkedList<>();
         }
         Deque<ModbusWriteRequestBlueprint> writes = new LinkedList<>();
@@ -173,7 +173,7 @@ public final class WriteRequestJsonUtilities {
                 }
                 // fall-through to WRITE_MULTIPLE_COILS
             case WRITE_MULTIPLE_COILS:
-                if (valuesElem.size() == 0) {
+                if (valuesElem.isEmpty()) {
                     throw new IllegalArgumentException("Must provide at least one coil");
                 } else if (valuesElem.size() > ModbusConstants.MAX_BITS_WRITE_COUNT) {
                     throw new IllegalArgumentException(

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
@@ -55,7 +55,7 @@ public class MqttBrokerConnectionConfig {
      */
     public String getBrokerID() {
         final String name = this.name;
-        if (name != null && name.length() > 0) {
+        if (name != null && !name.isEmpty()) {
             return name;
         } else {
             StringBuilder b = new StringBuilder();

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -267,7 +267,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                             .append(MessageFormat.format("[{0},{1}]: {2}\n", Integer.toString(diagnostic.getLine()),
                                     Integer.toString(diagnostic.getColumn()), diagnostic.getMessage()));
                 }
-                if (criticalErrors.length() > 0) {
+                if (!criticalErrors.isEmpty()) {
                     return criticalErrors.toString();
                 }
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptException.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptException.java
@@ -134,7 +134,7 @@ public abstract class ScriptException extends Exception {
 
             int i = 1;
             for (ScriptError e : getErrors()) {
-                if (sb.length() > 0) {
+                if (!sb.isEmpty()) {
                     sb.append('\n');
                 }
                 sb.append("   ");

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -736,7 +736,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     @Override
     public @Nullable Widget getWidget(Sitemap sitemap, String id) {
-        if (id.length() > 0) {
+        if (!id.isEmpty()) {
             // see if the id is an itemName and try to get the widget for it
             Widget w = getWidget(id);
             if (w == null) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -336,7 +336,7 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
             ignoreStateUpdates = getBooleanConfigValue(configuration, CONFIG_IGNORE_STATE_UPDATES);
             ignoreCommands = getBooleanConfigValue(configuration, CONFIG_IGNORE_COMMANDS);
 
-            if ((stateOrCommand != null) && (stateOrCommand.length() > 0)) {
+            if ((stateOrCommand != null) && (!stateOrCommand.isEmpty())) {
                 if (stateOrCommand.startsWith(COMMAND_PREFIX)) {
                     String commandString = stateOrCommand.substring(COMMAND_PREFIX.length());
                     expireCommand = TypeParser.parseCommand(item.getAcceptedCommandTypes(), commandString);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -129,7 +129,7 @@ public class StringUtils {
         final String delimiter = "_";
         StringBuilder capitalizedFully = new StringBuilder();
         for (String splitStr : str.split(delimiter)) {
-            if (splitStr.length() > 0) {
+            if (!splitStr.isEmpty()) {
                 capitalizedFully.append(splitStr.substring(0, 1).toUpperCase());
             }
             if (splitStr.length() > 1) {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
@@ -249,7 +249,7 @@ public class QueueingThreadPoolExecutorTest {
         for (int i = 0; i < n; i++) {
             // we can only test if name is at least one character,
             // otherwise there will be threads found (handles poolName="")
-            if (poolName.length() > 0) {
+            if (!poolName.isEmpty()) {
                 if (l[i].getName().startsWith(poolName)) {
                     // enable printout to see threads
                     // System.out.println("areThreadsFromPoolRunning: " +

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
@@ -141,7 +141,7 @@ public class ConfigDescriptionsTest extends JavaOSGiTest {
     private String join(Collection<?> elements, String separator) {
         StringBuilder sb = new StringBuilder();
         for (Object element : elements) {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 sb.append(separator);
             }
             if (element != null) {


### PR DESCRIPTION
`isEmpty()` expresses the intent more clearly and is therefore preferred. Counting the number of elements can also be an expensive operation e.g. when using linked lists.