### PR TITLE
Remove redundant modifiers

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -33,7 +33,7 @@ public interface AudioManager {
     /**
      * Name of the sub-directory of the config folder, holding sound files.
      */
-    static final String SOUND_DIR = "sounds";
+    String SOUND_DIR = "sounds";
 
     /**
      * Plays the passed audio stream using the default audio sink.

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
@@ -31,5 +31,5 @@ public interface ClonableAudioStream {
      * @return a new input stream that can be consumed by the caller
      * @throws AudioException if stream cannot be created
      */
-    public InputStream getClonedStream() throws AudioException;
+    InputStream getClonedStream() throws AudioException;
 }

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/SizeableAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/SizeableAudioStream.java
@@ -27,5 +27,5 @@ public interface SizeableAudioStream {
      *
      * @return absolute length in bytes
      */
-    public long length();
+    long length();
 }

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/StorageRecordType.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/StorageRecordType.java
@@ -29,7 +29,7 @@ public enum StorageRecordType {
 
     private String suffix;
 
-    private StorageRecordType(String suffix) {
+    StorageRecordType(String suffix) {
         this.suffix = suffix;
     }
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -33,7 +33,7 @@ import org.openhab.core.automation.module.script.internal.provider.ScriptModuleT
 @NonNullByDefault
 public interface ScriptEngineFactory {
 
-    static final ScriptEngineManager ENGINE_MANAGER = new ScriptEngineManager();
+    ScriptEngineManager ENGINE_MANAGER = new ScriptEngineManager();
 
     /**
      * Key to access engine identifier in script context.

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatus.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatus.java
@@ -84,7 +84,7 @@ public enum RuleStatus {
 
     private final int value;
 
-    private RuleStatus(final int newValue) {
+    RuleStatus(final int newValue) {
         value = newValue;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusDetail.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusDetail.java
@@ -95,7 +95,7 @@ public enum RuleStatusDetail {
 
     private final int value;
 
-    private RuleStatusDetail(final int newValue) {
+    RuleStatusDetail(final int newValue) {
         value = newValue;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
@@ -32,22 +32,22 @@ public interface Parser<T> {
      * Example : "parser.type" = "parser.module.type";
      * It is used as registration property of the corresponding service.
      */
-    static String PARSER_TYPE = "parser.type";
+    String PARSER_TYPE = "parser.type";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    static String PARSER_MODULE_TYPE = "parser.module.type";
+    String PARSER_MODULE_TYPE = "parser.module.type";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    static String PARSER_TEMPLATE = "parser.template";
+    String PARSER_TEMPLATE = "parser.template";
 
     /**
      * Defines one of the possible values of property {@link #PARSER_TYPE}.
      */
-    static String PARSER_RULE = "parser.rule";
+    String PARSER_RULE = "parser.rule";
 
     /**
      * Defines a service registration property used for recognition of which file format is supported by the parser.
@@ -55,12 +55,12 @@ public interface Parser<T> {
      * Example : "format" = "json";
      * It is used as registration property of the corresponding service.
      */
-    static String FORMAT = "format";
+    String FORMAT = "format";
 
     /**
      * Defines the possible value of property {@link #FORMAT}. It means that the parser supports json format.
      */
-    static String FORMAT_JSON = "json";
+    String FORMAT_JSON = "json";
 
     /**
      * Loads a file with some particular format and parse it to the corresponding automation objects.

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public final class ConfigParser {
-    private static final transient Logger LOGGER = LoggerFactory.getLogger(ConfigParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigParser.class);
     private static final Map<String, Class<?>> WRAPPER_CLASSES_MAP = Map.of(//
             "float", Float.class, //
             "double", Double.class, //

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentBundleTracker.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentBundleTracker.java
@@ -88,7 +88,7 @@ public class XmlDocumentBundleTracker<@NonNull T> extends BundleTracker<Bundle> 
      * create, close, open
      * This can be handled correctly using three states and checking the transition.
      */
-    private static enum OpenState {
+    private enum OpenState {
         CREATED,
         OPENED,
         CLOSED

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinder.java
@@ -30,7 +30,7 @@ public interface AddonFinder {
      * The framework calls this method to scan through the candidate list of {@link AddonInfo} and return a subset of
      * those that it suggests to be installed.
      */
-    public Set<AddonInfo> getSuggestedAddons();
+    Set<AddonInfo> getSuggestedAddons();
 
     /**
      * The framework calls this method to provide a list of {@link AddonInfo} elements which contain potential
@@ -39,10 +39,10 @@ public interface AddonFinder {
      *
      * @param candidates a list of AddonInfo candidates.
      */
-    public void setAddonCandidates(List<AddonInfo> candidates);
+    void setAddonCandidates(List<AddonInfo> candidates);
 
     /**
      * This method should be called from the framework to allow a finder to stop searching for add-ons and do cleanup.
      */
-    public void unsetAddonCandidates();
+    void unsetAddonCandidates();
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryService.java
@@ -50,7 +50,7 @@ public interface DiscoveryService {
      * Configuration property for enabling the auto discovery feature of a
      * DiscoveryService.
      */
-    static final String CONFIG_PROPERTY_BACKGROUND_DISCOVERY = "background";
+    String CONFIG_PROPERTY_BACKGROUND_DISCOVERY = "background";
 
     /**
      * Returns the list of {@code Thing} types which are supported by the {@link DiscoveryService}.

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusConstants.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusConstants.java
@@ -55,7 +55,7 @@ public class ModbusConstants {
      * @author Sami Salonen - Initial contribution
      *
      */
-    public static enum ValueType {
+    public enum ValueType {
         BIT("bit", 1),
         INT8("int8", 8),
         UINT8("uint8", 8),

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveErrorResponseException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveErrorResponseException.java
@@ -41,7 +41,7 @@ public abstract class ModbusSlaveErrorResponseException extends ModbusTransportE
      * @author Sami Salonen - Initial contribution
      *
      */
-    public static enum KnownExceptionCode {
+    public enum KnownExceptionCode {
         ILLEGAL_FUNCTION(1),
         ILLEGAL_DATA_ACCESS(2),
         ILLEGAL_DATA_VALUE(3),
@@ -55,7 +55,7 @@ public abstract class ModbusSlaveErrorResponseException extends ModbusTransportE
 
         private final int exceptionCode;
 
-        private KnownExceptionCode(int exceptionCode) {
+        KnownExceptionCode(int exceptionCode) {
             this.exceptionCode = exceptionCode;
         }
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -117,7 +117,7 @@ public class ModbusManagerImpl implements ModbusManager {
          *             (ill-behaving slave)
          * @throws ModbusUnexpectedResponseSizeException when data length of the response and request do not match
          */
-        public void accept(AggregateStopWatch timer, T task, ModbusSlaveConnection connection)
+        void accept(AggregateStopWatch timer, T task, ModbusSlaveConnection connection)
                 throws ModbusException, IIOException, ModbusUnexpectedTransactionIdException,
                 ModbusUnexpectedResponseFunctionCodeException, ModbusUnexpectedResponseSizeException;
     }

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/SimpleStopWatch.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/SimpleStopWatch.java
@@ -33,13 +33,13 @@ public class SimpleStopWatch {
     private volatile long resumed;
 
     @FunctionalInterface
-    public abstract interface SupplierWithPollTaskUnregisteredException<T> {
-        public abstract T get() throws ModbusManagerImpl.PollTaskUnregistered;
+    public interface SupplierWithPollTaskUnregisteredException<T> {
+        T get() throws ModbusManagerImpl.PollTaskUnregistered;
     }
 
     @FunctionalInterface
-    public abstract interface RunnableWithModbusException {
-        public abstract void run() throws ModbusException;
+    public interface RunnableWithModbusException {
+        void run() throws ModbusException;
     }
 
     /**

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPort.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPort.java
@@ -34,23 +34,23 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public interface SerialPort extends Closeable {
 
-    final int DATABITS_5 = 5;
-    final int DATABITS_6 = 6;
-    final int DATABITS_7 = 7;
-    final int DATABITS_8 = 8;
-    final int PARITY_NONE = 0;
-    final int PARITY_ODD = 1;
-    final int PARITY_EVEN = 2;
-    final int PARITY_MARK = 3;
-    final int PARITY_SPACE = 4;
-    final int STOPBITS_1 = 1;
-    final int STOPBITS_2 = 2;
-    final int STOPBITS_1_5 = 3;
-    final int FLOWCONTROL_NONE = 0;
-    final int FLOWCONTROL_RTSCTS_IN = 1;
-    final int FLOWCONTROL_RTSCTS_OUT = 2;
-    final int FLOWCONTROL_XONXOFF_IN = 4;
-    final int FLOWCONTROL_XONXOFF_OUT = 8;
+    int DATABITS_5 = 5;
+    int DATABITS_6 = 6;
+    int DATABITS_7 = 7;
+    int DATABITS_8 = 8;
+    int PARITY_NONE = 0;
+    int PARITY_ODD = 1;
+    int PARITY_EVEN = 2;
+    int PARITY_MARK = 3;
+    int PARITY_SPACE = 4;
+    int STOPBITS_1 = 1;
+    int STOPBITS_2 = 2;
+    int STOPBITS_1_5 = 3;
+    int FLOWCONTROL_NONE = 0;
+    int FLOWCONTROL_RTSCTS_IN = 1;
+    int FLOWCONTROL_RTSCTS_OUT = 2;
+    int FLOWCONTROL_XONXOFF_IN = 4;
+    int FLOWCONTROL_XONXOFF_OUT = 8;
 
     @Override
     void close();

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
@@ -21,16 +21,16 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 public interface SerialPortEvent {
-    final int DATA_AVAILABLE = 1;
-    final int OUTPUT_BUFFER_EMPTY = 2;
-    final int CTS = 3;
-    final int DSR = 4;
-    final int RI = 5;
-    final int CD = 6;
-    final int OE = 7;
-    final int PE = 8;
-    final int FE = 9;
-    final int BI = 10;
+    int DATA_AVAILABLE = 1;
+    int OUTPUT_BUFFER_EMPTY = 2;
+    int CTS = 3;
+    int DSR = 4;
+    int RI = 5;
+    int CD = 6;
+    int OE = 7;
+    int PE = 8;
+    int FE = 9;
+    int BI = 10;
 
     /**
      * Get the type of the event.

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/DSLScriptContextProvider.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/DSLScriptContextProvider.java
@@ -30,7 +30,7 @@ public interface DSLScriptContextProvider {
     /**
      * Identifier for scripts that are created from a DSL rule file
      */
-    static final String CONTEXT_IDENTIFIER = "// context: ";
+    String CONTEXT_IDENTIFIER = "// context: ";
 
     /**
      * Returns the evaluation context, i.e. the current state of the variables of the rule file.

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
@@ -22,7 +22,7 @@ import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 @SuppressWarnings("restriction")
 public interface Script {
 
-    static final String SCRIPT_FILEEXT = "script";
+    String SCRIPT_FILEEXT = "script";
 
     /**
      * Executes the script instance and returns the execution result

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
@@ -25,5 +25,5 @@ import org.openhab.core.config.core.ConfigOptionProvider;
 @NonNullByDefault
 public interface MagicService extends ConfigOptionProvider {
 
-    static final URI CONFIG_URI = URI.create("test:magic");
+    URI CONFIG_URI = URI.create("test:magic");
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
@@ -40,22 +40,22 @@ import org.openhab.core.thing.binding.ThingHandler;
 public interface Thing extends Identifiable<ThingUID> {
 
     /** the key for the vendor property */
-    final String PROPERTY_VENDOR = "vendor";
+    String PROPERTY_VENDOR = "vendor";
 
     /** the key for the model ID property */
-    final String PROPERTY_MODEL_ID = "modelId";
+    String PROPERTY_MODEL_ID = "modelId";
 
     /** the key for the serial number property */
-    final String PROPERTY_SERIAL_NUMBER = "serialNumber";
+    String PROPERTY_SERIAL_NUMBER = "serialNumber";
 
     /** the key for the hardware version property */
-    final String PROPERTY_HARDWARE_VERSION = "hardwareVersion";
+    String PROPERTY_HARDWARE_VERSION = "hardwareVersion";
 
     /** the key for the firmware version property */
-    final String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
+    String PROPERTY_FIRMWARE_VERSION = "firmwareVersion";
 
     /** the key for the MAC address property */
-    final String PROPERTY_MAC_ADDRESS = "macAddress";
+    String PROPERTY_MAC_ADDRESS = "macAddress";
 
     /**
      * Returns the human readable label for this thing.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
@@ -65,7 +65,7 @@ import org.openhab.core.thing.firmware.FirmwareUpdateService;
 public interface Firmware extends Comparable<Firmware> {
 
     /** The key for the requires a factory reset property. */
-    static final String PROPERTY_REQUIRES_FACTORY_RESET = "requiresFactoryReset";
+    String PROPERTY_REQUIRES_FACTORY_RESET = "requiresFactoryReset";
 
     /**
      * Returns the thing type UID, that this firmware is associated with.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
@@ -45,7 +45,7 @@ public interface ChannelHandler {
     void send(Command command);
 
     @FunctionalInterface
-    public interface Factory {
+    interface Factory {
         ChannelHandler create(Consumer<State> updateState, Consumer<Command> postCommand,
                 @Nullable Consumer<String> sendHttpValue, ChannelTransformation stateTransformations,
                 ChannelTransformation commandTransformations, ChannelValueConverterConfig channelConfig);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
@@ -114,7 +114,7 @@ public class ThingEventFactory extends AbstractEventFactory {
         }
     }
 
-    public static interface CommonChannelDescriptionFieldPayloadBean {
+    public interface CommonChannelDescriptionFieldPayloadBean {
     }
 
     public static class ChannelDescriptionPatternPayloadBean implements CommonChannelDescriptionFieldPayloadBean {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
@@ -75,7 +75,7 @@ public class AutoUpdateManager {
     private boolean enabled = true;
     private boolean sendOptimisticUpdates = false;
 
-    private static enum Recommendation {
+    private enum Recommendation {
         /*
          * An automatic state update must be sent because no channels are linked to the item.
          */

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -40,7 +40,7 @@ import org.openhab.core.types.State;
  */
 @NonNullByDefault
 public interface ItemUIRegistry extends ItemRegistry, ItemUIProvider {
-    public enum WidgetLabelSource {
+    enum WidgetLabelSource {
         /** Label is taken from widget definition in sitemap */
         SITEMAP_WIDGET,
         /** Label is taken from the widget's backing item definition */

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Role.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Role.java
@@ -22,10 +22,10 @@ public interface Role {
     /**
      * Role of users with administrative rights
      */
-    final String ADMIN = "administrator";
+    String ADMIN = "administrator";
 
     /**
      * Role of a regular user without any exceptional permissions or restrictions
      */
-    final String USER = "user";
+    String USER = "user";
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
@@ -300,7 +300,7 @@ public interface OAuthClientService extends AutoCloseable {
      * @param key The name of the key to add to the auth form
      * @param value The value of the new auth form param
      */
-    public void addExtraAuthField(String key, String value);
+    void addExtraAuthField(String key, String value);
 
     /**
      * Adds a custom GsonBuilder to be used with the OAuth service instance.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
@@ -30,7 +30,7 @@ public interface EventSubscriber {
      * The constant {@link #ALL_EVENT_TYPES} must be returned by the {@link #getSubscribedEventTypes()} method, if the
      * event subscriber should subscribe to all event types.
      */
-    static String ALL_EVENT_TYPES = "ALL";
+    String ALL_EVENT_TYPES = "ALL";
 
     /**
      * Gets the event types to which the event subscriber is subscribed to.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupFunction.java
@@ -60,7 +60,7 @@ public interface GroupFunction {
      *
      * @author Kai Kreuzer - Initial contribution
      */
-    static class Equality implements GroupFunction {
+    class Equality implements GroupFunction {
 
         @Override
         public State calculate(@Nullable Set<Item> items) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
@@ -28,7 +28,7 @@ import org.openhab.core.common.registry.Registry;
 @NonNullByDefault
 public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
 
-    static final String INTERNAL_NAMESPACE_PREFIX = "_";
+    String INTERNAL_NAMESPACE_PREFIX = "_";
 
     /**
      * Determines whether the given namespace is internal.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
@@ -43,7 +43,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
      * Through the getStateAs() method, it can be determined, how many
      * items actually are not in the 'activeState'.
      */
-    static class And implements GroupFunction {
+    class And implements GroupFunction {
 
         protected final State activeState;
         protected final State passiveState;
@@ -112,7 +112,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
      * Through the getStateAs() method, it can be determined, how many
      * items actually are in the 'activeState'.
      */
-    static class Or implements GroupFunction {
+    class Or implements GroupFunction {
 
         protected final State activeState;
         protected final State passiveState;
@@ -177,7 +177,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
      * value. E.g. when the 'and' operation calculates the activeValue the
      * passiveValue will be returned and vice versa.
      */
-    static class NAnd extends And {
+    class NAnd extends And {
 
         public NAnd(@Nullable State activeValue, @Nullable State passiveValue) {
             super(activeValue, passiveValue);
@@ -196,7 +196,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
      * value. E.g. when the 'or' operation calculates the activeValue the
      * passiveValue will be returned and vice versa.
      */
-    static class NOr extends Or {
+    class NOr extends Or {
 
         public NOr(@Nullable State activeValue, @Nullable State passiveValue) {
             super(activeValue, passiveValue);
@@ -212,7 +212,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the numeric average over all item states of decimal type.
      */
-    static class Avg implements GroupFunction {
+    class Avg implements GroupFunction {
 
         public Avg() {
         }
@@ -256,7 +256,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the numeric sum over all item states of decimal type.
      */
-    static class Sum implements GroupFunction {
+    class Sum implements GroupFunction {
 
         public Sum() {
         }
@@ -294,7 +294,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the minimum value of all item states of decimal type.
      */
-    static class Min implements GroupFunction {
+    class Min implements GroupFunction {
 
         public Min() {
         }
@@ -337,7 +337,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the maximum value of all item states of decimal type.
      */
-    static class Max implements GroupFunction {
+    class Max implements GroupFunction {
 
         public Max() {
         }
@@ -384,7 +384,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
      * Group:Number:COUNT("[5-9]") will count all items having a string state between 5 and 9
      * ...
      */
-    static class Count implements GroupFunction {
+    class Count implements GroupFunction {
 
         protected final Pattern pattern;
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
@@ -33,7 +33,7 @@ public interface DateTimeGroupFunction extends GroupFunction {
     /**
      * This calculates the maximum value of all item states of DateType type.
      */
-    static class Latest implements GroupFunction {
+    class Latest implements GroupFunction {
 
         public Latest() {
         }
@@ -76,7 +76,7 @@ public interface DateTimeGroupFunction extends GroupFunction {
     /**
      * This calculates the minimum value of all item states of DateType type.
      */
-    static class Earliest implements GroupFunction {
+    class Earliest implements GroupFunction {
 
         public Earliest() {
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
@@ -69,7 +69,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the numeric average over all item states of {@link QuantityType}.
      */
-    static class Avg extends DimensionalGroupFunction {
+    class Avg extends DimensionalGroupFunction {
 
         public Avg(Class<? extends Quantity<?>> dimension) {
             super(dimension);
@@ -114,7 +114,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the numeric sum over all item states of {@link QuantityType}.
      */
-    static class Sum extends DimensionalGroupFunction {
+    class Sum extends DimensionalGroupFunction {
 
         public Sum(Class<? extends Quantity<?>> dimension) {
             super(dimension);
@@ -151,7 +151,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the minimum value of all item states of {@link QuantityType}.
      */
-    static class Min extends DimensionalGroupFunction {
+    class Min extends DimensionalGroupFunction {
 
         public Min(Class<? extends Quantity<?>> dimension) {
             super(dimension);
@@ -184,7 +184,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
     /**
      * This calculates the maximum value of all item states of {@link QuantityType}.
      */
-    static class Max extends DimensionalGroupFunction {
+    class Max extends DimensionalGroupFunction {
 
         public Max(Class<? extends Quantity<?>> dimension) {
             super(dimension);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventType.java
@@ -31,7 +31,7 @@ public enum EventType {
 
     private String name;
 
-    private EventType(String name) {
+    EventType(String name) {
         this.name = name;
     }
 


### PR DESCRIPTION
Removes redundant modifiers from the code.
These modifiers redeclare the default modifiers that apply to interfaces, enums etc.