### PR TITLE
Use static inner classes

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1414,7 +1414,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         return result;
     }
 
-    class OutputRef {
+    static class OutputRef {
 
         private final String moduleId;
         private final String outputName;

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -188,7 +188,7 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
     }
 
     @ActionScope(name = "binding.test")
-    private class TestActionProvider implements AnnotatedActions {
+    private static class TestActionProvider implements AnnotatedActions {
 
         @RuleAction(label = ACTION_LABEL, description = ACTION_DESCRIPTION, visibility = Visibility.HIDDEN, tags = {
                 "tag1", "tag2" })

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -204,7 +204,7 @@ public class AnnotatedThingActionModuleTypeProviderTest extends JavaTest {
     }
 
     @ThingActionsScope(name = "test")
-    private class TestThingActionProvider implements ThingActions {
+    private static class TestThingActionProvider implements ThingActions {
 
         private @Nullable ThingHandler handler;
 

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -250,7 +250,7 @@ public class ReferenceResolverUtilTest {
                 ReferenceResolver.splitReferenceToTokens("[2].value")));
     }
 
-    public class B1<T> {
+    public static class B1<T> {
         @SuppressWarnings("unused")
         private final T value;
 
@@ -259,7 +259,7 @@ public class ReferenceResolverUtilTest {
         }
     }
 
-    public class B2<T> {
+    public static class B2<T> {
         public T value;
 
         public B2(T value) {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
@@ -44,7 +44,7 @@ public class XmlDocumentReaderTest {
 
     private static final String OHC_PACKAGE_PREFIX = "org.openhab.core.";
 
-    private class ConfigDescriptionReader extends XmlDocumentReader<ConfigDescription> {
+    private static class ConfigDescriptionReader extends XmlDocumentReader<ConfigDescription> {
         @Override
         protected void registerConverters(XStream xstream) {
         }

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
@@ -79,7 +79,7 @@ public class DeltaUsbSerialScanner {
     /**
      * Delta between two subsequent scan results.
      */
-    class Delta<T> {
+    static class Delta<T> {
 
         private final Set<T> added;
         private final Set<T> removed;

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -457,7 +457,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * Utility class to parse the key with parameters into the key and optional arguments.
      */
-    private final class ParsedKey {
+    private static final class ParsedKey {
 
         private static final int LIMIT = 2;
 

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
@@ -452,7 +452,7 @@ public class ConfigDispatcher {
      * Represents a result of parseLine().
      */
     @NonNullByDefault
-    private class ParseLineResult {
+    private static class ParseLineResult {
         public @Nullable String pid;
         public @Nullable String property;
         public @Nullable Object value;

--- a/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
+++ b/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
@@ -82,7 +82,7 @@ public class LogHandler implements RESTResource {
     /**
      * Container for a log message
      */
-    public class LogMessage {
+    public static class LogMessage {
         public long timestamp;
         public @Nullable String severity;
         public @Nullable URL url;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -530,7 +530,7 @@ public class SitemapResourceTest extends JavaTest {
         when(sitemapProviderMock.getSitemap(SITEMAP_MODEL_NAME)).thenReturn(defaultSitemapMock);
     }
 
-    private class TestItem extends GenericItem {
+    private static class TestItem extends GenericItem {
 
         public TestItem(String name) {
             super("Number", name);

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/JSONResponseTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/JSONResponseTest.java
@@ -131,7 +131,7 @@ public class JSONResponseTest {
     }
 
     @SuppressWarnings("unused")
-    private final class LargeEntity {
+    private static final class LargeEntity {
 
         private List<BigDecimal> randoms = getRandoms();
 

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
@@ -69,7 +69,7 @@ public class Stream2JSONInputStreamTest {
     }
 
     @SuppressWarnings("unused")
-    private class DummyObject {
+    private static class DummyObject {
         private final String key;
         private final String value;
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -121,7 +121,7 @@ public class MqttBrokerConnection {
      * The callback will interact with the {@link AbstractReconnectStrategy} as well as inform registered
      * {@link MqttConnectionObserver}s.
      */
-    public class ConnectionCallback implements MqttClientConnectedListener, MqttClientDisconnectedListener {
+    public static class ConnectionCallback implements MqttClientConnectedListener, MqttClientDisconnectedListener {
         private final MqttBrokerConnection connection;
         private final Runnable cancelTimeoutFuture;
         private CompletableFuture<Boolean> future = new CompletableFuture<>();

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -290,7 +290,7 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
         processItem(item);
     }
 
-    private class SemanticTagRegistryChangeListener implements RegistryChangeListener<SemanticTag> {
+    private static class SemanticTagRegistryChangeListener implements RegistryChangeListener<SemanticTag> {
 
         private SemanticsMetadataProvider provider;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -157,7 +157,7 @@ public final class ThingStatusInfoI18nLocalizationService {
     /**
      * Utility class to parse the thing status description into the text reference and optional arguments.
      */
-    private final class ParsedDescription {
+    private static final class ParsedDescription {
 
         private static final int LIMIT = 2;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
@@ -35,7 +35,7 @@ import org.openhab.core.types.StateDescriptionFragment;
 public class StateChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<StateChannelTypeBuilder>
         implements StateChannelTypeBuilder {
 
-    private class StateChannelTypeImpl extends ChannelType {
+    private static class StateChannelTypeImpl extends ChannelType {
         private StateChannelTypeImpl(ChannelTypeUID uid, boolean advanced, String itemType, String label,
                 @Nullable String description, @Nullable String category, @Nullable Set<String> tags,
                 @Nullable StateDescription state, @Nullable CommandDescription commandDescription,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
@@ -32,7 +32,7 @@ import org.openhab.core.types.EventDescription;
 public class TriggerChannelTypeBuilderImpl extends AbstractChannelTypeBuilder<TriggerChannelTypeBuilder>
         implements TriggerChannelTypeBuilder {
 
-    private class TriggerChannelTypeImpl extends ChannelType {
+    private static class TriggerChannelTypeImpl extends ChannelType {
         TriggerChannelTypeImpl(ChannelTypeUID uid, boolean advanced, String label, @Nullable String description,
                 @Nullable String category, @Nullable Set<String> tags, @Nullable EventDescription event,
                 @Nullable URI configDescriptionURI) throws IllegalArgumentException {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/firmware/ProgressCallbackTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/firmware/ProgressCallbackTest.java
@@ -382,7 +382,7 @@ public final class ProgressCallbackTest {
         assertThat(fpiEvent.getFirmwareUpdateResultInfo().getResult(), is(expectedResult));
     }
 
-    class DummyFirmwareHandler implements FirmwareUpdateHandler {
+    static class DummyFirmwareHandler implements FirmwareUpdateHandler {
 
         @Override
         public Thing getThing() {

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/AbstractFileTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/AbstractFileTransformationService.java
@@ -298,7 +298,7 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
         return Arrays.stream(path.listFiles(new FileExtensionsFilter(validExtensions))).map(File::getName).toList();
     }
 
-    protected class FileExtensionsFilter implements FilenameFilter {
+    protected static class FileExtensionsFilter implements FilenameFilter {
 
         private final String[] validExtensions;
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -31,7 +31,7 @@ import org.openhab.core.types.StateOption;
 @NonNullByDefault
 public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
-    private class StateDescriptionImpl extends StateDescription {
+    private static class StateDescriptionImpl extends StateDescription {
         StateDescriptionImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
                 @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
             super(minimum, maximum, step, pattern, readOnly, options);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/ArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/ArithmeticGroupFunctionTest.java
@@ -273,7 +273,7 @@ public class ArithmeticGroupFunctionTest {
         assertEquals(new DecimalType("2"), state);
     }
 
-    private class TestItem extends GenericItem {
+    private static class TestItem extends GenericItem {
 
         public TestItem(String name, State state) {
             super("Test", name);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
@@ -68,7 +68,7 @@ public class DateTimeGroupFunctionTest {
         assertTrue(expectedDateTime.isEqual(((DateTimeType) state).getZonedDateTime()));
     }
 
-    private class TestItem extends GenericItem {
+    private static class TestItem extends GenericItem {
 
         public TestItem(String name, State state) {
             super("Test", name);

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -220,7 +220,7 @@ public class RuntimeRuleTest extends JavaOSGiTest {
         });
     }
 
-    class TestItemProvider implements ItemProvider {
+    static class TestItemProvider implements ItemProvider {
         private final Collection<Item> items;
 
         TestItemProvider(Collection<Item> items) {

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -1076,7 +1076,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
         assertThat(future.get(), is(true));
     }
 
-    class DummyThingHandlerFactory extends BaseThingHandlerFactory {
+    static class DummyThingHandlerFactory extends BaseThingHandlerFactory {
 
         public DummyThingHandlerFactory(ComponentContext context) {
             super.activate(context);

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherOSGiTest.java
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherOSGiTest.java
@@ -88,7 +88,7 @@ public class ConfigDispatcherOSGiTest extends JavaOSGiTest {
         configDispatcher = new ConfigDispatcher(configAdmin);
     }
 
-    private class CopyDirectoryRecursive extends SimpleFileVisitor<Path> {
+    private static class CopyDirectoryRecursive extends SimpleFileVisitor<Path> {
         private final Path sourceDir;
         private final Path targetDir;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -136,7 +136,7 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         managedThingProvider.getAll().forEach(t -> managedThingProvider.remove(t.getUID()));
     }
 
-    class SimpleThingHandlerFactory extends BaseThingHandlerFactory {
+    static class SimpleThingHandlerFactory extends BaseThingHandlerFactory {
         private final Set<ThingHandler> handlers = new HashSet<>();
 
         @Override
@@ -180,7 +180,7 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class SimpleBridgeHandler extends BaseBridgeHandler {
+    static class SimpleBridgeHandler extends BaseBridgeHandler {
 
         SimpleBridgeHandler(Bridge bridge) {
             super(bridge);
@@ -434,7 +434,7 @@ public class BindingBaseClassesOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class YetAnotherThingHandlerFactory extends BaseThingHandlerFactory {
+    static class YetAnotherThingHandlerFactory extends BaseThingHandlerFactory {
 
         @Override
         public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
@@ -40,7 +40,7 @@ import org.openhab.core.thing.type.ThingTypeBuilder;
 @NonNullByDefault
 public class ThingEventOSGiTest extends JavaOSGiTest {
 
-    class ThingEventSubscriber implements EventSubscriber {
+    static class ThingEventSubscriber implements EventSubscriber {
 
         private @Nullable Event lastReceivedEvent;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
@@ -276,7 +276,7 @@ public class ThingStatusInfoI18nLocalizationServiceOSGiTest extends JavaOSGiTest
         ((SimpleThingHandler) thing.getHandler()).setThingStatusInfo(thingStatusInfo);
     }
 
-    private class SimpleThingHandlerFactory extends BaseThingHandlerFactory {
+    private static class SimpleThingHandlerFactory extends BaseThingHandlerFactory {
 
         @Override
         public void activate(ComponentContext componentContext) {
@@ -294,7 +294,7 @@ public class ThingStatusInfoI18nLocalizationServiceOSGiTest extends JavaOSGiTest
         }
     }
 
-    private class SimpleThingHandler extends AbstractThingHandler {
+    private static class SimpleThingHandler extends AbstractThingHandler {
 
         SimpleThingHandler(Thing thing) {
             super(thing);
@@ -316,7 +316,7 @@ public class ThingStatusInfoI18nLocalizationServiceOSGiTest extends JavaOSGiTest
         }
     }
 
-    private abstract class AbstractThingHandler extends BaseThingHandler {
+    private abstract static class AbstractThingHandler extends BaseThingHandler {
         public AbstractThingHandler(Thing thing) {
             super(thing);
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -326,7 +326,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class TestThingHandlerFactory extends BaseThingHandlerFactory {
+    static class TestThingHandlerFactory extends BaseThingHandlerFactory {
 
         @Override
         public void activate(final ComponentContext ctx) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -451,7 +451,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         }
     }
 
-    class TestThingHandlerFactory extends BaseThingHandlerFactory {
+    static class TestThingHandlerFactory extends BaseThingHandlerFactory {
 
         @Override
         public void activate(final ComponentContext ctx) {

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -89,7 +89,7 @@ import org.openhab.core.types.TimeSeries;
 @NonNullByDefault
 public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
-    private class ItemChannelLinkRegistryAdvanced extends ItemChannelLinkRegistry {
+    private static class ItemChannelLinkRegistryAdvanced extends ItemChannelLinkRegistry {
         public ItemChannelLinkRegistryAdvanced(ThingRegistry thingRegistry, ItemRegistry itemRegistry) {
             super(thingRegistry, itemRegistry);
         }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
@@ -375,7 +375,7 @@ public class ThingUpdateOSGiTest extends JavaOSGiTest {
         registerService(channelTypeRegistry);
     }
 
-    class TestThingHandlerFactory extends BaseThingHandlerFactory {
+    static class TestThingHandlerFactory extends BaseThingHandlerFactory {
         Logger logger = LoggerFactory.getLogger(TestThingHandlerFactory.class);
 
         @Override

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/LinkEventOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/LinkEventOSGiTest.java
@@ -40,7 +40,7 @@ public class LinkEventOSGiTest extends JavaOSGiTest {
     private @NonNullByDefault({}) ItemChannelLinkRegistry itemChannelLinkRegistry;
     private @NonNullByDefault({}) ItemChannelLinkEventSubscriber eventSubscriber;
 
-    class ItemChannelLinkEventSubscriber implements EventSubscriber {
+    static class ItemChannelLinkEventSubscriber implements EventSubscriber {
 
         private @Nullable Event lastReceivedEvent;
 


### PR DESCRIPTION
A static inner class does not keep an implicit reference to its enclosing instance. This prevents a common cause of memory leaks and uses less memory per instance of the class.