### PR TITLE
Iterate using Map entries

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1349,10 +1349,10 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
         OutputRef outputRef = null;
         boolean conflict = false;
         if (!inputTags.isEmpty()) {
-            for (Set<String> outTags : outputTagMap.keySet()) {
-                if (outTags.containsAll(inputTags)) { // input tags must be subset of the output ones
+            for (Entry<Set<String>, OutputRef> entry : outputTagMap.entrySet()) {
+                if (entry.getKey().containsAll(inputTags)) { // input tags must be subset of the output ones
                     if (outputRef == null) {
-                        outputRef = outputTagMap.get(outTags);
+                        outputRef = entry.getValue();
                     } else {
                         conflict = true; // already exist candidate for autoMap
                         break;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Map.Entry;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -95,9 +95,9 @@ public class CompositeModuleHandlerFactory extends BaseModuleHandlerFactory impl
         ModuleHandler handlerOfModule = getHandlers().get(getModuleIdentifier(childModulePrefix, module.getId()));
         if (handlerOfModule instanceof AbstractCompositeModuleHandler) {
             AbstractCompositeModuleHandler<ModuleImpl, ?, ?> h = (AbstractCompositeModuleHandler<ModuleImpl, ?, ?>) handlerOfModule;
-            Set<ModuleImpl> modules = h.moduleHandlerMap.keySet();
-            for (ModuleImpl child : modules) {
-                ModuleHandler childHandler = h.moduleHandlerMap.get(child);
+            for (Entry<ModuleImpl, @Nullable ? extends ModuleHandler> entry : h.moduleHandlerMap.entrySet()) {
+                ModuleImpl child = entry.getKey();
+                ModuleHandler childHandler = entry.getValue();
                 if (childHandler == null) {
                     continue;
                 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
@@ -54,9 +54,9 @@ public class HostFragmentMappingUtil {
         if (bundles != null) {
             hosts = Arrays.asList(bundles);
         } else {
-            for (Bundle host : hostFragmentMapping.keySet()) {
-                if (hostFragmentMapping.get(host).contains(fragment)) {
-                    hosts.add(host);
+            for (Entry<Bundle, List<Bundle>> entry : hostFragmentMapping.entrySet()) {
+                if (entry.getValue().contains(fragment)) {
+                    hosts.add(entry.getKey());
                 }
             }
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
@@ -151,8 +151,7 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
         if (portfolio == null) {
             for (Entry<Vendor, List<String>> entry : providerPortfolio.entrySet()) {
                 if (entry.getKey().getVendorSymbolicName().equals(vendor.getVendorSymbolicName())) {
-                    List<String> vendorPortfolio = entry.getValue();
-                    return vendorPortfolio == null ? List.of() : vendorPortfolio;
+                    return entry.getValue();
                 }
             }
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -148,9 +149,9 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
     protected List<String> getPreviousPortfolio(Vendor vendor) {
         List<String> portfolio = providerPortfolio.get(vendor);
         if (portfolio == null) {
-            for (Vendor v : providerPortfolio.keySet()) {
-                if (v.getVendorSymbolicName().equals(vendor.getVendorSymbolicName())) {
-                    List<String> vendorPortfolio = providerPortfolio.get(v);
+            for (Entry<Vendor, List<String>> entry : providerPortfolio.entrySet()) {
+                if (entry.getKey().getVendorSymbolicName().equals(vendor.getVendorSymbolicName())) {
+                    List<String> vendorPortfolio = entry.getValue();
                     return vendorPortfolio == null ? List.of() : vendorPortfolio;
                 }
             }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
@@ -105,32 +105,29 @@ public final class ConfigDescriptionValidatorImpl implements ConfigDescriptionVa
         for (Entry<String, ConfigDescriptionParameter> entry : map.entrySet()) {
             String key = entry.getKey();
             ConfigDescriptionParameter configDescriptionParameter = entry.getValue();
-            if (configDescriptionParameter != null) {
-                // If the parameter supports multiple selection, then it may be provided as an array
-                if (configDescriptionParameter.isMultiple() && configurationParameters.get(key) instanceof List) {
-                    List<Object> values = (List<Object>) configurationParameters.get(key);
-                    // check if multipleLimit is obeyed
-                    Integer multipleLimit = configDescriptionParameter.getMultipleLimit();
-                    if (multipleLimit != null && values.size() > multipleLimit) {
-                        MessageKey messageKey = MessageKey.MULTIPLE_LIMIT_VIOLATED;
-                        ConfigValidationMessage message = new ConfigValidationMessage(
-                                configDescriptionParameter.getName(), messageKey.defaultMessage, messageKey.key,
-                                multipleLimit, values.size());
-                        configDescriptionValidationMessages.add(message);
-                    }
-                    // Perform validation on each value in the list separately
-                    for (Object value : values) {
-                        ConfigValidationMessage message = validateParameter(configDescriptionParameter, value);
-                        if (message != null) {
-                            configDescriptionValidationMessages.add(message);
-                        }
-                    }
-                } else {
-                    ConfigValidationMessage message = validateParameter(configDescriptionParameter,
-                            configurationParameters.get(key));
+            // If the parameter supports multiple selection, then it may be provided as an array
+            if (configDescriptionParameter.isMultiple() && configurationParameters.get(key) instanceof List) {
+                List<Object> values = (List<Object>) configurationParameters.get(key);
+                // check if multipleLimit is obeyed
+                Integer multipleLimit = configDescriptionParameter.getMultipleLimit();
+                if (multipleLimit != null && values.size() > multipleLimit) {
+                    MessageKey messageKey = MessageKey.MULTIPLE_LIMIT_VIOLATED;
+                    ConfigValidationMessage message = new ConfigValidationMessage(configDescriptionParameter.getName(),
+                            messageKey.defaultMessage, messageKey.key, multipleLimit, values.size());
+                    configDescriptionValidationMessages.add(message);
+                }
+                // Perform validation on each value in the list separately
+                for (Object value : values) {
+                    ConfigValidationMessage message = validateParameter(configDescriptionParameter, value);
                     if (message != null) {
                         configDescriptionValidationMessages.add(message);
                     }
+                }
+            } else {
+                ConfigValidationMessage message = validateParameter(configDescriptionParameter,
+                        configurationParameters.get(key));
+                if (message != null) {
+                    configDescriptionValidationMessages.add(message);
                 }
             }
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -101,8 +102,9 @@ public final class ConfigDescriptionValidatorImpl implements ConfigDescriptionVa
 
         Collection<ConfigValidationMessage> configDescriptionValidationMessages = new ArrayList<>();
 
-        for (String key : map.keySet()) {
-            ConfigDescriptionParameter configDescriptionParameter = map.get(key);
+        for (Entry<String, ConfigDescriptionParameter> entry : map.entrySet()) {
+            String key = entry.getKey();
+            ConfigDescriptionParameter configDescriptionParameter = entry.getValue();
             if (configDescriptionParameter != null) {
                 // If the parameter supports multiple selection, then it may be provided as an array
                 if (configDescriptionParameter.isMultiple() && configurationParameters.get(key) instanceof List) {

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -156,13 +156,11 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
             for (UpnpIOParticipant participant : participants) {
                 if (Objects.equals(getDevice(participant), deviceRoot)) {
                     for (Entry<String, StateVariableValue> entry : values.entrySet()) {
-                        StateVariableValue value = entry.getValue();
-                        if (value.getValue() != null) {
-                            try {
-                                participant.onValueReceived(entry.getKey(), value.getValue().toString(), serviceId);
-                            } catch (Exception e) {
-                                logger.error("Participant threw an exception onValueReceived", e);
-                            }
+                        try {
+                            participant.onValueReceived(entry.getKey(), entry.getValue().getValue().toString(),
+                                    serviceId);
+                        } catch (Exception e) {
+                            logger.error("Participant threw an exception onValueReceived", e);
                         }
                     }
                     break;

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.transport.upnp.internal;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -154,11 +155,11 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
                     deviceRoot.getIdentity().getUdn());
             for (UpnpIOParticipant participant : participants) {
                 if (Objects.equals(getDevice(participant), deviceRoot)) {
-                    for (String stateVariable : values.keySet()) {
-                        StateVariableValue value = values.get(stateVariable);
+                    for (Entry<String, StateVariableValue> entry : values.entrySet()) {
+                        StateVariableValue value = entry.getValue();
                         if (value.getValue() != null) {
                             try {
-                                participant.onValueReceived(stateVariable, value.getValue().toString(), serviceId);
+                                participant.onValueReceived(entry.getKey(), value.getValue().toString(), serviceId);
                             } catch (Exception e) {
                                 logger.error("Participant threw an exception onValueReceived", e);
                             }
@@ -300,8 +301,8 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
                     if (action != null) {
                         ActionInvocation invocation = new ActionInvocation(action);
                         if (inputs != null) {
-                            for (String variable : inputs.keySet()) {
-                                invocation.setInput(variable, inputs.get(variable));
+                            for (Entry<String, String> entry : inputs.entrySet()) {
+                                invocation.setInput(entry.getKey(), entry.getValue());
                             }
                         }
 
@@ -316,10 +317,11 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
 
                         Map<String, ActionArgumentValue> result = invocation.getOutputMap();
                         if (result != null) {
-                            for (String variable : result.keySet()) {
+                            for (Entry<String, ActionArgumentValue> entry : result.entrySet()) {
+                                String variable = entry.getKey();
                                 final ActionArgumentValue newArgument;
                                 try {
-                                    newArgument = result.get(variable);
+                                    newArgument = entry.getValue();
                                 } catch (final Exception ex) {
                                     logger.debug("An exception '{}' occurred, cannot get argument for variable '{}'",
                                             ex.getMessage(), variable);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
@@ -14,6 +14,7 @@ package org.openhab.core.thing.binding;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -105,8 +106,8 @@ public class ThingFactory {
                             thingHandlerFactory.getClass(), thingTypeUID);
                 } else {
                     if (properties != null) {
-                        for (String key : properties.keySet()) {
-                            thing.setProperty(key, properties.get(key));
+                        for (Entry<String, String> entry : properties.entrySet()) {
+                            thing.setProperty(entry.getKey(), entry.getValue());
                         }
                     }
                 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
@@ -21,6 +21,7 @@ import java.util.Base64;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.Servlet;
@@ -161,8 +162,8 @@ public class ProxyServletService extends HttpServlet {
     private Hashtable<String, @Nullable String> propsFromConfig(Map<String, Object> config, Servlet servlet) {
         Hashtable<String, @Nullable String> props = new Hashtable<>();
 
-        for (String key : config.keySet()) {
-            props.put(key, config.get(key).toString());
+        for (Entry<String, Object> entry : config.entrySet()) {
+            props.put(entry.getKey(), entry.getValue().toString());
         }
 
         // must specify for Jetty proxy servlet, per http://stackoverflow.com/a/27625380

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -191,10 +192,11 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
             this.defaultVoice = config.containsKey(CONFIG_DEFAULT_VOICE) ? config.get(CONFIG_DEFAULT_VOICE).toString()
                     : null;
 
-            for (String key : config.keySet()) {
+            for (Entry<String, Object> entry : config.entrySet()) {
+                String key = entry.getKey();
                 if (key.startsWith(CONFIG_PREFIX_DEFAULT_VOICE)) {
                     String tts = key.substring(CONFIG_PREFIX_DEFAULT_VOICE.length());
-                    defaultVoices.put(tts, config.get(key).toString());
+                    defaultVoices.put(tts, entry.getValue().toString());
                 }
             }
         }

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -908,9 +908,9 @@ public class InboxOSGiTest extends JavaOSGiTest {
         assertNotNull(addedThing);
         assertNotNull(approvedThing);
         assertEquals(approvedThing, addedThing);
-        discoveryResultProperties.keySet().forEach(key -> {
+        discoveryResultProperties.forEach((key, value) -> {
             String thingProperty = addedThing.getProperties().get(key);
-            String descResultParam = String.valueOf(discoveryResultProperties.get(key));
+            String descResultParam = String.valueOf(value);
             assertThat(thingProperty, is(notNullValue()));
             assertThat(descResultParam, is(notNullValue()));
             assertThat(thingProperty, is(descResultParam));


### PR DESCRIPTION
Iteration using Map entries is preferred because it is more efficient and helps preventing NPEs.