### PR TITLE
Fix `SerialPort.getFlowControlMode()` infinite recursion

### DIFF
--- a/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortImpl.java
@@ -206,7 +206,7 @@ public class SerialPortImpl implements SerialPort {
 
     @Override
     public int getFlowControlMode() {
-        return getFlowControlMode();
+        return sp.getFlowControlMode();
     }
 
     @Override

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/rxtx/RxTxSerialPort.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/rxtx/RxTxSerialPort.java
@@ -206,7 +206,7 @@ public class RxTxSerialPort implements SerialPort {
 
     @Override
     public int getFlowControlMode() {
-        return getFlowControlMode();
+        return sp.getFlowControlMode();
     }
 
     @Override


### PR DESCRIPTION
An infinite recursion would occur when calling this method. I did not find any add-ons using this method but that could be due to this bug.