### PR TITLE
Fix `String.format` argument mismatches

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -289,16 +289,14 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
         }
 
         if (!canPerformScans()) {
-            String logString = String.format(
-                    "Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}",
-                    sysfsTtyDevicesDirectory, devDirectory);
+            String message = "Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}";
 
             if (configurationIsChanged) {
                 // Warn if the configuration was actively changed
-                logger.warn(logString);
+                logger.warn(message, sysfsTtyDevicesDirectory, devDirectory);
             } else {
                 // Otherwise, only debug log - so that, in particular, on Non-Linux systems users do not see warning
-                logger.debug(logString);
+                logger.debug(message, sysfsTtyDevicesDirectory, devDirectory);
             }
         }
     }

--- a/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/Bin2Json.java
+++ b/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/Bin2Json.java
@@ -88,7 +88,7 @@ public class Bin2Json {
         try {
             parser = JBBPParser.prepare(parserRule);
         } catch (JBBPException e) {
-            throw new ConversionException(String.format("Illegal parser rule, reason: %s", e.getMessage(), e));
+            throw new ConversionException(String.format("Illegal parser rule, reason: %s", e.getMessage()), e);
         }
     }
 
@@ -103,7 +103,7 @@ public class Bin2Json {
         try {
             return convert(HexUtils.hexToBytes(hexString));
         } catch (IllegalArgumentException e) {
-            throw new ConversionException(String.format("Illegal hexstring , reason: %s", e.getMessage(), e));
+            throw new ConversionException(String.format("Illegal hexstring , reason: %s", e.getMessage()), e);
         }
     }
 
@@ -117,10 +117,8 @@ public class Bin2Json {
     public JsonObject convert(byte[] data) throws ConversionException {
         try {
             return convert(parser.parse(data));
-        } catch (IOException e) {
-            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage(), e));
-        } catch (JBBPException e) {
-            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage(), e));
+        } catch (IOException | JBBPException e) {
+            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage()), e);
         }
     }
 
@@ -134,10 +132,8 @@ public class Bin2Json {
     public JsonObject convert(InputStream inputStream) throws ConversionException {
         try {
             return convert(parser.parse(inputStream));
-        } catch (IOException e) {
-            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage(), e));
-        } catch (JBBPException e) {
-            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage(), e));
+        } catch (IOException | JBBPException e) {
+            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage()), e);
         }
     }
 
@@ -151,7 +147,7 @@ public class Bin2Json {
             }
             return json;
         } catch (JBBPException e) {
-            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage(), e));
+            throw new ConversionException(String.format("Unexpected error, reason: %s", e.getMessage()), e);
         }
     }
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
@@ -169,7 +169,7 @@ public final class WriteRequestJsonUtilities {
                 writeSingle.set(true);
                 if (valuesElem.size() != 1) {
                     throw new IllegalArgumentException(String
-                            .format("Expecting single value with functionCode=%s, got: %d", functionCode, valuesElem));
+                            .format("Expecting single value with functionCode=%s, got: %s", functionCode, valuesElem));
                 }
                 // fall-through to WRITE_MULTIPLE_COILS
             case WRITE_MULTIPLE_COILS:
@@ -189,7 +189,7 @@ public final class WriteRequestJsonUtilities {
                 writeSingle.set(true);
                 if (valuesElem.size() != 1) {
                     throw new IllegalArgumentException(String
-                            .format("Expecting single value with functionCode=%s, got: %d", functionCode, valuesElem));
+                            .format("Expecting single value with functionCode=%s, got: %s", functionCode, valuesElem));
                 }
                 // fall-through to WRITE_MULTIPLE_REGISTERS
             case WRITE_MULTIPLE_REGISTERS: {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
@@ -101,7 +101,7 @@ public class PercentTypeTest {
             assertEquals(new PercentType("1"), new PercentType("1", locale));
             assertEquals(new PercentType("12"), new PercentType("12", locale));
             assertEquals(new PercentType("12.56"), new PercentType(String.format("12%s56", ds), locale));
-            assertEquals(new PercentType("100"), new PercentType(String.format("100", gs, gs), locale));
+            assertEquals(new PercentType("100"), new PercentType("100", locale));
         });
     }
 


### PR DESCRIPTION
These argument mismatches cause wrong messages being logged and thrown in exceptions.