### PR TITLE
Use protected modifier with constructor of abstract classes

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -83,7 +83,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractRemoteAddonService.class);
 
-    public AbstractRemoteAddonService(EventPublisher eventPublisher, ConfigurationAdmin configurationAdmin,
+    protected AbstractRemoteAddonService(EventPublisher eventPublisher, ConfigurationAdmin configurationAdmin,
             StorageService storageService, AddonInfoRegistry addonInfoRegistry, String servicePid) {
         this.addonInfoRegistry = addonInfoRegistry;
         this.eventPublisher = eventPublisher;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
@@ -52,7 +52,7 @@ public abstract class AbstractScriptDependencyTracker
     private final BidiSetBag<String, String> scriptToLibs = new BidiSetBag<>();
     private final WatchService watchService;
 
-    public AbstractScriptDependencyTracker(WatchService watchService, final String fileDirectory) {
+    protected AbstractScriptDependencyTracker(WatchService watchService, final String fileDirectory) {
         this.watchService = watchService;
         this.libraryPath = watchService.getWatchPath().resolve(fileDirectory);
 

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
@@ -96,7 +96,7 @@ public abstract class AbstractScriptFileWatcher implements WatchService.WatchEve
 
     private volatile int currentStartLevel;
 
-    public AbstractScriptFileWatcher(final WatchService watchService, final ScriptEngineManager manager,
+    protected AbstractScriptFileWatcher(final WatchService watchService, final ScriptEngineManager manager,
             final ReadyService readyService, final StartLevelService startLevelService, final String fileDirectory,
             boolean watchSubDirectories) {
         this.watchService = watchService;

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -59,7 +59,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
 
     protected final String ruleUID;
 
-    public AbstractScriptModuleHandler(T module, String ruleUID, ScriptEngineManager scriptEngineManager) {
+    protected AbstractScriptModuleHandler(T module, String ruleUID, ScriptEngineManager scriptEngineManager) {
         super(module);
         this.scriptEngineManager = scriptEngineManager;
         this.ruleUID = ruleUID;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AbstractRuleRegistryEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AbstractRuleRegistryEvent.java
@@ -36,7 +36,7 @@ public abstract class AbstractRuleRegistryEvent extends AbstractEvent {
      * @param source the source of the event
      * @param rule the rule for which this event is created
      */
-    public AbstractRuleRegistryEvent(String topic, String payload, @Nullable String source, RuleDTO rule) {
+    protected AbstractRuleRegistryEvent(String topic, String payload, @Nullable String source, RuleDTO rule) {
         super(topic, payload, source);
         this.rule = rule;
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AbstractCommandProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AbstractCommandProvider.java
@@ -94,7 +94,7 @@ public abstract class AbstractCommandProvider<@NonNull E> implements ServiceTrac
      * @param context is the {@link BundleContext}, used for creating a tracker for {@link Parser} services.
      */
     @SuppressWarnings("unchecked")
-    public AbstractCommandProvider(BundleContext context) {
+    protected AbstractCommandProvider(BundleContext context) {
         this.bundleContext = context;
         parserTracker = new ServiceTracker(context, Parser.class.getName(), this);
         parserTracker.open();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
@@ -67,7 +67,8 @@ public abstract class AbstractCompositeModuleHandler<M extends Module, MT extend
      * @param mapModuleToHandler map containing pairs of child modules instances (defined by module type) and their
      *            handlers
      */
-    public AbstractCompositeModuleHandler(M module, MT moduleType, LinkedHashMap<M, @Nullable H> mapModuleToHandler) {
+    protected AbstractCompositeModuleHandler(M module, MT moduleType,
+            LinkedHashMap<M, @Nullable H> mapModuleToHandler) {
         this.module = module;
         this.moduleType = moduleType;
         this.moduleHandlerMap = mapModuleToHandler;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class AbstractResourceBundleProvider<@NonNull E> {
 
-    public AbstractResourceBundleProvider(String path) {
+    protected AbstractResourceBundleProvider(String path) {
         this.path = path;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -86,7 +86,7 @@ public abstract class AbstractFileProvider<@NonNull E> implements Provider<E> {
     private final Map<String, List<URL>> urls = new ConcurrentHashMap<>();
     private final List<ProviderChangeListener<E>> listeners = new ArrayList<>();
 
-    public AbstractFileProvider(String root) {
+    protected AbstractFileProvider(String root) {
         this.rootSubdirectory = root;
         configurationRoots = new String[] { OpenHAB.getConfigFolder() + File.separator + "automation" };
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -86,7 +86,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            enable background discovery or not.
      * @throws IllegalArgumentException if {@code timeout < 0}
      */
-    public AbstractDiscoveryService(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout,
+    protected AbstractDiscoveryService(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout,
             boolean backgroundDiscoveryEnabledByDefault) throws IllegalArgumentException {
         if (timeout < 0) {
             throw new IllegalArgumentException("The timeout must be >= 0!");
@@ -105,7 +105,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            If set to 0, disables the automatic stop.
      * @throws IllegalArgumentException if {@code timeout < 0}
      */
-    public AbstractDiscoveryService(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout)
+    protected AbstractDiscoveryService(@Nullable Set<ThingTypeUID> supportedThingTypes, int timeout)
             throws IllegalArgumentException {
         this(supportedThingTypes, timeout, true);
     }
@@ -118,7 +118,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            If set to 0, disables the automatic stop.
      * @throws IllegalArgumentException if {@code timeout < 0}
      */
-    public AbstractDiscoveryService(int timeout) throws IllegalArgumentException {
+    protected AbstractDiscoveryService(int timeout) throws IllegalArgumentException {
         this(null, timeout);
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/AbstractInboxEvent.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/AbstractInboxEvent.java
@@ -35,7 +35,7 @@ public abstract class AbstractInboxEvent extends AbstractEvent {
      * @param payload the payload
      * @param discoveryResult the discovery-result data transfer object
      */
-    public AbstractInboxEvent(String topic, String payload, DiscoveryResultDTO discoveryResult) {
+    protected AbstractInboxEvent(String topic, String payload, DiscoveryResultDTO discoveryResult) {
         super(topic, payload, null);
         this.discoveryResult = discoveryResult;
     }

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/AbstractConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/AbstractConsoleCommandExtension.java
@@ -32,7 +32,7 @@ public abstract class AbstractConsoleCommandExtension implements ConsoleCommandE
      * @param cmd The command the extension is used for.
      * @param desc The description what this extension is handling.
      */
-    public AbstractConsoleCommandExtension(final String cmd, final String desc) {
+    protected AbstractConsoleCommandExtension(final String cmd, final String desc) {
         this.cmd = cmd;
         this.desc = desc;
     }

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AbstractAuthPageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AbstractAuthPageServlet.java
@@ -67,7 +67,7 @@ public abstract class AbstractAuthPageServlet extends HttpServlet {
 
     protected String pageTemplate;
 
-    public AbstractAuthPageServlet(BundleContext bundleContext, @Reference UserRegistry userRegistry,
+    protected AbstractAuthPageServlet(BundleContext bundleContext, @Reference UserRegistry userRegistry,
             @Reference AuthenticationProvider authProvider, @Reference LocaleProvider localeProvider) {
         this.userRegistry = userRegistry;
         this.authProvider = authProvider;

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/AbstractRequestComparer.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/AbstractRequestComparer.java
@@ -29,7 +29,7 @@ abstract class AbstractRequestComparer<T extends ModbusWriteRequestBlueprint> ex
     private ModbusWriteFunctionCode expectedFunctionCode;
     private int expectedMaxTries;
 
-    public AbstractRequestComparer(int expectedUnitId, int expectedAddress,
+    protected AbstractRequestComparer(int expectedUnitId, int expectedAddress,
             ModbusWriteFunctionCode expectedFunctionCode, int expectedMaxTries) {
         this.expectedUnitId = expectedUnitId;
         this.expectedAddress = expectedAddress;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
@@ -75,7 +75,7 @@ public abstract class AbstractStorageBasedTypeProvider
      *
      * @param storageService a persistent {@link StorageService}
      */
-    public AbstractStorageBasedTypeProvider(StorageService storageService) {
+    protected AbstractStorageBasedTypeProvider(StorageService storageService) {
         String thingTypeStorageName = getClass().getName() + "-ThingType";
         String channelTypeStorageName = getClass().getName() + "-ChannelType";
         String channelGroupTypeStorageName = getClass().getName() + "-ChannelGroupType";

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
@@ -33,7 +33,7 @@ public abstract class AbstractThingDTO {
     public String thingTypeUID;
     public String location;
 
-    public AbstractThingDTO() {
+    protected AbstractThingDTO() {
     }
 
     protected AbstractThingDTO(String thingTypeUID, String uid, String label, String bridgeUID,

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
@@ -41,7 +41,7 @@ public abstract class AbstractTransformingChannelHandler implements ChannelHandl
 
     protected final ChannelValueConverterConfig channelConfig;
 
-    public AbstractTransformingChannelHandler(Consumer<State> updateState, Consumer<Command> postCommand,
+    protected AbstractTransformingChannelHandler(Consumer<State> updateState, Consumer<Command> postCommand,
             @Nullable Consumer<String> sendValue, ChannelTransformation stateTransformations,
             ChannelTransformation commandTransformations, ChannelValueConverterConfig channelConfig) {
         this.updateState = updateState;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLink.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLink.java
@@ -45,12 +45,12 @@ public abstract class AbstractLink implements Identifiable<String> {
      * @param itemName the item name for the link
      * @throws IllegalArgumentException if the item name is invalid
      */
-    public AbstractLink(String itemName) {
+    protected AbstractLink(String itemName) {
         ItemUtil.assertValidItemName(itemName);
         this.itemName = itemName;
     }
 
-    AbstractLink() {
+    protected AbstractLink() {
         this.itemName = null;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/AbstractLinkDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/AbstractLinkDTO.java
@@ -27,7 +27,7 @@ public abstract class AbstractLinkDTO {
     protected AbstractLinkDTO() {
     }
 
-    public AbstractLinkDTO(String itemName) {
+    protected AbstractLinkDTO(String itemName) {
         this.itemName = itemName;
     }
 }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/AbstractItemChannelLinkRegistryEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/AbstractItemChannelLinkRegistryEvent.java
@@ -26,7 +26,7 @@ public abstract class AbstractItemChannelLinkRegistryEvent extends AbstractEvent
 
     private final ItemChannelLinkDTO link;
 
-    public AbstractItemChannelLinkRegistryEvent(String topic, String payload, ItemChannelLinkDTO link) {
+    protected AbstractItemChannelLinkRegistryEvent(String topic, String payload, ItemChannelLinkDTO link) {
         super(topic, payload, null);
         this.link = link;
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
@@ -49,7 +49,7 @@ public abstract class AbstractDescriptionType implements Identifiable<UID> {
      * @param configDescriptionURI the {@link URI} that references the {@link ConfigDescription} of this type
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
-    public AbstractDescriptionType(UID uid, String label, @Nullable String description,
+    protected AbstractDescriptionType(UID uid, String label, @Nullable String description,
             @Nullable URI configDescriptionURI) throws IllegalArgumentException {
         if (label.isEmpty()) {
             throw new IllegalArgumentException("The label must neither be null nor empty!");

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
@@ -54,7 +54,7 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
      * @param clazz the class of the result type (must not be null)
      * @param type the name of the type (e.g. "thing-type", "channel-type")
      */
-    public AbstractDescriptionTypeConverter(Class<T> clazz, String type) {
+    protected AbstractDescriptionTypeConverter(Class<T> clazz, String type) {
         super(clazz);
         this.type = type;
         this.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "id", "true" } });

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
@@ -45,7 +45,7 @@ public abstract class AbstractResourceIconProvider implements IconProvider {
 
     protected final TranslationProvider i18nProvider;
 
-    public AbstractResourceIconProvider(final TranslationProvider i18nProvider) {
+    protected AbstractResourceIconProvider(final TranslationProvider i18nProvider) {
         this.i18nProvider = i18nProvider;
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
@@ -32,7 +32,7 @@ public abstract class AbstractCachedTTSService implements CachedTTSService {
 
     private final TTSCache ttsCache;
 
-    public AbstractCachedTTSService(final @Reference TTSCache ttsCache) {
+    protected AbstractCachedTTSService(final @Reference TTSCache ttsCache) {
         this.ttsCache = ttsCache;
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -161,7 +161,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         }
     };
 
-    public AbstractRuleBasedInterpreter(final EventPublisher eventPublisher, final ItemRegistry itemRegistry,
+    protected AbstractRuleBasedInterpreter(final EventPublisher eventPublisher, final ItemRegistry itemRegistry,
             final MetadataRegistry metadataRegistry) {
         this.eventPublisher = eventPublisher;
         this.itemRegistry = itemRegistry;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -32,9 +32,9 @@ public abstract class AbstractUID {
     private String uid = "";
 
     /**
-     * Constructor must be public, otherwise it can not be called by subclasses from another package.
+     * Constructor must be protected, otherwise it can not be called by subclasses from another package.
      */
-    public AbstractUID() {
+    protected AbstractUID() {
         segments = List.of();
     }
 
@@ -44,7 +44,7 @@ public abstract class AbstractUID {
      *
      * @param uid uid in form a string
      */
-    public AbstractUID(String uid) {
+    protected AbstractUID(String uid) {
         this(splitToSegments(uid));
         this.uid = uid;
     }
@@ -54,7 +54,7 @@ public abstract class AbstractUID {
      *
      * @param segments the id segments
      */
-    public AbstractUID(final String... segments) {
+    protected AbstractUID(final String... segments) {
         this(Arrays.asList(segments));
     }
 
@@ -63,7 +63,7 @@ public abstract class AbstractUID {
      *
      * @param segments segments
      */
-    public AbstractUID(List<String> segments) {
+    protected AbstractUID(List<String> segments) {
         int minNumberOfSegments = getMinimalNumberOfSegments();
         int numberOfSegments = segments.size();
         if (numberOfSegments < minNumberOfSegments) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
@@ -50,7 +50,7 @@ public abstract class AbstractManagedProvider<@NonNull E extends Identifiable<K>
 
     protected final Logger logger = LoggerFactory.getLogger(AbstractManagedProvider.class);
 
-    public AbstractManagedProvider(final StorageService storageService) {
+    protected AbstractManagedProvider(final StorageService storageService) {
         storage = storageService.getStorage(getStorageName(), this.getClass().getClassLoader());
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEvent.java
@@ -36,7 +36,7 @@ public abstract class AbstractEvent implements Event {
      * @param payload the payload
      * @param source the source
      */
-    public AbstractEvent(String topic, String payload, @Nullable String source) {
+    protected AbstractEvent(String topic, String payload, @Nullable String source) {
         this.topic = topic;
         this.payload = payload;
         this.source = source;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEventFactory.java
@@ -38,7 +38,7 @@ public abstract class AbstractEventFactory implements EventFactory {
      *
      * @param supportedEventTypes the supported event types
      */
-    public AbstractEventFactory(Set<String> supportedEventTypes) {
+    protected AbstractEventFactory(Set<String> supportedEventTypes) {
         this.supportedEventTypes = Set.copyOf(supportedEventTypes);
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/AbstractI18nException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/AbstractI18nException.java
@@ -37,7 +37,7 @@ public abstract class AbstractI18nException extends RuntimeException {
      * @param message the exception message; use "@text/key" to reference "key" entry in the properties file
      * @param msgParams the optional arguments of the message defined in the properties file
      */
-    public AbstractI18nException(String message, @Nullable Object @Nullable... msgParams) {
+    protected AbstractI18nException(String message, @Nullable Object @Nullable... msgParams) {
         this(message, null, msgParams);
     }
 
@@ -48,7 +48,8 @@ public abstract class AbstractI18nException extends RuntimeException {
      *            and indicates that the cause is nonexistent or unknown.
      * @param msgParams the optional arguments of the message defined in the properties file
      */
-    public AbstractI18nException(String message, @Nullable Throwable cause, @Nullable Object @Nullable... msgParams) {
+    protected AbstractI18nException(String message, @Nullable Throwable cause,
+            @Nullable Object @Nullable... msgParams) {
         super(I18nUtil.isConstant(message) ? null : message, cause);
         if (I18nUtil.isConstant(message)) {
             this.msgKey = I18nUtil.stripConstant(message);
@@ -62,7 +63,7 @@ public abstract class AbstractI18nException extends RuntimeException {
      *
      * @param cause the cause (which is saved for later retrieval by the getCause() method).
      */
-    public AbstractI18nException(Throwable cause) {
+    protected AbstractI18nException(Throwable cause) {
         super(cause);
         this.msgKey = "";
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
@@ -317,7 +317,7 @@ public class ThingStatusInfoI18nLocalizationServiceOSGiTest extends JavaOSGiTest
     }
 
     private abstract static class AbstractThingHandler extends BaseThingHandler {
-        public AbstractThingHandler(Thing thing) {
+        protected AbstractThingHandler(Thing thing) {
             super(thing);
         }
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -376,7 +376,7 @@ public class ChannelCommandDescriptionProviderOSGiTest extends JavaOSGiTest {
     }
 
     private abstract static class AbstractThingHandler extends BaseThingHandler {
-        public AbstractThingHandler(Thing thing) {
+        protected AbstractThingHandler(Thing thing) {
             super(thing);
         }
     }

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -501,7 +501,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
     }
 
     private abstract static class AbstractThingHandler extends BaseThingHandler {
-        public AbstractThingHandler(Thing thing) {
+        protected AbstractThingHandler(Thing thing) {
             super(thing);
         }
     }


### PR DESCRIPTION
Abstract classes should not have public constructors.
Constructors of abstract classes can only be called in constructors of their subclasses.
So there is no point in making them public.
The protected modifier should be enough.