### PR TITLE
Fix CurrencyUnit

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyConverter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyConverter.java
@@ -12,8 +12,10 @@
  */
 package org.openhab.core.internal.library.unit;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.measure.UnitConverter;
@@ -22,6 +24,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import tech.units.indriya.function.AbstractConverter;
+import tech.units.indriya.function.Calculus;
 
 /**
  * The {@link CurrencyConverter} implements an {@link UnitConverter} for
@@ -81,5 +84,29 @@ public class CurrencyConverter extends AbstractConverter {
     @Override
     public boolean isLinear() {
         return true;
+    }
+
+    /**
+     * This is currently necessary because conversion of {@link tech.units.indriya.unit.ProductUnit}s requires a
+     * converter that is properly registered. This is currently not possible. We can't use the registered providers,
+     * because they only have package-private constructors.
+     *
+     * {@see https://github.com/unitsofmeasurement/indriya/issues/402}
+     */
+    static {
+        // call to ensure map is initialized
+        Map<Class<? extends AbstractConverter>, Integer> normalFormOrder = (Map<Class<? extends AbstractConverter>, Integer>) Calculus
+                .getNormalFormOrder();
+        try {
+            Field field = Calculus.class.getDeclaredField("normalFormOrder");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<Class<? extends AbstractConverter>, Integer> original = (Map<Class<? extends AbstractConverter>, Integer>) field
+                    .get(null);
+            original.put(CurrencyConverter.class, 1000);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException("Could not add currency converter", e);
+        }
+
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
@@ -108,8 +108,10 @@ public class CurrencyService {
         Unit<Currency> baseCurrency = currencyProvider.getBaseCurrency();
         ((CurrencyUnit) BASE_CURRENCY).setSymbol(baseCurrency.getSymbol());
         ((CurrencyUnit) BASE_CURRENCY).setName(baseCurrency.getName());
-        unitFormatter.label(BASE_CURRENCY,
-                Objects.requireNonNullElse(baseCurrency.getSymbol(), baseCurrency.getName()));
+        unitFormatter.label(BASE_CURRENCY, baseCurrency.getName());
+        if (baseCurrency.getSymbol() != null) {
+            unitFormatter.alias(BASE_CURRENCY, baseCurrency.getSymbol());
+        }
 
         currencyProvider.getAdditionalCurrencies().forEach(CurrencyUnits::addUnit);
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/CurrencyUnitTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/CurrencyUnitTest.java
@@ -33,6 +33,7 @@ import org.openhab.core.internal.library.unit.CurrencyService;
 import org.openhab.core.library.dimension.Currency;
 import org.openhab.core.library.dimension.EnergyPrice;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.types.util.UnitUtils;
 
 /**
  * The {@link CurrencyUnitTest} contains tests for the currency units
@@ -95,6 +96,16 @@ public class CurrencyUnitTest {
         assertThat(price, is(notNullValue()));
         assertThat(price.getUnit(), is(TestCurrencyProvider.EUR));
         assertThat(price.doubleValue(), closeTo(1.25, 1E-4));
+    }
+
+    @Test
+    public void testEnergyPriceConversion() {
+        QuantityType<EnergyPrice> price = new QuantityType<>("0.25 EUR/kWh");
+        QuantityType<EnergyPrice> convertedPrice = price.toUnit("DKK/kWh");
+
+        assertThat(convertedPrice, is(notNullValue()));
+        assertThat(convertedPrice.getUnit(), is(UnitUtils.parseUnit("DKK/kWh")));
+        assertThat(convertedPrice.doubleValue(), closeTo(1.8625, 1e-4));
     }
 
     private static class TestCurrencyProvider implements CurrencyProvider {


### PR DESCRIPTION
This fixes some issues that were recently detected regarding the new currency units:

- Currency codes could not be used for the base currency (but for additional currencies) when a symbol is defined. The reason is that in this case only the symbol and not symbol and label were added to the unit formatter.

- Units composed of a currency and an additional currency (like `EUR/kWh`) were not properly converted (only the non-currency part was converted). This was caused by two problems: `CurrencyUnit` did not inherit from `AbstractUnit` and therefore the converter was not properly found (always `IDENTITY`). After I fixed that, an additional problem occurred: the `CurrencyConverter` could not be used because the list of converters is a final, non-accessible list.

@jlaur FYI.