### PR TITLE
Simplify Map operations using `computeIfAbsent`

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -154,11 +155,8 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
             return obj;
         }
 
-        Map<String, Object> objects = objectCache.get(scriptIdentifier);
-        if (objects == null) {
-            objects = new HashMap<>();
-            objectCache.put(scriptIdentifier, objects);
-        }
+        Map<String, Object> objects = Objects
+                .requireNonNull(objectCache.computeIfAbsent(scriptIdentifier, k -> new HashMap<>()));
 
         obj = objects.get(type);
         if (obj != null) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -376,11 +377,8 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
      */
     private void updateRuleTemplateMapping(String templateUID, String ruleUID, boolean resolved) {
         synchronized (this) {
-            Set<String> ruleUIDs = mapTemplateToRules.get(templateUID);
-            if (ruleUIDs == null) {
-                ruleUIDs = new HashSet<>();
-                mapTemplateToRules.put(templateUID, ruleUIDs);
-            }
+            Set<String> ruleUIDs = Objects
+                    .requireNonNull(mapTemplateToRules.computeIfAbsent(templateUID, k -> new HashSet<>()));
             if (resolved) {
                 ruleUIDs.remove(ruleUID);
             } else {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -252,11 +253,7 @@ public abstract class AbstractFileProvider<@NonNull E> implements Provider<E> {
             }
         } else {
             synchronized (urls) {
-                List<URL> value = urls.get(parserType);
-                if (value == null) {
-                    value = new ArrayList<>();
-                    urls.put(parserType, value);
-                }
+                List<URL> value = Objects.requireNonNull(urls.computeIfAbsent(parserType, k -> new ArrayList<>()));
                 value.add(url);
             }
             logger.debug("Parser {} not available", parserType, new Exception());

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/WatchServiceUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/WatchServiceUtil.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.service.WatchService;
@@ -35,11 +36,8 @@ public class WatchServiceUtil {
             WatchService watchService) {
         AutomationWatchService aws = null;
         synchronized (WATCH_SERVICES) {
-            Map<String, AutomationWatchService> watchers = WATCH_SERVICES.get(provider);
-            if (watchers == null) {
-                watchers = new HashMap<>();
-                WATCH_SERVICES.put(provider, watchers);
-            }
+            Map<String, AutomationWatchService> watchers = Objects
+                    .requireNonNull(WATCH_SERVICES.computeIfAbsent(provider, k -> new HashMap<>()));
             if (watchers.get(watchingDir) == null) {
                 aws = new AutomationWatchService(provider, watchService, watchingDir);
                 watchers.put(watchingDir, aws);

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlBasedProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlBasedProvider.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -78,24 +79,13 @@ public abstract class AbstractXmlBasedProvider<@NonNull T_ID, @NonNull T_OBJECT 
         if (objectList.isEmpty()) {
             return;
         }
-        List<T_OBJECT> objects = acquireObjects(bundle);
-        if (objects == null) {
-            return;
-        }
+        List<T_OBJECT> objects = Objects
+                .requireNonNull(bundleObjectMap.computeIfAbsent(bundle, k -> new CopyOnWriteArrayList<>()));
         objects.addAll(objectList);
         for (T_OBJECT object : objectList) {
             // just make sure no old entry remains in the cache
             removeCachedEntries(object);
         }
-    }
-
-    private @Nullable List<T_OBJECT> acquireObjects(Bundle bundle) {
-        List<T_OBJECT> objects = bundleObjectMap.get(bundle);
-        if (objects == null) {
-            objects = new CopyOnWriteArrayList<>();
-            bundleObjectMap.put(bundle, objects);
-        }
-        return objects;
     }
 
     /**

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -89,24 +90,17 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
         }
         ItemChannelLink itemChannelLink = new ItemChannelLink(itemName, channelUIDObject, configuration);
 
-        Set<String> itemNames = contextMap.get(context);
-        if (itemNames == null) {
-            itemNames = new HashSet<>();
-            contextMap.put(context, itemNames);
-        }
+        Set<String> itemNames = Objects.requireNonNull(contextMap.computeIfAbsent(context, k -> new HashSet<>()));
         itemNames.add(itemName);
         if (previousItemNames != null) {
             previousItemNames.remove(itemName);
         }
 
-        Map<ChannelUID, ItemChannelLink> links = itemChannelLinkMap.get(itemName);
-        if (links == null) {
-            // Create a HashMap with an initial capacity of 2 (the default is 16) to save memory
-            // because most items have only one channel. A capacity of 2 is enough to avoid
-            // resizing the HashMap in most cases, whereas 1 would trigger a resize as soon as
-            // one element is added.
-            itemChannelLinkMap.put(itemName, links = new HashMap<>(2));
-        }
+        // Create a HashMap with an initial capacity of 2 (the default is 16) to save memory because most items have
+        // only one channel. A capacity of 2 is enough to avoid resizing the HashMap in most cases, whereas 1 would
+        // trigger a resize as soon as one element is added.
+        Map<ChannelUID, ItemChannelLink> links = Objects
+                .requireNonNull(itemChannelLinkMap.computeIfAbsent(itemName, k -> new HashMap<>(2)));
 
         ItemChannelLink oldLink = links.put(channelUIDObject, itemChannelLink);
         if (oldLink == null) {

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
@@ -22,6 +22,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -264,11 +265,8 @@ public class JavaOSGiTest extends JavaTest {
     }
 
     private void saveServiceRegistration(final String interfaceName, final ServiceRegistration<?> srvReg) {
-        List<ServiceRegistration<?>> regs = registeredServices.get(interfaceName);
-        if (regs == null) {
-            regs = new ArrayList<>();
-            registeredServices.put(interfaceName, regs);
-        }
+        List<ServiceRegistration<?>> regs = Objects
+                .requireNonNull(registeredServices.computeIfAbsent(interfaceName, k -> new ArrayList<>()));
         regs.add(srvReg);
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -73,18 +74,10 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
         try {
             Set<L> set;
 
-            set = itemNameToLink.get(itemName);
-            if (set == null) {
-                set = new HashSet<>();
-                itemNameToLink.put(itemName, set);
-            }
+            set = Objects.requireNonNull(itemNameToLink.computeIfAbsent(itemName, k -> new HashSet<>()));
             set.add(element);
 
-            set = linkedUidToLink.get(linkedUid);
-            if (set == null) {
-                set = new HashSet<>();
-                linkedUidToLink.put(linkedUid, set);
-            }
+            set = Objects.requireNonNull(linkedUidToLink.computeIfAbsent(linkedUid, k -> new HashSet<>()));
             set.add(element);
         } finally {
             toLinkLock.writeLock().unlock();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
@@ -15,6 +15,7 @@ package org.openhab.core.internal.common;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -86,11 +87,8 @@ public class SafeCallManagerImpl implements SafeCallManager {
     @Override
     public void enqueue(Invocation invocation) {
         synchronized (queues) {
-            Queue<Invocation> queue = queues.get(invocation.getIdentifier());
-            if (queue == null) {
-                queue = new LinkedList<>();
-                queues.put(invocation.getIdentifier(), queue);
-            }
+            Queue<Invocation> queue = Objects
+                    .requireNonNull(queues.computeIfAbsent(invocation.getIdentifier(), k -> new LinkedList<>()));
             queue.add(invocation);
         }
         trigger(invocation.getIdentifier());


### PR DESCRIPTION
If the specified key is not already associated with a value (or is mapped to null), the given mapping function computes the value.