### PR TITLE
Replace Markdown backticks with JavaDoc code tags

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -206,7 +206,7 @@ public interface AudioManager {
     /**
      * Get a list of source ids that match a given pattern
      *
-     * @param pattern pattern to search, can include `*` and `?` placeholders
+     * @param pattern pattern to search, can include {@code *} and {@code ?} placeholders
      * @return ids of matching sources
      */
     Set<String> getSourceIds(String pattern);
@@ -248,7 +248,7 @@ public interface AudioManager {
     /**
      * Get a list of sink ids that match a given pattern
      *
-     * @param pattern pattern to search, can include `*` and `?` placeholders
+     * @param pattern pattern to search, can include {@code *} and {@code ?} placeholders
      * @return ids of matching sinks
      */
     Set<String> getSinkIds(String pattern);

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -52,8 +52,8 @@ public class CommandWrapper implements Command, Action {
 
     /**
      * The constructor for the "help" instance of this class. This instance will be created by
-     * org.apache.karaf.shell.impl.action.command.ManagerImpl.instantiate(Class<? extends T>, Registry) and
-     * is used to print all usages from the `openhab` scope.
+     * {@code org.apache.karaf.shell.impl.action.command.ManagerImpl.instantiate(Class, Registry)} and
+     * is used to print all usages from the {@code openhab} scope.
      * The wrapped command is unused here because the karaf infrastructure will call the {@link #execute()} method.
      */
     public CommandWrapper() {

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -52,7 +52,7 @@ public class CommandWrapper implements Command, Action {
 
     /**
      * The constructor for the "help" instance of this class. This instance will be created by
-     * {@code org.apache.karaf.shell.impl.action.command.ManagerImpl.instantiate(Class, Registry)} and
+     * {@code org.apache.karaf.shell.impl.action.command.ManagerImpl.instantiate(Class<? extends T>, Registry)} and
      * is used to print all usages from the {@code openhab} scope.
      * The wrapped command is unused here because the karaf infrastructure will call the {@link #execute()} method.
      */

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
@@ -26,8 +26,8 @@ import org.openhab.core.io.transport.mqtt.internal.client.MqttAsyncClientWrapper
 import com.hivemq.client.mqtt.MqttClientState;
 
 /**
- * We need an extended MqttBrokerConnection to overwrite the protected `connectionCallbacks` with
- * an instance that takes the mocked version of `MqttBrokerConnection` and overwrite the connection state.
+ * We need an extended MqttBrokerConnection to overwrite the protected {@link #connectionCallback} with
+ * an instance that takes the mocked version of {@link MqttBrokerConnection} and overwrite the connection state.
  *
  * We also mock the internal Mqtt3AsyncClient that in respect to the success flags
  * immediately succeed or fail with publish, subscribe, unsubscribe, connect, disconnect.

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Bridge.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Bridge.java
@@ -22,7 +22,7 @@ import org.openhab.core.thing.binding.BridgeHandler;
  * A {@link Bridge} is a {@link Thing} that connects other {@link Thing}s.
  *
  * @author Dennis Nobel - Initial contribution
- * @author Christoph Weitkamp - Added method `getThing(ThingUID)`
+ * @author Christoph Weitkamp - Added method {@code getThing(ThingUID)}
  */
 @NonNullByDefault
 public interface Bridge extends Thing {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Jochen Hiller - Bugfix 455434: added default constructor
  * @author Dennis Nobel - Added channel group id
  * @author Kai Kreuzer - Changed creation of channels to not require a thing type
- * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single `#` or none
+ * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single {@code #} or none
  */
 @NonNullByDefault
 public class ChannelUID extends UID {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
@@ -34,7 +34,7 @@ import org.openhab.core.thing.binding.ThingHandler;
  * @author Simon Kaufmann - Added label, location
  * @author Kai Kreuzer - Removed linked items from Thing
  * @author Yordan Zhelev - Added method for getting the enabled status
- * @author Christoph Weitkamp - Added method `getChannel(ChannelUID)`
+ * @author Christoph Weitkamp - Added method {@code getChannel(ChannelUID)}
  */
 @NonNullByDefault
 public interface Thing extends Identifiable<ThingUID> {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/BridgeImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/BridgeImpl.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  *
  * @author Denis Nobel - Initial contribution
- * @author Christoph Weitkamp - Added method `getThing(ThingUID)`
+ * @author Christoph Weitkamp - Added method {@code getThing(ThingUID)}
  */
 @NonNullByDefault
 public class BridgeImpl extends ThingImpl implements Bridge {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -43,7 +43,7 @@ import org.openhab.core.thing.binding.builder.ThingStatusInfoBuilder;
  *         ThingType Description
  * @author Thomas Höfer - Added thing and thing type properties
  * @author Simon Kaufmann - Added label
- * @author Christoph Weitkamp - Added method `getChannel(ChannelUID)`
+ * @author Christoph Weitkamp - Added method {@code getChannel(ChannelUID)}
  */
 @NonNullByDefault
 public class ThingImpl implements Thing {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelUIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelUIDTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
  * Tests for class {@link ChannelUID}.
  *
  * @author Simon Kaufmann - Initial contribution
- * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single `#` or none
+ * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single {@code #} or none
  */
 @NonNullByDefault
 public class ChannelUIDTest {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheAsync.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheAsync.java
@@ -65,8 +65,8 @@ public class ExpiringCacheAsync<V> {
      * @param requestNewValueFuture If the value is expired, this supplier is called to supply the cache with a future
      *            that on completion will update the cached value
      * @return the value in form of a CompletableFuture. You can for instance use it this way:
-     *         `getValue().thenAccept(value->useYourValueHere(value));`. If you need the value synchronously you can use
-     *         `getValue().get()`.
+     *         {@code getValue().thenAccept(value->useYourValueHere(value));}. If you need the value synchronously you
+     *         can use {@code getValue().get()}.
      */
     public CompletableFuture<V> getValue(Supplier<CompletableFuture<V>> requestNewValueFuture) {
         if (isExpired()) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
@@ -227,7 +227,7 @@ public class ColorUtil {
 
     /**
      * Transform <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSV</a> based {@link HSBType} to
-     * <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> `xy` format.
+     * <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> {@code xy} format.
      *
      * See <a href=
      * "https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/">Hue
@@ -242,7 +242,7 @@ public class ColorUtil {
 
     /**
      * Transform <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSV</a> based {@link HSBType} to
-     * <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> `xy` format.
+     * <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> {@code xy} format.
      *
      * See <a href=
      * "https://developers.meethue.com/develop/application-design-guidance/color-conversion-formulas-rgb-to-xy-and-back/">Hue
@@ -398,7 +398,7 @@ public class ColorUtil {
     }
 
     /**
-     * Transform <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> `xy` format to
+     * Transform <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> {@code xy} format to
      * <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSV</a> based {@link HSBType}.
      *
      * See <a href=
@@ -414,7 +414,7 @@ public class ColorUtil {
     }
 
     /**
-     * Transform <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> `xy` format to
+     * Transform <a href="https://en.wikipedia.org/wiki/CIE_1931_color_space">CIE 1931</a> {@code xy} format to
      * <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSV</a> based {@link HSBType}.
      *
      * See <a href=
@@ -560,9 +560,9 @@ public class ColorUtil {
         /**
          * Color <a href="https://en.wikipedia.org/wiki/Gamut">gamut</a>
          *
-         * @param r double array with `xy` coordinates for red, x, y between 0.0000 and 1.0000.
-         * @param g double array with `xy` coordinates for green, x, y between 0.0000 and 1.0000.
-         * @param b double array with `xy` coordinates for blue, x, y between 0.0000 and 1.0000.
+         * @param r double array with {@code xy} coordinates for red, x, y between 0.0000 and 1.0000.
+         * @param g double array with {@code xy} coordinates for green, x, y between 0.0000 and 1.0000.
+         * @param b double array with {@code xy} coordinates for blue, x, y between 0.0000 and 1.0000.
          */
         public Gamut {
         }


### PR DESCRIPTION
The proper way to format code with JavaDoc is using code tags and not Markdown backticks.