### PR TITLE
[discovery] Refactor `java.util.Date` usages to `java.time.Instant`

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.core.config.discovery;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -69,7 +69,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     private final Set<ThingTypeUID> supportedThingTypes;
     private final int timeout;
 
-    private long timestampOfLastScan = 0L;
+    private Instant timestampOfLastScan = Instant.MIN;
 
     private @Nullable ScheduledFuture<?> scheduledStop;
 
@@ -190,7 +190,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
                     }
                 }, getScanTimeout(), TimeUnit.SECONDS);
             }
-            timestampOfLastScan = new Date().getTime();
+            timestampOfLastScan = Instant.now();
 
             try {
                 startScan();
@@ -421,7 +421,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      * @return timestamp as long
      */
     protected long getTimestampOfLastScan() {
-        return timestampOfLastScan;
+        return Instant.MIN.equals(timestampOfLastScan) ? 0 : timestampOfLastScan.toEpochMilli();
     }
 
     private String inferKey(DiscoveryResult discoveryResult, String lastSegment) {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.core.config.discovery.internal;
 
+import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,7 +43,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     private @Nullable String representationProperty;
     private @NonNullByDefault({}) DiscoveryResultFlag flag;
     private @NonNullByDefault({}) String label;
-    private long timestamp;
+    private Instant timestamp = Instant.MIN;
     private long timeToLive = TTL_UNLIMITED;
 
     /**
@@ -86,7 +86,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         this.representationProperty = representationProperty;
         this.label = label == null ? "" : label;
 
-        this.timestamp = new Date().getTime();
+        this.timestamp = Instant.now();
         this.timeToLive = timeToLive;
 
         this.flag = DiscoveryResultFlag.NEW;
@@ -157,7 +157,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
             this.properties = sourceResult.getProperties();
             this.representationProperty = sourceResult.getRepresentationProperty();
             this.label = sourceResult.getLabel();
-            this.timestamp = new Date().getTime();
+            this.timestamp = Instant.now();
             this.timeToLive = sourceResult.getTimeToLive();
         }
     }
@@ -221,7 +221,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
 
     @Override
     public long getTimestamp() {
-        return timestamp;
+        return Instant.MIN.equals(timestamp) ? 0 : timestamp.toEpochMilli();
     }
 
     @Override

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -14,7 +14,7 @@ package org.openhab.core.config.discovery.internal.console;
 
 import static org.openhab.core.config.discovery.inbox.InboxPredicates.*;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -163,7 +163,7 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
             ThingUID bridgeId = discoveryResult.getBridgeUID();
             Map<String, Object> properties = discoveryResult.getProperties();
             String representationProperty = discoveryResult.getRepresentationProperty();
-            String timestamp = new Date(discoveryResult.getTimestamp()).toString();
+            String timestamp = Instant.ofEpochMilli(discoveryResult.getTimestamp()).toString();
             String timeToLive = discoveryResult.getTimeToLive() == DiscoveryResult.TTL_UNLIMITED ? "UNLIMITED"
                     : "" + discoveryResult.getTimeToLive();
             console.println(String.format(

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -20,9 +20,9 @@ import static org.openhab.core.config.discovery.inbox.InboxPredicates.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -148,7 +148,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
             put("pnr", 1234455);
             put("snr", 12345);
             put("manufacturer", "huawei");
-            put("manufactured", new Date(12344));
+            put("manufactured", Instant.ofEpochMilli(12344));
         }
     };
 
@@ -1019,7 +1019,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatRemoveOlderResultsOnlyRemovesResultsFromTheSameDiscoveryService() {
         inbox.thingDiscovered(discoveryService1, testDiscoveryResult);
-        long now = new Date().getTime() + 1;
+        long now = Instant.now().toEpochMilli() + 1;
         assertThat(inbox.getAll().size(), is(1));
 
         // should not remove a result
@@ -1034,7 +1034,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatRemoveOlderResultsRemovesResultsWithoutAsource() {
         inbox.add(testDiscoveryResult);
-        long now = new Date().getTime() + 1;
+        long now = Instant.now().toEpochMilli() + 1;
         assertThat(inbox.getAll().size(), is(1));
 
         // should remove a result


### PR DESCRIPTION
This refactors some [java.util.Date](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Date.html) usages to the more modern [time API](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/package-summary.html).

The API is preserved as epoch milliseconds, so this is a non-breaking change.

There is two user-facing changes, though.

1. This console command has changed formatting:
```shell
openhab> openhab:inbox list
NEW [mydevice]: My Device [thingId=my:device:0, bridgeId=null, properties={ipAddress=192.168.0.1}, representationProperty=null, timestamp=2024-01-07T15:33:15.500Z, timeToLive=UNLIMITED]
```

Previously this would be displayed like this:
```shell
openhab> openhab:inbox list
NEW [mydevice]: My Device [thingId=my:device:0, bridgeId=null, properties={ipAddress=192.168.0.1}, representationProperty=null, timestamp=Sat Nov 11 16:33:15 CET 2023, timeToLive=UNLIMITED]
```

Since this is already quite technical, I didn't see a reason to invest in preserving the old formatting.

2. Changed debug logging

This is now UTC-formatted:
> Removed thing 'mydevice' from inbox because it was older than 2024-01-07T15:33:15.500Z