### PR TITLE
[discovery] Fix deserialization of DiscoveryResult

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -43,7 +43,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     private @Nullable String representationProperty;
     private @NonNullByDefault({}) DiscoveryResultFlag flag;
     private @NonNullByDefault({}) String label;
-    private Instant timestamp = Instant.MIN;
+    private long timestamp;
     private long timeToLive = TTL_UNLIMITED;
 
     /**
@@ -86,7 +86,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         this.representationProperty = representationProperty;
         this.label = label == null ? "" : label;
 
-        this.timestamp = Instant.now();
+        this.timestamp = Instant.now().toEpochMilli();
         this.timeToLive = timeToLive;
 
         this.flag = DiscoveryResultFlag.NEW;
@@ -157,7 +157,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
             this.properties = sourceResult.getProperties();
             this.representationProperty = sourceResult.getRepresentationProperty();
             this.label = sourceResult.getLabel();
-            this.timestamp = Instant.now();
+            this.timestamp = Instant.now().toEpochMilli();
             this.timeToLive = sourceResult.getTimeToLive();
         }
     }
@@ -216,12 +216,12 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     public String toString() {
         return "DiscoveryResult [thingUID=" + thingUID + ", properties=" + properties + ", representationProperty="
                 + representationProperty + ", flag=" + flag + ", label=" + label + ", bridgeUID=" + bridgeUID + ", ttl="
-                + timeToLive + ", timestamp=" + timestamp + "]";
+                + timeToLive + ", timestamp=" + Instant.ofEpochMilli(timestamp) + "]";
     }
 
     @Override
     public long getTimestamp() {
-        return Instant.MIN.equals(timestamp) ? 0 : timestamp.toEpochMilli();
+        return timestamp;
     }
 
     @Override


### PR DESCRIPTION
Partially revert #4026

See https://github.com/openhab/openhab-core/pull/4026/files#r1445323983

Even with this fix, there will be issues for discovery results created by the snapshot version today. A better solution might be to provide a custom deserializer for supporting both epoch and UTC, but I'm not sure how to do this right now for the storage service. I'm providing this PR as one option for fixing the regression.