### PR TITLE
Fix wrong class name logged in LocaleServiceImpl

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleServiceImpl.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleServiceImpl.java
@@ -62,12 +62,12 @@ public class LocaleServiceImpl implements LocaleService {
 
     @Reference(policy = ReferencePolicy.DYNAMIC)
     protected void setLocaleProvider(LocaleProvider provider) {
-        logger.debug("The localeProvider in LocaleUtilService has been set");
+        logger.debug("The localeProvider in {} has been set", LocaleServiceImpl.class.getSimpleName());
         localeProvider = provider;
     }
 
     protected void unsetLocaleProvider(LocaleProvider provider) {
-        logger.debug("The localeProvider in LocaleUtilService has been unset");
+        logger.debug("The localeProvider in {} has been unset", LocaleServiceImpl.class.getSimpleName());
         localeProvider = null;
     }
 


### PR DESCRIPTION
The logging will be less confusing when the correct class name is logged.