### PR TITLE
Fix logging in ChannelCommandDescriptionProvider

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
@@ -95,7 +95,7 @@ public class ChannelCommandDescriptionProvider implements CommandDescriptionProv
                     if (dynamicCommandDescription == originalCommandDescription) {
                         logger.error(
                                 "Dynamic command description matches original command description. DynamicCommandDescriptionProvider implementations must never return the original command description. {} has to be fixed.",
-                                dynamicCommandDescription.getClass());
+                                dynamicCommandDescriptionProvider.getClass());
                     } else {
                         return dynamicCommandDescription;
                     }


### PR DESCRIPTION
The class of the broken provider should be logged, not the class of the command description.

Found while investigating https://github.com/openhab/openhab-addons/issues/14747