### PR TITLE
[marketplace] Update CommunityUIWidgetAddonHandler.java to give a more helpful error

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -86,7 +86,7 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
             } else if (yamlContent != null) {
                 addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
-                throw new IllegalArgumentException("Couldn't find the widget in the add-on entry");
+                throw new IllegalArgumentException("Couldn't find the widget in the add-on entry, or the starting code fence is not marked as ```yaml");
             }
         } catch (IOException e) {
             logger.error("Widget from marketplace cannot be downloaded: {}", e.getMessage());

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -86,7 +86,8 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
             } else if (yamlContent != null) {
                 addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
-                throw new IllegalArgumentException("Couldn't find the widget in the add-on entry. The starting code fence may not be marked as ```yaml");
+                throw new IllegalArgumentException(
+                        "Couldn't find the widget in the add-on entry. The starting code fence may not be marked as ```yaml");
             }
         } catch (IOException e) {
             logger.error("Widget from marketplace cannot be downloaded: {}", e.getMessage());

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -86,7 +86,7 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
             } else if (yamlContent != null) {
                 addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
-                throw new IllegalArgumentException("Couldn't find the widget in the add-on entry, or the starting code fence is not marked as ```yaml");
+                throw new IllegalArgumentException("Couldn't find the widget in the add-on entry. The starting code fence may not be marked as ```yaml");
             }
         } catch (IOException e) {
             logger.error("Widget from marketplace cannot be downloaded: {}", e.getMessage());


### PR DESCRIPTION
Installing from marketplace gives an Error that is not very helpful.

Couldn’t find the widget in the add-on entry

The cause was missing ```yaml code fence when a normal code fence was used. This used to work in the past so a number of widgets are done this way and will not install. Suggest a more useful message to help guide widget devs.
