### PR TITLE
[transport.serial] add PORT_DISCONNECTED event

### DIFF
--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
@@ -31,6 +31,7 @@ public interface SerialPortEvent {
     int PE = 8;
     int FE = 9;
     int BI = 10;
+    int PORT_DISCONNECTED = 11;
 
     /**
      * Get the type of the event.


### PR DESCRIPTION
### Motivation
Several USB sticks are integrated via Serial Transport's SerialPort and related implementations.
Since these USB sticks can be removed causing the port to be not available anymore, it's useful to track this event by bindings that are interested to handle it, for example to change state of the corresponding Thing to OFFLINE.
A [HARDWARE_ERROR event has been introduced](https://github.com/NeuronRobotics/nrjavaserial/blob/5d6d4e6a8ee4d6706e3c7b19467aabccde58f765/src/main/java/gnu/io/SerialPortEvent.java#L83C2-L83C49) in NRJavaSerial 5.x but has not been added yet to OH Serial Transport.

This PR adds a PORT_DISCONNECTED event to the SerialPortEvent interface.

Fixes #4055 


