### PR TITLE
Script profile: Separate toHandlerScript for commands and states

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -43,8 +43,8 @@ public class ScriptProfile implements StateProfile {
 
     public static final String CONFIG_TO_ITEM_SCRIPT = "toItemScript";
     public static final String CONFIG_TO_HANDLER_SCRIPT = "toHandlerScript";
-    public static final String CONFIG_TO_HANDLER_COMMAND_SCRIPT = "toHandlerCommandScript";
-    public static final String CONFIG_TO_HANDLER_STATE_SCRIPT = "toHandlerStateScript";
+    public static final String CONFIG_COMMAND_FROM_ITEM_SCRIPT = "commandFromItemScript";
+    public static final String CONFIG_STATE_FROM_ITEM_SCRIPT = "stateFromItemScript";
 
     private final Logger logger = LoggerFactory.getLogger(ScriptProfile.class);
 
@@ -56,8 +56,8 @@ public class ScriptProfile implements StateProfile {
     private final List<Class<? extends Command>> handlerAcceptedCommandTypes;
 
     private final String toItemScript;
-    private final String toHandlerCommandScript;
-    private final String toHandlerStateScript;
+    private final String commandFromItemScript;
+    private final String stateFromItemScript;
     private final ProfileTypeUID profileTypeUID;
 
     private final boolean isConfigured;
@@ -76,20 +76,20 @@ public class ScriptProfile implements StateProfile {
                 String.class, "");
         String toHandlerScript = ConfigParser
                 .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_HANDLER_SCRIPT), String.class, "");
-        String localToHandlerCommandScript = ConfigParser.valueAsOrElse(
-                profileContext.getConfiguration().get(CONFIG_TO_HANDLER_COMMAND_SCRIPT), String.class, "");
-        this.toHandlerCommandScript = localToHandlerCommandScript.isBlank() ? toHandlerScript
-                : localToHandlerCommandScript;
-        this.toHandlerStateScript = ConfigParser
-                .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_TO_HANDLER_STATE_SCRIPT), String.class, "");
+        String localCommandFromItemScript = ConfigParser.valueAsOrElse(
+                profileContext.getConfiguration().get(CONFIG_COMMAND_FROM_ITEM_SCRIPT), String.class, "");
+        this.commandFromItemScript = localCommandFromItemScript.isBlank() ? toHandlerScript
+                : localCommandFromItemScript;
+        this.stateFromItemScript = ConfigParser
+                .valueAsOrElse(profileContext.getConfiguration().get(CONFIG_STATE_FROM_ITEM_SCRIPT), String.class, "");
 
-        if (!toHandlerScript.isBlank() && toHandlerCommandScript.isBlank()) {
-            logger.warn("'toHandlerScript' has been deprecated! Please use 'toHandlerCommandScript' instead.");
+        if (!toHandlerScript.isBlank() && commandFromItemScript.isBlank()) {
+            logger.warn("'toHandlerScript' has been deprecated! Please use 'commandFromItemScript' instead.");
         }
 
-        if (toItemScript.isBlank() && toHandlerCommandScript.isBlank() && toHandlerStateScript.isBlank()) {
+        if (toItemScript.isBlank() && commandFromItemScript.isBlank() && stateFromItemScript.isBlank()) {
             logger.error(
-                    "Neither 'toItemScript', 'toHandlerCommandScript' nor 'toHandlerStateScript' defined in link '{}'. Profile will discard all states and commands.",
+                    "Neither 'toItemScript', 'commandFromItemScript' nor 'stateFromItemScript' defined in link '{}'. Profile will discard all states and commands.",
                     callback.getItemChannelLink());
             isConfigured = false;
             return;
@@ -105,25 +105,27 @@ public class ScriptProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        if (isConfigured && !toHandlerStateScript.isBlank()) {
-            internalFromItem(toHandlerStateScript, state);
+        if (isConfigured) {
+            fromItem(stateFromItemScript, state);
         }
     }
 
     @Override
     public void onCommandFromItem(Command command) {
-        if (isConfigured && !toHandlerCommandScript.isBlank()) {
-            internalFromItem(toHandlerCommandScript, command);
+        if (isConfigured) {
+            fromItem(commandFromItemScript, command);
         }
     }
 
-    private void internalFromItem(String script, Type type) {
+    private void fromItem(String script, Type type) {
         String returnValue = executeScript(script, type);
         if (returnValue != null) {
             // try to parse the value
             Command newCommand = TypeParser.parseCommand(handlerAcceptedCommandTypes, returnValue);
             if (newCommand != null) {
                 callback.handleCommand(newCommand);
+            } else {
+                logger.debug("The given type {} could not be transformed to a command", type);
             }
         }
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -11,13 +11,13 @@
 				may return null to discard the updates/commands and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
-		<parameter name="toHandlerCommandScript" type="text">
+		<parameter name="commandFromItemScript" type="text">
 			<label>Item Command To Thing Transformation</label>
 			<description>The Script for transforming commands from the item to the Thing handler. The script may return null to
 				discard the commands and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
-		<parameter name="toHandlerStateScript" type="text">
+		<parameter name="stateFromItemScript" type="text">
 			<label>Item State To Thing Transformation</label>
 			<description>The Script for transforming states from the item to the Thing handler. The script may return null to
 				discard the states and not pass them through.</description>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -7,19 +7,19 @@
 	<config-description uri="profile:transform:SCRIPT">
 		<parameter name="toItemScript" type="text">
 			<label>Thing To Item Transformation</label>
-			<description>The Script for transforming state updates and commands from the Thing handler to the Item. The script
+			<description>The Script for transforming state updates and commands from the Thing handler to the item. The script
 				may return null to discard the updates/commands and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
 		<parameter name="toHandlerCommandScript" type="text">
 			<label>Item Command To Thing Transformation</label>
-			<description>The Script for transforming commands from the Item to the Thing handler. The script may return null to
+			<description>The Script for transforming commands from the item to the Thing handler. The script may return null to
 				discard the commands and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
 		<parameter name="toHandlerStateScript" type="text">
 			<label>Item State To Thing Transformation</label>
-			<description>The Script for transforming states from the Item to the Thing handler. The script may return null to
+			<description>The Script for transforming states from the item to the Thing handler. The script may return null to
 				discard the states and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -27,8 +27,9 @@
 			<label>Item To Thing Transformation (DEPRECATED)</label>
 			<description>The Script for transforming commands from the item to the Thing handler. The script may return null to
 				discard the commands and not pass them through. This is deprecated and has been replaced by
-				'toHandlerCommandScript'.</description>
+				'commandFromItemScript'.</description>
 			<limitToOptions>false</limitToOptions>
+			<advanced>true</advanced>
 		</parameter>
 	</config-description>
 

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/config/script-profile.xml
@@ -7,14 +7,27 @@
 	<config-description uri="profile:transform:SCRIPT">
 		<parameter name="toItemScript" type="text">
 			<label>Thing To Item Transformation</label>
-			<description>The Script for transforming state updates and commands from the Thing handler to the item. The script
+			<description>The Script for transforming state updates and commands from the Thing handler to the Item. The script
 				may return null to discard the updates/commands and not pass them through.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
-		<parameter name="toHandlerScript" type="text">
-			<label>Item To Thing Transformation</label>
-			<description>The Script for transforming commands from the item to the Thing handler. The script may return null to
+		<parameter name="toHandlerCommandScript" type="text">
+			<label>Item Command To Thing Transformation</label>
+			<description>The Script for transforming commands from the Item to the Thing handler. The script may return null to
 				discard the commands and not pass them through.</description>
+			<limitToOptions>false</limitToOptions>
+		</parameter>
+		<parameter name="toHandlerStateScript" type="text">
+			<label>Item State To Thing Transformation</label>
+			<description>The Script for transforming states from the Item to the Thing handler. The script may return null to
+				discard the states and not pass them through.</description>
+			<limitToOptions>false</limitToOptions>
+		</parameter>
+		<parameter name="toHandlerScript" type="text">
+			<label>Item To Thing Transformation (DEPRECATED)</label>
+			<description>The Script for transforming commands from the item to the Thing handler. The script may return null to
+				discard the commands and not pass them through. This is deprecated and has been replaced by
+				'toHandlerCommandScript'.</description>
 			<limitToOptions>false</limitToOptions>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -3,6 +3,6 @@ profile.config.transform.SCRIPT.commandFromItemScript.description = The Script f
 profile.config.transform.SCRIPT.stateFromItemScript.label = Item State To Thing Transformation
 profile.config.transform.SCRIPT.stateFromItemScript.description = The Script for transforming states from the item to the Thing handler. The script may return null to discard the states and not pass them through.
 profile.config.transform.SCRIPT.toHandlerScript.label = Item To Thing Transformation (DEPRECATED)
-profile.config.transform.SCRIPT.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through. This is deprecated and has been replaced by 'toHandlerCommandScript'.
+profile.config.transform.SCRIPT.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through. This is deprecated and has been replaced by 'commandFromItemScript'.
 profile.config.transform.SCRIPT.toItemScript.label = Thing To Item Transformation
 profile.config.transform.SCRIPT.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,8 +1,8 @@
-profile.config.transform.SCRIPT.toHandlerCommandScript.label = Item Command To Thing Transformation
-profile.config.transform.SCRIPT.toHandlerCommandScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.config.transform.SCRIPT.commandFromItemScript.label = Item Command To Thing Transformation
+profile.config.transform.SCRIPT.commandFromItemScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.config.transform.SCRIPT.stateFromItemScript.label = Item State To Thing Transformation
+profile.config.transform.SCRIPT.stateFromItemScript.description = The Script for transforming states from the item to the Thing handler. The script may return null to discard the states and not pass them through.
 profile.config.transform.SCRIPT.toHandlerScript.label = Item To Thing Transformation (DEPRECATED)
 profile.config.transform.SCRIPT.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through. This is deprecated and has been replaced by 'toHandlerCommandScript'.
-profile.config.transform.SCRIPT.toHandlerStateScript.label = Item State To Thing Transformation
-profile.config.transform.SCRIPT.toHandlerStateScript.description = The Script for transforming states from the item to the Thing handler. The script may return null to discard the states and not pass them through.
 profile.config.transform.SCRIPT.toItemScript.label = Thing To Item Transformation
 profile.config.transform.SCRIPT.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,4 +1,8 @@
-profile.system.script.toItemScript.label = Thing To Item Transformation
-profile.system.script.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.
-profile.system.script.toHandlerScript.label = Item To Thing Transformation
-profile.system.script.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.config.transform.SCRIPT.toHandlerCommandScript.label = Item Command To Thing Transformation
+profile.config.transform.SCRIPT.toHandlerCommandScript.description = The Script for transforming commands from the Item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.config.transform.SCRIPT.toHandlerScript.label = Item To Thing Transformation (DEPRECATED)
+profile.config.transform.SCRIPT.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through. This is deprecated and has been replaced by 'toHandlerCommandScript'.
+profile.config.transform.SCRIPT.toHandlerStateScript.label = Item State To Thing Transformation
+profile.config.transform.SCRIPT.toHandlerStateScript.description = The Script for transforming states from the Item to the Thing handler. The script may return null to discard the states and not pass them through.
+profile.config.transform.SCRIPT.toItemScript.label = Thing To Item Transformation
+profile.config.transform.SCRIPT.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the Item. The script may return null to discard the updates/commands and not pass them through.

--- a/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
+++ b/bundles/org.openhab.core.automation.module.script/src/main/resources/OH-INF/i18n/scriptprofile.properties
@@ -1,8 +1,8 @@
 profile.config.transform.SCRIPT.toHandlerCommandScript.label = Item Command To Thing Transformation
-profile.config.transform.SCRIPT.toHandlerCommandScript.description = The Script for transforming commands from the Item to the Thing handler. The script may return null to discard the commands and not pass them through.
+profile.config.transform.SCRIPT.toHandlerCommandScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through.
 profile.config.transform.SCRIPT.toHandlerScript.label = Item To Thing Transformation (DEPRECATED)
 profile.config.transform.SCRIPT.toHandlerScript.description = The Script for transforming commands from the item to the Thing handler. The script may return null to discard the commands and not pass them through. This is deprecated and has been replaced by 'toHandlerCommandScript'.
 profile.config.transform.SCRIPT.toHandlerStateScript.label = Item State To Thing Transformation
-profile.config.transform.SCRIPT.toHandlerStateScript.description = The Script for transforming states from the Item to the Thing handler. The script may return null to discard the states and not pass them through.
+profile.config.transform.SCRIPT.toHandlerStateScript.description = The Script for transforming states from the item to the Thing handler. The script may return null to discard the states and not pass them through.
 profile.config.transform.SCRIPT.toItemScript.label = Thing To Item Transformation
-profile.config.transform.SCRIPT.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the Item. The script may return null to discard the updates/commands and not pass them through.
+profile.config.transform.SCRIPT.toItemScript.description = The Script for transforming state updates and commands from the Thing handler to the item. The script may return null to discard the updates/commands and not pass them through.

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -18,9 +18,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_HANDLER_COMMAND_SCRIPT;
+import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_COMMAND_FROM_ITEM_SCRIPT;
+import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_STATE_FROM_ITEM_SCRIPT;
 import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_HANDLER_SCRIPT;
-import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_HANDLER_STATE_SCRIPT;
 import static org.openhab.core.automation.module.script.profile.ScriptProfile.CONFIG_TO_ITEM_SCRIPT;
 
 import java.util.HashMap;
@@ -92,14 +92,14 @@ public class ScriptProfileTest extends JavaTest {
         verify(profileCallback, never()).sendCommand(any());
 
         assertLogMessage(ScriptProfile.class, LogLevel.ERROR,
-                "Neither 'toItemScript', 'toHandlerCommandScript' nor 'toHandlerStateScript' defined in link '"
+                "Neither 'toItemScript', 'commandFromItemScript' nor 'stateFromItemScript' defined in link '"
                         + link.toString() + "'. Profile will discard all states and commands.");
     }
 
     @Test
     public void scriptExecutionErrorForwardsNoValueToCallback() throws TransformationException {
         ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
-                .withToHandlerCommandScript("outScript").withToHandlerStateScript("outScript").build();
+                .withCommandFromItemScript("outScript").withStateFromItemScript("outScript").build();
 
         when(transformationServiceMock.transform(any(), any()))
                 .thenThrow(new TransformationException("intentional failure"));
@@ -121,7 +121,7 @@ public class ScriptProfileTest extends JavaTest {
     @Test
     public void scriptExecutionResultNullForwardsNoValueToCallback() throws TransformationException {
         ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
-                .withToHandlerCommandScript("outScript").withToHandlerStateScript("outScript").build();
+                .withCommandFromItemScript("outScript").withStateFromItemScript("outScript").build();
 
         when(transformationServiceMock.transform(any(), any())).thenReturn(null);
 
@@ -142,7 +142,7 @@ public class ScriptProfileTest extends JavaTest {
     @Test
     public void scriptExecutionResultForwardsTransformedValueToCallback() throws TransformationException {
         ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
-                .withToHandlerCommandScript("outScript").withToHandlerStateScript("outScript")
+                .withCommandFromItemScript("outScript").withStateFromItemScript("outScript")
                 .withAcceptedCommandTypes(List.of(OnOffType.class)).withAcceptedDataTypes(List.of(OnOffType.class))
                 .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
 
@@ -186,7 +186,7 @@ public class ScriptProfileTest extends JavaTest {
 
     @Test
     public void onlyToHandlerCommandScriptDoesNotForwardInboundCommands() throws TransformationException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withToHandlerCommandScript("outScript")
+        ProfileContext profileContext = ProfileContextBuilder.create().withCommandFromItemScript("outScript")
                 .withAcceptedCommandTypes(List.of(DecimalType.class)).withAcceptedDataTypes(List.of(DecimalType.class))
                 .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
 
@@ -208,7 +208,7 @@ public class ScriptProfileTest extends JavaTest {
 
     @Test
     public void onlyToHandlerStateScriptDoesNotForwardInboundCommands() throws TransformationException {
-        ProfileContext profileContext = ProfileContextBuilder.create().withToHandlerStateScript("outScript")
+        ProfileContext profileContext = ProfileContextBuilder.create().withStateFromItemScript("outScript")
                 .withAcceptedCommandTypes(List.of(DecimalType.class)).withAcceptedDataTypes(List.of(DecimalType.class))
                 .withHandlerAcceptedCommandTypes(List.of(OnOffType.class)).build();
 
@@ -231,7 +231,7 @@ public class ScriptProfileTest extends JavaTest {
     @Test
     public void incompatibleStateOrCommandNotForwardedToCallback() throws TransformationException {
         ProfileContext profileContext = ProfileContextBuilder.create().withToItemScript("inScript")
-                .withToHandlerCommandScript("outScript").withToHandlerStateScript("outScript")
+                .withCommandFromItemScript("outScript").withStateFromItemScript("outScript")
                 .withAcceptedCommandTypes(List.of(DecimalType.class)).withAcceptedDataTypes(List.of(PercentType.class))
                 .withHandlerAcceptedCommandTypes(List.of(HSBType.class)).build();
 
@@ -293,13 +293,13 @@ public class ScriptProfileTest extends JavaTest {
             return this;
         }
 
-        public ProfileContextBuilder withToHandlerCommandScript(String toHandlerCommandScript) {
-            configuration.put(CONFIG_TO_HANDLER_COMMAND_SCRIPT, toHandlerCommandScript);
+        public ProfileContextBuilder withCommandFromItemScript(String commandFromItemScript) {
+            configuration.put(CONFIG_COMMAND_FROM_ITEM_SCRIPT, commandFromItemScript);
             return this;
         }
 
-        public ProfileContextBuilder withToHandlerStateScript(String toHandlerStateScript) {
-            configuration.put(CONFIG_TO_HANDLER_STATE_SCRIPT, toHandlerStateScript);
+        public ProfileContextBuilder withStateFromItemScript(String stateFromItemScript) {
+            configuration.put(CONFIG_STATE_FROM_ITEM_SCRIPT, stateFromItemScript);
             return this;
         }
 


### PR DESCRIPTION
This allows much more fine-grained control for the script profile. 

E.g. it is now possible to mimic the behaviour of the `system:follow` profile, but apply a script transformation to the forwarded state. I discovered the need for this when trying to make a KNX channel follow an Item state, but at the same time needed to transform the Item state before sending it to KNX.