### PR TITLE
Use precompiled regular expressions to validate the segments of a UID

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
@@ -78,8 +78,7 @@ public class MetadataSelectorMatcher {
             result.addAll(metadataNamespaces);
 
             // filter all name spaces which do not match the UID segment pattern (this will be the regex tokens):
-            return result.stream().filter(namespace -> namespace.matches(AbstractUID.SEGMENT_PATTERN))
-                    .collect(Collectors.toSet());
+            return result.stream().filter(AbstractUID::isValid).collect(Collectors.toSet());
         }
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -14,6 +14,7 @@ package org.openhab.core.common;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -26,7 +27,7 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public abstract class AbstractUID {
 
-    public static final String SEGMENT_PATTERN = "[\\w-]*";
+    private static final Pattern SEGMENT_PATTERN = Pattern.compile("[\\w-]*");
     public static final String SEPARATOR = ":";
     private final List<String> segments;
     private String uid = "";
@@ -95,8 +96,12 @@ public abstract class AbstractUID {
         return segments.get(segment);
     }
 
+    public static boolean isValid(@Nullable String segment) {
+        return segment != null && SEGMENT_PATTERN.matcher(segment).matches();
+    }
+
     protected void validateSegment(String segment, int index, int length) {
-        if (!segment.matches(SEGMENT_PATTERN)) {
+        if (!isValid(segment)) {
             throw new IllegalArgumentException(String.format(
                     "ID segment '%s' contains invalid characters. Each segment of the ID must match the pattern %s.",
                     segment, SEGMENT_PATTERN));


### PR DESCRIPTION
# Description
Avoid to compile the SEGMENT_PATTERN for each validated segment of a UID.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>