### PR TITLE
Use the ChannelUID to retrieve the Channel from a Thing

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
@@ -204,7 +204,7 @@ public class AutoUpdateManager {
         for (ChannelUID channelUID : linkedChannelUIDs) {
             Thing thing = thingRegistry.get(channelUID.getThingUID());
             if (thing == null //
-                    || thing.getChannel(channelUID.getId()) == null //
+                    || thing.getChannel(channelUID) == null //
                     || thing.getHandler() == null //
                     || !ThingStatus.ONLINE.equals(thing.getStatus()) //
             ) {
@@ -223,7 +223,7 @@ public class AutoUpdateManager {
                 continue;
             }
             AutoUpdatePolicy policy = AutoUpdatePolicy.DEFAULT;
-            Channel channel = thing.getChannel(channelUID.getId());
+            Channel channel = thing.getChannel(channelUID);
             if (channel != null) {
                 AutoUpdatePolicy channelpolicy = channel.getAutoUpdatePolicy();
                 if (channelpolicy != null) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -234,7 +234,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 return null;
             }
 
-            channel = thing.getChannel(link.getLinkedUID().getId());
+            channel = thing.getChannel(link.getLinkedUID());
             if (channel == null) {
                 return null;
             }
@@ -399,7 +399,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             ThingUID thingUID = channelUID.getThingUID();
             Thing thing = thingRegistry.get(thingUID);
             if (thing != null) {
-                Channel channel = thing.getChannel(channelUID.getId());
+                Channel channel = thing.getChannel(channelUID);
                 if (channel != null) {
                     if (thing.getHandler() != null) {
                         // fix QuantityType/DecimalType, leave others as-is

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingConfigDescriptionAliasProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingConfigDescriptionAliasProvider.java
@@ -106,7 +106,7 @@ public class ThingConfigDescriptionAliasProvider implements ConfigDescriptionAli
             return null;
         }
 
-        Channel channel = thing.getChannel(channelUID.getId());
+        Channel channel = thing.getChannel(channelUID);
         if (channel == null) {
             return null;
         }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
@@ -226,7 +226,7 @@ class ThingHandlerCallbackImpl implements ThingHandlerCallback {
 
     @Override
     public ChannelBuilder editChannel(Thing thing, ChannelUID channelUID) {
-        Channel channel = thing.getChannel(channelUID.getId());
+        Channel channel = thing.getChannel(channelUID);
         if (channel == null) {
             throw new IllegalArgumentException(
                     String.format("Channel '%s' does not exist for thing '%s'", channelUID, thing.getUID()));

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
@@ -80,7 +80,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
         ThingUID thingUID = channelUID.getThingUID();
         Thing thing = get(thingUID);
         if (thing != null) {
-            return thing.getChannel(channelUID.getId());
+            return thing.getChannel(channelUID);
         }
         return null;
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
@@ -90,7 +90,7 @@ public class ItemChannelLinkConfigDescriptionProvider implements ConfigDescripti
             if (thing == null) {
                 return null;
             }
-            Channel channel = thing.getChannel(link.getLinkedUID().getId());
+            Channel channel = thing.getChannel(link.getLinkedUID());
             if (channel == null) {
                 return null;
             }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -110,16 +110,16 @@ public class AutoUpdateManagerTest {
 
         when(onlineThingMock.getHandler()).thenReturn(handlerMock);
         when(onlineThingMock.getStatus()).thenReturn(ThingStatus.ONLINE);
-        when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_1.getId())))
+        when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_1)))
                 .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_1, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_ONLINE_1)).build());
-        when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_2.getId())))
+        when(onlineThingMock.getChannel(eq(CHANNEL_UID_ONLINE_2)))
                 .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_ONLINE_2, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_ONLINE_2)).build());
 
         when(offlineThingMock.getHandler()).thenReturn(handlerMock);
         when(offlineThingMock.getStatus()).thenReturn(ThingStatus.OFFLINE);
-        when(offlineThingMock.getChannel(eq(CHANNEL_UID_OFFLINE_1.getId())))
+        when(offlineThingMock.getChannel(eq(CHANNEL_UID_OFFLINE_1)))
                 .thenAnswer(answer -> ChannelBuilder.create(CHANNEL_UID_OFFLINE_1, CoreItemFactory.STRING)
                         .withAutoUpdatePolicy(policies.get(CHANNEL_UID_OFFLINE_1)).build());
 


### PR DESCRIPTION
# Description

There is no need to recreate the ChannelUID to read the Channel from a Thing when it is already there.
This will avoid the instance creation and validation of the UID segments of the channel.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>