### PR TITLE
[UoM] Add dimension for emission intensity

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -75,6 +75,7 @@ import org.openhab.core.library.dimension.DataAmount;
 import org.openhab.core.library.dimension.DataTransferRate;
 import org.openhab.core.library.dimension.Density;
 import org.openhab.core.library.dimension.ElectricConductivity;
+import org.openhab.core.library.dimension.EmissionIntensity;
 import org.openhab.core.library.dimension.EnergyPrice;
 import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.dimension.RadiationSpecificActivity;
@@ -411,6 +412,7 @@ public class I18nProviderImpl
         addDefaultUnit(dimensionMap, ElectricInductance.class, Units.HENRY);
         addDefaultUnit(dimensionMap, ElectricPotential.class, Units.VOLT);
         addDefaultUnit(dimensionMap, ElectricResistance.class, Units.OHM);
+        addDefaultUnit(dimensionMap, EmissionIntensity.class, Units.GRAM_PER_KILOWATT_HOUR);
         addDefaultUnit(dimensionMap, Energy.class, Units.KILOWATT_HOUR);
         addDefaultUnit(dimensionMap, Force.class, Units.NEWTON);
         addDefaultUnit(dimensionMap, Frequency.class, Units.HERTZ);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EmissionIntensity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EmissionIntensity.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.library.dimension;
+
+import javax.measure.Quantity;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Define emission intensity type (basic unit is g/kWh)
+ * See <a href="https://en.wikipedia.org/wiki/Emission_intensity">Wikipedia</a>
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+@NonNullByDefault
+public interface EmissionIntensity extends Quantity<EmissionIntensity> {
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -55,6 +55,7 @@ import org.openhab.core.library.dimension.DataAmount;
 import org.openhab.core.library.dimension.DataTransferRate;
 import org.openhab.core.library.dimension.Density;
 import org.openhab.core.library.dimension.ElectricConductivity;
+import org.openhab.core.library.dimension.EmissionIntensity;
 import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.dimension.RadiationSpecificActivity;
 import org.openhab.core.library.dimension.VolumetricFlowRate;
@@ -131,6 +132,8 @@ public final class Units extends CustomUnits {
             new ProductUnit<>(tech.units.indriya.unit.Units.WATT.multiply(tech.units.indriya.unit.Units.HOUR)));
     public static final Unit<Energy> KILOWATT_HOUR = addUnit(MetricPrefix.KILO(WATT_HOUR));
     public static final Unit<Energy> MEGAWATT_HOUR = addUnit(MetricPrefix.MEGA(WATT_HOUR));
+    public static final Unit<EmissionIntensity> GRAM_PER_KILOWATT_HOUR = addUnit(
+            new ProductUnit<>(tech.units.indriya.unit.Units.GRAM.divide(KILOWATT_HOUR)));
     public static final Unit<Power> VAR = addUnit(new AlternateUnit<>(tech.units.indriya.unit.Units.WATT, "var"));
     public static final Unit<Power> KILOVAR = addUnit(MetricPrefix.KILO(VAR));
     public static final Unit<Energy> VAR_HOUR = addUnit(
@@ -261,6 +264,7 @@ public final class Units extends CustomUnits {
         SimpleUnitFormat.getInstance().label(DEGREE_ANGLE, "°");
         SimpleUnitFormat.getInstance().label(DEUTSCHE_HAERTE, "°dH");
         SimpleUnitFormat.getInstance().label(DOBSON_UNIT, "DU");
+        SimpleUnitFormat.getInstance().label(GRAM_PER_KILOWATT_HOUR, "g/kWh");
         SimpleUnitFormat.getInstance().label(GIGABYTE, "GB");
         SimpleUnitFormat.getInstance().label(GIBIBYTE, "GiB");
         SimpleUnitFormat.getInstance().alias(GIBIBYTE, "Gio");

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
@@ -112,6 +112,11 @@ public class UnitsTest {
     }
 
     @Test
+    public void testGramPerKiloWattHourUnitSymbol() {
+        assertThat(Units.GRAM_PER_KILOWATT_HOUR.toString(), is("g/kWh"));
+    }
+
+    @Test
     public void testPascal2mmHgConversion() {
         Quantity<Pressure> pascal = Quantities.getQuantity(new BigDecimal("133.322368"), SIUnits.PASCAL);
 


### PR DESCRIPTION
This adds a dimension that can be used to express emission rate of a given pollutant relative to the intensity of a specific activity, for example CO2 emissions in g/kWh (mass/energy). See https://en.wikipedia.org/wiki/Emission_intensity.

This is a preparation to support UoM for new datasets in the Energi Data Service binding:
![image](https://github.com/openhab/openhab-core/assets/19519842/9e90bb1d-e494-446f-8b32-7966221ed6e8)
