### PR TITLE
Fix reloading channel config changes in .items file

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -101,6 +101,10 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
 
         Map<ChannelUID, ItemChannelLink> links = itemChannelLinkMap.get(itemName);
         if (links == null) {
+            // Create a HashMap with an initial capacity of 2 (the default is 16) to save memory
+            // because most items have only one channel. A capacity of 2 is enough to avoid
+            // resizing the HashMap in most cases, whereas 1 would trigger a resize as soon as
+            // one element is added.
             itemChannelLinkMap.put(itemName, links = new HashMap<>(2));
         }
 

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -136,9 +136,7 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
             // we remove all binding configurations that were not processed
             Map<ChannelUID, ItemChannelLink> links = itemChannelLinkMap.remove(itemName);
             if (links != null) {
-                for (ItemChannelLink removedItemChannelLink : links.values()) {
-                    notifyListenersAboutRemovedElement(removedItemChannelLink);
-                }
+                links.values().forEach(this::notifyListenersAboutRemovedElement);
             }
         }
         Optional.ofNullable(contextMap.get(context)).ifPresent(ctx -> ctx.removeAll(previousItemNames));


### PR DESCRIPTION
Apply channel config changes in .items file

Changes in channel config weren't applied because ItemChannelLink.equals() include the link configurations in the comparison. This caused the new link not being found in the set lookup, which leads to erroneously calling notifyListenersAboutAddedElement, when it should've called notifyListenersAboutUpdatedElement instead.

The problem that this PR fixes:

Changing channel config in an .items file, e.g. only the `function` is being changed from:
```
String Test { channel="foo" [ profile="transform:REGEX", function="moo" ] }
```
to:
```
String Test { channel="foo" [ profile="transform:REGEX", function="cow" ] }
```

This wouldn't take effect unless a more severe measure was taken, e.g. commenting out the item and re-adding it, or in many cases, users would restart openHAB to reload such changes.

Reported here: 
https://community.openhab.org/t/problems-at-reducing-item-changes-with-regex/153400/6

Related:
https://github.com/openhab/openhab-core/issues/3235

This problem may have been started / caused by #1794

Note: I've set the initial capacity for the hashmap to 2, because most items only have 1 link, hopefully it saves a bit of memory by not pre-allocating for 16 slots by default.
