### PR TITLE
[UoM] Change Dimensionless default unit to percent

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -402,7 +402,7 @@ public class I18nProviderImpl
         addDefaultUnit(dimensionMap, DataAmount.class, Units.BYTE);
         addDefaultUnit(dimensionMap, DataTransferRate.class, Units.MEGABIT_PER_SECOND);
         addDefaultUnit(dimensionMap, Density.class, Units.KILOGRAM_PER_CUBICMETRE);
-        addDefaultUnit(dimensionMap, Dimensionless.class, Units.ONE);
+        addDefaultUnit(dimensionMap, Dimensionless.class, Units.PERCENT);
         addDefaultUnit(dimensionMap, ElectricCapacitance.class, Units.FARAD);
         addDefaultUnit(dimensionMap, ElectricCharge.class, Units.COULOMB);
         addDefaultUnit(dimensionMap, ElectricConductance.class, Units.SIEMENS);


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4077

There has been a lot of debate and confusion about the default unit for QuantityType<Dimensionless>. There is some consensus that the most used case for Dimensionless is percent, and therefore it would make more sense to have this as the default unit.

This PR is breaking as anyone that is using the current default Unit.ONE in persistence will see there persisted data scale. It will require manually changing the unit for this item to Unit.ONE. The expectation is there are very few cases where Unit.ONE is the right unit.