### PR TITLE
Fix the recursive group membership check

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -105,10 +105,10 @@ public class EnrichedItemDTOMapper {
                 for (Item member : groupItem.getMembers()) {
                     if (parents.contains(member)) {
                         LOGGER.error(
-                                "Recursive group membership found: {} is both, a direct or indirect parent and a child of {}.",
+                                "Recursive group membership found: {} is a member of {}, but it is also one of its ancestors.",
                                 member.getName(), groupItem.getName());
                     } else if (itemFilter == null || itemFilter.test(member)) {
-                        members.add(mapRecursive(member, itemFilter, uriBuilder, locale, parents));
+                        members.add(mapRecursive(member, itemFilter, uriBuilder, locale, new ArrayList<>(parents)));
                     }
                 }
                 memberDTOs = members.toArray(new EnrichedItemDTO[0]);

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -95,7 +95,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
 
         assertLogMessage(EnrichedItemDTOMapper.class, LogLevel.ERROR,
-                "Recursive group membership found: group1 is both, a direct or indirect parent and a child of group2.");
+                "Recursive group membership found: group1 is a member of group2, but it is also one of its ancestors.");
     }
 
     @Test
@@ -111,7 +111,7 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         assertDoesNotThrow(() -> EnrichedItemDTOMapper.map(groupItem1, true, null, null, null));
 
         assertLogMessage(EnrichedItemDTOMapper.class, LogLevel.ERROR,
-                "Recursive group membership found: group1 is both, a direct or indirect parent and a child of group3.");
+                "Recursive group membership found: group1 is a member of group3, but it is also one of its ancestors.");
     }
 
     @Test
@@ -123,6 +123,21 @@ public class EnrichedItemDTOMapperTest extends JavaTest {
         groupItem1.addMember(groupItem2);
         groupItem1.addMember(numberItem);
         groupItem2.addMember(numberItem);
+
+        EnrichedItemDTOMapper.map(groupItem1, true, null, null, null);
+
+        assertNoLogMessage(EnrichedItemDTOMapper.class);
+    }
+
+    @Test
+    public void testDuplicateMembershipOfGroupItemsDoesNotTriggerWarning() {
+        GroupItem groupItem1 = new GroupItem("group1");
+        GroupItem groupItem2 = new GroupItem("group2");
+        GroupItem groupItem3 = new GroupItem("group3");
+
+        groupItem1.addMember(groupItem2);
+        groupItem1.addMember(groupItem3);
+        groupItem2.addMember(groupItem3);
 
         EnrichedItemDTOMapper.map(groupItem1, true, null, null, null);
 

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -143,10 +143,10 @@ public class SemanticsMetadataProvider extends AbstractProvider<Metadata>
             for (Item memberItem : groupItem.getMembers()) {
                 if (parentItems.contains(memberItem.getName())) {
                     logger.error(
-                            "Recursive group membership found: {} is both, a direct or indirect parent and a child of {}.",
+                            "Recursive group membership found: {} is a member of {}, but it is also one of its ancestors.",
                             memberItem.getName(), groupItem.getName());
                 } else {
-                    processItem(memberItem, parentItems);
+                    processItem(memberItem, new ArrayList<>(parentItems));
                 }
             }
         }

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
@@ -250,7 +250,7 @@ public class SemanticsMetadataProviderTest extends JavaTest {
         assertDoesNotThrow(() -> semanticsMetadataProvider.added(groupItem1));
 
         assertLogMessage(SemanticsMetadataProvider.class, LogLevel.ERROR,
-                "Recursive group membership found: group1 is both, a direct or indirect parent and a child of group2.");
+                "Recursive group membership found: group1 is a member of group2, but it is also one of its ancestors.");
     }
 
     @Test
@@ -266,7 +266,7 @@ public class SemanticsMetadataProviderTest extends JavaTest {
         assertDoesNotThrow(() -> semanticsMetadataProvider.added(groupItem1));
 
         assertLogMessage(SemanticsMetadataProvider.class, LogLevel.ERROR,
-                "Recursive group membership found: group1 is both, a direct or indirect parent and a child of group3.");
+                "Recursive group membership found: group1 is a member of group3, but it is also one of its ancestors.");
     }
 
     @Test
@@ -278,6 +278,21 @@ public class SemanticsMetadataProviderTest extends JavaTest {
         groupItem1.addMember(groupItem2);
         groupItem1.addMember(numberItem);
         groupItem2.addMember(numberItem);
+
+        semanticsMetadataProvider.added(groupItem1);
+
+        assertNoLogMessage(SemanticsMetadataProvider.class);
+    }
+
+    @Test
+    public void testDuplicateMembershipOfGroupItemsDoesNotTriggerWarning() {
+        GroupItem groupItem1 = new GroupItem("group1");
+        GroupItem groupItem2 = new GroupItem("group2");
+        GroupItem groupItem3 = new GroupItem("group3");
+
+        groupItem1.addMember(groupItem2);
+        groupItem1.addMember(groupItem3);
+        groupItem2.addMember(groupItem3);
 
         semanticsMetadataProvider.added(groupItem1);
 


### PR DESCRIPTION
Allow a group to be a member of its direct parent and also its parent's ancestors without raising an error.

So this scenario is now allowed:
```
Group G1
Group G2 (G1)
Group G3 (G1, G2)
```

Looping membership is still detected and prevented as before, thus Stack Overflow is still avoided.
So this scenario is still not allowed, as it was originally intended:
```
Group R1 (R2)
Group R2 (R1)
```

and also not allowed:
```
Group R1 (R3)
Group R2 (R1)
Group R3 (R2)
```

Hopefully the new error message is also easier to understand, although it will only be issued when a real membership loop occurred.

See https://community.openhab.org/t/recursive-group-membership-found/135192
https://github.com/openhab/openhab-core/pull/3748
