### PR TITLE
[net] Expose Jetty EndPoint in http requests

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -424,7 +424,8 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
     }
 
     /**
-     * Extends the default {@link HttpClientTransportOverHTTP) but exposes the underling {@link EndPoint} of each request/response.
+     * Extends the default {@link HttpClientTransportOverHTTP) but exposes the underling {@link EndPoint} of each
+     * request/response.
      * It mimics the way it's done in higher Jetty Http client versions.
      */
     private static class CustomHttpClientTransportOverHTTP extends HttpClientTransportOverHTTP {
@@ -444,6 +445,7 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
                 }
             };
         }
+
         private static class CustomHttpReceiverOverHTTP extends HttpReceiverOverHTTP {
             private final HttpChannelOverHTTP channel;
 
@@ -464,6 +466,4 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
             }
         }
     }
-
-
 }

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -24,11 +24,20 @@ import javax.net.ssl.TrustManager;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpDestination;
+import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.api.Connection;
+import org.eclipse.jetty.client.http.HttpChannelOverHTTP;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
+import org.eclipse.jetty.client.http.HttpConnectionOverHTTP;
+import org.eclipse.jetty.client.http.HttpReceiverOverHTTP;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.PreEncodedHttpField;
 import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
@@ -235,7 +244,7 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
         try {
             logger.debug("creating http client for consumer {}", consumerName);
 
-            HttpClient httpClient = new HttpClient(
+            HttpClient httpClient = new HttpClient(new CustomHttpClientTransportOverHTTP(),
                     sslContextFactory != null ? sslContextFactory : createSslContextFactory());
 
             // If proxy is set as property (standard Java property), provide the proxy information to Jetty HTTP
@@ -413,4 +422,48 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
                     "unexpected checked exception during initialization of the Jetty HTTP/2 client", e);
         }
     }
+
+    /**
+     * Extends the default {@link HttpClientTransportOverHTTP) but exposes the underling {@link EndPoint} of each request/response.
+     * It mimics the way it's done in higher Jetty Http client versions.
+     */
+    private static class CustomHttpClientTransportOverHTTP extends HttpClientTransportOverHTTP {
+        @Override
+        @NonNullByDefault({})
+        protected HttpConnectionOverHTTP newHttpConnection(EndPoint endPoint, HttpDestination destination,
+                Promise<Connection> promise) {
+            return new HttpConnectionOverHTTP(endPoint, destination, promise) {
+                @Override
+                protected HttpChannelOverHTTP newHttpChannel() {
+                    return new HttpChannelOverHTTP(this) {
+                        @Override
+                        protected HttpReceiverOverHTTP newHttpReceiver() {
+                            return new CustomHttpReceiverOverHTTP(this);
+                        }
+                    };
+                }
+            };
+        }
+        private static class CustomHttpReceiverOverHTTP extends HttpReceiverOverHTTP {
+            private final HttpChannelOverHTTP channel;
+
+            public CustomHttpReceiverOverHTTP(HttpChannelOverHTTP channel) {
+                super(channel);
+                this.channel = channel;
+            }
+
+            @Override
+            public boolean headerComplete() {
+                HttpExchange exchange = getHttpExchange();
+                if (exchange != null) {
+                    // Store the EndPoint is case of upgrades
+                    exchange.getRequest().getConversation().setAttribute(EndPoint.class.getName(),
+                            channel.getHttpConnection().getEndPoint());
+                }
+                return super.headerComplete();
+            }
+        }
+    }
+
+
 }


### PR DESCRIPTION
Hello, I would like to merge these small workaround that allows to access the underling Jetty EndPoint when using an http client created using the WebClientFactory.

It mimics the way the EndPoint is exposed in recent Jetty versions so it will become useless in case of an update.

I need it in order to proxy the socket data for upgraded WebSocket connections through the OpenHAB Cloud Connector.