### PR TITLE
Call, Contact, Image items: Don't create command descr from state descr

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -468,11 +468,9 @@ public abstract class GenericItem implements ActiveItem {
 
     @Override
     public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
-        if (commandDescriptionService != null) {
-            CommandDescription commandDescription = commandDescriptionService.getCommandDescription(this.name, locale);
-            if (commandDescription != null) {
-                return commandDescription;
-            }
+        CommandDescription commandOptions = getCommandOptions(locale);
+        if (commandOptions != null) {
+            return commandOptions;
         }
 
         StateDescription stateDescription = getStateDescription(locale);
@@ -502,6 +500,17 @@ public abstract class GenericItem implements ActiveItem {
     protected void logSetTypeError(TimeSeries timeSeries) {
         logger.error("Tried to set invalid state in time series {} on item {} of type {}, ignoring it", timeSeries,
                 getName(), getClass().getSimpleName());
+    }
+
+    protected @Nullable CommandDescription getCommandOptions(@Nullable Locale locale) {
+        if (commandDescriptionService != null) {
+            CommandDescription commandDescription = commandDescriptionService.getCommandDescription(this.name, locale);
+            if (commandDescription != null) {
+                return commandDescription;
+            }
+        }
+
+        return null;
     }
 
     private CommandDescription stateOptions2CommandOptions(StateDescription stateDescription) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/CallItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/CallItem.java
@@ -13,12 +13,15 @@
 package org.openhab.core.library.items;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.StringListType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.TimeSeries;
@@ -67,5 +70,10 @@ public class CallItem extends GenericItem {
         } else {
             logSetTypeError(timeSeries);
         }
+    }
+
+    @Override
+    public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
+        return getCommandOptions(locale);
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
@@ -74,6 +74,6 @@ public class ContactItem extends GenericItem {
 
     @Override
     public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
-        return null;
+        return getCommandOptions(locale);
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
@@ -13,12 +13,15 @@
 package org.openhab.core.library.items;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.OpenClosedType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.TimeSeries;
@@ -67,5 +70,10 @@ public class ContactItem extends GenericItem {
         } else {
             logSetTypeError(timeSeries);
         }
+    }
+
+    @Override
+    public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
+        return null;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
@@ -13,12 +13,15 @@
 package org.openhab.core.library.items;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.RawType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
 import org.openhab.core.types.TimeSeries;
@@ -65,5 +68,10 @@ public class ImageItem extends GenericItem {
         } else {
             logSetTypeError(timeSeries);
         }
+    }
+
+    @Override
+    public @Nullable CommandDescription getCommandDescription(@Nullable Locale locale) {
+        return getCommandOptions(locale);
     }
 }


### PR DESCRIPTION
If a state description is set on a contact item, currently a command description is automatically created as well.
This is wrong as contact items do not accept commands (except refresh) and caused the UI to display a control for the default (list) widget for these contacts.