### PR TITLE
Upgrade jUPnP to 3.0.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -203,8 +203,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <!-- Uses the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
-      <version>2.7.1.OH1</version>
+      <version>3.0.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/openhab-core/pom.xml
+++ b/bom/openhab-core/pom.xml
@@ -378,6 +378,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.config.jupnp</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.config.serial</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -475,8 +475,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <!-- Uses the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
-      <version>2.7.1.OH1</version>
+      <version>3.0.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.config.jupnp/.classpath
+++ b/bundles/org.openhab.core.config.jupnp/.classpath
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.config.jupnp/.project
+++ b/bundles/org.openhab.core.config.jupnp/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.config.jupnp</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.config.jupnp/NOTICE
+++ b/bundles/org.openhab.core.config.jupnp/NOTICE
@@ -1,0 +1,14 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core
+

--- a/bundles/org.openhab.core.config.jupnp/pom.xml
+++ b/bundles/org.openhab.core.config.jupnp/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>4.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.config.jupnp</artifactId>
+
+  <name>openHAB Core :: Bundles :: Configuration jUPnP</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jupnp</groupId>
+      <artifactId>org.jupnp</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.config.jupnp/src/main/java/org/openhab/core/config/jupnp/internal/OHUpnpServiceConfiguration.java
+++ b/bundles/org.openhab.core.config.jupnp/src/main/java/org/openhab/core/config/jupnp/internal/OHUpnpServiceConfiguration.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.config.jupnp.internal;
+
+import java.util.concurrent.ExecutorService;
+
+import org.jupnp.OSGiUpnpServiceConfiguration;
+import org.jupnp.QueueingThreadPoolExecutor;
+import org.jupnp.UpnpServiceConfiguration;
+import org.openhab.basefixes.util.concurrent.LinkedTransferQueue;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+/**
+ * Uses the Java 11 {@link LinkedTransferQueue} with jUPnP as workaround for the buggy OpenJDK 17 implementation.
+ *
+ * @see <a href="https://bugs.openjdk.org/browse/JDK-8301341">JDK-8301341: LinkedTransferQueue does not respect timeout
+ *      for poll()</a>
+ * @see <a href="https://github.com/openhab/openhab-core/issues/3755">openhab-core#3755: LinkedTransferQueue in OpenJDK
+ *      17 sometimes causes high CPU usage</a>
+ *
+ * @author Wouter Born - Initial contribution
+ */
+@Component(configurationPid = "org.jupnp", configurationPolicy = ConfigurationPolicy.REQUIRE, service = UpnpServiceConfiguration.class)
+public class OHUpnpServiceConfiguration extends OSGiUpnpServiceConfiguration {
+    @Override
+    protected ExecutorService createMainExecutorService() {
+        return QueueingThreadPoolExecutor.createInstance("upnp-main", threadPoolSize, new LinkedTransferQueue<>());
+    }
+
+    @Override
+    protected ExecutorService createAsyncProtocolExecutorService() {
+        return QueueingThreadPoolExecutor.createInstance("upnp-async", asyncThreadPoolSize,
+                new LinkedTransferQueue<>());
+    }
+
+    @Override
+    protected ExecutorService createRemoteProtocolExecutorService() {
+        return QueueingThreadPoolExecutor.createInstance("upnp-remote", remoteThreadPoolSize,
+                new LinkedTransferQueue<>());
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -43,6 +43,7 @@
     <module>org.openhab.core.config.discovery.usbserial.windowsregistry</module>
     <module>org.openhab.core.config.discovery.upnp</module>
     <module>org.openhab.core.config.dispatch</module>
+    <module>org.openhab.core.config.jupnp</module>
     <module>org.openhab.core.config.serial</module>
     <module>org.openhab.core</module>
     <module>org.openhab.core.audio</module>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -194,12 +194,14 @@
 	</feature>
 
 	<feature name="openhab.tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">
-		<capability>openhab.tp;feature=jupnp;version=2.7.1</capability>
+		<capability>openhab.tp;feature=jupnp;version=3.0.0</capability>
 		<feature dependency="true">http</feature>
 		<feature dependency="true">scr</feature>
 		<feature dependency="true">openhab.tp-httpclient</feature>
+		<!-- Use the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
 		<bundle>mvn:org.openhab/base-fixes/1.0.0</bundle>
-		<bundle>mvn:org.jupnp/org.jupnp/2.7.1.OH1</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.jupnp/${project.version}</bundle>
+		<bundle>mvn:org.jupnp/org.jupnp/3.0.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">


### PR DESCRIPTION
* Upgrades jUPnP from 2.7.1 to 3.0.0.
* Uses a custom OSGiUpnpServiceConfiguration for JDK-8301341 workaround

For release notes, see:

https://github.com/jupnp/jupnp/releases/tag/3.0.0