### PR TITLE
unitSymbol in REST response for GroupItem

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -99,6 +99,9 @@ public class EnrichedItemDTOMapper {
             unitSymbol = numberItem.getUnitSymbol();
         }
         if (item instanceof GroupItem groupItem) {
+            if (groupItem.getBaseItem() instanceof NumberItem baseNumberItem) {
+                unitSymbol = baseNumberItem.getUnitSymbol();
+            }
             EnrichedItemDTO[] memberDTOs;
             if (drillDown) {
                 Collection<EnrichedItemDTO> members = new LinkedHashSet<>();


### PR DESCRIPTION
The item REST response does include a field `unitSymbol` for Number items, but not for Group items with Number base type. While the info can be retrieved by querying the metadata, it is easier in the UI to be able to use the same field.

This PR adds unitSymbol for Group items with base type Number in the REST response.

Required to avoid workaround for groups in https://github.com/openhab/openhab-webui/pull/2312