### PR TITLE
Replace deprecated `hamcrest-library` with `hamcrest` in test BOM

### DIFF
--- a/bom/test/pom.xml
+++ b/bom/test/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
+      <artifactId>hamcrest</artifactId>
       <version>2.2</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Background: `hamcrest-library` and `hamcrest-core` are obsolete because they were combined into `hamcrest`.

Both deprecated JARs contain the following text file:

```
All the classes in hamcrest-core.jar and hamcrest-library.jar has moved
into hamcrest.jar. Please update your dependencies.
```

Resolves #4112