### PR TITLE
Audio parsing : Fix byte / bit confusion

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
@@ -70,7 +70,7 @@ public class AudioSinkUtilsImpl implements AudioSinkUtils {
                             e);
                     Integer bitRate = audioFormat.getBitRate();
                     if (bitRate != null && bitRate != 0) {
-                        long computedDuration = Float.valueOf((1f * dataTransferedLength / bitRate) * 1000000000)
+                        long computedDuration = Float.valueOf((8f * dataTransferedLength / bitRate) * 1000000000)
                                 .longValue();
                         return startTime + computedDuration;
                     } else {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
@@ -64,7 +64,7 @@ public class AudioWaveUtils {
             } else {
                 codecPCMSignedOrUnsigned = null;
             }
-            Integer bitRate = Math.round(format.getFrameRate() * format.getFrameSize()) * format.getChannels();
+            Integer bitRate = Math.round(format.getFrameRate() * format.getSampleSizeInBits() * format.getChannels());
             Long frequency = Float.valueOf(format.getSampleRate()).longValue();
             return new AudioFormat(AudioFormat.CONTAINER_WAVE, codecPCMSignedOrUnsigned, format.isBigEndian(),
                     format.getSampleSizeInBits(), bitRate, frequency, format.getChannels());


### PR DESCRIPTION
Fix two errors for calculating bitrate and duration of sound.

In AudioSinkUtilsImpl : confusion between byte / bit
In AudioWaveUtils : confusion between byte / bit AND with the definition of framesize (framesize already includes number of channels)
