### PR TITLE
[rest] Enable filters for cacheable items list

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -263,7 +263,7 @@ public class ItemResource implements RESTResource {
                 cacheableListsLastModified.put(namespaceSelector, lastModifiedDate);
             }
 
-            Stream<EnrichedItemDTO> itemStream = getItems(null, null).stream() //
+            Stream<EnrichedItemDTO> itemStream = getItems(type, tags).stream() //
                     .map(item -> EnrichedItemDTOMapper.map(item, false, null, uriBuilder, locale)) //
                     .peek(dto -> addMetadata(dto, namespaces, null)) //
                     .peek(dto -> dto.editable = isEditable(dto.name));


### PR DESCRIPTION
This allows the usage of filters when using `staticDataOnly=true`.