### PR TITLE
Add numericState and unit to StateDTO

### DIFF
--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -91,6 +91,10 @@ public class SseItemStatesEventBuilder {
                 if (item.getState() instanceof DecimalType decimalState) {
                     stateDto.numericState = decimalState.floatValue();
                 }
+                if (item.getState() instanceof QuantityType quantityState) {
+                    stateDto.numericState = quantityState.floatValue();
+                    stateDto.unit = quantityState.getUnit().toString();
+                }
                 payload.put(itemName, stateDto);
             } catch (ItemNotFoundException e) {
                 if (startLevelService.getStartLevel() >= StartLevelService.STARTLEVEL_MODEL) {

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -31,6 +31,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.types.DateTimeType;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.transform.TransformationException;
@@ -86,6 +87,9 @@ public class SseItemStatesEventBuilder {
                 // Only include the display state if it's different than the raw state
                 if (stateDto.state != null && !stateDto.state.equals(displayState)) {
                     stateDto.displayState = displayState;
+                }
+                if (item.getState() instanceof DecimalType decimalState) {
+                    stateDto.numericState = decimalState.floatValue();
                 }
                 payload.put(itemName, stateDto);
             } catch (ItemNotFoundException e) {

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
@@ -20,6 +20,7 @@ package org.openhab.core.io.rest.sse.internal.dto;
 public class StateDTO {
     public String state;
     public String displayState;
+    public Number numericState;
 
     public String type;
 

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
@@ -21,6 +21,7 @@ public class StateDTO {
     public String state;
     public String displayState;
     public Number numericState;
+    public String unit;
 
     public String type;
 


### PR DESCRIPTION
This would avoid having to use parseFloat for item state by making the numericState readily available.
