### PR TITLE
[auth] Set doctype for auth page

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/pages/authorize.html
+++ b/bundles/org.openhab.core.io.http.auth/pages/authorize.html
@@ -1,4 +1,4 @@
-<html>
+<!DOCTYPE html>
 <head>
 <title>openHAB</title>
 <meta charset="utf-8">


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/issues/2443.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode.