### PR TITLE
REST response default persistence strategy when no persistence configuration

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -54,11 +54,13 @@ import org.openhab.core.persistence.FilterCriteria;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
+import org.openhab.core.persistence.PersistenceItemConfiguration;
 import org.openhab.core.persistence.PersistenceItemInfo;
 import org.openhab.core.persistence.PersistenceManager;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
 import org.openhab.core.persistence.QueryablePersistenceService;
+import org.openhab.core.persistence.config.PersistenceAllConfig;
 import org.openhab.core.persistence.dto.ItemHistoryDTO;
 import org.openhab.core.persistence.dto.PersistenceServiceConfigurationDTO;
 import org.openhab.core.persistence.dto.PersistenceServiceDTO;
@@ -66,7 +68,6 @@ import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurat
 import org.openhab.core.persistence.registry.PersistenceServiceConfiguration;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationDTOMapper;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
-import org.openhab.core.persistence.strategy.PersistenceCronStrategy;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 import org.openhab.core.types.TypeParser;
@@ -177,10 +178,10 @@ public class PersistenceResource implements RESTResource {
         if (configuration == null) {
             PersistenceService service = persistenceServiceRegistry.get(serviceId);
             if (service != null) {
-                List<PersistenceStrategy> defaults = service.getDefaultStrategies();
-                List<PersistenceStrategy> strategies = defaults.stream()
-                        .filter(s -> s instanceof PersistenceCronStrategy).toList();
-                configuration = new PersistenceServiceConfiguration(serviceId, List.of(), defaults, strategies,
+                List<PersistenceStrategy> strategies = service.getDefaultStrategies();
+                List<PersistenceItemConfiguration> configs = List.of(
+                        new PersistenceItemConfiguration(List.of(new PersistenceAllConfig()), null, strategies, null));
+                configuration = new PersistenceServiceConfiguration(serviceId, configs, strategies, strategies,
                         List.of());
                 editable = true;
             }


### PR DESCRIPTION
The persistence REST response, when no persistence configuration is available, is a 404 at the moment.

This PR changes that and will serve a persistence configuration matching the default persistence strategy for the persistence service if one is available.

This allows the UI to show this default strategy if none is configured and the user to change this default in the UI.