### PR TITLE
[rest] special handling for StreamingOutput

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
@@ -23,6 +23,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.ext.MessageBodyWriter;
 
 import org.openhab.core.io.rest.JSONInputStream;
@@ -81,6 +82,8 @@ public class GsonMessageBodyWriter<T> implements MessageBodyWriter<T> {
         try {
             if (object instanceof InputStream stream && object instanceof JSONInputStream) {
                 stream.transferTo(entityStream);
+            } else if (object instanceof StreamingOutput streaming) {
+                streaming.write(entityStream);
             } else {
                 entityStream.write(gson.toJson(object).getBytes(StandardCharsets.UTF_8));
             }


### PR DESCRIPTION
Should fix #4144, by handling the StreamingOutput inside the GsonMessageBodyWriter.