### PR TITLE
[automation] Allow empty script for script action & script condition

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -65,13 +65,14 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         this.ruleUID = ruleUID;
         this.engineIdentifier = UUID.randomUUID().toString();
 
-        this.type = getValidConfigParameter(SCRIPT_TYPE, module.getConfiguration(), module.getId());
-        this.script = getValidConfigParameter(SCRIPT, module.getConfiguration(), module.getId());
+        this.type = getValidConfigParameter(SCRIPT_TYPE, module.getConfiguration(), module.getId(), false);
+        this.script = getValidConfigParameter(SCRIPT, module.getConfiguration(), module.getId(), true);
     }
 
-    private static String getValidConfigParameter(String parameter, Configuration config, String moduleId) {
+    private static String getValidConfigParameter(String parameter, Configuration config, String moduleId,
+            boolean emptyAllowed) {
         Object value = config.get(parameter);
-        if (value instanceof String string && !string.trim().isEmpty()) {
+        if (value instanceof String string && (emptyAllowed || !string.trim().isEmpty())) {
             return string;
         } else {
             throw new IllegalStateException(String.format(

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -65,6 +65,10 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
     public @Nullable Map<String, Object> execute(final Map<String, Object> context) {
         Map<String, Object> resultMap = new HashMap<>();
 
+        if (script.isEmpty()) {
+            return resultMap;
+        }
+
         getScriptEngine().ifPresent(scriptEngine -> {
             setExecutionContext(scriptEngine, context);
             try {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -45,6 +45,11 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
     @Override
     public boolean isSatisfied(final Map<String, Object> context) {
         boolean result = false;
+
+        if (script.isEmpty()) {
+            return true;
+        }
+
         Optional<ScriptEngine> engine = getScriptEngine();
 
         if (engine.isPresent()) {


### PR DESCRIPTION
Required to fix https://github.com/openhab/openhab-webui/issues/2461.

Currently when adding a new script action or script condition to a rule in the UI, the first thing the user sees is a red error message, because the script is not defined yet.
As this is confusing and might worry especially new users, this issue should be fixed.

My proposal is to add support for empty script to script action and script condition and update the UI to create the script field as empty when creating a new script action or condition.

Script action and condition both short-evaluate to a value they don't affect the rule's execution when the script is empty.