### PR TITLE
[rest] TokenResource: Set SameSite attribute for session id cookie

### DIFF
--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
@@ -246,8 +246,7 @@ public class TokenResource implements RESTResource {
             try {
                 URI domainUri = new URI(session.get().getRedirectUri());
                 // workaround to set the SameSite cookie attribute until we upgrade to
-                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer, which is provided by
-                // org.apache.aries.spec/org.apache.aries.javax.jax.rs-api
+                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer
                 response.header("Set-Cookie",
                         SESSIONID_COOKIE_FORMAT.formatted(UUID.randomUUID(), domainUri.getHost()));
             } catch (Exception e) {
@@ -355,8 +354,7 @@ public class TokenResource implements RESTResource {
                             "Will not honor the request to set a session cookie for this client, because it's only allowed for root redirect URIs");
                 }
                 // workaround to set the SameSite cookie attribute until we upgrade to
-                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer, which is provided by
-                // org.apache.aries.spec/org.apache.aries.javax.jax.rs-api
+                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer
                 response.header("Set-Cookie", SESSIONID_COOKIE_FORMAT.formatted(sessionId, domainUri.getHost()));
 
                 // also mark the session as supported by a cookie

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
@@ -33,7 +33,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -95,6 +94,8 @@ public class TokenResource implements RESTResource {
 
     /** The name of the HTTP-only cookie holding the session ID */
     public static final String SESSIONID_COOKIE_NAME = "X-OPENHAB-SESSIONID";
+    private static final String SESSIONID_COOKIE_FORMAT = SESSIONID_COOKIE_NAME
+            + "=%s; Domain=%s; Path=/; Max-Age=2147483647; HttpOnly; SameSite=Strict";
 
     /** The default lifetime of tokens in minutes before they expire */
     public static final int TOKEN_LIFETIME = 60;
@@ -244,9 +245,11 @@ public class TokenResource implements RESTResource {
         if (sessionCookie != null && sessionCookie.getValue().equals(session.get().getSessionId())) {
             try {
                 URI domainUri = new URI(session.get().getRedirectUri());
-                NewCookie newCookie = new NewCookie(SESSIONID_COOKIE_NAME, null, "/", domainUri.getHost(), null, 0,
-                        false, true);
-                response.cookie(newCookie);
+                // workaround to set the SameSite cookie attribute until we upgrade to
+                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer, which is provided by
+                // org.apache.aries.spec/org.apache.aries.javax.jax.rs-api
+                response.header("Set-Cookie",
+                        SESSIONID_COOKIE_FORMAT.formatted(UUID.randomUUID(), domainUri.getHost()));
             } catch (Exception e) {
             }
         }
@@ -351,9 +354,10 @@ public class TokenResource implements RESTResource {
                     throw new IllegalArgumentException(
                             "Will not honor the request to set a session cookie for this client, because it's only allowed for root redirect URIs");
                 }
-                NewCookie newCookie = new NewCookie(SESSIONID_COOKIE_NAME, sessionId, "/", domainUri.getHost(), null,
-                        2147483647, false, true);
-                response.cookie(newCookie);
+                // workaround to set the SameSite cookie attribute until we upgrade to
+                // jakarta.ws.rs/jakarta.ws.rs-api/3.1.0 or newer, which is provided by
+                // org.apache.aries.spec/org.apache.aries.javax.jax.rs-api
+                response.header("Set-Cookie", SESSIONID_COOKIE_FORMAT.formatted(sessionId, domainUri.getHost()));
 
                 // also mark the session as supported by a cookie
                 newSession.setSessionCookie(true);


### PR DESCRIPTION
Fixes #4159.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value.

Because our current implementation of `javax.ws.rs.core.NewCookie` (which is `jakarta.ws.rs/jakarta.ws.rs-api/2.1.6` provided by `org.apache.aries.spec/org.apache.aries.javax.jax.rs-api/1.0.4`) does not allow to set the SameSite attribute, we have to workaround that limitation by setting the cookie directly through a response header. 
Once our implementation is `jakarta.ws.rs/jakarta.ws.rs-api/3.1.0` or newer, we can use `NewCookie` again.
Implementing the required changes to NewCookie on our own does not work, because the servlet also needs adustment.