### PR TITLE
[util] Add abbreviate method

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -28,6 +28,25 @@ import org.eclipse.jdt.annotation.Nullable;
 public class StringUtils {
 
     /**
+     * Input string is shortened to the maxwidth, the last 3 chars are replaced by ...
+     * 
+     * For example: (maxWidth 18) input="openHAB is the greatest ever", return="openHAB is the ..."
+     * 
+     * @param input input string
+     * @param maxWidth maxmimum amount of characters to return (including ...)
+     * @return Abbreviated String
+     */
+    public static @Nullable String abbreviate(final @Nullable String input, final int maxWidth) {
+        if (input != null) {
+            if (input.length() < 4 || input.length() <= maxWidth) {
+                return input;
+            }
+            return input.substring(0, maxWidth - 3) + "...";
+        }
+        return input;
+    }
+
+    /**
      * If a newline char exists at the end of the line, it is removed
      *
      * <pre>

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
@@ -26,6 +26,17 @@ import org.junit.jupiter.api.Test;
 public class StringUtilsTest {
 
     @Test
+    public void abbreviateTest() {
+        assertEquals("", StringUtils.abbreviate("", 10));
+        assertEquals(null, StringUtils.abbreviate(null, 5));
+        assertEquals("openHAB is the ...", StringUtils.abbreviate("openHAB is the greatest ever", 18));
+        assertEquals("four", StringUtils.abbreviate("four", 4));
+        assertEquals("...", StringUtils.abbreviate("four", 3));
+        assertEquals("abc", StringUtils.abbreviate("abc", 3));
+        assertEquals("abc", StringUtils.abbreviate("abc", 2));
+    }
+
+    @Test
     public void chompTest() {
         assertEquals("", StringUtils.chomp(""));
         assertNull(StringUtils.chomp(null));


### PR DESCRIPTION
While trying to remove the apache libs from the addons i found one more string method that should be moved to this core utility. 

It is used in the Max binding, i'll update the related PR accordingly: https://github.com/openhab/openhab-addons/pull/14413

