### PR TITLE
Move to JUPnP v3.0.1

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -475,7 +475,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.config.jupnp/pom.xml
+++ b/bundles/org.openhab.core.config.jupnp/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.0</version>
+      <version>3.0.1</version>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.core.config.jupnp/src/main/java/org/openhab/core/config/jupnp/internal/OHUpnpServiceConfiguration.java
+++ b/bundles/org.openhab.core.config.jupnp/src/main/java/org/openhab/core/config/jupnp/internal/OHUpnpServiceConfiguration.java
@@ -20,6 +20,8 @@ import org.jupnp.UpnpServiceConfiguration;
 import org.openhab.basefixes.util.concurrent.LinkedTransferQueue;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.HttpService;
 
 /**
  * Uses the Java 11 {@link LinkedTransferQueue} with jUPnP as workaround for the buggy OpenJDK 17 implementation.
@@ -33,6 +35,12 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
  */
 @Component(configurationPid = "org.jupnp", configurationPolicy = ConfigurationPolicy.REQUIRE, service = UpnpServiceConfiguration.class)
 public class OHUpnpServiceConfiguration extends OSGiUpnpServiceConfiguration {
+    @Reference
+    @Override
+    public void setHttpService(HttpService httpService) {
+        super.setHttpService(httpService);
+    }
+
     @Override
     protected ExecutorService createMainExecutorService() {
         return QueueingThreadPoolExecutor.createInstance("upnp-main", threadPoolSize, new LinkedTransferQueue<>());

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -194,14 +194,14 @@
 	</feature>
 
 	<feature name="openhab.tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">
-		<capability>openhab.tp;feature=jupnp;version=3.0.0</capability>
+		<capability>openhab.tp;feature=jupnp;version=3.0.1</capability>
 		<feature dependency="true">http</feature>
 		<feature dependency="true">scr</feature>
 		<feature dependency="true">openhab.tp-httpclient</feature>
 		<!-- Use the Java 11 LinkedTransferQueue as workaround for JDK-8301341 -->
 		<bundle>mvn:org.openhab/base-fixes/1.0.0</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.config.jupnp/${project.version}</bundle>
-		<bundle>mvn:org.jupnp/org.jupnp/3.0.0</bundle>
+		<bundle>mvn:org.jupnp/org.jupnp/3.0.1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">


### PR DESCRIPTION
This requires first the release of JUPnP 3.0.1 including the following fix:
https://github.com/jupnp/jupnp/pull/227#issuecomment-2029533316

Fix #4140 

Signed-off-by: Laurent Garnier <lg.hc@free.fr>