### PR TITLE
Do not create new `BigDecimals` if a given object is already `BigDecimal`

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -55,6 +55,8 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
             this.value = type.toBigDecimal();
         } else if (value instanceof HSBType type) {
             this.value = type.toBigDecimal();
+        } else if (value instanceof BigDecimal decimal) {
+            this.value = decimal;
         } else {
             this.value = new BigDecimal(value.toString());
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -169,7 +169,12 @@ public class QuantityType<T extends Quantity<T>> extends Number
      */
     public QuantityType(Number value, Unit<T> unit) {
         // Avoid scientific notation for double
-        BigDecimal bd = new BigDecimal(value.toString());
+        BigDecimal bd;
+        if (value instanceof BigDecimal decimal) {
+            bd = decimal;
+        } else {
+            bd = new BigDecimal(value.toString());
+        }
         quantity = (Quantity<T>) Quantities.getQuantity(bd, unit, Scale.RELATIVE);
     }
 


### PR DESCRIPTION
Hey, i just wanted to add small optimization to not create a new `BigDecimal` if given object is already this class