### PR TITLE
Upgrade Jollyday to 0.27.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -365,7 +365,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.23.2</version>
+      <version>0.27.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -950,7 +950,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.23.2</version>
+      <version>0.27.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -95,10 +95,6 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     final Map<String, Set<DayOfWeek>> daysets = new HashMap<>();
     private final Map<Object, HolidayManager> holidayManagers = new HashMap<>();
     private final List<String> countryParameters = new ArrayList<>();
-    /**
-     * Utility for accessing resources.
-     */
-    private final ResourceUtil resourceUtil = new ResourceUtil();
 
     private final LocaleProvider localeProvider;
     private final Bundle bundle;
@@ -432,6 +428,6 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
 
     @Override
     public @Nullable String getHolidayDescription(@Nullable String holiday) {
-        return holiday != null ? resourceUtil.getHolidayDescription(localeProvider.getLocale(), holiday) : null;
+        return holiday != null ? ResourceUtil.getHolidayDescription(localeProvider.getLocale(), holiday) : null;
     }
 }

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -174,12 +174,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.23.2</capability>
+		<capability>openhab.tp;feature=jollyday;version=0.27.0</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.7.2</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/0.23.2</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/0.23.2</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/0.27.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/0.27.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -64,8 +64,6 @@ Fragment-Host: org.openhab.core.automation
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -64,8 +64,6 @@ Fragment-Host: org.openhab.core.automation
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -61,8 +61,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
@@ -78,4 +76,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -64,8 +64,6 @@ Fragment-Host: org.openhab.core.automation
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -64,8 +64,6 @@ Fragment-Host: org.openhab.core.automation
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -61,7 +61,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.openhab.core.transform;version='[4.2.0,4.2.1)',\
 	org.osgi.service.component.annotations;version='[1.5.0,1.5.1)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
 	org.eclipse.jetty.http;version='[9.4.53,9.4.54)',\

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -60,8 +60,6 @@ feature.openhab-config: \
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	org.threeten.extra;version='[1.7.2,1.7.3)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
 	org.eclipse.jetty.http;version='[9.4.53,9.4.54)',\
@@ -76,4 +74,6 @@ feature.openhab-config: \
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -84,8 +84,6 @@ Fragment-Host: org.openhab.core.model.item
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.google.guava;version='[33.0.0,33.0.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
@@ -123,10 +121,11 @@ Fragment-Host: org.openhab.core.model.item
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.openhab.core.model.persistence.runtime;version='[4.2.0,4.2.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
 	org.ops4j.pax.web.pax-web-api;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.24,8.0.25)',\
-	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)'
+	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -88,8 +88,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.google.guava;version='[33.0.0,33.0.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
@@ -126,10 +124,11 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.openhab.core.model.persistence.runtime;version='[4.2.0,4.2.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
 	org.ops4j.pax.web.pax-web-api;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.24,8.0.25)',\
-	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)'
+	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -92,8 +92,6 @@ Fragment-Host: org.openhab.core.model.script
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.google.guava;version='[33.0.0,33.0.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
@@ -130,10 +128,11 @@ Fragment-Host: org.openhab.core.model.script
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.openhab.core.model.persistence.runtime;version='[4.2.0,4.2.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
 	org.ops4j.pax.web.pax-web-api;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.24,8.0.25)',\
-	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)'
+	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -93,8 +93,6 @@ Fragment-Host: org.openhab.core.model.thing
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.0,2.16.1)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.16.0,2.16.1)',\
 	stax2-api;version='[4.2.1,4.2.2)',\
-	de.focus_shift.jollyday-core;version='[0.23.2,0.23.3)',\
-	de.focus_shift.jollyday-jackson;version='[0.23.2,0.23.3)',\
 	org.openhab.core.addon;version='[4.2.0,4.2.1)',\
 	com.google.guava;version='[33.0.0,33.0.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
@@ -132,10 +130,11 @@ Fragment-Host: org.openhab.core.model.thing
 	org.objectweb.asm.tree;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
-	org.openhab.core.model.persistence.runtime;version='[4.2.0,4.2.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.6,2.2.7)',\
 	org.ops4j.pax.web.pax-web-api;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-jetty;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.24,8.0.25)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.24,8.0.25)',\
-	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)'
+	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.24,8.0.25)',\
+	de.focus_shift.jollyday-core;version='[0.27.0,0.27.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.27.0,0.27.1)'


### PR DESCRIPTION
Upgrades Jollyday from 0.23.2 to 0.27.0.

For release notes, see:

https://github.com/focus-shift/jollyday/releases