### PR TITLE
Fix marketplace showing incompatible add-ons by default

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -314,7 +314,7 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             Dictionary<String, Object> properties = configuration.getProperties();
             if (properties == null) {
                 // if we can't determine a set property, we use false (default is show compatible only)
-                return true;
+                return false;
             }
             return ConfigParser.valueAsOrElse(properties.get(CONFIG_INCLUDE_INCOMPATIBLE), Boolean.class, false);
         } catch (IOException e) {


### PR DESCRIPTION
Fixes #4180 

I really wonder why this is showing up now, since the bug was there since quite some time. "Show incompatible" can be configured in the add-on management section and should default to "false", instead it was "true".

Should be backported to 4.1.x