### PR TITLE
Extend sitemap syntax for switch to support press & release buttons

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
@@ -18,12 +18,14 @@ package org.openhab.core.io.rest.sitemap.internal;
  * @author Kai Kreuzer - Initial contribution
  * @author Laurent Garnier - New fields position and icon
  * @author Laurent Garnier - Replace field position by fields row and column
+ * @author Laurent Garnier - New field releaseCommand
  */
 public class MappingDTO {
 
     public Integer row;
     public Integer column;
     public String command;
+    public String releaseCommand;
     public String label;
     public String icon;
 

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -139,6 +139,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Laurent Garnier - Added icon field for mappings used for switch element
  * @author Laurent Garnier - Support added for multiple AND conditions in labelcolor/valuecolor/visibility
  * @author Laurent Garnier - New widget icon parameter based on conditional rules
+ * @author Laurent Garnier - Added releaseCmd field for mappings used for switch element
  */
 @Component(service = { RESTResource.class, EventSubscriber.class })
 @JaxrsResource
@@ -565,6 +566,7 @@ public class SitemapResource
             for (Mapping mapping : switchWidget.getMappings()) {
                 MappingDTO mappingBean = new MappingDTO();
                 mappingBean.command = mapping.getCmd();
+                mappingBean.releaseCommand = mapping.getReleaseCmd();
                 mappingBean.label = mapping.getLabel();
                 mappingBean.icon = mapping.getIcon();
                 bean.mappings.add(mappingBean);

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -204,7 +204,7 @@ Button:
     row=INT ':' column=INT ':' cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;
 
 Mapping:
-    cmd=Command '=' label=(ID | STRING) ('=' icon=Icon)?;
+    cmd=Command (':' releaseCmd=Command)? '=' label=(ID | STRING) ('=' icon=Icon)?;
 
 VisibilityRule:
     conditions+=Condition ('AND' conditions+=Condition)*;

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -99,6 +99,11 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
     private static final Pattern CONDITION_PATTERN = Pattern
             .compile("(?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>)?\\s*(?<sign>\\+|-)?(?<state>.+)");
+    private static final Pattern COMMANDS_PATTERN1 = Pattern.compile("^\"(?<cmd1>[^\"]*)\":\"(?<cmd2>[^\"]*)\"$");
+    private static final Pattern COMMANDS_PATTERN2 = Pattern.compile("^\"(?<cmd1>[^\"]*)\":(?<cmd2>.*)$");
+    private static final Pattern COMMANDS_PATTERN3 = Pattern.compile("^(?<cmd1>.*):\"(?<cmd2>[^\"]*)\"$");
+    private static final Pattern COMMANDS_PATTERN4 = Pattern.compile("^\"(?<cmd>.*)\"$");
+    private static final Pattern COMMANDS_PATTERN5 = Pattern.compile("^(?<cmd1>.*):\"(?<cmd2>.*)$");
 
     private Map<String, Sitemap> sitemaps = new HashMap<>();
     private @Nullable UIComponentRegistryFactory componentRegistryFactory;
@@ -359,9 +364,36 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 for (Object sourceMapping : (Collection<?>) sourceMappings) {
                     if (sourceMapping instanceof String) {
                         String[] splitMapping = sourceMapping.toString().split("=");
-                        String[] splitCmd = splitMapping[0].trim().split(":");
-                        String cmd = splitCmd[0].trim();
-                        String releaseCmd = splitCmd.length < 2 ? null : splitCmd[1].trim();
+                        String cmd = splitMapping[0].trim();
+                        String releaseCmd = null;
+                        Matcher matcher = COMMANDS_PATTERN1.matcher(cmd);
+                        if (matcher.matches()) {
+                            cmd = matcher.group("cmd1");
+                            releaseCmd = matcher.group("cmd2");
+                        } else {
+                            matcher = COMMANDS_PATTERN2.matcher(cmd);
+                            if (matcher.matches()) {
+                                cmd = matcher.group("cmd1");
+                                releaseCmd = matcher.group("cmd2");
+                            } else {
+                                matcher = COMMANDS_PATTERN3.matcher(cmd);
+                                if (matcher.matches()) {
+                                    cmd = matcher.group("cmd1");
+                                    releaseCmd = matcher.group("cmd2");
+                                } else {
+                                    matcher = COMMANDS_PATTERN4.matcher(cmd);
+                                    if (matcher.matches()) {
+                                        cmd = matcher.group("cmd");
+                                    } else {
+                                        matcher = COMMANDS_PATTERN5.matcher(cmd);
+                                        if (matcher.matches()) {
+                                            cmd = matcher.group("cmd1");
+                                            releaseCmd = matcher.group("cmd2");
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         String label = splitMapping[1].trim();
                         String icon = splitMapping.length < 3 ? null : splitMapping[2].trim();
                         MappingImpl mapping = (MappingImpl) SitemapFactory.eINSTANCE.createMapping();

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -359,11 +359,14 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 for (Object sourceMapping : (Collection<?>) sourceMappings) {
                     if (sourceMapping instanceof String) {
                         String[] splitMapping = sourceMapping.toString().split("=");
-                        String cmd = splitMapping[0].trim();
+                        String[] splitCmd = splitMapping[0].trim().split(":");
+                        String cmd = splitCmd[0].trim();
+                        String releaseCmd = splitCmd.length < 2 ? null : splitCmd[1].trim();
                         String label = splitMapping[1].trim();
                         String icon = splitMapping.length < 3 ? null : splitMapping[2].trim();
                         MappingImpl mapping = (MappingImpl) SitemapFactory.eINSTANCE.createMapping();
                         mapping.setCmd(cmd);
+                        mapping.setReleaseCmd(releaseCmd);
                         mapping.setLabel(label);
                         mapping.setIcon(icon);
                         mappings.add(mapping);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -99,11 +99,6 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
 
     private static final Pattern CONDITION_PATTERN = Pattern
             .compile("(?<item>[A-Za-z]\\w*)?\\s*(?<condition>==|!=|<=|>=|<|>)?\\s*(?<sign>\\+|-)?(?<state>.+)");
-    private static final Pattern COMMANDS_PATTERN1 = Pattern.compile("^\"(?<cmd1>[^\"]*)\":\"(?<cmd2>[^\"]*)\"$");
-    private static final Pattern COMMANDS_PATTERN2 = Pattern.compile("^\"(?<cmd1>[^\"]*)\":(?<cmd2>.*)$");
-    private static final Pattern COMMANDS_PATTERN3 = Pattern.compile("^(?<cmd1>.*):\"(?<cmd2>[^\"]*)\"$");
-    private static final Pattern COMMANDS_PATTERN4 = Pattern.compile("^\"(?<cmd>.*)\"$");
-    private static final Pattern COMMANDS_PATTERN5 = Pattern.compile("^(?<cmd1>.*):\"(?<cmd2>.*)$");
 
     private Map<String, Sitemap> sitemaps = new HashMap<>();
     private @Nullable UIComponentRegistryFactory componentRegistryFactory;
@@ -365,40 +360,10 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                     if (sourceMapping instanceof String) {
                         String[] splitMapping = sourceMapping.toString().split("=");
                         String cmd = splitMapping[0].trim();
-                        String releaseCmd = null;
-                        Matcher matcher = COMMANDS_PATTERN1.matcher(cmd);
-                        if (matcher.matches()) {
-                            cmd = matcher.group("cmd1");
-                            releaseCmd = matcher.group("cmd2");
-                        } else {
-                            matcher = COMMANDS_PATTERN2.matcher(cmd);
-                            if (matcher.matches()) {
-                                cmd = matcher.group("cmd1");
-                                releaseCmd = matcher.group("cmd2");
-                            } else {
-                                matcher = COMMANDS_PATTERN3.matcher(cmd);
-                                if (matcher.matches()) {
-                                    cmd = matcher.group("cmd1");
-                                    releaseCmd = matcher.group("cmd2");
-                                } else {
-                                    matcher = COMMANDS_PATTERN4.matcher(cmd);
-                                    if (matcher.matches()) {
-                                        cmd = matcher.group("cmd");
-                                    } else {
-                                        matcher = COMMANDS_PATTERN5.matcher(cmd);
-                                        if (matcher.matches()) {
-                                            cmd = matcher.group("cmd1");
-                                            releaseCmd = matcher.group("cmd2");
-                                        }
-                                    }
-                                }
-                            }
-                        }
                         String label = splitMapping[1].trim();
                         String icon = splitMapping.length < 3 ? null : splitMapping[2].trim();
                         MappingImpl mapping = (MappingImpl) SitemapFactory.eINSTANCE.createMapping();
                         mapping.setCmd(cmd);
-                        mapping.setReleaseCmd(releaseCmd);
                         mapping.setLabel(label);
                         mapping.setIcon(icon);
                         mappings.add(mapping);


### PR DESCRIPTION
Mappings attribute for switch element now accepts one or two commands for each button. If only one command is provided, the button is a click button, the command is sent to the item when the button is clicked. If two commands are provided (separated by ":"), the button is a press & release button, the first command is sent to the item when the button is pressed and the second when the button is released.

Syntax example for a click button: Switch item=DemoSwitch mappings=[ ON="ON" ]
Syntax example for a press & release button: Switch item=DemoSwitch mappings=[ ON:OFF="ON" ]

Related to #3822

Signed-off-by: Laurent Garnier <lg.hc@free.fr>