### PR TITLE
Use FeatureInstaller for suggestion finder installation

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderConstants.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderConstants.java
@@ -26,34 +26,30 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class AddonFinderConstants {
 
     public static final String ADDON_SUGGESTION_FINDER = "-addon-suggestion-finder";
-    private static final String ADDON_SUGGESTION_FINDER_FEATURE = "openhab-core-config-discovery-addon-";
 
     public static final String SERVICE_TYPE_IP = "ip";
     public static final String CFG_FINDER_IP = "suggestionFinderIp";
     public static final String SERVICE_NAME_IP = SERVICE_TYPE_IP + ADDON_SUGGESTION_FINDER;
-    public static final String FEATURE_IP = ADDON_SUGGESTION_FINDER_FEATURE + SERVICE_TYPE_IP;
 
     public static final String SERVICE_TYPE_MDNS = "mdns";
     public static final String CFG_FINDER_MDNS = "suggestionFinderMdns";
     public static final String SERVICE_NAME_MDNS = SERVICE_TYPE_MDNS + ADDON_SUGGESTION_FINDER;
-    public static final String FEATURE_MDNS = ADDON_SUGGESTION_FINDER_FEATURE + SERVICE_TYPE_MDNS;
 
     public static final String SERVICE_TYPE_UPNP = "upnp";
     public static final String CFG_FINDER_UPNP = "suggestionFinderUpnp";
     public static final String SERVICE_NAME_UPNP = SERVICE_TYPE_UPNP + ADDON_SUGGESTION_FINDER;
-    public static final String FEATURE_UPNP = ADDON_SUGGESTION_FINDER_FEATURE + SERVICE_TYPE_UPNP;
 
     public static final String SERVICE_TYPE_USB = "usb";
     public static final String CFG_FINDER_USB = "suggestionFinderUsb";
     public static final String SERVICE_NAME_USB = SERVICE_TYPE_USB + ADDON_SUGGESTION_FINDER;
-    public static final String FEATURE_USB = ADDON_SUGGESTION_FINDER_FEATURE + SERVICE_TYPE_USB;
 
     public static final List<String> SUGGESTION_FINDERS = List.of(SERVICE_NAME_IP, SERVICE_NAME_MDNS, SERVICE_NAME_UPNP,
             SERVICE_NAME_USB);
 
+    public static final Map<String, String> SUGGESTION_FINDER_TYPES = Map.of(SERVICE_NAME_IP, SERVICE_TYPE_IP,
+            SERVICE_NAME_MDNS, SERVICE_TYPE_MDNS, SERVICE_NAME_UPNP, SERVICE_TYPE_UPNP, SERVICE_NAME_USB,
+            SERVICE_TYPE_USB);
+
     public static final Map<String, String> SUGGESTION_FINDER_CONFIGS = Map.of(SERVICE_NAME_IP, CFG_FINDER_IP,
             SERVICE_NAME_MDNS, CFG_FINDER_MDNS, SERVICE_NAME_UPNP, CFG_FINDER_UPNP, SERVICE_NAME_USB, CFG_FINDER_USB);
-
-    public static final Map<String, String> SUGGESTION_FINDER_FEATURES = Map.of(SERVICE_NAME_IP, FEATURE_IP,
-            SERVICE_NAME_MDNS, FEATURE_MDNS, SERVICE_NAME_UPNP, FEATURE_UPNP, SERVICE_NAME_USB, FEATURE_USB);
 }

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -91,8 +91,7 @@ public class FeatureInstaller implements ConfigurationListener {
 
     public static final String FINDER_ADDON_TYPE = "core-config-discovery-addon";
     public static final List<String> ADDON_TYPES = Stream
-            .concat(AddonType.DEFAULT_TYPES.stream().map(AddonType::getId), Stream.of(FINDER_ADDON_TYPE))
-            .toList();
+            .concat(AddonType.DEFAULT_TYPES.stream().map(AddonType::getId), Stream.of(FINDER_ADDON_TYPE)).toList();
 
     private final Logger logger = LoggerFactory.getLogger(FeatureInstaller.class);
 

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -89,7 +89,10 @@ public class FeatureInstaller implements ConfigurationListener {
     private static final String ADDONS_PID = "org.openhab.addons";
     private static final String PROPERTY_MVN_REPOS = "org.ops4j.pax.url.mvn.repositories";
 
-    public static final List<String> ADDON_TYPES = AddonType.DEFAULT_TYPES.stream().map(AddonType::getId).toList();
+    public static final String FINDER_ADDON_TYPE = "core-config-discovery-addon";
+    public static final List<String> ADDON_TYPES = Stream
+            .concat(AddonType.DEFAULT_TYPES.stream().map(AddonType::getId), Stream.of(FINDER_ADDON_TYPE))
+            .toList();
 
     private final Logger logger = LoggerFactory.getLogger(FeatureInstaller.class);
 

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonFinderService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonFinderService.java
@@ -12,15 +12,12 @@
  */
 package org.openhab.core.karaf.internal;
 
-import org.apache.karaf.features.FeaturesService;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.discovery.addon.AddonFinderService;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This service is an implementation of an openHAB {@link AddonFinderService} using the Karaf features
@@ -31,14 +28,12 @@ import org.slf4j.LoggerFactory;
 @Component(name = "org.openhab.core.karafaddonfinders", immediate = true)
 @NonNullByDefault
 public class KarafAddonFinderService implements AddonFinderService {
-    private final Logger logger = LoggerFactory.getLogger(KarafAddonFinderService.class);
-
-    private final FeaturesService featuresService;
+    private final FeatureInstaller featureInstaller;
     private boolean deactivated;
 
     @Activate
-    public KarafAddonFinderService(final @Reference FeaturesService featuresService) {
-        this.featuresService = featuresService;
+    public KarafAddonFinderService(final @Reference FeatureInstaller featureInstaller) {
+        this.featureInstaller = featureInstaller;
     }
 
     @Deactivate
@@ -49,30 +44,14 @@ public class KarafAddonFinderService implements AddonFinderService {
     @Override
     public void install(String id) {
         if (!deactivated) {
-            try {
-                if (!featuresService.isInstalled(featuresService.getFeature(id))) {
-                    featuresService.installFeature(id);
-                }
-            } catch (Exception e) {
-                if (!deactivated) {
-                    logger.error("Failed to install add-on suggestion finder {}", id, e);
-                }
-            }
+            featureInstaller.addAddon(FeatureInstaller.FINDER_ADDON_TYPE, id);
         }
     }
 
     @Override
     public void uninstall(String id) {
         if (!deactivated) {
-            try {
-                if (featuresService.isInstalled(featuresService.getFeature(id))) {
-                    featuresService.uninstallFeature(id);
-                }
-            } catch (Exception e) {
-                if (!deactivated) {
-                    logger.error("Failed to uninstall add-on suggestion finder {}", id, e);
-                }
-            }
+            featureInstaller.removeAddon(FeatureInstaller.FINDER_ADDON_TYPE, id);
         }
     }
 }


### PR DESCRIPTION
See https://github.com/openhab/openhab-core/issues/3983

This PR changes the installation/deinstallation of suggestion finders, not directly calling the FeatureService, but through FeatureInstaller. This should reduce the amount of bundle refreshes happening, but will not completely avoid it (the root cause is not with the finders, but the refersh on install/deinstall of any bundle).
At a minimum, it moves the installation/deinstallation into the same code as installing/deinstalling addons, so improvements in that code will also benefit the installation/deinstallation of the addon finders.

@J-N-K @lolodomo let me know if this change is worth doing, or the benefit is too limited.