### PR TITLE
[persistence] improve building the ItemHistoryDTO

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -406,7 +406,6 @@ public class PersistenceResource implements RESTResource {
         }
 
         Iterable<HistoricItem> result;
-        State state;
 
         long quantity = 0L;
 
@@ -446,23 +445,24 @@ public class PersistenceResource implements RESTResource {
         Iterator<HistoricItem> it = result.iterator();
 
         // Iterate through the data
-        HistoricItem lastItem = null;
+        State lastState = null;
         while (it.hasNext()) {
             HistoricItem historicItem = it.next();
-            state = historicItem.getState();
+            State state = historicItem.getState();
+            long timestamp = historicItem.getTimestamp().toInstant().toEpochMilli();
 
             // For 'binary' states, we need to replicate the data
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
-                if (lastItem != null) {
-                    dto.addData(historicItem.getTimestamp().toInstant().toEpochMilli(), lastItem.getState());
+                if (lastState != null && !lastState.equals(state)) {
+                    dto.addData(timestamp, lastState);
                     quantity++;
                 }
             }
 
-            dto.addData(historicItem.getTimestamp().toInstant().toEpochMilli(), state);
+            dto.addData(timestamp, state);
             quantity++;
-            lastItem = historicItem;
+            lastState = state;
         }
 
         if (boundary) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
@@ -15,6 +15,7 @@ package org.openhab.core.persistence.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.types.State;
 
@@ -41,12 +42,15 @@ public class ItemHistoryDTO {
      * @param time the time of the record
      * @param state the state at this time
      */
-    public void addData(Long time, State state) {
+    public void addData(long time, State state) {
         HistoryDataBean newVal = new HistoryDataBean();
         newVal.time = time;
         if (state instanceof QuantityType quantityState) {
             // we strip the unit from the state, since historic item states are expected to be all in the default unit
             newVal.state = quantityState.toBigDecimal().toString();
+        } else if (state instanceof DecimalType decimalType) {
+            // use BigDecimal.toString() to hit the internal cache
+            newVal.state = decimalType.toBigDecimal().toString();
         } else {
             newVal.state = state.toString();
         }
@@ -54,7 +58,7 @@ public class ItemHistoryDTO {
     }
 
     public static class HistoryDataBean {
-        public Long time;
+        public long time;
         public String state;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -358,7 +358,12 @@ public class QuantityType<T extends Quantity<T>> extends Number
     }
 
     public BigDecimal toBigDecimal() {
-        return new BigDecimal(quantity.getValue().toString());
+        Number value = quantity.getValue();
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        } else {
+            return new BigDecimal(value.toString());
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR will improve throughput and memory consumption while building the ItemHistoryDTO by:
- removing not needed auto-boxing of a field
- apply the diagonal lines workaround only when needed
- ensure the internal cache of `BigDecimal.toString` is hit and the `BigDecimal` is not rebuilded (relevant since PR #16379 reuses the State)