### PR TITLE
Update plugins

### DIFF
--- a/bundles/org.openhab.core.audio/pom.xml
+++ b/bundles/org.openhab.core.audio/pom.xml
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>embed-dependencies</id>

--- a/bundles/org.openhab.core.io.jetty.certificate/pom.xml
+++ b/bundles/org.openhab.core.io.jetty.certificate/pom.xml
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.3</version>
         <executions>
           <execution>
             <goals>

--- a/bundles/org.openhab.core.io.monitor/pom.xml
+++ b/bundles/org.openhab.core.io.monitor/pom.xml
@@ -62,7 +62,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>embed-dependencies</id>

--- a/bundles/org.openhab.core.io.transport.modbus/pom.xml
+++ b/bundles/org.openhab.core.io.transport.modbus/pom.xml
@@ -45,7 +45,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>embed-dependencies</id>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -167,7 +167,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>unpack-eea</id>
@@ -204,7 +204,7 @@
           <plugin>
             <groupId>org.jvnet.jaxb2.maven2</groupId>
             <artifactId>maven-jaxb2-plugin</artifactId>
-            <version>0.15.2</version>
+            <version>0.15.3</version>
             <configuration>
               <schemaDirectory>schema</schemaDirectory>
               <bindingDirectory>schema/binding</bindingDirectory>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>unpack-eea</id>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <sat.version>0.16.0</sat.version>
     <slf4j.version>2.0.7</slf4j.version>
     <xtext.version>2.34.0</xtext.version>
-    <spotless.version>2.38.0</spotless.version>
+    <spotless.version>2.43.0</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>
@@ -268,7 +268,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
         </plugin>
 
         <plugin>
@@ -317,13 +317,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.2</version>
+          <version>3.6.3</version>
           <configuration>
             <failOnError>true</failOnError>
             <failOnWarnings>true</failOnWarnings>
@@ -355,20 +355,12 @@ Import-Package: \\
               </tag>
             </tags>
           </configuration>
-          <dependencies>
-            <!-- This newer version fixes issues with resolving tech.units:indriya packages -->
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-java</artifactId>
-              <version>1.0.7</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.0</version>
         </plugin>
 
         <plugin>
@@ -395,13 +387,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.5</version>
           <configuration>
             <argLine>
               --add-opens java.base/java.net=ALL-UNNAMED
@@ -436,13 +428,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.2</version>
+          <version>4.3</version>
           <configuration>
             <basedir>${basedir}</basedir>
             <quiet>false</quiet>
@@ -499,7 +491,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.openhab.core.tools</groupId>
           <artifactId>i18n-maven-plugin</artifactId>
-          <version>4.0.2</version>
+          <version>4.1.2</version>
         </plugin>
 
         <plugin>
@@ -529,7 +521,7 @@ Import-Package: \\
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -666,6 +658,9 @@ Import-Package: \\
             </goals>
             <configuration>
               <rules>
+                <requireMavenVersion>
+                  <version>3.6.3</version>
+                </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17.0,18.0),[21.0,22.0)</version>
                 </requireJavaVersion>

--- a/tools/archetype/binding/pom.xml
+++ b/tools/archetype/binding/pom.xml
@@ -37,7 +37,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tools/i18n-plugin/pom.xml
+++ b/tools/i18n-plugin/pom.xml
@@ -21,7 +21,7 @@
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
-    <maven.plugin.plugin.version>3.11.0</maven.plugin.plugin.version>
+    <maven.plugin.plugin.version>3.12.0</maven.plugin.plugin.version>
     <maven.plugin.compiler.version>3.8.1</maven.plugin.compiler.version>
   </properties>
 

--- a/tools/upgradetool/pom.xml
+++ b/tools/upgradetool/pom.xml
@@ -80,7 +80,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>unpack-eea</id>
@@ -102,7 +102,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.7.1</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
Update all plugins listed by
```mvn versions:display-plugin-updates -nsu  -B -Dversions.outputLineWidth=120 | grep -- '->' | sort -u```
(except the ones related to Karaf 4.4.6 update and milestone/snapshot releases;
exec-maven-plugin is kept untouched due to not yet resolved change in configuration)

* set minimum Maven version to 3.6.3
* build-helper-maven-plugin, 3.4.0 to 3.5.0, see https://github.com/mojohaus/build-helper-maven-plugin/releases/tag/3.5.0
* exec-maven-plugin, 3.0.0 to 3.2.0, see https://github.com/mojohaus/exec-maven-plugin/releases
* jvnet maven-jaxb2-plugin, 0.15.2 to 0.15.3
* license-maven-plugin, 4.2 to 4.3
* maven-archetype-plugin, 3.0.1 to 3.2.1
* maven-assembly-plugin, 3.4.2 to 3.7.1, see https://github.com/apache/maven-assembly-plugin/releases
* maven-clean-plugin, 3.3.1 to 3.3.2, see https://github.com/apache/maven-clean-plugin/releases
* maven-dependency-plugin, 3.6.0/3.3.0/3.1.1 to 3.6.1, see https://github.com/apache/maven-dependency-plugin/releases/tag/maven-dependency-plugin-3.6.1
* maven-jar-plugin, 3.3.0 to 3.4.1, see https://github.com/apache/maven-jar-plugin/releases
* maven-javadoc-plugin, 3.6.2 to 3.6.3, see https://github.com/apache/maven-javadoc-plugin/releases
* maven-plugin-plugin, 3.11.0 to 3.12.0, see https://github.com/apache/maven-plugin-tools/releases/tag/maven-plugin-tools-3.12.0
* maven-shade-pluginm 3.5.2 to 3.5.3
* maven-source-plugin, 3.3.0 to 3.3.1
* maven-surefire-plugin, 3.1.2 to 3.2.5, seee https://github.com/apache/maven-surefire/releases
* sortpom-maven-plugin, 3.3.0 to 3.4.1, see https://github.com/Ekryd/sortpom/releases
* spotless-maven-plugin, 2.38.0 to 2.43.0, see https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md
* openhab 18n-maven-plugin, 4.0.2 to 4.1.2

<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- Introduce metadata for all add-ons
- Fix memory leak in ScriptedRuleProvider

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the Core README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis?
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

If your pull request contains a new contribution, it will likely take some time
before it is reviewed and processed by maintainers.
-->
