### PR TITLE
Reuse existing BigDecimals in rules while converting types

### DIFF
--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
@@ -24,7 +24,11 @@ import javax.measure.quantity.Length;
 import javax.measure.quantity.Temperature;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.PercentType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.types.Type;
@@ -858,5 +862,29 @@ public class NumberExtensionsTest {
         result = NumberExtensions.operator_lessEqualsThan((Type) type, x);
 
         assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "0.2", "0.1111111111111111111111111111111111111111111111111111111", "1" })
+    public void testNumberToBigDecimal(String value) {
+        DecimalType dt = new DecimalType(value);
+        assertEquals(value, NumberExtensions.numberToBigDecimal(dt).toString());
+
+        PercentType pt = new PercentType(value);
+        assertEquals(value, NumberExtensions.numberToBigDecimal(pt).toString());
+
+        // HSBTye is a subclass of DecimalType, it converts part "V" to a BigDecimal
+        HSBType hsb = new HSBType(dt, pt, pt);
+        assertEquals(value, NumberExtensions.numberToBigDecimal(hsb).toString());
+
+        int integerTestValue = (int) (Double.valueOf(value).doubleValue() * 1000);
+        Integer intValue = Integer.valueOf(integerTestValue);
+        assertEquals("" + integerTestValue, NumberExtensions.numberToBigDecimal(intValue).toString());
+
+        Long longValue = Long.valueOf(integerTestValue);
+        assertEquals("" + integerTestValue, NumberExtensions.numberToBigDecimal(longValue).toString());
+
+        BigDecimal bd = new BigDecimal(value);
+        assertEquals(value, NumberExtensions.numberToBigDecimal(bd).toString());
     }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
@@ -380,6 +380,20 @@ public class NumberExtensions {
             }
             return null;
         }
+        if (number instanceof DecimalType dtype) {
+            return dtype.toBigDecimal();
+        }
+        if (number instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (number instanceof Long value) {
+            // use valueOf to hit the internal cache
+            return BigDecimal.valueOf(value);
+        }
+        if (number instanceof Integer value) {
+            // use valueOf to hit the internal cache
+            return BigDecimal.valueOf(value);
+        }
         if (number != null) {
             return new BigDecimal(number.toString());
         } else {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -53,7 +53,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     public DecimalType(Number value) {
         if (value instanceof QuantityType type) {
             this.value = type.toBigDecimal();
-        } else if (value instanceof HSBType type) {
+        } else if (value instanceof DecimalType type) {
             this.value = type.toBigDecimal();
         } else if (value instanceof BigDecimal decimal) {
             this.value = decimal;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
@@ -131,7 +131,7 @@ public class PercentType extends DecimalType {
         } else if (target == HSBType.class) {
             return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO, this));
         } else if (target == QuantityType.class) {
-            return target.cast(new QuantityType<>(toBigDecimal().doubleValue(), Units.PERCENT));
+            return target.cast(new QuantityType<>(toBigDecimal(), Units.PERCENT));
         } else {
             return defaultConversion(target);
         }


### PR DESCRIPTION
# Description

This PR will speed up calculations in rules by handling translation of common number types to `BigDecimal`.
These common number types should match most cases when calculations are done in rules.