### PR TITLE
[audio|voice] Add console commands to troubleshoot audio sources and speech-to-text services

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -386,8 +386,9 @@ public class AudioFormat {
                 continue;
             }
 
-            // Prefer WAVE container
-            if (!CONTAINER_WAVE.equals(format.getContainer())) {
+            // Prefer WAVE container or raw SIGNED PCM encoded audio
+            if (!CONTAINER_WAVE.equals(format.getContainer())
+                    && !(CONTAINER_NONE.equals(format.getContainer()) && CODEC_PCM_SIGNED.equals(format.getCodec()))) {
                 continue;
             }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -26,6 +26,7 @@ import org.openhab.core.library.types.PercentType;
  * @author Kai Kreuzer - removed unwanted dependencies
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Added methods for getting all sinks and sources
+ * @author Miguel Álvarez - Add record method
  */
 @NonNullByDefault
 public interface AudioManager {
@@ -150,6 +151,15 @@ public interface AudioManager {
      * @param volume The volume to be used or null if the default notification volume should be used
      */
     void playMelody(String melody, @Nullable String sinkId, @Nullable PercentType volume);
+
+    /**
+     * Record audio as a WAV file of the specified length to the sounds folder.
+     *
+     * @param seconds seconds to record.
+     * @param filename record filename.
+     * @param sourceId The id of the audio source to use or null for the default.
+     */
+    void record(int seconds, String filename, @Nullable String sourceId) throws AudioException;
 
     /**
      * Retrieves the current volume of a sink

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
@@ -194,11 +194,11 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
             int seconds = Integer.parseInt(args.length > 2 ? args[1] : args[0]);
             String filename = args.length > 2 ? args[2] : args[1];
             audioManager.record(seconds, filename, sourceId);
-            console.println("Record done.");
+            console.println("Recording completed");
         } catch (NumberFormatException e) {
-            console.println("Unable to parse record time: " + e.getMessage());
+            console.println("Unable to parse the recording time: " + e.getMessage());
         } catch (AudioException e) {
-            console.println("Record terminated with audio exception: " + e.getMessage());
+            console.println("Recording terminated with audio exception: " + e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
@@ -42,12 +42,14 @@ import org.osgi.service.component.annotations.Reference;
  * @author Kai Kreuzer - refactored to match AudioManager implementation
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Sort audio sink and source options
+ * @author Miguel Álvarez Díez - Add record command
  */
 @Component(service = ConsoleCommandExtension.class)
 @NonNullByDefault
 public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtension {
 
     static final String SUBCMD_PLAY = "play";
+    static final String SUBCMD_RECORD = "record";
     static final String SUBCMD_STREAM = "stream";
     static final String SUBCMD_SYNTHESIZE = "synthesize";
     static final String SUBCMD_SOURCES = "sources";
@@ -71,6 +73,8 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
                         "plays a sound file from the sounds folder through the optionally specified audio sink(s)"),
                 buildCommandUsage(SUBCMD_PLAY + " <sink> <filename> <volume>",
                         "plays a sound file from the sounds folder through the specified audio sink(s) with the specified volume"),
+                buildCommandUsage(SUBCMD_RECORD + " [<source>] <seconds> <filename>",
+                        "record an audio file of the specified seconds to the sounds folder. The extension '.wav' will be added to the filename if missed."),
                 buildCommandUsage(SUBCMD_STREAM + " [<sink>] <url>",
                         "streams the sound from the url through the optionally specified audio sink(s)"),
                 buildCommandUsage(SUBCMD_SYNTHESIZE + " [<sink>] \"<melody>\"",
@@ -93,6 +97,14 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
                     } else {
                         console.println(
                                 "Specify file to play, and optionally the sink(s) to use (e.g. 'play javasound hello.mp3')");
+                    }
+                    return;
+                case SUBCMD_RECORD:
+                    if (args.length > 2) {
+                        record(Arrays.copyOfRange(args, 1, args.length), console);
+                    } else {
+                        console.println(
+                                "Specify time to record and the desired filename, and optionally the source to use (e.g. 'record javasound 10 good_morning.wav')");
                     }
                     return;
                 case SUBCMD_STREAM:
@@ -172,6 +184,21 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 break;
             default:
                 break;
+        }
+    }
+
+    private void record(String[] args, Console console) {
+        try {
+            @Nullable
+            String sourceId = args.length > 2 ? args[0] : null;
+            int seconds = Integer.parseInt(args.length > 2 ? args[1] : args[0]);
+            String filename = args.length > 2 ? args[2] : args[1];
+            audioManager.record(seconds, filename, sourceId);
+            console.println("Record done.");
+        } catch (NumberFormatException e) {
+            console.println("Unable to parse record time: " + e.getMessage());
+        } catch (AudioException e) {
+            console.println("Record terminated with audio exception: " + e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -233,12 +233,12 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
                         break;
                     }
                     if (recordBuffer.position() + bytes.length > recordBuffer.limit()) {
-                        logger.debug("Record limit reached");
+                        logger.debug("Recording limit reached");
                         break;
                     }
                     recordBuffer.put(bytes);
                 } catch (IOException e) {
-                    logger.warn("Read failed");
+                    logger.warn("Reading audio data failed");
                 }
             }
         } catch (IOException e) {

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -14,9 +14,13 @@ package org.openhab.core.audio.internal;
 
 import static java.util.Comparator.comparing;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -25,6 +29,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sound.sampled.AudioFileFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -37,6 +45,7 @@ import org.openhab.core.audio.AudioSource;
 import org.openhab.core.audio.AudioStream;
 import org.openhab.core.audio.FileAudioStream;
 import org.openhab.core.audio.URLAudioStream;
+import org.openhab.core.audio.utils.AudioWaveUtils;
 import org.openhab.core.audio.utils.ToneSynthesizer;
 import org.openhab.core.config.core.ConfigOptionProvider;
 import org.openhab.core.config.core.ConfigurableService;
@@ -61,6 +70,7 @@ import org.slf4j.LoggerFactory;
  * @author Christoph Weitkamp - Added getSupportedStreams() and UnsupportedAudioStreamException
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Sort audio sink and source options
+ * @author Miguel Álvarez - Add record from source
  */
 @NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.audio", //
@@ -147,8 +157,7 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     @Override
     public void playFile(String fileName, @Nullable String sinkId, @Nullable PercentType volume) throws AudioException {
         Objects.requireNonNull(fileName, "File cannot be played as fileName is null.");
-
-        File file = new File(OpenHAB.getConfigFolder() + File.separator + SOUND_DIR + File.separator + fileName);
+        File file = Path.of(OpenHAB.getConfigFolder(), SOUND_DIR, fileName).toFile();
         FileAudioStream is = new FileAudioStream(file);
         play(is, sinkId, volume);
     }
@@ -192,6 +201,67 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
             play(audioStream, sinkId, volume);
         } catch (IOException | ParseException e) {
             logger.warn("Failed playing melody: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void record(int seconds, String filename, @Nullable String sourceId) throws AudioException {
+        var audioSource = sourceId != null ? getSource(sourceId) : getSource();
+        if (audioSource == null) {
+            throw new AudioException("Audio source '" + (sourceId != null ? sourceId : "default") + "' not available");
+        }
+        var audioFormat = AudioFormat.getBestMatch(audioSource.getSupportedFormats(),
+                Set.of(AudioFormat.PCM_SIGNED, AudioFormat.WAV));
+        if (audioFormat == null) {
+            throw new AudioException("Unable to find valid audio format");
+        }
+        javax.sound.sampled.AudioFormat jAudioFormat = new javax.sound.sampled.AudioFormat(
+                Objects.requireNonNull(audioFormat.getFrequency()), Objects.requireNonNull(audioFormat.getBitDepth()),
+                Objects.requireNonNull(audioFormat.getChannels()), true, false);
+        int secondByteLength = ((int) jAudioFormat.getSampleRate() * jAudioFormat.getFrameSize());
+        int targetByteLength = secondByteLength * seconds;
+        ByteBuffer recordBuffer = ByteBuffer.allocate(targetByteLength);
+        try (var audioStream = audioSource.getInputStream(audioFormat)) {
+            if (audioFormat.isCompatible(AudioFormat.WAV)) {
+                AudioWaveUtils.removeFMT(audioStream);
+            }
+            while (true) {
+                try {
+                    var bytes = audioStream.readNBytes(secondByteLength);
+                    if (bytes.length == 0) {
+                        logger.debug("End of input audio stream reached");
+                        break;
+                    }
+                    if (recordBuffer.position() + bytes.length > recordBuffer.limit()) {
+                        logger.debug("Record limit reached");
+                        break;
+                    }
+                    recordBuffer.put(bytes);
+                } catch (IOException e) {
+                    logger.warn("Read failed");
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("IOException while reading audioStream: {}", e.getMessage());
+        }
+        String recordFilename = filename.endsWith(".wav") ? filename : filename + ".wav";
+        logger.info("Saving record file: {}", recordFilename);
+        byte[] audioBytes = new byte[recordBuffer.position()];
+        logger.info("Saving bytes: {}", audioBytes.length);
+        recordBuffer.rewind();
+        recordBuffer.get(audioBytes);
+        File recordFile = new File(
+                OpenHAB.getConfigFolder() + File.separator + SOUND_DIR + File.separator + recordFilename);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(recordFile)) {
+            AudioSystem.write(
+                    new AudioInputStream(new ByteArrayInputStream(audioBytes), jAudioFormat,
+                            (long) Math.ceil(((double) audioBytes.length) / jAudioFormat.getFrameSize())), //
+                    AudioFileFormat.Type.WAVE, //
+                    fileOutputStream //
+            );
+            fileOutputStream.flush();
+        } catch (IOException e) {
+            logger.warn("IOException while saving record file: {}", e.getMessage());
         }
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -14,11 +14,13 @@ package org.openhab.core.voice;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.AudioSource;
+import org.openhab.core.audio.AudioStream;
 import org.openhab.core.library.types.PercentType;
 import org.openhab.core.voice.text.HumanLanguageInterpreter;
 import org.openhab.core.voice.text.InterpretationException;
@@ -30,6 +32,7 @@ import org.openhab.core.voice.text.InterpretationException;
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Laurent Garnier - Updated methods startDialog and added method stopDialog
  * @author Miguel Álvarez - New dialog methods using DialogContext
+ * @author Miguel Álvarez - Add transcribe method
  */
 @NonNullByDefault
 public interface VoiceManager {
@@ -92,6 +95,26 @@ public interface VoiceManager {
      * @param volume The volume to be used or null if the default notification volume should be used
      */
     void say(String text, @Nullable String voiceId, @Nullable String sinkId, @Nullable PercentType volume);
+
+    /**
+     * Run speech-to-text using the provided audio source.
+     *
+     * @param audioSourceId Audio source to listen.
+     * @param sttId The id of the speech-to-text service to use or null to use the default.
+     * @param locale The locale to use or null to use the default.
+     * @return a human language transcription or empty.
+     */
+    String transcribe(@Nullable String audioSourceId, @Nullable String sttId, @Nullable Locale locale);
+
+    /**
+     * Run speech-to-text over the provided audio stream.
+     *
+     * @param audioStream Audio stream to transcribe.
+     * @param sttId The id of the speech-to-text service to use or null to use the default.
+     * @param locale The locale to use or null to use the default.
+     * @return a human language transcription or empty.
+     */
+    String transcribe(AudioStream audioStream, @Nullable String sttId, @Nullable Locale locale);
 
     /**
      * Interprets the passed string using the default services for HLI and locale.

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -99,7 +99,7 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
     @Override
     public List<String> getUsages() {
         return List.of(buildCommandUsage(SUBCMD_SAY + " <text>", "speaks a text"), buildCommandUsage(
-                SUBCMD_TRANSCRIBE + " [--source <source>]|[--file <file>] [<sttId>] [<locale>]",
+                SUBCMD_TRANSCRIBE + " [--source <source>]|[--file <file>] [--stt <stt>] [--locale <locale>]",
                 "transcribe audio from default source, optionally specify a different source/file, speech-to-text service or locale"),
                 buildCommandUsage(SUBCMD_INTERPRET + " <command>", "interprets a human language command"),
                 buildCommandUsage(SUBCMD_VOICES, "lists available voices of the TTS services"),
@@ -353,9 +353,9 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
                 console.println("Error: File '" + parameters.get("file") + "' not found in sound folder.");
                 return;
             }
-            text = voiceManager.transcribe(fileAudioStream, parameters.get("sttId"), locale);
+            text = voiceManager.transcribe(fileAudioStream, parameters.get("stt"), locale);
         } else {
-            text = voiceManager.transcribe(parameters.get("source"), parameters.get("sttId"), null);
+            text = voiceManager.transcribe(parameters.get("source"), parameters.get("stt"), null);
         }
         if (!text.isBlank()) {
             console.println("Transcription: " + text);

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -101,7 +101,6 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
         return List.of(buildCommandUsage(SUBCMD_SAY + " <text>", "speaks a text"), buildCommandUsage(
                 SUBCMD_TRANSCRIBE + " [--source <source>]|[--file <file>] [<sttId>] [<locale>]",
                 "transcribe audio from default source, optionally specify a different source/file, speech-to-text service or locale"),
-                buildCommandUsage(SUBCMD_SAY + " <text>", "speaks a text"),
                 buildCommandUsage(SUBCMD_INTERPRET + " <command>", "interprets a human language command"),
                 buildCommandUsage(SUBCMD_VOICES, "lists available voices of the TTS services"),
                 buildCommandUsage(SUBCMD_DIALOGS, "lists the running dialog and their audio/voice services"),
@@ -361,7 +360,7 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
         if (!text.isBlank()) {
             console.println("Transcription: " + text);
         } else {
-            console.println("No transcription generated.");
+            console.println("No transcription generated");
         }
     }
 

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.voice.internal;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,15 +29,19 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.audio.AudioException;
 import org.openhab.core.audio.AudioFormat;
 import org.openhab.core.audio.AudioManager;
 import org.openhab.core.audio.AudioSink;
@@ -55,7 +60,13 @@ import org.openhab.core.storage.StorageService;
 import org.openhab.core.voice.DialogContext;
 import org.openhab.core.voice.DialogRegistration;
 import org.openhab.core.voice.KSService;
+import org.openhab.core.voice.RecognitionStartEvent;
+import org.openhab.core.voice.RecognitionStopEvent;
+import org.openhab.core.voice.STTException;
 import org.openhab.core.voice.STTService;
+import org.openhab.core.voice.STTServiceHandle;
+import org.openhab.core.voice.SpeechRecognitionErrorEvent;
+import org.openhab.core.voice.SpeechRecognitionEvent;
 import org.openhab.core.voice.TTSException;
 import org.openhab.core.voice.TTSService;
 import org.openhab.core.voice.Voice;
@@ -85,6 +96,7 @@ import org.slf4j.LoggerFactory;
  * @author Wouter Born - Sort TTS options
  * @author Laurent Garnier - Updated methods startDialog and added method stopDialog
  * @author Miguel Álvarez - Use dialog context
+ * @author Miguel Álvarez - Add transcribe method
  */
 @Component(immediate = true, configurationPid = VoiceManagerImpl.CONFIGURATION_PID, //
         property = Constants.SERVICE_PID + "=org.openhab.voice")
@@ -286,6 +298,91 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider, Dia
                 logger.warn("Error saying '{}': {}", text, e.getMessage());
             }
         }
+    }
+
+    @Override
+    public String transcribe(@Nullable String audioSourceId, @Nullable String sttId, @Nullable Locale locale) {
+        var audioSource = audioSourceId != null ? audioManager.getSource(audioSourceId) : audioManager.getSource();
+        if (audioSource == null) {
+            logger.warn("Audio source '{}' not available", audioSourceId != null ? audioSourceId : "default");
+            return "";
+        }
+        var sttService = sttId != null ? getSTT(sttId) : getSTT();
+        if (sttService == null) {
+            logger.warn("Speech-to-text service '{}' not available", sttId != null ? sttId : "default");
+            return "";
+        }
+        var sttFormat = VoiceManagerImpl.getBestMatch(audioSource.getSupportedFormats(),
+                sttService.getSupportedFormats());
+        if (sttFormat == null) {
+            logger.warn("No compatible audio format found for stt '{}' and the provided audio stream",
+                    sttService.getId());
+            return "";
+        }
+        AudioStream audioStream;
+        try {
+            audioStream = audioSource.getInputStream(sttFormat);
+        } catch (AudioException e) {
+            logger.warn("AudioException creating source audio stream: {}", e.getMessage());
+            return "";
+        }
+        return transcribe(audioStream, sttService, locale);
+    }
+
+    @Override
+    public String transcribe(AudioStream audioStream, @Nullable String sttId, @Nullable Locale locale) {
+        var sttService = sttId != null ? getSTT(sttId) : getSTT();
+        if (sttService == null) {
+            logger.warn("Speech-to-text service '{}' not available", sttId != null ? sttId : "default");
+            return "";
+        }
+        var sttFormat = VoiceManagerImpl.getBestMatch(Set.of(audioStream.getFormat()),
+                sttService.getSupportedFormats());
+        if (sttFormat == null) {
+            logger.warn("No compatible audio format found for stt '{}' and the provided audio stream",
+                    sttService.getId());
+            return "";
+        }
+        return transcribe(audioStream, sttService, locale);
+    }
+
+    private String transcribe(AudioStream audioStream, STTService sttService, @Nullable Locale locale) {
+        Locale nullSafeLocale = locale != null ? locale : localeProvider.getLocale();
+        CompletableFuture<String> transcriptionResult = new CompletableFuture<>();
+        STTServiceHandle sttServiceHandle;
+        try {
+            sttServiceHandle = sttService.recognize(sttEvent -> {
+                if (sttEvent instanceof SpeechRecognitionEvent sre) {
+                    logger.debug("SpeechRecognitionEvent event received");
+                    String transcript = sre.getTranscript();
+                    logger.debug("Text recognized: {}", transcript);
+                    transcriptionResult.complete(transcript);
+                } else if (sttEvent instanceof RecognitionStartEvent) {
+                    logger.debug("RecognitionStartEvent event received");
+                } else if (sttEvent instanceof RecognitionStopEvent) {
+                    logger.debug("RecognitionStopEvent event received");
+                } else if (sttEvent instanceof SpeechRecognitionErrorEvent sre) {
+                    logger.debug("SpeechRecognitionErrorEvent event received");
+                    transcriptionResult.completeExceptionally(
+                            new IOException("SpeechRecognitionErrorEvent emitted: " + sre.getMessage()));
+                }
+            }, audioStream, nullSafeLocale, new HashSet<>());
+        } catch (STTException e) {
+            logger.warn("STTException while running transcription");
+            return "";
+        }
+        try {
+            return transcriptionResult.get(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("InterruptedException waiting for transcription: {}", e.getMessage());
+            sttServiceHandle.abort();
+        } catch (ExecutionException e) {
+            logger.warn("ExecutionException running transcription: {}", e.getCause().getMessage());
+        } catch (TimeoutException e) {
+            logger.warn("TimeoutException waiting for transcription");
+            sttServiceHandle.abort();
+        }
+        return "";
     }
 
     @Override


### PR DESCRIPTION
I would like add these new console commands to allow testing the audio sources and audio transcription capabilities.

Recently I was mentioned at https://community.openhab.org/t/problems-with-dialog-processing-with-pulseaudiobinding/155573 asking for help about these matters and it's difficult to give support about remote setups, so I though that having these commands can help users to troubleshot problems with the audio input and the transcription add-ons.

The new commands are:

### Voice Transcribe

Transcribe audio from default source, optionally specify a different source/file, speech-to-text service or locale.

#### Signature
```sh
voice transcribe [--source <source>]|[--file <file>] [<sttId>] [<locale>]
```
#### Example run:

```sh
openhab> voice transcribe --file turn_on_light.wav
Transcription: turn on light.
```

### Audio Record

Record a wav file of the specified seconds to the sounds folder.

#### Signature

```sh
audio record  [<source>] <seconds> <filename>
````

#### Example run:

```sh
openhab> audio record pulseaudio:source:df54bf45b3:Jabra_Speak2_40_Echo_Cancel_Source 5 turn_on_light
Record done.
```
 