### PR TITLE
Make input formatting for transformations consistent everywhere

### DIFF
--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -810,6 +810,45 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
+    public void getLabelFailingTransformation() throws ItemNotFoundException {
+        String testLabel = "Memory [FOO(echo %s):__%d__]";
+        Widget w = mock(Widget.class);
+        Item item = mock(Item.class);
+        when(w.getLabel()).thenReturn(testLabel);
+        when(w.getItem()).thenReturn(ITEM_NAME);
+        when(registryMock.getItem(ITEM_NAME)).thenReturn(item);
+        when(item.getState()).thenReturn(new DecimalType(11));
+        String label = uiRegistry.getLabel(w);
+        assertEquals("Memory [11]", label);
+    }
+
+    @Test
+    public void getLabelFailingTransformationWithNullState() throws ItemNotFoundException {
+        String testLabel = "Memory [FOO(echo %s):__%d__]";
+        Widget w = mock(Widget.class);
+        Item item = mock(Item.class);
+        when(w.getLabel()).thenReturn(testLabel);
+        when(w.getItem()).thenReturn(ITEM_NAME);
+        when(registryMock.getItem(ITEM_NAME)).thenReturn(item);
+        when(item.getState()).thenReturn(UnDefType.NULL);
+        String label = uiRegistry.getLabel(w);
+        assertEquals("Memory [-]", label);
+    }
+
+    @Test
+    public void getLabelFailingTransformationWithUndefState() throws ItemNotFoundException {
+        String testLabel = "Memory [FOO(echo %s):__%d__]";
+        Widget w = mock(Widget.class);
+        Item item = mock(Item.class);
+        when(w.getLabel()).thenReturn(testLabel);
+        when(w.getItem()).thenReturn(ITEM_NAME);
+        when(registryMock.getItem(ITEM_NAME)).thenReturn(item);
+        when(item.getState()).thenReturn(UnDefType.UNDEF);
+        String label = uiRegistry.getLabel(w);
+        assertEquals("Memory [-]", label);
+    }
+
+    @Test
     public void getLabelColorLabelWithDecimalValue() {
         String testLabel = "Label [%.3f]";
 


### PR DESCRIPTION
Use item state formatter to format input of transformation, meaning using state.format(format) instead of String.format(format, state.toString())
This was already the case in sitemap API but not in other APIs used by Main UI.

Make sure to call transformation even for NULL and UNDEF states.
It was not the case in one API used by Main UI.

When calling transformation and state is NULL or UNDEF, do not apply format to the input value and do not replace by "-".
That means the transformation will be called with "NULL" or "UNDEF".
Sitemap API was calling the transformation using a pattern containing "-".

Fix #4101 
Also related to discussion in openhab/openhab-addons#13777

Signed-off-by: Laurent Garnier <lg.hc@free.fr>
