### PR TITLE
Fix initial suggestion finder installation

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -81,6 +81,7 @@ public class AddonSuggestionService implements AutoCloseable {
         this.localeProvider = localeProvider;
 
         SUGGESTION_FINDERS.forEach(f -> baseFinderConfig.put(f, true));
+        modified(config);
 
         // Changes to the configuration are expected to call the {@link modified} method. This works well when running
         // in Eclipse. Running in Karaf, the method was not consistently called. Therefore regularly check for changes


### PR DESCRIPTION
https://github.com/openhab/openhab-core/pull/4188 caused finders not to be installed anymore by default.
This PR should fix the issue.
