### PR TITLE
Fix javadoc build

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
@@ -333,7 +333,7 @@ public class ColorUtil {
      * Transform <a href="https://en.wikipedia.org/wiki/SRGB">sRGB</a> color format to
      * <a href="https://en.wikipedia.org/wiki/HSL_and_HSV">HSV</a> based {@link HSBType}.
      *
-     * @param rgb array of three or four {@link PercentType} with the RGB(W) values in the range 0 to 100 percent.
+     * @param rgbw array of three or four {@link PercentType} with the RGB(W) values in the range 0 to 100 percent.
      * @return the corresponding {@link HSBType}.
      * @throws IllegalArgumentException when input array has wrong size or exceeds allowed value range.
      */


### PR DESCRIPTION
javadoc is broken since ~10 days due to a wrong parameter name in a description of a function.
Maybe we should extend github actions to include javadoc...