### PR TITLE
Fix suggestion finder installation

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -80,7 +80,7 @@ public class AddonSuggestionService implements AutoCloseable {
         this.configurationAdmin = configurationAdmin;
         this.localeProvider = localeProvider;
 
-        SUGGESTION_FINDERS.forEach(f -> baseFinderConfig.put(f, true));
+        SUGGESTION_FINDERS.forEach(f -> baseFinderConfig.put(f, false));
         modified(config);
 
         // Changes to the configuration are expected to call the {@link modified} method. This works well when running
@@ -115,13 +115,13 @@ public class AddonSuggestionService implements AutoCloseable {
             String cfgParam = SUGGESTION_FINDER_CONFIGS.get(finder);
             if (cfgParam != null) {
                 boolean enabled = (config != null)
-                        ? ConfigParser.valueAsOrElse(config.get(cfgParam), Boolean.class, cfg)
-                        : cfg;
+                        ? ConfigParser.valueAsOrElse(config.get(cfgParam), Boolean.class, true)
+                        : true;
                 if (cfg != enabled) {
-                    baseFinderConfig.put(finder, enabled);
                     String type = SUGGESTION_FINDER_TYPES.get(finder);
                     AddonFinderService finderService = addonFinderService;
                     if (type != null && finderService != null) {
+                        baseFinderConfig.put(finder, enabled);
                         if (enabled) {
                             finderService.install(type);
                         } else {

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -116,7 +116,7 @@ public class AddonSuggestionService implements AutoCloseable {
             if (cfgParam != null) {
                 boolean enabled = (config != null)
                         ? ConfigParser.valueAsOrElse(config.get(cfgParam), Boolean.class, true)
-                        : true;
+                        : cfg;
                 if (cfg != enabled) {
                     String type = SUGGESTION_FINDER_TYPES.get(finder);
                     AddonFinderService finderService = addonFinderService;


### PR DESCRIPTION
It looks like https://github.com/openhab/openhab-core/pull/4206 didn't fix the issue completely.

Here is a complement, that so far works well for me. The issue was in the variable sequence of starting the AddonSuggestionService and KarafAddonFinderService.

@jlaur Can you have a look if this works for you as well?

@J-N-K Sorry for these iterations. Hopefully, it works out well this time.