### PR TITLE
Prevent potential incorrect cache lookup due to hash collisions

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -97,7 +97,6 @@ import org.slf4j.LoggerFactory;
 public class CommunicationManager implements EventSubscriber, RegistryChangeListener<ItemChannelLink> {
 
     private record CacheKey(String type, Profile profile, Thing thing) {
-
     }
 
     private static final Profile NO_OP_PROFILE = new Profile() {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.thing.internal;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -28,7 +27,6 @@ import javax.measure.Unit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.cache.ExpiringCacheMap;
 import org.openhab.core.common.AbstractUID;
 import org.openhab.core.common.SafeCaller;
 import org.openhab.core.common.registry.RegistryChangeListener;
@@ -98,6 +96,10 @@ import org.slf4j.LoggerFactory;
 @Component(service = { EventSubscriber.class, CommunicationManager.class }, immediate = true)
 public class CommunicationManager implements EventSubscriber, RegistryChangeListener<ItemChannelLink> {
 
+    private record CacheKey(String type, Profile profile, Thing thing) {
+
+    }
+
     private static final Profile NO_OP_PROFILE = new Profile() {
         private final ProfileTypeUID noOpProfileUID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "noop");
 
@@ -111,9 +113,6 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             // no-op
         }
     };
-
-    // how long to cache profile safe call instances
-    private static final Duration CACHE_EXPIRATION = Duration.ofMinutes(30);
 
     // the timeout to use for any item event processing
     public static final long THINGHANDLER_EVENT_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
@@ -132,7 +131,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     private final SafeCaller safeCaller;
     private final ThingRegistry thingRegistry;
 
-    private final ExpiringCacheMap<Integer, Profile> profileSafeCallCache = new ExpiringCacheMap<>(CACHE_EXPIRATION);
+    private final ConcurrentHashMap<CacheKey, Profile> profileSafeCallCache = new ConcurrentHashMap<>();
 
     @Activate
     public CommunicationManager(final @Reference AutoUpdateManager autoUpdateManager,
@@ -352,10 +351,10 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     }
 
     private void applyProfileForUpdate(Profile profile, Thing thing, State convertedState) {
-        int key = Objects.hash("UPDATE", profile, thing);
-        Profile p = profileSafeCallCache.putIfAbsentAndGet(key, () -> safeCaller.create(profile, Profile.class) //
+        CacheKey key = new CacheKey("UPDATE", profile, thing);
+        Profile p = profileSafeCallCache.computeIfAbsent(key, (k) -> safeCaller.create(k.profile, Profile.class) //
                 .withAsync() //
-                .withIdentifier(thing) //
+                .withIdentifier(k.thing) //
                 .withTimeout(THINGHANDLER_EVENT_TIMEOUT) //
                 .build());
         if (p != null) {
@@ -366,12 +365,12 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     }
 
     private void applyProfileForCommand(Profile profile, Thing thing, Command convertedCommand) {
-        if (profile instanceof StateProfile stateProfile) {
-            int key = Objects.hash("COMMAND", profile, thing);
-            Profile p = profileSafeCallCache.putIfAbsentAndGet(key,
-                    () -> safeCaller.create(stateProfile, StateProfile.class) //
+        if (profile instanceof StateProfile) {
+            CacheKey key = new CacheKey("COMMAND", profile, thing);
+            Profile p = profileSafeCallCache.computeIfAbsent(key,
+                    (k) -> safeCaller.create((StateProfile) k.profile, StateProfile.class) //
                             .withAsync() //
-                            .withIdentifier(thing) //
+                            .withIdentifier(k.thing) //
                             .withTimeout(THINGHANDLER_EVENT_TIMEOUT) //
                             .build());
             if (p instanceof StateProfile profileP) {


### PR DESCRIPTION
This PR does replace the hash as key for the cache lookup with a `record` and removes the `ExpiringCacheMap`.

1. The lookup inside the cache could return wrong results when identical hashs are computed. This might be unlikely but possible and should be avoided. 
**Note:** Using `Objects.hash` does create an array for the varargs, so there should be no performance penalty when creating a new `record` instead.

2. The `ExpiringCacheMap` does not actively remove entries, it will only prevent entries older than the timeout to be read. There is no need to rebuild the cache after some time, i guess the idea was not to leak memory here. But this is not the case, therefore the regular `ConcurrentHashMap` can be used.
**Note:** This was the only use of `ExpiringCacheMap` i could see, so this class might get deprecated?
