### PR TITLE
[sitemap] Do not try to convert item state into OnOffType for Switch widget if item has options

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -727,7 +727,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                 returnState = itemState.as(DecimalType.class);
             }
         } else if (w instanceof Switch sw) {
-            if (sw.getMappings().isEmpty()) {
+            StateDescription stateDescr = i.getStateDescription();
+            if (sw.getMappings().isEmpty() && (stateDescr == null || stateDescr.getOptions().isEmpty())) {
                 returnState = itemState.as(OnOffType.class);
             }
         }


### PR DESCRIPTION
When the Switch widget has mappings or when the item has a state description with options, the Switch widget is rendered by UIs with buttons. There was no state conversion into OnOffType when the switch widget has mappings. But when the item has a state description with options, it was wrongly converted into OnOffType.

See this community discussion for an example:
https://community.openhab.org/t/item-statedescription-and-sitemaps/155935

Signed-off-by: Laurent Garnier <lg.hc@free.fr>