### PR TITLE
Fix a wrongly failing validation rule for sitemap

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -179,7 +179,7 @@ Input:
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)*) ']')?);
 
 Buttongrid:
-    'Buttongrid' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
+    {Buttongrid} 'Buttongrid' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &
     (('icon=' icon=Icon) |
         ('icon=[' (IconRules+=IconRule (',' IconRules+=IconRule)*) ']') |
         ('staticIcon=' staticIcon=Icon))? &

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -16,7 +16,6 @@
 package org.openhab.core.model.sitemap.validation
 
 import org.openhab.core.model.sitemap.sitemap.Button
-import org.openhab.core.model.sitemap.sitemap.ButtonDefinition
 import org.openhab.core.model.sitemap.sitemap.Buttongrid
 import org.openhab.core.model.sitemap.sitemap.Frame
 import org.openhab.core.model.sitemap.sitemap.LinkableWidget
@@ -112,13 +111,10 @@ class SitemapValidator extends AbstractSitemapValidator {
 
     @Check
     def void checkWidgetsInButtongrid(Buttongrid grid) {
-        var nb = 0
-        for (ButtonDefinition b : grid.getButtons) {
-            nb = nb + 1
-        }
+        val nb = grid.getButtons.size()
         if (nb > 0 && grid.item === null) {
             error("To use the \"buttons\" parameter in a Buttongrid, the \"item\" parameter is required",
-                SitemapPackage.Literals.BUTTONGRID.getEStructuralFeature(SitemapPackage.BUTTONGRID__CHILDREN));
+                SitemapPackage.Literals.BUTTONGRID.getEStructuralFeature(SitemapPackage.BUTTONGRID__ITEM));
         }
         for (Widget w : grid.children) {
             if (!(w instanceof Button)) {


### PR DESCRIPTION
Problem introduced by #4223

checkFramesInWidgetList for LinkableWidget was triggering an error when the Buttongrid element has no parameter set.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>