### PR TITLE
Change icon for channel type `system.mute`

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -266,7 +266,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      */
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
             .state(SYSTEM_CHANNEL_TYPE_UID_MUTE, "Mute", CoreItemFactory.SWITCH)
-            .withDescription("Mute audio of the device").withCategory("SoundVolume")
+            .withDescription("Mute audio of the device").withCategory("SoundVolume_Mute")
             .withTags(List.of("Switch", "SoundVolume")).build();
 
     /**


### PR DESCRIPTION
There is a classic icon `SoundVolume_Mute` available:
https://www.openhab.org/docs/configuration/iconsets/classic/

Icon is here:
https://github.com/openhab/openhab-webui/blob/main/bundles/org.openhab.ui.iconset.classic/src/main/resources/icons/soundvolume_mute.svg

This is not used for channel type `system.mute` which currently uses the same icon as `system.volume`.