### PR TITLE
Add .xsd to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.java text=auto
 *.xml text=auto
 *.xml_gen text=auto
+*.xsd text=auto


### PR DESCRIPTION
Closes #4246

This should help git clients and spotless on windows systems to select the correct line-endings for .xsd files.