### PR TITLE
[serial] Use a fast path to avoid pattern matching

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -222,7 +222,10 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
      * of a USB device.
      */
     private @Nullable Path getUsbInterfaceParentPath(Path sysfsPath) {
-        if (sysfsPath.getFileName() == null) {
+        if (sysfsPath.toString().indexOf('-') == -1) {
+            // a fast path to avoid pattern matching for dozens of not matching directories
+            return null;
+        } else if (sysfsPath.getFileName() == null) {
             return null;
         } else if (SYSFS_USB_INTERFACE_DIRECTORY_PATTERN.matcher(sysfsPath.getFileName().toString()).matches()) {
             return sysfsPath;


### PR DESCRIPTION
I was wondering why a fresh installed openhab instance without addons was creating ~ 1000 `int[]` instances every 15s.
This fallout is visible when monitoring the free memory of the instance:
![image](https://github.com/openhab/openhab-core/assets/16140691/f86bdefb-5ac4-4297-85bf-bd444578658a)

This PR will add a fast path to avoid this fallout from matching a regex against dozens of not matching directories.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>
