### PR TITLE
Fix persistence extensions for group items and number dimension items with different units

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -994,7 +994,14 @@ public class PersistenceExtensions {
             State state = historicItem.getState();
             if ((unit != null) && state instanceof QuantityType<?> qtState) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    state = qtState;
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, historicItem.getTimestamp(), unit);
+                    continue;
+                }
             }
             DecimalType value = state.as(DecimalType.class);
             if (value != null) {
@@ -1130,7 +1137,14 @@ public class PersistenceExtensions {
             State state = historicItem.getState();
             if ((unit != null) && state instanceof QuantityType<?> qtState) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    state = qtState;
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, historicItem.getTimestamp(), unit);
+                    continue;
+                }
             }
             DecimalType value = state.as(DecimalType.class);
             if (value != null) {
@@ -1267,7 +1281,14 @@ public class PersistenceExtensions {
                 State state = historicItem.getState();
                 if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                     qtState = qtState.toUnit(unit);
-                    state = (qtState != null) ? qtState : state;
+                    if (qtState != null) {
+                        state = qtState;
+                    } else {
+                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                                state, historicItem.getTimestamp(), unit);
+                        continue;
+                    }
                 }
                 DecimalType value = state.as(DecimalType.class);
                 if (value != null) {
@@ -1562,7 +1583,14 @@ public class PersistenceExtensions {
                 State state = lastItem.getState();
                 if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                     qtState = qtState.toUnit(unit);
-                    state = qtState != null ? qtState : state;
+                    if (qtState != null) {
+                        state = qtState;
+                    } else {
+                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                                state, lastItem.getTimestamp(), unit);
+                        continue;
+                    }
                 }
                 DecimalType dtState = state.as(DecimalType.class);
                 if (dtState != null) {
@@ -1703,7 +1731,14 @@ public class PersistenceExtensions {
                 State state = historicItem.getState();
                 if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                     qtState = qtState.toUnit(unit);
-                    state = qtState != null ? qtState : state;
+                    if (qtState != null) {
+                        state = qtState;
+                    } else {
+                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                                state, historicItem.getTimestamp(), unit);
+                        continue;
+                    }
                 }
                 DecimalType value = state.as(DecimalType.class);
                 if (value != null) {
@@ -1832,18 +1867,32 @@ public class PersistenceExtensions {
             State state = itemStart.getState();
             if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    valueStart = qtState.as(DecimalType.class);
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, itemStart.getTimestamp(), unit);
+                }
+            } else {
+                valueStart = state.as(DecimalType.class);
             }
-            valueStart = state.as(DecimalType.class);
         }
         DecimalType valueStop = null;
         if (itemStop != null) {
             State state = itemStop.getState();
             if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    valueStop = qtState.as(DecimalType.class);
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, itemStop.getTimestamp(), unit);
+                }
+            } else {
+                valueStop = state.as(DecimalType.class);
             }
-            valueStop = state.as(DecimalType.class);
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {
@@ -2082,18 +2131,32 @@ public class PersistenceExtensions {
             State state = itemStart.getState();
             if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    valueStart = qtState.as(DecimalType.class);
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, itemStart.getTimestamp(), unit);
+                }
+            } else {
+                valueStart = state.as(DecimalType.class);
             }
-            valueStart = state.as(DecimalType.class);
         }
         DecimalType valueStop = null;
         if (itemStop != null) {
             State state = itemStop.getState();
             if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
                 qtState = qtState.toUnit(unit);
-                state = qtState != null ? qtState : state;
+                if (qtState != null) {
+                    valueStop = qtState.as(DecimalType.class);
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
+                            state, itemStop.getTimestamp(), unit);
+                }
+            } else {
+                valueStop = state.as(DecimalType.class);
             }
-            valueStop = state.as(DecimalType.class);
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -2647,7 +2647,7 @@ public class PersistenceExtensions {
             } else {
                 LoggerFactory.getLogger(PersistenceExtensions.class).warn(
                         "Item {} is QuantityType but state {} at time {} retrieved from persistence has no unit",
-                        historicItem.getName(), historicItem.getTimestamp());
+                        historicItem.getName(), historicItem.getState(), historicItem.getTimestamp());
                 return null;
             }
         }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -991,19 +991,7 @@ public class PersistenceExtensions {
         DecimalType maximum = null;
         while (it.hasNext()) {
             HistoricItem historicItem = it.next();
-            State state = historicItem.getState();
-            if ((unit != null) && state instanceof QuantityType<?> qtState) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    state = qtState;
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, historicItem.getTimestamp(), unit);
-                    continue;
-                }
-            }
-            DecimalType value = state.as(DecimalType.class);
+            DecimalType value = getPersistedValue(historicItem, unit);
             if (value != null) {
                 if (maximum == null || value.compareTo(maximum) > 0) {
                     maximum = value;
@@ -1134,19 +1122,7 @@ public class PersistenceExtensions {
         DecimalType minimum = null;
         while (it.hasNext()) {
             HistoricItem historicItem = it.next();
-            State state = historicItem.getState();
-            if ((unit != null) && state instanceof QuantityType<?> qtState) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    state = qtState;
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, historicItem.getTimestamp(), unit);
-                    continue;
-                }
-            }
-            DecimalType value = state.as(DecimalType.class);
+            DecimalType value = getPersistedValue(historicItem, unit);
             if (value != null) {
                 if (minimum == null || value.compareTo(minimum) < 0) {
                     minimum = value;
@@ -1278,19 +1254,7 @@ public class PersistenceExtensions {
             Iterator<HistoricItem> it = result.iterator();
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();
-                State state = historicItem.getState();
-                if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                    qtState = qtState.toUnit(unit);
-                    if (qtState != null) {
-                        state = qtState;
-                    } else {
-                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                                state, historicItem.getTimestamp(), unit);
-                        continue;
-                    }
-                }
-                DecimalType value = state.as(DecimalType.class);
+                DecimalType value = getPersistedValue(historicItem, unit);
                 if (value != null) {
                     count++;
                     sum = sum.add(value.toBigDecimal().subtract(average, MathContext.DECIMAL64).pow(2,
@@ -1580,19 +1544,7 @@ public class PersistenceExtensions {
         while (it.hasNext()) {
             HistoricItem thisItem = it.next();
             if (lastItem != null) {
-                State state = lastItem.getState();
-                if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                    qtState = qtState.toUnit(unit);
-                    if (qtState != null) {
-                        state = qtState;
-                    } else {
-                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                                state, lastItem.getTimestamp(), unit);
-                        continue;
-                    }
-                }
-                DecimalType dtState = state.as(DecimalType.class);
+                DecimalType dtState = getPersistedValue(lastItem, unit);
                 if (dtState != null) {
                     BigDecimal value = dtState.toBigDecimal();
                     BigDecimal weight = BigDecimal
@@ -1728,19 +1680,7 @@ public class PersistenceExtensions {
             BigDecimal sum = BigDecimal.ZERO;
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();
-                State state = historicItem.getState();
-                if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                    qtState = qtState.toUnit(unit);
-                    if (qtState != null) {
-                        state = qtState;
-                    } else {
-                        LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                                "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                                state, historicItem.getTimestamp(), unit);
-                        continue;
-                    }
-                }
-                DecimalType value = state.as(DecimalType.class);
+                DecimalType value = getPersistedValue(historicItem, unit);
                 if (value != null) {
                     sum = sum.add(value.toBigDecimal());
                 }
@@ -1864,35 +1804,12 @@ public class PersistenceExtensions {
 
         DecimalType valueStart = null;
         if (itemStart != null) {
-            State state = itemStart.getState();
-            if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    valueStart = qtState.as(DecimalType.class);
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, itemStart.getTimestamp(), unit);
-                }
-            } else {
-                valueStart = state.as(DecimalType.class);
-            }
+            valueStart = getPersistedValue(itemStart, unit);
         }
         DecimalType valueStop = null;
         if (itemStop != null) {
-            State state = itemStop.getState();
-            if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    valueStop = qtState.as(DecimalType.class);
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, itemStop.getTimestamp(), unit);
-                }
-            } else {
-                valueStop = state.as(DecimalType.class);
-            }
+            valueStop = getPersistedValue(itemStop, unit);
+
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {
@@ -2128,35 +2045,12 @@ public class PersistenceExtensions {
 
         DecimalType valueStart = null;
         if (itemStart != null) {
-            State state = itemStart.getState();
-            if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    valueStart = qtState.as(DecimalType.class);
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, itemStart.getTimestamp(), unit);
-                }
-            } else {
-                valueStart = state.as(DecimalType.class);
-            }
+            valueStart = getPersistedValue(itemStart, unit);
         }
         DecimalType valueStop = null;
         if (itemStop != null) {
-            State state = itemStop.getState();
-            if ((unit != null) && (state instanceof QuantityType<?> qtState)) {
-                qtState = qtState.toUnit(unit);
-                if (qtState != null) {
-                    valueStop = qtState.as(DecimalType.class);
-                } else {
-                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
-                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {}",
-                            state, itemStop.getTimestamp(), unit);
-                }
-            } else {
-                valueStop = state.as(DecimalType.class);
-            }
+            valueStop = getPersistedValue(itemStop, unit);
+
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {
@@ -2735,6 +2629,29 @@ public class PersistenceExtensions {
             }
         }
         return item.getStateAs(DecimalType.class);
+    }
+
+    private static @Nullable DecimalType getPersistedValue(HistoricItem historicItem, @Nullable Unit<?> unit) {
+        State state = historicItem.getState();
+        if (unit != null) {
+            if (state instanceof QuantityType<?> qtState) {
+                qtState = qtState.toUnit(unit);
+                if (qtState != null) {
+                    state = qtState;
+                } else {
+                    LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                            "Unit of state {} at time {} retrieved from persistence not compatible with item unit {} for item {}",
+                            state, historicItem.getTimestamp(), unit, historicItem.getName());
+                    return null;
+                }
+            } else {
+                LoggerFactory.getLogger(PersistenceExtensions.class).warn(
+                        "Item {} is QuantityType but state {} at time {} retrieved from persistence has no unit",
+                        historicItem.getName(), historicItem.getTimestamp());
+                return null;
+            }
+        }
+        return state.as(DecimalType.class);
     }
 
     private static @Nullable HistoricItem historicItemOrCurrentState(Item item, @Nullable HistoricItem historicItem) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -28,6 +28,7 @@ import javax.measure.Unit;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.TimeZoneProvider;
+import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.items.NumberItem;
 import org.openhab.core.library.types.DecimalType;
@@ -1245,7 +1246,11 @@ public class PersistenceExtensions {
             // avoid division by zero
             if (count > 0) {
                 BigDecimal variance = sum.divide(BigDecimal.valueOf(count), MathContext.DECIMAL64);
-                if (item instanceof NumberItem numberItem) {
+                Item baseItem = item;
+                if (baseItem instanceof GroupItem groupItem) {
+                    baseItem = groupItem.getBaseItem();
+                }
+                if (baseItem instanceof NumberItem numberItem) {
                     Unit<?> unit = numberItem.getUnit();
                     if (unit != null) {
                         return new QuantityType<>(variance, unit.multiply(unit));
@@ -1385,7 +1390,11 @@ public class PersistenceExtensions {
             // avoid ArithmeticException if variance is less than zero
             if (dt != null && DecimalType.ZERO.compareTo(dt) <= 0) {
                 BigDecimal deviation = dt.toBigDecimal().sqrt(MathContext.DECIMAL64);
-                if (item instanceof NumberItem numberItem) {
+                Item baseItem = item;
+                if (baseItem instanceof GroupItem groupItem) {
+                    baseItem = groupItem.getBaseItem();
+                }
+                if (baseItem instanceof NumberItem numberItem) {
                     Unit<?> unit = numberItem.getUnit();
                     if (unit != null) {
                         return new QuantityType<>(deviation, unit);
@@ -1538,7 +1547,11 @@ public class PersistenceExtensions {
                 return null;
             }
             BigDecimal average = sum.divide(totalDuration, MathContext.DECIMAL64);
-            if (item instanceof NumberItem numberItem) {
+            Item baseItem = item;
+            if (baseItem instanceof GroupItem groupItem) {
+                baseItem = groupItem.getBaseItem();
+            }
+            if (baseItem instanceof NumberItem numberItem) {
                 Unit<?> unit = numberItem.getUnit();
                 if (unit != null) {
                     return new QuantityType<>(average, unit);
@@ -1655,7 +1668,11 @@ public class PersistenceExtensions {
                     sum = sum.add(value.toBigDecimal());
                 }
             }
-            if (item instanceof NumberItem numberItem) {
+            Item baseItem = item;
+            if (baseItem instanceof GroupItem groupItem) {
+                baseItem = groupItem.getBaseItem();
+            }
+            if (baseItem instanceof NumberItem numberItem) {
                 Unit<?> unit = numberItem.getUnit();
                 if (unit != null) {
                     return new QuantityType<>(sum, unit);
@@ -1779,7 +1796,11 @@ public class PersistenceExtensions {
 
         if (valueStart != null && valueStop != null) {
             BigDecimal delta = valueStop.toBigDecimal().subtract(valueStart.toBigDecimal());
-            if (item instanceof NumberItem numberItem) {
+            Item baseItem = item;
+            if (baseItem instanceof GroupItem groupItem) {
+                baseItem = groupItem.getBaseItem();
+            }
+            if (baseItem instanceof NumberItem numberItem) {
                 Unit<?> unit = numberItem.getUnit();
                 return (unit != null) ? new QuantityType<>(delta, unit) : new DecimalType(delta);
             }
@@ -2559,7 +2580,11 @@ public class PersistenceExtensions {
     }
 
     private static @Nullable DecimalType getItemValue(Item item) {
-        if (item instanceof NumberItem numberItem) {
+        Item baseItem = item;
+        if (baseItem instanceof GroupItem groupItem) {
+            baseItem = groupItem.getBaseItem();
+        }
+        if (baseItem instanceof NumberItem numberItem) {
             Unit<?> unit = numberItem.getUnit();
             if (unit != null) {
                 QuantityType<?> qt = item.getStateAs(QuantityType.class);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -29,6 +29,7 @@ import javax.measure.Unit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.NumberItem;
@@ -183,7 +184,11 @@ public class TestPersistenceService implements QueryablePersistenceService {
                     @Override
                     public State getState() {
                         Item item = itemRegistry.get(Objects.requireNonNull(filter.getItemName()));
-                        Unit<?> unit = item instanceof NumberItem ni ? ni.getUnit() : null;
+                        Item baseItem = item;
+                        if (baseItem instanceof GroupItem groupItem) {
+                            baseItem = groupItem.getBaseItem();
+                        }
+                        Unit<?> unit = baseItem instanceof NumberItem ni ? ni.getUnit() : null;
                         return unit == null ? new DecimalType(year) : QuantityType.valueOf(year, unit);
                     }
 


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4254

Persistence extensions retrieving persisted data for GroupItems with a QuantityType as base type returned null or a value without the unit. This PR fixes that issue.
This was not an issue before https://github.com/openhab/openhab-core/pull/3736 as a DecimalType would be returned, ignoring the unit.

Second issue this resolves:
In the (rare) case a persistence service would have values stored with different units than the default (or configured) unit, the calculation would be off. This PR also corrects that. Most persistence services today assume the unit is the default (or configured) unit and don't store it explicitly. But it would be possible for some services.