### PR TITLE
Persistence extensions, add lastChange and nextChange

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -335,7 +335,6 @@ public class PersistenceExtensions {
     private static @Nullable ZonedDateTime internalAdjacentUpdate(Item item, boolean forward,
             @Nullable String serviceId) {
         return internalAdjacent(item, forward, false, serviceId);
-
     }
 
     /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -415,11 +415,16 @@ public class PersistenceExtensions {
 
             Iterable<HistoricItem> items = qService.query(filter);
             Iterator<HistoricItem> itemIterator = items.iterator();
+            State state = item.getState();
             if (itemIterator.hasNext()) {
                 if (!skipEqual) {
-                    return itemIterator.next().getTimestamp();
+                    HistoricItem historicItem = itemIterator.next();
+                    if (!forward && !historicItem.getState().equals(state)) {
+                        // Past stored value different from current value, so it must have updated since last persist.
+                        return ZonedDateTime.now();
+                    }
+                    return historicItem.getTimestamp();
                 } else {
-                    State state = item.getState();
                     HistoricItem historicItem = itemIterator.next();
                     int itemCount = 1;
                     if (!historicItem.getState().equals(state)) {

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -1533,6 +1533,28 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testLastChange() {
+        ZonedDateTime lastChange = PersistenceExtensions.lastChange(numberItem, SERVICE_ID);
+        assertNotNull(lastChange);
+        assertEquals(ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), lastChange);
+
+        // default persistence service
+        lastChange = PersistenceExtensions.lastChange(numberItem);
+        assertNull(lastChange);
+    }
+
+    @Test
+    public void testNextChange() {
+        ZonedDateTime nextChange = PersistenceExtensions.nextChange(numberItem, SERVICE_ID);
+        assertNotNull(nextChange);
+        assertEquals(ZonedDateTime.of(FUTURE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), nextChange);
+
+        // default persistence service
+        nextChange = PersistenceExtensions.nextChange(numberItem);
+        assertNull(nextChange);
+    }
+
+    @Test
     public void testDeltaSince() {
         State delta = PersistenceExtensions.deltaSince(numberItem,
                 ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -36,6 +36,7 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.FilterCriteria;
+import org.openhab.core.persistence.FilterCriteria.Operator;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceItemInfo;
@@ -145,6 +146,11 @@ public class TestPersistenceService implements QueryablePersistenceService {
             Stream<HistoricItem> stream = results.stream();
             if (filter.getPageNumber() > 0) {
                 stream = stream.skip(filter.getPageSize() * filter.getPageNumber());
+            }
+
+            State state = filter.getState();
+            if (state != null && Operator.NEQ.equals(filter.getOperator())) {
+                stream = stream.filter(hi -> !state.equals(hi.getState()));
             }
 
             if (filter.getPageSize() != Integer.MAX_VALUE) {

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -36,7 +36,6 @@ import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
 import org.openhab.core.persistence.FilterCriteria;
-import org.openhab.core.persistence.FilterCriteria.Operator;
 import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceItemInfo;
@@ -146,11 +145,6 @@ public class TestPersistenceService implements QueryablePersistenceService {
             Stream<HistoricItem> stream = results.stream();
             if (filter.getPageNumber() > 0) {
                 stream = stream.skip(filter.getPageSize() * filter.getPageNumber());
-            }
-
-            State state = filter.getState();
-            if (state != null && Operator.NEQ.equals(filter.getOperator())) {
-                stream = stream.filter(hi -> !state.equals(hi.getState()));
             }
 
             if (filter.getPageSize() != Integer.MAX_VALUE) {


### PR DESCRIPTION
Persistence extensions have lastUpdate and nextUpdate methods. However, when the same value is stored multiple times in the database (e.g. with a everyMinute persistence policy), it doesn't say anything about when the lastChange was.
This PR adds lastChange and nextChange methods.

To further extend on the situation:

Imagine the following persisted values at timestamps 1 to 4 (4 is most recent):

1. 10
2. 10
3. 20
4. 20

Currently existing persistence methods will return following timestamps:

- `previousState.timestamp`: 4
- `previousState(skipEqual = true).timestamp`: 2
- `lastUpdate`: 4

This enhancement adds a `lastChange` method which will return timestamp 3, somethings required if one wants to know when an item last changed. All existing methods also suffer from the impact of a persistence strategy. In the example above, if the strategy would have been `everyChange`, and not e.g. `everyMinute`, timestamps 2 and 4 would not have existed and the existing methods would have given different results.

Depending on the persistence strategy and sequence of events, it is possible the current state is not equal to the last persisted state. In that case, the new `lastChange` method will return `null` as no precise change timestamp can be established. It is the users responsability to then take appropriate actions (e.g. check for `null` and use `now` when calling the `lastChange` method). In the same logic, the existing `lastUpdate` method has been adjusted to also return `null` in that case.

A `nextChange` method was added to have a symetric method, but is not impacted by the reasoning above. Existing methods would yield the expected results already.
