### PR TITLE
Fix ip suggestion finder default parameter

### DIFF
--- a/bundles/org.openhab.core/src/main/resources/OH-INF/config/addons.xml
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/config/addons.xml
@@ -33,6 +33,7 @@
 			<advanced>true</advanced>
 			<label>IP-based Suggestion Finder</label>
 			<description>Use IP network discovery broadcasts to suggest add-ons. Enabling/disabling may take up to 1 minute.</description>
+			<default>true</default>
 		</parameter>
 		<parameter name="suggestionFinderSddp" type="boolean">
 			<advanced>true</advanced>


### PR DESCRIPTION
The IP addon suggestion finder is on by default (like all other suggestion finders).

Because the default parameter was missing, it was wrongly shown in the UI.