### PR TITLE
Add support for SDDP IDENTIFY packets

### DIFF
--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
@@ -85,6 +85,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
     private static final String SEARCH_RESPONSE_HEADER = "SDDP/1.0 200 OK";
 
     private static final String NOTIFY_ALIVE_HEADER = "NOTIFY ALIVE SDDP/1.0";
+    private static final String NOTIFY_IDENTIFY_HEADER = "NOTIFY IDENTIFY SDDP/1.0";
     private static final String NOTIFY_OFFLINE_HEADER = "NOTIFY OFFLINE SDDP/1.0";
 
     private final Logger logger = LoggerFactory.getLogger(SddpDiscoveryService.class);
@@ -160,7 +161,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
             if (lines.size() > 1) {
                 String statement = lines.get(0).strip();
                 boolean offline = statement.startsWith(NOTIFY_OFFLINE_HEADER);
-                if (offline || statement.startsWith(NOTIFY_ALIVE_HEADER)
+                if (offline || statement.startsWith(NOTIFY_ALIVE_HEADER) || statement.startsWith(NOTIFY_IDENTIFY_HEADER)
                         || statement.startsWith(SEARCH_RESPONSE_HEADER)) {
                     Map<String, String> headers = new HashMap<>();
                     for (int i = 1; i < lines.size(); i++) {

--- a/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
@@ -54,6 +54,18 @@ public class SddpDiscoveryServiceTests {
             Driver: "projector_JVCKENWOOD_DLA-RS3100_NZ8.c4i"
             """;
 
+    private static final String IDENTIFY_NOTIFICATION = """
+            NOTIFY IDENTIFY SDDP/1.0
+            From: "192.168.4.237:1902"
+            Host: "JVC_PROJECTOR-E0DADC152802"
+            Type: "JVCKENWOOD:Projector"
+            Primary-Proxy: "projector"
+            Proxies: "projector"
+            Manufacturer: "JVCKENWOOD"
+            Model: "DLA-RS3100_NZ8"
+            Driver: "projector_JVCKENWOOD_DLA-RS3100_NZ8.c4i"
+            """;
+
     private static final String BAD_HEADER = """
             SDDP/1.0 404 NOT FOUND\r
             From: "192.168.4.237:1902"\r
@@ -103,6 +115,29 @@ public class SddpDiscoveryServiceTests {
             assertEquals("192.168.4.237:1902", device.from);
             assertEquals("JVC_PROJECTOR-E0DADC152802", device.host);
             assertEquals("1800", device.maxAge);
+            assertEquals("JVCKENWOOD:Projector", device.type);
+            assertEquals("projector", device.primaryProxy);
+            assertEquals("projector", device.proxies);
+            assertEquals("JVCKENWOOD", device.manufacturer);
+            assertEquals("DLA-RS3100_NZ8", device.model);
+            assertEquals("projector_JVCKENWOOD_DLA-RS3100_NZ8.c4i", device.driver);
+            assertEquals("192.168.4.237", device.ipAddress);
+            assertEquals("e0-da-dc-15-28-02", device.macAddress);
+            assertEquals("1902", device.port);
+        }
+    }
+
+    @Test
+    void testIdentifyNotification() throws Exception {
+        try (SddpDiscoveryService service = new SddpDiscoveryService(null, networkAddressService,
+                mock(TranslationProvider.class), mock(LocaleProvider.class))) {
+            Optional<SddpDevice> deviceOptional = service.createSddpDevice(IDENTIFY_NOTIFICATION);
+            assertTrue(deviceOptional.isPresent());
+            SddpDevice device = deviceOptional.orElse(null);
+            assertNotNull(device);
+            assertEquals("192.168.4.237:1902", device.from);
+            assertEquals("JVC_PROJECTOR-E0DADC152802", device.host);
+            assertTrue(device.maxAge.isBlank());
             assertEquals("JVCKENWOOD:Projector", device.type);
             assertEquals("projector", device.primaryProxy);
             assertEquals("projector", device.proxies);


### PR DESCRIPTION
The Atlona hdmi switch does not respond to SDDP SEARCH requests (although it periodically sends NOTIFY ALIVE packets). As an alternative it has a button in its web-ui that when pushed sends out a NOTIFY IDENTIFY packet that is the same the NOTIFY ALIVE packet, less the 'Max-Age' field. This PR changes SddpDiscoveryService to handle these packets as well.

reference (but not depended on by) https://github.com/openhab/openhab-addons/pull/16832

> NOTIFY IDENTIFY SDDP/1.0
From: "192.168.1.10:1902"
Host: "AT-UHD-PRO3-44M_B898B0030F4D"
Type: "AT-UHD-PRO3-44M"
Primary-Proxy: "avswitch"
Proxies: "avswitch"
Manufacturer: "Atlona"
Model: "AT-UHD-PRO3-44M"
Driver: "avswitch_Atlona_AT-UHD-PRO3-44M_IP.c4i"
Config-URL: "http://192.168.1.10/"