### PR TITLE
RulesDSL: add triggeringGroup and triggeringGroupName to rule context

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -131,6 +131,10 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                 rule.toMethod("_" + rule.name, ruleModel.newTypeRef(Void.TYPE)) [
                     static = true
                     if ((containsCommandTrigger(rule)) || (containsStateChangeTrigger(rule)) || (containsStateUpdateTrigger(rule))) {
+                        val groupTypeRef = ruleModel.newTypeRef(Item)
+                        parameters += rule.toParameter(VAR_TRIGGERING_GROUP, groupTypeRef)
+                        val groupNameRef = ruleModel.newTypeRef(String)
+                        parameters += rule.toParameter(VAR_TRIGGERING_GROUP_NAME, groupNameRef)
                         val itemTypeRef = ruleModel.newTypeRef(Item)
                         parameters += rule.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
                         val itemNameRef = ruleModel.newTypeRef(String)


### PR DESCRIPTION
This was missed from #3536

This PR makes this possible:

```
rule "test"
when
  Member of TestSwitches received command
  Member of TestSwitches changed
then
  logInfo("test", "TriggeringGroup: {}", triggeringGroup)
  logInfo("test", "TriggeringGroupName: {}", triggeringGroupName)
end
```