### PR TITLE
[voice] Avoid text concatenation on speech recognition errors

### DIFF
--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -362,12 +362,14 @@ public class DialogProcessor implements KSListener, STTListener {
             logger.debug("RecognitionStopEvent event received");
             toggleProcessing(false);
         } else if (sttEvent instanceof SpeechRecognitionErrorEvent sre) {
-            logger.debug("SpeechRecognitionErrorEvent event received");
+            String message = sre.getMessage();
+            logger.debug("SpeechRecognitionErrorEvent event received: {}", message);
             if (!isSTTServerAborting) {
                 abortSTT();
                 toggleProcessing(false);
-                String text = i18nProvider.getText(bundle, "error.stt-error", null, dialogContext.locale());
-                say(text == null ? sre.getMessage() : text.replace("{0}", sre.getMessage()));
+                if (!message.isEmpty()) {
+                    say(message);
+                }
             }
         }
     }

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = TTS Cache Maximum Text Length
 system.config.voice.maxTextLengthCacheTTS.description = The maximum length of texts handled by the TTS cache (in character). If exceeded, will pass the text to the TTS without storing it. 0 for no limit.
 
 error.ks-error = Encountered error while spotting keywords, {0}
-error.stt-error = Encountered error while recognizing text, {0}
 error.stt-exception = Error during recognition, {0}
 service.system.voice.label = Voice

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_cs.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_cs.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Chyba při hledání klíčových slov, {0}
-error.stt-error = Při rozpoznávání textu došlo k chybě {0}
 error.stt-exception = Chyba během rozpoznání, {0}
 service.system.voice.label = Hlas

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_de.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_de.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Ein Fehler ist bei der Erkennung des Keywords aufgetreten\: {0}
-error.stt-error = Ein Fehler ist bei der Texterkennung aufgetreten\: {0}
 error.stt-exception = Ein Fehler ist bei der Spracherkennung aufgetreten\: {0}
 service.system.voice.label = Sprache

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_el.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_el.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Παρουσιάστηκε σφάλμα κατά τον εντοπισμό λέξεων-κλειδιών, {0}
-error.stt-error = Παρουσιάστηκε σφάλμα κατά την αναγνώριση κειμένου, {0}
 error.stt-exception = Σφάλμα κατά την αναγνώριση, {0}
 service.system.voice.label = Φωνή

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_fi.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_fi.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = TTS-puskurin tekstin enimmäis
 system.config.voice.maxTextLengthCacheTTS.description = TTS-puskurin käsittelemien tekstien enimmäispituus. Jos rajoitus ylitetään, välitetään teksti TTS-palvelulle ilman puskurointia. Arvo 0 poistaa rajoituksen.
 
 error.ks-error = Virhe havaittaessa avainsanoja, {0}
-error.stt-error = Virhe tunnistettaessa tekstiä, {0}
 error.stt-exception = Virhe tunnistuksen aikana, {0}
 service.system.voice.label = Puheääni

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_fr.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_fr.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = Longueur maximale du texte pou
 system.config.voice.maxTextLengthCacheTTS.description = La longueur limite d'un texte géré par le cache TTS. Au-delà, le texte sera géré par le service TTS sans le stocker. 0 pour aucune limite.
 
 error.ks-error = Erreur rencontrée lors du repérage des mots clés, {0}
-error.stt-error = Erreur rencontrée lors de la reconnaissance du texte, {0}
 error.stt-exception = Erreur lors de la reconnaissance, {0}
 service.system.voice.label = Voix

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_he.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_he.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = מטמון TTS אורך טקס
 system.config.voice.maxTextLengthCacheTTS.description = האורך המרבי של טקסטים המטופלים על ידי מטמון ה-TTS (בתווים). אם חורג, יעביר את הטקסט ל-TTS מבלי לאחסן אותו. 0 ללא הגבלה.
 
 error.ks-error = נתקל בשגיאה בעת איתור מילות מפתח, {0}
-error.stt-error = נתקל בשגיאה בעת זיהוי טקסט, {0}
 error.stt-exception = שגיאה במהלך זיהוי, {0}
 service.system.voice.label = קול

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_hu.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_hu.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = A TTS gyorsítótár maximáli
 system.config.voice.maxTextLengthCacheTTS.description = A TTS gyorsítótár maximális szöveghossza (karakterben). Az ennél hosszabb szöveget nem menti el, csak átadja a TTS-nek. 0 megadásával a korlát kikapcsolható.
 
 error.ks-error = Hiba történt a kulcsszavak észlelésekor, {0}
-error.stt-error = Hiba történt a szöveg felismerésekor, {0}
 error.stt-exception = Hiba felismerés közben, {0}
 service.system.voice.label = Beszéd

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_it.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_it.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = Lunghezza Massima del Testo De
 system.config.voice.maxTextLengthCacheTTS.description = La lunghezza limite di un testo gestito dalla cache TTS. Se superato, passerà al TTS senza memorizzarlo. 0 per nessun limite.
 
 error.ks-error = Errore rilevato durante l''individuazione delle parole chiave, {0}
-error.stt-error = Errore rilevato durante il riconoscimento del testo, {0}
 error.stt-exception = Errore durante il riconoscimento, {0}
 service.system.voice.label = Voce

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_nl.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_nl.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Probleem bij het vinden van trefwoorden, {0}
-error.stt-error = Probleem bij het herkennen van tekst, {0}
 error.stt-exception = Probleem tijdens herkenning, {0}
 service.system.voice.label = Spraak

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_no.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_no.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Det oppstod feil under gjenkjenning av nøkkelord, {0}
-error.stt-error = Det oppstod feil under gjenkjennelse av tekst, {0}
 error.stt-exception = Feil under gjenkjennelse, {0}
 service.system.voice.label = Stemme

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_pl.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_pl.properties
@@ -25,6 +25,5 @@ system.config.voice.maxTextLengthCacheTTS.label = Maksymalna długość pamięci
 system.config.voice.maxTextLengthCacheTTS.description = Limit długości tekstu obsługiwanego przez pamięć podręczną TTS. Jeśli zostanie przekroczona, przejdzie do TTS bez zapisywania. 0 oznacza brak limitu.
 
 error.ks-error = Wystąpił błąd podczas punktowania słów kluczowych, {0}
-error.stt-error = Wystąpił błąd podczas rozpoznawania tekstu, {0}
 error.stt-exception = Błąd podczas rozpoznawania, {0}
 service.system.voice.label = Głos

--- a/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_sl.properties
+++ b/bundles/org.openhab.core.voice/src/main/resources/OH-INF/i18n/voice_sl.properties
@@ -19,6 +19,5 @@ system.config.voice.listeningMelody.option.F\# = F\#
 system.config.voice.listeningMelody.option.E = E
 
 error.ks-error = Napaka pri opazovanju ključnih besed, {0}
-error.stt-error = Napaka pri prepoznavanju besedila, {0}
 error.stt-exception = Napaka pri prepoznavanju, {0}
 service.system.voice.label = Glas

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -360,7 +360,7 @@ public class VoiceManagerImplTest extends JavaOSGiTest {
         assertFalse(sttService.isRecognized());
         assertThat(hliStub.getQuestion(), is(""));
         assertThat(hliStub.getAnswer(), is(""));
-        assertThat(ttsService.getSynthesized(), is("Encountered error while recognizing text, STT error"));
+        assertThat(ttsService.getSynthesized(), is("STT error"));
         assertTrue(sink.getIsStreamProcessed());
 
         voiceManager.stopDialog(source);


### PR DESCRIPTION
<s>I would like to add this fix to the dialog processor, which avoid playing the content of the SpeechRecognitionErrorEvent unless it's explicitly indicated on it.

I think is more friendly to just fail and don't continue the dialog than to "speak" a text that can be a forwarded exception message, so I changed the log for the SpeechRecognitionErrorEvent and added the "notify" field on the SpeechRecognitionErrorEvent class which is false by default.</s>

I would like to add this fix to the dialog processor, which avoids the text concatenation on the content of the SpeechRecognitionErrorEvent and also allows to emit silent errors by passing an empty message.