### PR TITLE
Extend Stringutils with padRight

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -15,6 +15,7 @@ package org.openhab.core.util;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -188,7 +189,7 @@ public class StringUtils {
      * @return the padded String
      */
     public static String padLeft(@Nullable String str, int minSize, String padString) {
-        String paddedString = str == null ? "" : str;
+        String paddedString = Objects.requireNonNullElse(str, "");
         return String.format("%" + minSize + "s", paddedString).replace(" ", padString);
     }
 
@@ -207,7 +208,7 @@ public class StringUtils {
      * @return the padded String
      */
     public static String padRight(@Nullable String str, int minSize, String padString) {
-        String paddedString = str == null ? "" : str;
+        String paddedString = Objects.requireNonNullElse(str, "");
         return String.format("%-" + minSize + "s", paddedString).replace(" ", padString);
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -193,6 +193,25 @@ public class StringUtils {
     }
 
     /**
+     * Pads the string from the right
+     *
+     * <pre>
+      * padRight("9", 4, "0")        => "9000"
+      * padRight("3112", 12, "*")    => "3112********"
+      * padRight("openHAB", 4, "*")  => "openHAB"
+     * </pre>
+     *
+     * @param str the String to pad, may be null
+     * @param minSize the minimum String size to return
+     * @param padString the String to add when padding
+     * @return the padded String
+     */
+    public static String padRight(@Nullable String str, int minSize, String padString) {
+        String paddedString = str == null ? "" : str;
+        return String.format("%-" + minSize + "s", paddedString).replace(" ", padString);
+    }
+
+    /**
      * Creates a random string
      *
      * @param length the length of the String to return

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -190,7 +190,8 @@ public class StringUtils {
      */
     public static String padLeft(@Nullable String str, int minSize, String padString) {
         String paddedString = Objects.requireNonNullElse(str, "");
-        return String.format("%" + minSize + "s", paddedString).replace(" ", padString);
+        return paddedString.length() >= minSize ? paddedString
+                : padString.repeat(minSize - paddedString.length()) + paddedString;
     }
 
     /**
@@ -209,7 +210,8 @@ public class StringUtils {
      */
     public static String padRight(@Nullable String str, int minSize, String padString) {
         String paddedString = Objects.requireNonNullElse(str, "");
-        return String.format("%-" + minSize + "s", paddedString).replace(" ", padString);
+        return (paddedString.length() >= minSize) ? paddedString
+                : paddedString + padString.repeat(minSize - paddedString.length());
     }
 
     /**

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
@@ -91,6 +91,7 @@ public class StringUtilsTest {
         assertEquals("AAAAAAp3RF@CT", StringUtils.padLeft("p3RF@CT", 13, "A"));
         assertEquals("nopaddingshouldhappen", StringUtils.padLeft("nopaddingshouldhappen", 21, "x"));
         assertEquals("LongerStringThenMinSize", StringUtils.padLeft("LongerStringThenMinSize", 10, "x"));
+        assertEquals("xxxhas space", StringUtils.padLeft("has space", 12, "x"));
     }
 
     @Test
@@ -101,6 +102,7 @@ public class StringUtilsTest {
         assertEquals("p3RF@CTAAAAAA", StringUtils.padRight("p3RF@CT", 13, "A"));
         assertEquals("nopaddingshouldhappen", StringUtils.padRight("nopaddingshouldhappen", 21, "x"));
         assertEquals("LongerStringThenMinSize", StringUtils.padRight("LongerStringThenMinSize", 10, "x"));
+        assertEquals("has spacexxx", StringUtils.padRight("has space", 12, "x"));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
@@ -94,6 +94,16 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void padRight() {
+        assertEquals("000000", StringUtils.padRight("", 6, "0"));
+        assertEquals("000000", StringUtils.padRight(null, 6, "0"));
+        assertEquals("teststr000", StringUtils.padRight("teststr", 10, "0"));
+        assertEquals("p3RF@CTAAAAAA", StringUtils.padRight("p3RF@CT", 13, "A"));
+        assertEquals("nopaddingshouldhappen", StringUtils.padRight("nopaddingshouldhappen", 21, "x"));
+        assertEquals("LongerStringThenMinSize", StringUtils.padRight("LongerStringThenMinSize", 10, "x"));
+    }
+
+    @Test
     public void splitByCharacterType() {
         assertArrayEquals(new String[0], StringUtils.splitByCharacterType(null));
         assertArrayEquals(new String[0], StringUtils.splitByCharacterType(""));


### PR DESCRIPTION
Earlier some string utils where added to core in order to remove the dependency on `org.apache.commons.lang3.StringUtils`.
While doing so i create a `padLeft`, but forgot a `padRight` method. This PR corrects that.