### PR TITLE
Fix parsing of mac address in SDDP Discovery

### DIFF
--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
@@ -110,7 +110,7 @@ public class SddpDevice {
 
     /**
      * Constructor.
-     *
+     * 
      * @param headers a map of parameter name / value pairs.
      * @param offline indicates if the device is being created from a NOTIFY OFFLINE announcement.
      */

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
@@ -35,7 +35,7 @@ public class SddpDevice {
 
     /**
      * The host address of the device.
-     * For example: JVC_PROJECTOR-E0DADC152802
+     * For example: JVC_PROJECTOR-E0DADC152802 or JVC_PROJECTOR-E0:DA:DC:15:28:02
      * Note: the last 12 characters represent the MAC address of the device.
      */
     public final String host;
@@ -131,7 +131,7 @@ public class SddpDevice {
 
         String[] hostParts = host.split("-|_");
         macAddress = hostParts.length <= 1 ? ""
-                : hostParts[hostParts.length - 1].replaceAll("(..)(?!$)", "$1-").toLowerCase();
+                : hostParts[hostParts.length - 1].replaceAll(":", "").replaceAll("(..)(?!$)", "$1-").toLowerCase();
 
         expireInstant = offline ? Instant.now().minusMillis(1)
                 : Instant.now().plusSeconds(maxAge.isBlank() ? 0 : Integer.parseInt(maxAge));

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
@@ -36,7 +36,7 @@ public class SddpDevice {
     /**
      * The host address of the device.
      * For example: JVC_PROJECTOR-E0DADC152802 or JVC_PROJECTOR-E0:DA:DC:15:28:02
-     * Note: the last 12 characters represent the MAC address of the device.
+     * Note: the last 12 resp. 17 characters represent the MAC address of the device.
      */
     public final String host;
 
@@ -110,7 +110,7 @@ public class SddpDevice {
 
     /**
      * Constructor.
-     * 
+     *
      * @param headers a map of parameter name / value pairs.
      * @param offline indicates if the device is being created from a NOTIFY OFFLINE announcement.
      */
@@ -131,7 +131,7 @@ public class SddpDevice {
 
         String[] hostParts = host.split("-|_");
         macAddress = hostParts.length <= 1 ? ""
-                : hostParts[hostParts.length - 1].replaceAll(":", "").replaceAll("(..)(?!$)", "$1-").toLowerCase();
+                : hostParts[hostParts.length - 1].replace(":", "").replaceAll("(..)(?!$)", "$1-").toLowerCase();
 
         expireInstant = offline ? Instant.now().minusMillis(1)
                 : Instant.now().plusSeconds(maxAge.isBlank() ? 0 : Integer.parseInt(maxAge));

--- a/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
@@ -57,7 +57,7 @@ public class SddpDiscoveryServiceTests {
     private static final String IDENTIFY_NOTIFICATION = """
             NOTIFY IDENTIFY SDDP/1.0
             From: "192.168.4.237:1902"
-            Host: "JVC_PROJECTOR-E0DADC152802"
+            Host: "JVC_PROJECTOR-E0:DA:DC:15:28:02"
             Type: "JVCKENWOOD:Projector"
             Primary-Proxy: "projector"
             Proxies: "projector"
@@ -136,7 +136,7 @@ public class SddpDiscoveryServiceTests {
             SddpDevice device = deviceOptional.orElse(null);
             assertNotNull(device);
             assertEquals("192.168.4.237:1902", device.from);
-            assertEquals("JVC_PROJECTOR-E0DADC152802", device.host);
+            assertEquals("JVC_PROJECTOR-E0:DA:DC:15:28:02", device.host);
             assertTrue(device.maxAge.isBlank());
             assertEquals("JVCKENWOOD:Projector", device.type);
             assertEquals("projector", device.primaryProxy);


### PR DESCRIPTION
Fix issue reported by: https://github.com/openhab/openhab-addons/issues/16964

If the SDDP host address field contains colons in the mac address, remove them.

@andrewfg @lolodomo 