### PR TITLE
Ensure the PoolBasedSequentialScheduledExecutorService does keep a minimum size

### DIFF
--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadPoolManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadPoolManagerTest.java
@@ -202,7 +202,7 @@ public class ThreadPoolManagerTest {
                 block.countDown();
             }, 20, TimeUnit.MILLISECONDS);
 
-            assertTrue(check.await(80, TimeUnit.MILLISECONDS));
+            assertTrue(check.await(800, TimeUnit.MILLISECONDS));
         }
     }
 


### PR DESCRIPTION
This PR will ensure the `PoolBasedSequentialScheduledExecutorService` does keep the configured minimum size.
The unit test does now only need to spawn 10 new threads instead of up to 20, this should fix the latency issue.

@holgerfriedrich could you please run the CI multiple times for this PR to see if it does fix the issue?

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>