### PR TITLE
[PersistenceExtensions] Fix TimeSeries policy `REPLACE` not being applied

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -218,6 +218,10 @@ public class PersistenceExtensions {
         TimeZoneProvider tzProvider = timeZoneProvider;
         ZoneId timeZone = tzProvider != null ? tzProvider.getTimeZone() : ZoneId.systemDefault();
         if (service instanceof ModifiablePersistenceService modifiableService) {
+            if (timeSeries.getPolicy() == TimeSeries.Policy.REPLACE) {
+                internalRemoveAllStatesBetween(item, timeSeries.getBegin().atZone(timeZone),
+                        timeSeries.getEnd().atZone(timeZone), serviceId);
+            }
             timeSeries.getStates()
                     .forEach(s -> modifiableService.store(item, s.timestamp().atZone(timeZone), s.state()));
             return;


### PR DESCRIPTION
This is a very quick attempt, tested manually, but without test coverage, sorry.

Logic is similar to this:
https://github.com/openhab/openhab-core/blob/b932a4df5e6d4f0706afee20b112b710683d16d7/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java#L318-L326

Fixes #4297 