### PR TITLE
PersistenceExtensions: fix DateTimeException when persisting an empty TimeSeries

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -211,7 +211,7 @@ public class PersistenceExtensions {
 
     private static void internalPersist(Item item, TimeSeries timeSeries, @Nullable String serviceId) {
         String effectiveServiceId = serviceId == null ? getDefaultServiceId() : serviceId;
-        if (effectiveServiceId == null) {
+        if (effectiveServiceId == null || timeSeries.size() == 0) {
             return;
         }
         PersistenceService service = getService(effectiveServiceId);


### PR DESCRIPTION
Fix regression from #4298

When a TimeSeries is empty, `getBegin()` and `getEnd()` return `Instant.MAX` and `Instant.MIN` which when converted to a ZonedDateTime causes a DateTimeException