### PR TITLE
Config parameter: Change inferred i18n key for add-ons + alternative key

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
@@ -14,6 +14,7 @@ package org.openhab.core.config.core.internal.i18n;
 
 import java.net.URI;
 import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -31,6 +32,7 @@ import org.osgi.framework.FrameworkUtil;
  * @author Dennis Nobel - Initial contribution
  * @author Alex Tugarev - Extended for pattern and option label
  * @author Thomas Höfer - Extended for unit label
+ * @author Laurent Garnier - Changed inferred key for add-ons + alternative key
  */
 @NonNullByDefault
 public class ConfigDescriptionI18nUtil {
@@ -38,6 +40,8 @@ public class ConfigDescriptionI18nUtil {
     private final TranslationProvider i18nProvider;
 
     private static final Pattern DELIMITER = Pattern.compile("[:=\\s]");
+    private static final Set<String> ADDON_TYPES = Set.of("automation", "binding", "io", "misc", "persistence", "voice",
+            "ui");
 
     public ConfigDescriptionI18nUtil(TranslationProvider i18nProvider) {
         this.i18nProvider = i18nProvider;
@@ -45,23 +49,18 @@ public class ConfigDescriptionI18nUtil {
 
     public @Nullable String getParameterPattern(Bundle bundle, URI configDescriptionURI, String parameterName,
             @Nullable String defaultPattern, @Nullable Locale locale) {
-        String key = I18nUtil.stripConstantOr(defaultPattern,
-                () -> inferKey(configDescriptionURI, parameterName, "pattern"));
-        return i18nProvider.getText(bundle, key, defaultPattern, locale);
+        return getParameterValue(bundle, configDescriptionURI, parameterName, "pattern", defaultPattern, locale);
     }
 
     public @Nullable String getParameterDescription(Bundle bundle, URI configDescriptionURI, String parameterName,
             @Nullable String defaultDescription, @Nullable Locale locale) {
-        String key = I18nUtil.stripConstantOr(defaultDescription,
-                () -> inferKey(configDescriptionURI, parameterName, "description"));
-        return i18nProvider.getText(bundle, key, defaultDescription, locale);
+        return getParameterValue(bundle, configDescriptionURI, parameterName, "description", defaultDescription,
+                locale);
     }
 
     public @Nullable String getParameterLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
             @Nullable String defaultLabel, @Nullable Locale locale) {
-        String key = I18nUtil.stripConstantOr(defaultLabel,
-                () -> inferKey(configDescriptionURI, parameterName, "label"));
-        return i18nProvider.getText(bundle, key, defaultLabel, locale);
+        return getParameterValue(bundle, configDescriptionURI, parameterName, "label", defaultLabel, locale);
     }
 
     public @Nullable String getParameterOptionLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
@@ -70,10 +69,8 @@ public class ConfigDescriptionI18nUtil {
             return defaultOptionLabel;
         }
 
-        String key = I18nUtil.stripConstantOr(defaultOptionLabel,
-                () -> inferKey(configDescriptionURI, parameterName, "option." + optionValue));
-
-        return i18nProvider.getText(bundle, key, defaultOptionLabel, locale);
+        return getParameterValue(bundle, configDescriptionURI, parameterName, "option." + optionValue,
+                defaultOptionLabel, locale);
     }
 
     public @Nullable String getParameterUnitLabel(Bundle bundle, URI configDescriptionURI, String parameterName,
@@ -84,14 +81,28 @@ public class ConfigDescriptionI18nUtil {
                 return label;
             }
         }
-        String key = I18nUtil.stripConstantOr(defaultUnitLabel,
-                () -> inferKey(configDescriptionURI, parameterName, "unitLabel"));
-        return i18nProvider.getText(bundle, key, defaultUnitLabel, locale);
+        return getParameterValue(bundle, configDescriptionURI, parameterName, "unitLabel", defaultUnitLabel, locale);
     }
 
-    private String inferKey(URI configDescriptionURI, String parameterName, String lastSegment) {
+    private @Nullable String getParameterValue(Bundle bundle, URI configDescriptionURI, String parameterName,
+            String parameterAttribute, @Nullable String defaultValue, @Nullable Locale locale) {
+        String key = I18nUtil.stripConstantOr(defaultValue,
+                () -> inferKey(true, configDescriptionURI, parameterName, parameterAttribute));
+        String value = i18nProvider.getText(bundle, key, null, locale);
+        if (value == null && ADDON_TYPES.contains(configDescriptionURI.getScheme())) {
+            key = I18nUtil.stripConstantOr(defaultValue,
+                    () -> inferKey(false, configDescriptionURI, parameterName, parameterAttribute));
+            value = i18nProvider.getText(bundle, key, null, locale);
+        }
+        return value != null ? value : defaultValue;
+    }
+
+    private String inferKey(boolean checkAddonType, URI configDescriptionURI, String parameterName,
+            String lastSegment) {
+        String prefix = checkAddonType && ADDON_TYPES.contains(configDescriptionURI.getScheme()) ? "addon"
+                : configDescriptionURI.getScheme();
         String uri = configDescriptionURI.getSchemeSpecificPart().replace(":", ".");
-        return configDescriptionURI.getScheme() + ".config." + uri + "." + parameterName + "." + lastSegment;
+        return prefix + ".config." + uri + "." + parameterName + "." + lastSegment;
     }
 
     private boolean isValidPropertyKey(@Nullable String key) {


### PR DESCRIPTION
Fix openhab/openhab-webui#2641

The i18n key for add-on configuration parameter should now start with `addon.config.<param>`.
To maintain compatibility with hundreds of existing translations, an alternative key starting with `<type>.config.<param>` is still accepted for an add-on parameter

Signed-off-by: Laurent Garnier <lg.hc@free.fr>