### PR TITLE
Fix translation of label for system:addons service

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -54,6 +54,7 @@ import org.openhab.core.io.rest.core.config.ConfigurationService;
 import org.openhab.core.io.rest.core.service.ConfigurableServiceDTO;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -307,7 +308,11 @@ public class ConfigurableServiceResource implements RESTResource {
                 String key = I18nUtil.stripConstantOr(defaultLabel,
                         () -> inferKey(configurableService.description_uri(), "label"));
 
-                String label = i18nProvider.getText(serviceReference.getBundle(), key, defaultLabel, locale);
+                // i18n file containing label for system:addons service is exceptionally located in bundle
+                // org.openhab.core (and not in bundle org.openhab.core.addon.eclipse)
+                String label = i18nProvider.getText("system:addons".equals(configurableService.description_uri())
+                        ? FrameworkUtil.getBundle(OpenHAB.class)
+                        : serviceReference.getBundle(), key, defaultLabel, locale);
 
                 String category = configurableService.category();
 


### PR DESCRIPTION
The i18n file containing this label is in org.openhab.core bundle.

Fix openhab/openhab-webui#1669

Signed-off-by: Laurent Garnier <lg.hc@free.fr>