### PR TITLE
Fix merge of AddonInfo (masterAddonInfo field)

### DIFF
--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -106,8 +106,8 @@ public class AddonInfoRegistry {
             builder.withName(b.getName());
             builder.withDescription(b.getDescription());
         }
-        if (!(a.isMasterAddonInfo() || b.isMasterAddonInfo())) {
-            builder.isMasterAddonInfo(false);
+        if (!a.isMasterAddonInfo() && b.isMasterAddonInfo()) {
+            builder.isMasterAddonInfo(true);
         }
         if (a.getConnection() == null && b.getConnection() != null) {
             builder.withConnection(b.getConnection());


### PR DESCRIPTION
This fix allows having translated label for bindings when showing list of installed bindings in Main UI parameters.

Fix openhab/openhab-webui#2639

Signed-off-by: Laurent Garnier <lg.hc@free.fr>