### PR TITLE
PersistenceExtensions: fix DateTimeException when persisting an empty TimeSeries

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -211,7 +211,7 @@ public class PersistenceExtensions {
 
     private static void internalPersist(Item item, TimeSeries timeSeries, @Nullable String serviceId) {
         String effectiveServiceId = serviceId == null ? getDefaultServiceId() : serviceId;
-        if (effectiveServiceId == null) {
+        if (effectiveServiceId == null || timeSeries.size() == 0) {
             return;
         }
         PersistenceService service = getService(effectiveServiceId);


### PR DESCRIPTION
backport of #4303 to 4.2.x series, regression from #4298 