### PR TITLE
Clean up removed links in GenericItemChannelLinkProvider

### DIFF
--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -151,7 +151,7 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
         Optional.ofNullable(contextMap.get(context)).ifPresent(ctx -> ctx.removeAll(previousItemNames));
 
         addedItemChannels.forEach((itemName, addedChannelUIDs) -> {
-            Map<ChannelUID, ItemChannelLink> links = Objects.requireNonNull(itemChannelLinkMap.get(itemName));
+            Map<ChannelUID, ItemChannelLink> links = itemChannelLinkMap.getOrDefault(itemName, Map.of());
             Set<ChannelUID> removedChannelUIDs = new HashSet<>(links.keySet());
             removedChannelUIDs.removeAll(addedChannelUIDs);
             removedChannelUIDs.forEach(removedChannelUID -> {

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.model.thing.internal;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,6 +79,18 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
         }
         for (String uid : uids) {
             createItemChannelLink(context, itemName, uid.trim(), configuration);
+        }
+        // clean up removed links
+        Map<ChannelUID, ItemChannelLink> links = itemChannelLinkMap.get(itemName);
+        if (links != null) {
+            links.keySet().removeIf(channelUID -> {
+                if (Arrays.stream(uids).anyMatch(channelUID.toString()::equals)) {
+                    return false;
+                }
+                ItemChannelLink removedLink = links.get(channelUID);
+                notifyListenersAboutRemovedElement(removedLink);
+                return true;
+            });
         }
     }
 


### PR DESCRIPTION
Fix an issue reported in https://community.openhab.org/t/openhab-4-2-updating-an-items-file-does-not-remove-links-to-channels/157331