### PR TITLE
[rules] Don't attempt to pre-compile disabled rules

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1555,15 +1555,16 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     /**
-     * This method compiles the conditions and actions of all rules. It is called when the rule engine is started.
+     * This method compiles the conditions and actions of all enabled rules.
+     * It is called when the rule engine is started.
      * By compiling when the rule engine is started, we make sure all conditions and actions are compiled, even if their
      * handlers weren't available when the rule was added to the rule engine.
      */
     private void compileRules() {
         getScheduledExecutor().submit(() -> {
-            ruleRegistry.getAll().forEach(r -> {
-                compileRule(r.getUID());
-            });
+            ruleRegistry.getAll().stream() //
+                    .filter(r -> isEnabled(r.getUID())) //
+                    .forEach(r -> compileRule(r.getUID()));
             executeRulesWithStartLevel();
         });
     }


### PR DESCRIPTION
Fixes an issue, where an error that compilation failed for disabled rules.

Reported on the community: https://community.openhab.org/t/oh-4-2-snapshot-disabled-rules-failed-to-compile-error-in-opehab-log/157402.
Follow-up for #4289.