### PR TITLE
Support lists for metadata properties in items files

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
@@ -49,7 +49,7 @@ ModelBinding:
 ;
 
 ModelProperty:
-    key=ID '=' value=ValueType
+    key=ID '=' value+=ValueType (',' value+=ValueType)*
 ;
 
 ValueType returns ecore::EJavaObject:

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -349,7 +349,15 @@ public class GenericItemProvider extends AbstractProvider<Item>
             String config = binding.getConfiguration();
 
             Configuration configuration = new Configuration();
-            binding.getProperties().forEach(p -> configuration.put(p.getKey(), p.getValue()));
+            binding.getProperties().forEach(p -> {
+                Object value = p.getValue();
+                // Single valued lists get unwrapped to just their one value for
+                // backwards compatibility
+                if (value instanceof List listValue && listValue.size() == 1) {
+                    value = listValue.get(0);
+                }
+                configuration.put(p.getKey(), value);
+            });
 
             BindingConfigReader localReader = reader;
             if (reader == null) {

--- a/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
+++ b/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
@@ -624,6 +624,41 @@ public class GenericItemProviderTest extends JavaOSGiTest {
     }
 
     @Test
+    public void testMetadataPropertyTypes() {
+        String model = "Switch simple { namespace=\"value\"[string=\"string\", bool=false, int=2, stringList=\"string1\",\"string2\", boolList=false,true] } ";
+
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
+        Item item = itemRegistry.get("simple");
+        assertThat(item, is(notNullValue()));
+
+        Metadata res = metadataRegistry.get(new MetadataKey("namespace", "simple"));
+        assertThat(res, is(notNullValue()));
+        assertThat(res.getValue(), is("value"));
+        assertThat(res.getConfiguration(), is(notNullValue()));
+        var config = res.getConfiguration();
+        assertThat(config.size(), is(5));
+        assertThat(config.get("string"), is("string"));
+        assertThat(config.get("bool"), is(false));
+        assertThat(config.get("int"), is(new BigDecimal("2")));
+
+        var list = config.get("stringList");
+        assertThat(list, is(notNullValue()));
+        assertThat(list, instanceOf(List.class));
+        List<Object> values = (List<Object>) list;
+        assertThat(values.size(), is(2));
+        assertThat(values.get(0), is("string1"));
+        assertThat(values.get(1), is("string2"));
+
+        list = config.get("boolList");
+        assertThat(list, is(notNullValue()));
+        assertThat(list, instanceOf(List.class));
+        values = (List<Object>) list;
+        assertThat(values.size(), is(2));
+        assertThat(values.get(0), is(false));
+        assertThat(values.get(1), is(true));
+    }
+
+    @Test
     public void testTagUpdate() {
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream("Switch s [foo]".getBytes()));
         Item item1 = itemRegistry.get("s");


### PR DESCRIPTION
I'm looking into adding a feature to the HomeKit add-on that is best implemented with array/list properties. I'm able to create arrays just fine in MainUI with the code editor, but it's not currently possible with file based items.

https://github.com/openhab/openhab-addons/pull/17144 is the PR utilizing this feature.