### PR TITLE
Fix favicon for authorize/login page

### DIFF
--- a/bundles/org.openhab.core.io.http.auth/pages/authorize.html
+++ b/bundles/org.openhab.core.io.http.auth/pages/authorize.html
@@ -10,7 +10,7 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <link rel="apple-touch-icon" href="res/icons/apple-touch-icon.png">
-<link rel="icon" href="res/icons/favicon.png">
+<link rel="icon" href="res/icons/favicon.svg">
 <link rel="manifest" href="/manifest.json">
 <style>
 body {


### PR DESCRIPTION
The icon files are provided by the UI bundle, see https://github.com/openhab/openhab-webui/tree/85cd64e147e9b2cca32e2dc60d8686c354591639/bundles/org.openhab.ui/web/src/res/icons.