### PR TITLE
Upgrade Jollyday to 0.30.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -365,7 +365,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.28.1</version>
+      <version>0.30.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -950,7 +950,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.28.1</version>
+      <version>0.30.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -174,12 +174,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.28.1</capability>
+		<capability>openhab.tp;feature=jollyday;version=0.30.0</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/0.28.1</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/0.28.1</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/0.30.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/0.30.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -69,8 +69,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.automation;version='[4.3.0,4.3.1)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -69,8 +69,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.automation;version='[4.3.0,4.3.1)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -65,8 +65,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.automation;version='[4.3.0,4.3.1)',\
@@ -78,4 +76,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -69,8 +69,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.automation;version='[4.3.0,4.3.1)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -69,8 +69,6 @@ Fragment-Host: org.openhab.core.automation
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.automation;version='[4.3.0,4.3.1)',\
@@ -81,4 +79,6 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -69,11 +69,11 @@ feature.openhab-config: \
 	org.objectweb.asm.tree.analysis;version='[9.6.0,9.6.1)',\
 	org.objectweb.asm.util;version='[9.6.0,9.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.7,2.2.8)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.config.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.ephemeris;version='[4.3.0,4.3.1)',\
 	org.openhab.core.ephemeris.tests;version='[4.3.0,4.3.1)',\
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -99,8 +99,6 @@ Fragment-Host: org.openhab.core.model.item
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.27,8.0.28)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.audio;version='[4.3.0,4.3.1)',\
@@ -127,4 +125,7 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
+	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -102,8 +102,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.27,8.0.28)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.audio;version='[4.3.0,4.3.1)',\
@@ -116,7 +114,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.io.net;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.item;version='[4.3.0,4.3.1)',\
-	org.openhab.core.model.item.runtime;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.persistence;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.rule;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)',\
@@ -131,4 +128,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -107,8 +107,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.27,8.0.28)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.audio;version='[4.3.0,4.3.1)',\
@@ -121,7 +119,6 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.io.net;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.item;version='[4.3.0,4.3.1)',\
-	org.openhab.core.model.item.runtime;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.persistence;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.rule;version='[4.3.0,4.3.1)',\
 	org.openhab.core.model.script;version='[4.3.0,4.3.1)',\
@@ -135,4 +132,7 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
+	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -106,8 +106,6 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.web.pax-web-runtime;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-spi;version='[8.0.27,8.0.28)',\
 	org.ops4j.pax.web.pax-web-tomcat-common;version='[8.0.27,8.0.28)',\
-	de.focus_shift.jollyday-core;version='[0.28.1,0.28.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.28.1,0.28.2)',\
 	org.openhab.core;version='[4.3.0,4.3.1)',\
 	org.openhab.core.addon;version='[4.3.0,4.3.1)',\
 	org.openhab.core.audio;version='[4.3.0,4.3.1)',\
@@ -136,4 +134,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
-	stax2-api;version='[4.2.2,4.2.3)'
+	stax2-api;version='[4.2.2,4.2.3)',\
+	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
+	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'


### PR DESCRIPTION
Upgrades Jollyday from 0.28.1 to 0.30.0.

For release notes, see:

https://github.com/focus-shift/jollyday/releases/tag/v0.30.0