### PR TITLE
Fix itests on machines with lots of processors

### DIFF
--- a/itests/itest-include.bndrun
+++ b/itests/itest-include.bndrun
@@ -21,7 +21,8 @@ Test-Cases: ${classes;CONCRETE;PUBLIC;NAMED;*Test}
 # This property is set by the build-helper-maven-plugin in the itests pom.xml
 -runvm: \
 	-Djdk.util.zip.disableZip64ExtraFieldValidation=true,\
-	-Dorg.osgi.service.http.port=${org.osgi.service.http.port}
+	-Dorg.osgi.service.http.port=${org.osgi.service.http.port},\
+	-DJETTY_AVAILABLE_PROCESSORS=4
 
 # The integration test itself does not export anything.
 Export-Package:


### PR DESCRIPTION
When this JVM variable is not set Jetty creates selectors based on the number of available processors (`Runtime.getRuntime().availableProcessors()`). Jetty will also throw an exception when there is a mismatch between the max thread pool size and the number of selectors. This causes issues with the default thread pool size of 10 on machines with more than 10 available processors.

See also [`SelectorManager.defaultSelectors(Executor)`](https://github.com/jetty/jetty.project/blob/70015831e5195ba74da6383c4ab7c90c56bb08af/jetty-io/src/main/java/org/eclipse/jetty/io/SelectorManager.java#L71-L80).