### PR TITLE
Add `getLastStateChange`, `getLastStateUpdate`, and `getLastState` to GenericItem

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
@@ -24,11 +24,11 @@ import org.openhab.core.types.StateDescription;
  */
 public class EnrichedGroupItemDTO extends EnrichedItemDTO {
 
-    public EnrichedGroupItemDTO(ItemDTO itemDTO, EnrichedItemDTO[] members, String link, String state,
-            String previousState, Long lastUpdate, Long lastChange, String transformedState,
-            StateDescription stateDescription, String unitSymbol) {
-        super(itemDTO, link, state, previousState, lastUpdate, lastChange, transformedState, stateDescription, null,
-                unitSymbol);
+    public EnrichedGroupItemDTO(ItemDTO itemDTO, EnrichedItemDTO[] members, String link, String state, String lastState,
+            Long lastStateUpdate, Long lastStateChange, String transformedState, StateDescription stateDescription,
+            String unitSymbol) {
+        super(itemDTO, link, state, lastState, lastStateUpdate, lastStateChange, transformedState, stateDescription,
+                null, unitSymbol);
         this.members = members;
         this.groupType = ((GroupItemDTO) itemDTO).groupType;
         this.function = ((GroupItemDTO) itemDTO).function;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
@@ -25,8 +25,10 @@ import org.openhab.core.types.StateDescription;
 public class EnrichedGroupItemDTO extends EnrichedItemDTO {
 
     public EnrichedGroupItemDTO(ItemDTO itemDTO, EnrichedItemDTO[] members, String link, String state,
-            String transformedState, StateDescription stateDescription, String unitSymbol) {
-        super(itemDTO, link, state, transformedState, stateDescription, null, unitSymbol);
+            String previousState, Long lastUpdate, Long lastChange, String transformedState,
+            StateDescription stateDescription, String unitSymbol) {
+        super(itemDTO, link, state, previousState, lastUpdate, lastChange, transformedState, stateDescription, null,
+                unitSymbol);
         this.members = members;
         this.groupType = ((GroupItemDTO) itemDTO).groupType;
         this.function = ((GroupItemDTO) itemDTO).function;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
@@ -32,13 +32,17 @@ public class EnrichedItemDTO extends ItemDTO {
     public String state;
     public String transformedState;
     public StateDescription stateDescription;
-    public String unitSymbol;
     public CommandDescription commandDescription;
+    public String previousState;
+    public Long lastUpdate;
+    public Long lastChange;
+    public String unitSymbol;
     public Map<String, Object> metadata;
     public Boolean editable;
 
-    public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String transformedState,
-            StateDescription stateDescription, CommandDescription commandDescription, String unitSymbol) {
+    public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String previousState, Long lastUpdate,
+            Long lastChange, String transformedState, StateDescription stateDescription,
+            CommandDescription commandDescription, String unitSymbol) {
         this.type = itemDTO.type;
         this.name = itemDTO.name;
         this.label = itemDTO.label;
@@ -50,6 +54,9 @@ public class EnrichedItemDTO extends ItemDTO {
         this.transformedState = transformedState;
         this.stateDescription = stateDescription;
         this.commandDescription = commandDescription;
+        this.previousState = previousState;
+        this.lastUpdate = lastUpdate;
+        this.lastChange = lastChange;
         this.unitSymbol = unitSymbol;
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
@@ -33,15 +33,15 @@ public class EnrichedItemDTO extends ItemDTO {
     public String transformedState;
     public StateDescription stateDescription;
     public CommandDescription commandDescription;
-    public String previousState;
-    public Long lastUpdate;
-    public Long lastChange;
+    public String lastState;
+    public Long lastStateUpdate;
+    public Long lastStateChange;
     public String unitSymbol;
     public Map<String, Object> metadata;
     public Boolean editable;
 
-    public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String previousState, Long lastUpdate,
-            Long lastChange, String transformedState, StateDescription stateDescription,
+    public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String lastState, Long lastStateUpdate,
+            Long lastStateChange, String transformedState, StateDescription stateDescription,
             CommandDescription commandDescription, String unitSymbol) {
         this.type = itemDTO.type;
         this.name = itemDTO.name;
@@ -54,9 +54,9 @@ public class EnrichedItemDTO extends ItemDTO {
         this.transformedState = transformedState;
         this.stateDescription = stateDescription;
         this.commandDescription = commandDescription;
-        this.previousState = previousState;
-        this.lastUpdate = lastUpdate;
-        this.lastChange = lastChange;
+        this.lastState = lastState;
+        this.lastStateUpdate = lastStateUpdate;
+        this.lastStateChange = lastStateChange;
         this.unitSymbol = unitSymbol;
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -91,6 +92,12 @@ public class EnrichedItemDTOMapper {
         }
         StateDescription stateDescription = considerTransformation(item.getStateDescription(locale));
 
+        String previousState = Optional.ofNullable(item.getPreviousState()).map(State::toFullString).orElse(null);
+        Long lastUpdate = Optional.ofNullable(item.getLastUpdate()).map(zdt -> zdt.toInstant().toEpochMilli())
+                .orElse(null);
+        Long lastChange = Optional.ofNullable(item.getLastChange()).map(zdt -> zdt.toInstant().toEpochMilli())
+                .orElse(null);
+
         final String link;
         if (uriBuilder != null) {
             link = uriBuilder.build(itemDTO.name).toASCIIString();
@@ -124,11 +131,11 @@ public class EnrichedItemDTOMapper {
             } else {
                 memberDTOs = new EnrichedItemDTO[0];
             }
-            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, transformedState,
-                    stateDescription, unitSymbol);
+            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, previousState, lastUpdate,
+                    lastChange, transformedState, stateDescription, unitSymbol);
         } else {
-            enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, transformedState, stateDescription,
-                    item.getCommandDescription(locale), unitSymbol);
+            enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, previousState, lastUpdate, lastChange,
+                    transformedState, stateDescription, item.getCommandDescription(locale), unitSymbol);
         }
 
         return enrichedItemDTO;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -92,10 +92,10 @@ public class EnrichedItemDTOMapper {
         }
         StateDescription stateDescription = considerTransformation(item.getStateDescription(locale));
 
-        String previousState = Optional.ofNullable(item.getPreviousState()).map(State::toFullString).orElse(null);
-        Long lastUpdate = Optional.ofNullable(item.getLastUpdate()).map(zdt -> zdt.toInstant().toEpochMilli())
+        String lastState = Optional.ofNullable(item.getLastState()).map(State::toFullString).orElse(null);
+        Long lastStateUpdate = Optional.ofNullable(item.getLastStateUpdate()).map(zdt -> zdt.toInstant().toEpochMilli())
                 .orElse(null);
-        Long lastChange = Optional.ofNullable(item.getLastChange()).map(zdt -> zdt.toInstant().toEpochMilli())
+        Long lastStateChange = Optional.ofNullable(item.getLastStateChange()).map(zdt -> zdt.toInstant().toEpochMilli())
                 .orElse(null);
 
         final String link;
@@ -131,10 +131,10 @@ public class EnrichedItemDTOMapper {
             } else {
                 memberDTOs = new EnrichedItemDTO[0];
             }
-            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, previousState, lastUpdate,
-                    lastChange, transformedState, stateDescription, unitSymbol);
+            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, lastState, lastStateUpdate,
+                    lastStateChange, transformedState, stateDescription, unitSymbol);
         } else {
-            enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, previousState, lastUpdate, lastChange,
+            enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, lastState, lastStateUpdate, lastStateChange,
                     transformedState, stateDescription, item.getCommandDescription(locale), unitSymbol);
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.items;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,6 +78,10 @@ public abstract class GenericItem implements ActiveItem {
     protected final String type;
 
     protected State state = UnDefType.NULL;
+    protected @Nullable State previousState;
+
+    protected @Nullable ZonedDateTime lastUpdate;
+    protected @Nullable ZonedDateTime lastChange;
 
     protected @Nullable String label;
 
@@ -101,6 +106,21 @@ public abstract class GenericItem implements ActiveItem {
     @Override
     public <T extends State> @Nullable T getStateAs(Class<T> typeClass) {
         return state.as(typeClass);
+    }
+
+    @Override
+    public @Nullable State getPreviousState() {
+        return previousState;
+    }
+
+    @Override
+    public @Nullable ZonedDateTime getLastUpdate() {
+        return lastUpdate;
+    }
+
+    @Override
+    public @Nullable ZonedDateTime getLastChange() {
+        return lastChange;
     }
 
     @Override
@@ -218,13 +238,20 @@ public abstract class GenericItem implements ActiveItem {
      * @param state new state of this item
      */
     protected final void applyState(State state) {
+        ZonedDateTime now = ZonedDateTime.now();
         State oldState = this.state;
+        boolean stateChanged = !oldState.equals(state);
         this.state = state;
+        if (stateChanged) {
+            previousState = oldState; // update before we notify listeners
+        }
         notifyListeners(oldState, state);
         sendStateUpdatedEvent(state);
-        if (!oldState.equals(state)) {
+        if (stateChanged) {
             sendStateChangedEvent(state, oldState);
+            lastChange = now; // update after we've notified listeners
         }
+        lastUpdate = now;
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -78,10 +78,10 @@ public abstract class GenericItem implements ActiveItem {
     protected final String type;
 
     protected State state = UnDefType.NULL;
-    protected @Nullable State previousState;
+    protected @Nullable State lastState;
 
-    protected @Nullable ZonedDateTime lastUpdate;
-    protected @Nullable ZonedDateTime lastChange;
+    protected @Nullable ZonedDateTime lastStateUpdate;
+    protected @Nullable ZonedDateTime lastStateChange;
 
     protected @Nullable String label;
 
@@ -109,18 +109,18 @@ public abstract class GenericItem implements ActiveItem {
     }
 
     @Override
-    public @Nullable State getPreviousState() {
-        return previousState;
+    public @Nullable State getLastState() {
+        return lastState;
     }
 
     @Override
-    public @Nullable ZonedDateTime getLastUpdate() {
-        return lastUpdate;
+    public @Nullable ZonedDateTime getLastStateUpdate() {
+        return lastStateUpdate;
     }
 
     @Override
-    public @Nullable ZonedDateTime getLastChange() {
-        return lastChange;
+    public @Nullable ZonedDateTime getLastStateChange() {
+        return lastStateChange;
     }
 
     @Override
@@ -243,15 +243,15 @@ public abstract class GenericItem implements ActiveItem {
         boolean stateChanged = !oldState.equals(state);
         this.state = state;
         if (stateChanged) {
-            previousState = oldState; // update before we notify listeners
+            lastState = oldState; // update before we notify listeners
         }
         notifyListeners(oldState, state);
         sendStateUpdatedEvent(state);
         if (stateChanged) {
             sendStateChangedEvent(state, oldState);
-            lastChange = now; // update after we've notified listeners
+            lastStateChange = now; // update after we've notified listeners
         }
-        lastUpdate = now;
+        lastStateUpdate = now;
     }
 
     /**

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.items;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -55,6 +56,30 @@ public interface Item extends Identifiable<String> {
      *         null, if state cannot be provided as the requested type
      */
     <T extends State> @Nullable T getStateAs(Class<T> typeClass);
+
+    /**
+     * Returns the previous state of the item.
+     * 
+     * @return the previous state of the item, or null if the item has never been changed.
+     */
+    @Nullable
+    State getPreviousState();
+
+    /**
+     * Returns the time the item was last updated.
+     * 
+     * @return the time the item was last updated, or null if the item has never been updated.
+     */
+    @Nullable
+    ZonedDateTime getLastUpdate();
+
+    /**
+     * Returns the time the item was last changed.
+     * 
+     * @return the time the item was last changed, or null if the item has never been changed.
+     */
+    @Nullable
+    ZonedDateTime getLastChange();
 
     /**
      * returns the name of the item

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -63,7 +63,7 @@ public interface Item extends Identifiable<String> {
      * @return the previous state of the item, or null if the item has never been changed.
      */
     @Nullable
-    State getPreviousState();
+    State getLastState();
 
     /**
      * Returns the time the item was last updated.
@@ -71,7 +71,7 @@ public interface Item extends Identifiable<String> {
      * @return the time the item was last updated, or null if the item has never been updated.
      */
     @Nullable
-    ZonedDateTime getLastUpdate();
+    ZonedDateTime getLastStateUpdate();
 
     /**
      * Returns the time the item was last changed.
@@ -79,7 +79,7 @@ public interface Item extends Identifiable<String> {
      * @return the time the item was last changed, or null if the item has never been changed.
      */
     @Nullable
-    ZonedDateTime getLastChange();
+    ZonedDateTime getLastStateChange();
 
     /**
      * returns the name of the item

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -13,11 +13,14 @@
 package org.openhab.core.items;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 
@@ -39,6 +42,7 @@ import org.openhab.core.types.CommandOption;
 import org.openhab.core.types.State;
 import org.openhab.core.types.StateDescriptionFragmentBuilder;
 import org.openhab.core.types.StateOption;
+import org.openhab.core.types.UnDefType;
 
 /**
  * The GenericItemTest tests functionality of the GenericItem.
@@ -131,6 +135,47 @@ public class GenericItemTest {
         TestItem item = new TestItem("member1");
         item.setState(StringType.valueOf("Hello World"));
         assertNull(item.getStateAs(toNull()));
+    }
+
+    @Test
+    public void testGetLastUpdate() {
+        TestItem item = new TestItem("member1");
+        assertNull(item.getLastUpdate());
+        item.setState(PercentType.HUNDRED);
+        assertThat(item.getLastUpdate().toInstant().toEpochMilli() * 1.0,
+                is(closeTo(ZonedDateTime.now().toInstant().toEpochMilli(), 5)));
+    }
+
+    @Test
+    public void testGetLastChange() throws InterruptedException {
+        TestItem item = new TestItem("member1");
+        assertNull(item.getLastChange());
+        item.setState(PercentType.HUNDRED);
+        ZonedDateTime initialChangeTime = ZonedDateTime.now();
+        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+                is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
+
+        Thread.sleep(50);
+        item.setState(PercentType.HUNDRED);
+        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+                is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
+
+        Thread.sleep(50);
+        ZonedDateTime secondChangeTime = ZonedDateTime.now();
+        item.setState(PercentType.ZERO);
+        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+                is(closeTo(secondChangeTime.toInstant().toEpochMilli(), 5)));
+    }
+
+    @Test
+    public void testGetPreviousState() {
+        TestItem item = new TestItem("member1");
+        assertEquals(UnDefType.NULL, item.getState());
+        assertNull(item.getPreviousState());
+        item.setState(PercentType.HUNDRED);
+        assertEquals(UnDefType.NULL, item.getPreviousState());
+        item.setState(PercentType.ZERO);
+        assertEquals(PercentType.HUNDRED, item.getPreviousState());
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -138,44 +138,44 @@ public class GenericItemTest {
     }
 
     @Test
-    public void testGetLastUpdate() {
+    public void testGetLastStateUpdate() {
         TestItem item = new TestItem("member1");
-        assertNull(item.getLastUpdate());
+        assertNull(item.getLastStateUpdate());
         item.setState(PercentType.HUNDRED);
-        assertThat(item.getLastUpdate().toInstant().toEpochMilli() * 1.0,
+        assertThat(item.getLastStateUpdate().toInstant().toEpochMilli() * 1.0,
                 is(closeTo(ZonedDateTime.now().toInstant().toEpochMilli(), 5)));
     }
 
     @Test
-    public void testGetLastChange() throws InterruptedException {
+    public void testGetLastStateChange() throws InterruptedException {
         TestItem item = new TestItem("member1");
-        assertNull(item.getLastChange());
+        assertNull(item.getLastStateChange());
         item.setState(PercentType.HUNDRED);
         ZonedDateTime initialChangeTime = ZonedDateTime.now();
-        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+        assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
                 is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
 
         Thread.sleep(50);
         item.setState(PercentType.HUNDRED);
-        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+        assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
                 is(closeTo(initialChangeTime.toInstant().toEpochMilli(), 5)));
 
         Thread.sleep(50);
         ZonedDateTime secondChangeTime = ZonedDateTime.now();
         item.setState(PercentType.ZERO);
-        assertThat(item.getLastChange().toInstant().toEpochMilli() * 1.0,
+        assertThat(item.getLastStateChange().toInstant().toEpochMilli() * 1.0,
                 is(closeTo(secondChangeTime.toInstant().toEpochMilli(), 5)));
     }
 
     @Test
-    public void testGetPreviousState() {
+    public void testGetLastState() {
         TestItem item = new TestItem("member1");
         assertEquals(UnDefType.NULL, item.getState());
-        assertNull(item.getPreviousState());
+        assertNull(item.getLastState());
         item.setState(PercentType.HUNDRED);
-        assertEquals(UnDefType.NULL, item.getPreviousState());
+        assertEquals(UnDefType.NULL, item.getLastState());
         item.setState(PercentType.ZERO);
-        assertEquals(PercentType.HUNDRED, item.getPreviousState());
+        assertEquals(PercentType.HUNDRED, item.getLastState());
     }
 
     @Test


### PR DESCRIPTION
These methods are handy in many situations and isn't possible with mapdb persistence, so previously it would require something like influxdb.

It also solves the issue of needing to wait until persistence write operation is finished (if it was at all set up to persist on change), so this gives us a cheap and reliable / dependable way of getting the last change / last update time.

See discussions in 
https://community.openhab.org/t/persistence-on-off-transitions-with-influx/156271/
https://community.openhab.org/t/blockly-persistence-last-changed-returns-no-result-quite-often/157842