### PR TITLE
Add isTransform(), isEmpty() and isPresent() to ChannelTransformation

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -71,15 +71,28 @@ public class ChannelTransformation {
         return Arrays.stream(transformationString.split("∩")).filter(s -> !s.isBlank());
     }
 
+    public boolean isEmpty() {
+        return transformationSteps.isEmpty();
+    }
+
+    public boolean isPresent() {
+        return !isEmpty();
+    }
+
     public Optional<String> apply(String value) {
         Optional<String> valueOptional = Optional.of(value);
 
         // process all transformations
         for (TransformationStep transformationStep : transformationSteps) {
-            valueOptional = valueOptional.flatMap(transformationStep::apply);
+            valueOptional = valueOptional.flatMap(v -> {
+                Optional<String> result = transformationStep.apply(v);
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Transformed '{}' to '{}' using '{}'", v, result.orElse(null), transformationStep);
+                }
+                return result;
+            });
         }
 
-        logger.trace("Transformed '{}' to '{}' using '{}'", value, valueOptional, transformationSteps);
         return valueOptional;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -72,32 +72,30 @@ public class ChannelTransformation {
     }
 
     /**
-     * Checks whether the given string contains valid transformations.
+     * Checks whether this object contains no transformation steps.
      * 
-     * Valid single and chained transformations will return true.
-     * 
-     * @param value the transformation string to check.
-     * @return <code>true</code> if the string contains valid transformations, <code>false</code> otherwise.
+     * @return <code>true</code> if the transformation is empty, <code>false</code> otherwise.
      */
-    public static boolean isTransform(@Nullable String value) {
-        if (value == null || value.isBlank()) {
-            return false;
-        }
-        try {
-            return splitTransformationString(value).map(TransformationStep::new).count() > 0;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-    }
-
     public boolean isEmpty() {
         return transformationSteps.isEmpty();
     }
 
+    /**
+     * Checks whether this object contains at least one transformation step.
+     * 
+     * @return <code>true</code> if the transformation is present, <code>false</code> otherwise.
+     */
     public boolean isPresent() {
         return !isEmpty();
     }
 
+    /**
+     * Applies all transformations to the given value.
+     * 
+     * @param value the value to transform.
+     * @return the transformed value or an empty optional if the transformation failed.
+     *         If the transformation is empty, the original value is returned.
+     */
     public Optional<String> apply(String value) {
         Optional<String> valueOptional = Optional.of(value);
 
@@ -113,6 +111,25 @@ public class ChannelTransformation {
         }
 
         return valueOptional;
+    }
+
+    /**
+     * Checks whether the given string contains valid transformations.
+     * 
+     * Valid single and chained transformations will return true.
+     * 
+     * @param value the transformation string to check.
+     * @return <code>true</code> if the string contains valid transformations, <code>false</code> otherwise.
+     */
+    public static boolean isValidTransformation(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        try {
+            return splitTransformationString(value).map(TransformationStep::new).count() > 0;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     private static class TransformationStep {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -71,6 +71,25 @@ public class ChannelTransformation {
         return Arrays.stream(transformationString.split("∩")).filter(s -> !s.isBlank());
     }
 
+    /**
+     * Checks whether the given string contains valid transformations.
+     * 
+     * Valid single and chained transformations will return true.
+     * 
+     * @param value the transformation string to check.
+     * @return <code>true</code> if the string contains valid transformations, <code>false</code> otherwise.
+     */
+    public static boolean isTransform(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        try {
+            return splitTransformationString(value).map(TransformationStep::new).count() > 0;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     public boolean isEmpty() {
         return transformationSteps.isEmpty();
     }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
@@ -270,44 +270,44 @@ public class ChannelTransformationTest {
     }
 
     @Test
-    public void testIsTransform() {
+    public void testIsValidTransform() {
         // single with colon
-        assertTrue(ChannelTransformation.isTransform("FOO:BAR"));
-        assertTrue(ChannelTransformation.isTransform(" FOO : BAR "));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO:BAR"));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO : BAR "));
 
         // single with parens
-        assertTrue(ChannelTransformation.isTransform("FOO(BAR())"));
-        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR) )")); // deliberate extra closing parens
+        assertTrue(ChannelTransformation.isValidTransformation("FOO(BAR())"));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO ( BAR) )")); // deliberate extra closing parens
 
         // chained with colon
-        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ:QUX"));
-        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ:QUX()"));
-        assertTrue(ChannelTransformation.isTransform(" FOO : BAR ∩ BAZ : QUX() "));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO:BAR∩BAZ:QUX"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO:BAR∩BAZ:QUX()"));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO : BAR ∩ BAZ : QUX() "));
 
         // chained with parens
-        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX)"));
-        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX())"));
-        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX))")); // deliberate extra closing parens
-        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ ( QUX )"));
-        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ ( QUX() )"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO(BAR)∩BAZ(QUX)"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO(BAR)∩BAZ(QUX())"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO(BAR)∩BAZ(QUX))")); // deliberate extra parens
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO ( BAR ) ∩ BAZ ( QUX )"));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO ( BAR ) ∩ BAZ ( QUX() )"));
 
         // mixed chains
-        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ(QUX)"));
-        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ:QUX"));
-        assertTrue(ChannelTransformation.isTransform("FOO:BAR()∩BAZ(QUX())"));
-        assertTrue(ChannelTransformation.isTransform(" FOO : BAR ∩ BAZ ( QUX ) "));
-        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ : QUX "));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO:BAR∩BAZ(QUX)"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO(BAR)∩BAZ:QUX"));
+        assertTrue(ChannelTransformation.isValidTransformation("FOO:BAR()∩BAZ(QUX())"));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO : BAR ∩ BAZ ( QUX ) "));
+        assertTrue(ChannelTransformation.isValidTransformation(" FOO ( BAR ) ∩ BAZ : QUX "));
 
         // invalid syntaxes
-        assertFalse(ChannelTransformation.isTransform(null));
-        assertFalse(ChannelTransformation.isTransform(""));
-        assertFalse(ChannelTransformation.isTransform(" "));
-        assertFalse(ChannelTransformation.isTransform("FOOBAR"));
-        assertFalse(ChannelTransformation.isTransform("(FOO)BAR"));
-        assertFalse(ChannelTransformation.isTransform("FOO∩BAR"));
-        assertFalse(ChannelTransformation.isTransform("FOO:BAR∩BAZ"));
-        assertFalse(ChannelTransformation.isTransform("FOO(BAR)∩BAZ"));
-        assertFalse(ChannelTransformation.isTransform("FOO∩BAZ:BAR"));
-        assertFalse(ChannelTransformation.isTransform("FOO∩BAZ(BAR)"));
+        assertFalse(ChannelTransformation.isValidTransformation(null));
+        assertFalse(ChannelTransformation.isValidTransformation(""));
+        assertFalse(ChannelTransformation.isValidTransformation(" "));
+        assertFalse(ChannelTransformation.isValidTransformation("FOOBAR"));
+        assertFalse(ChannelTransformation.isValidTransformation("(FOO)BAR"));
+        assertFalse(ChannelTransformation.isValidTransformation("FOO∩BAR"));
+        assertFalse(ChannelTransformation.isValidTransformation("FOO:BAR∩BAZ"));
+        assertFalse(ChannelTransformation.isValidTransformation("FOO(BAR)∩BAZ"));
+        assertFalse(ChannelTransformation.isValidTransformation("FOO∩BAZ:BAR"));
+        assertFalse(ChannelTransformation.isValidTransformation("FOO∩BAZ(BAR)"));
     }
 }

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
@@ -13,7 +13,9 @@
 package org.openhab.core.thing.binding.generic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -265,5 +267,47 @@ public class ChannelTransformationTest {
         String result = transformation.apply(T1_INPUT).orElse(null);
 
         assertEquals(T2_RESULT, result);
+    }
+
+    @Test
+    public void testIsTransform() {
+        // single with colon
+        assertTrue(ChannelTransformation.isTransform("FOO:BAR"));
+        assertTrue(ChannelTransformation.isTransform(" FOO : BAR "));
+
+        // single with parens
+        assertTrue(ChannelTransformation.isTransform("FOO(BAR())"));
+        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR) )")); // deliberate extra closing parens
+
+        // chained with colon
+        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ:QUX"));
+        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ:QUX()"));
+        assertTrue(ChannelTransformation.isTransform(" FOO : BAR ∩ BAZ : QUX() "));
+
+        // chained with parens
+        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX)"));
+        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX())"));
+        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ(QUX))")); // deliberate extra closing parens
+        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ ( QUX )"));
+        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ ( QUX() )"));
+
+        // mixed chains
+        assertTrue(ChannelTransformation.isTransform("FOO:BAR∩BAZ(QUX)"));
+        assertTrue(ChannelTransformation.isTransform("FOO(BAR)∩BAZ:QUX"));
+        assertTrue(ChannelTransformation.isTransform("FOO:BAR()∩BAZ(QUX())"));
+        assertTrue(ChannelTransformation.isTransform(" FOO : BAR ∩ BAZ ( QUX ) "));
+        assertTrue(ChannelTransformation.isTransform(" FOO ( BAR ) ∩ BAZ : QUX "));
+
+        // invalid syntaxes
+        assertFalse(ChannelTransformation.isTransform(null));
+        assertFalse(ChannelTransformation.isTransform(""));
+        assertFalse(ChannelTransformation.isTransform(" "));
+        assertFalse(ChannelTransformation.isTransform("FOOBAR"));
+        assertFalse(ChannelTransformation.isTransform("(FOO)BAR"));
+        assertFalse(ChannelTransformation.isTransform("FOO∩BAR"));
+        assertFalse(ChannelTransformation.isTransform("FOO:BAR∩BAZ"));
+        assertFalse(ChannelTransformation.isTransform("FOO(BAR)∩BAZ"));
+        assertFalse(ChannelTransformation.isTransform("FOO∩BAZ:BAR"));
+        assertFalse(ChannelTransformation.isTransform("FOO∩BAZ(BAR)"));
     }
 }


### PR DESCRIPTION
This is needed by the user of this class, e.g. mqtt binding, to know whether to convert the command to `StringType` when transformations were involved, or continue using the native type.

Example use cases

https://github.com/openhab/openhab-addons/blob/0d6feb72aa23dcfce946e1367ea0ce8b8c03b330/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java#L136

https://github.com/openhab/openhab-addons/blob/0d6feb72aa23dcfce946e1367ea0ce8b8c03b330/bundles/org.openhab.binding.mqtt.generic/src/main/java/org/openhab/binding/mqtt/generic/ChannelState.java#L340


`isTransform()` is needed by the [modbus addon](https://github.com/openhab/openhab-addons/pull/17306)