### PR TITLE
Filter out blank lines and comments in a multi-line transformations

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -56,8 +56,13 @@ public class ChannelTransformation {
     public ChannelTransformation(@Nullable List<String> transformationStrings) {
         if (transformationStrings != null) {
             try {
-                transformationSteps = transformationStrings.stream()
-                        .flatMap(ChannelTransformation::splitTransformationString).map(TransformationStep::new)
+                transformationSteps = transformationStrings.stream() //
+                        .map(String::trim) //
+                        .filter(line -> !line.isBlank()) //
+                        .filter(line -> !line.startsWith("#")) //
+                        .filter(line -> !line.startsWith("//")) //
+                        .flatMap(ChannelTransformation::splitTransformationString) //
+                        .map(TransformationStep::new) //
                         .toList();
                 return;
             } catch (IllegalArgumentException e) {

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
@@ -349,4 +349,15 @@ public class ChannelTransformationTest {
         assertFalse(ChannelTransformation.isValidTransformation("FOO∩BAZ:BAR"));
         assertFalse(ChannelTransformation.isValidTransformation("FOO∩BAZ(BAR)"));
     }
+
+    @Test
+    public void testBlanksAndCommentsAreDiscarded() {
+        List<String> pattern = List.of("#hash comment", "//double slashes", "  # preceded by spaces",
+                "  // ditto for slashes", "     ", "\t", "\t\t\t", "\t# preceded by a tab",
+                "\t // preceded by tab and space");
+
+        ChannelTransformation transformation = new ChannelTransformation(pattern);
+
+        assertTrue(transformation.isEmpty());
+    }
 }


### PR DESCRIPTION
This allows users to insert comments inbetween transformations in a multi-line / chained (or even a single transformation).

e.g.

```
# Extract value only if it's two digits of more
REGEX(\d{2,})
```