### PR TITLE
Add missing ScriptProfile parameter options

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -242,7 +242,9 @@ public class ScriptTransformationService implements TransformationService, Confi
             return null;
         }
 
-        if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param) || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)) {
+        if (ScriptProfile.CONFIG_TO_HANDLER_SCRIPT.equals(param) || ScriptProfile.CONFIG_TO_ITEM_SCRIPT.equals(param)
+                || ScriptProfile.CONFIG_COMMAND_FROM_ITEM_SCRIPT.equals(param)
+                || ScriptProfile.CONFIG_STATE_FROM_ITEM_SCRIPT.equals(param)) {
             return transformationRegistry.getTransformations(List.of(scriptType.toLowerCase())).stream()
                     .map(c -> new ParameterOption(c.getUID(), c.getLabel())).toList();
         }


### PR DESCRIPTION
for commandFromItemScript and stateFromItemScript
See https://github.com/openhab/openhab-core/pull/4058

This could perhaps be cherry picked to 4.2.x