### PR TITLE
Persistence aliases

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;
@@ -58,6 +58,7 @@ import org.openhab.core.types.UnDefType;
  * Tests for PersistenceItem Restresource
  *
  * @author Stefan Triller - Initial contribution
+ * @author Mark Herwege - Implement aliases
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -112,7 +113,7 @@ public class PersistenceResourceTest {
             });
         }
 
-        when(pServiceMock.query(any())).thenReturn(items);
+        when(pServiceMock.query(any(), any())).thenReturn(items);
 
         when(persistenceServiceRegistryMock.get(PERSISTENCE_SERVICE_ID)).thenReturn(pServiceMock);
         when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.systemDefault());

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -11,6 +11,7 @@ PersistenceModel:
 	'}'
 	('Filters' '{' filters+=Filter* '}')?
 	('Items' '{' configs+=PersistenceConfiguration* '}')?
+	('Aliases' '{' aliases+=AliasConfiguration* '}')?
 ;
 
 Strategy:
@@ -57,7 +58,7 @@ NotIncludeFilter:
 
 PersistenceConfiguration:
 	items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig)
-	   (',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* ('->' alias=STRING)? 
+	   (',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* 
 	((':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)? 
 		 ('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
 		| ';')
@@ -82,6 +83,10 @@ ItemExcludeConfig:
 
 GroupExcludeConfig:
     '!' groupExclude=ID '*'
+;
+
+AliasConfiguration:
+    item=ID '->' alias=(ID|STRING)
 ;
 
 DECIMAL returns ecore::EBigDecimal :

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.persistence.internal;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import org.openhab.core.common.registry.AbstractProvider;
 import org.openhab.core.model.core.EventType;
 import org.openhab.core.model.core.ModelRepository;
 import org.openhab.core.model.core.ModelRepositoryChangeListener;
+import org.openhab.core.model.persistence.persistence.AliasConfiguration;
 import org.openhab.core.model.persistence.persistence.AllConfig;
 import org.openhab.core.model.persistence.persistence.CronStrategy;
 import org.openhab.core.model.persistence.persistence.EqualsFilter;
@@ -71,6 +73,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  * @author Markus Rathgeb - Move non-model logic to core.persistence
  * @author Jan N. Klug - Refactored to {@link PersistenceServiceConfigurationProvider}
+ * @author Mark Herwege - Separate alias handling
  */
 @Component(immediate = true, service = PersistenceServiceConfigurationProvider.class)
 @NonNullByDefault
@@ -112,8 +115,9 @@ public class PersistenceModelManager extends AbstractProvider<PersistenceService
 
                 if (model != null) {
                     PersistenceServiceConfiguration newConfiguration = new PersistenceServiceConfiguration(serviceName,
-                            mapConfigs(model.getConfigs()), mapStrategies(model.getDefaults()),
-                            mapStrategies(model.getStrategies()), mapFilters(model.getFilters()));
+                            mapConfigs(model.getConfigs()), mapAliases(model.getAliases()),
+                            mapStrategies(model.getDefaults()), mapStrategies(model.getStrategies()),
+                            mapFilters(model.getFilters()));
                     PersistenceServiceConfiguration oldConfiguration = configurations.put(serviceName,
                             newConfiguration);
                     if (oldConfiguration == null) {
@@ -167,8 +171,16 @@ public class PersistenceModelManager extends AbstractProvider<PersistenceService
                 items.add(new PersistenceItemExcludeConfig(itemExcludeConfig.getItemExclude()));
             }
         }
-        return new PersistenceItemConfiguration(items, config.getAlias(), mapStrategies(config.getStrategies()),
+        return new PersistenceItemConfiguration(items, mapStrategies(config.getStrategies()),
                 mapFilters(config.getFilters()));
+    }
+
+    private Map<String, String> mapAliases(List<AliasConfiguration> aliases) {
+        final Map<String, String> map = new HashMap<>();
+        for (final AliasConfiguration alias : aliases) {
+            map.put(alias.getItem(), alias.getAlias());
+        }
+        return map;
     }
 
     private List<PersistenceStrategy> mapStrategies(List<Strategy> strategies) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
@@ -35,8 +35,8 @@ import org.openhab.core.types.State;
  * a filter.
  *
  * @author Kai Kreuzer - Initial contribution
- * @author Lyubomir Papazov - Deprecate methods using java.util and add methods
- *         that use Java8's ZonedDateTime
+ * @author Lyubomir Papazov - Deprecate methods using java.util and add methods that use Java8's ZonedDateTime
+ * @author Mark Herwege - Copy constructor
  */
 @NonNullByDefault
 public class FilterCriteria {
@@ -90,6 +90,20 @@ public class FilterCriteria {
 
     /** Filter result to only contain entries that evaluate to true with the given operator and state */
     private @Nullable State state;
+
+    public FilterCriteria() {
+    }
+
+    public FilterCriteria(FilterCriteria filter) {
+        this.itemName = filter.itemName;
+        this.beginDate = filter.beginDate;
+        this.endDate = filter.endDate;
+        this.pageNumber = filter.pageNumber;
+        this.pageSize = filter.pageSize;
+        this.operator = filter.operator;
+        this.ordering = filter.ordering;
+        this.state = filter.state;
+    }
 
     public @Nullable String getItemName() {
         return itemName;

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
@@ -25,6 +25,7 @@ import org.openhab.core.types.State;
  * and then periodically provide it to the server to be accommodated.
  *
  * @author Chris Jackson - Initial contribution
+ * @author Mark Herwege - Implement aliases
  */
 @NonNullByDefault
 public interface ModifiablePersistenceService extends QueryablePersistenceService {
@@ -70,10 +71,35 @@ public interface ModifiablePersistenceService extends QueryablePersistenceServic
      * Removes data associated with an item from a persistence service.
      * If all data is removed for the specified item, the persistence service should free any resources associated with
      * the item (e.g. remove any tables or delete files from the storage).
+     * If the persistence service implementing this method supports aliases for item names, the default implementation
+     * of {@link #remove(FilterCriteria, String)} should be overriden as well.
      *
      * @param filter the filter to apply to the data removal. ItemName can not be null.
      * @return true if the query executed successfully
      * @throws IllegalArgumentException if item name is null.
      */
     boolean remove(FilterCriteria filter) throws IllegalArgumentException;
+
+    /**
+     * Removes data associated with an item from a persistence service.
+     * If all data is removed for the specified item, the persistence service should free any resources associated with
+     * the item (e.g. remove any tables or delete files from the storage).
+     * Persistence services supporting aliases, and relying on lookups in the item registry, should override the default
+     * implementation from this interface.
+     *
+     * @param filter the filter to apply to the data removal. ItemName can not be null.
+     * @param alias for item name in database
+     * @return true if the query executed successfully
+     * @throws IllegalArgumentException if item name is null.
+     */
+    default boolean remove(FilterCriteria filter, @Nullable String alias) throws IllegalArgumentException {
+        // Default implementation changes the filter to have the alias as itemName.
+        // This gives correct results as long as the persistence service does not rely on a lookup in the item registry
+        // (in which case the item will not be found).
+        if (alias != null) {
+            FilterCriteria aliasFilter = new FilterCriteria(filter).setItemName(alias);
+            return remove(aliasFilter);
+        }
+        return remove(filter);
+    }
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemConfiguration.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemConfiguration.java
@@ -25,15 +25,15 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  * This class holds the configuration of a persistence strategy for specific items.
  *
  * @author Markus Rathgeb - Initial contribution
+ * @author Mark Herwege - Extract alias configuration
  */
 @NonNullByDefault
-public record PersistenceItemConfiguration(List<PersistenceConfig> items, @Nullable String alias,
-        List<PersistenceStrategy> strategies, List<PersistenceFilter> filters) {
+public record PersistenceItemConfiguration(List<PersistenceConfig> items, List<PersistenceStrategy> strategies,
+        List<PersistenceFilter> filters) {
 
-    public PersistenceItemConfiguration(final List<PersistenceConfig> items, @Nullable final String alias,
+    public PersistenceItemConfiguration(final List<PersistenceConfig> items,
             @Nullable final List<PersistenceStrategy> strategies, @Nullable final List<PersistenceFilter> filters) {
         this.items = items;
-        this.alias = alias;
         this.strategies = Objects.requireNonNullElse(strategies, List.of());
         this.filters = Objects.requireNonNullElse(filters, List.of());
     }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
@@ -39,7 +39,7 @@ public interface QueryablePersistenceService extends PersistenceService {
     /**
      * Queries the {@link PersistenceService} for historic data with a given {@link FilterCriteria}.
      * If the persistence service implementing this class supports using aliases for item names, the default
-     * implementation of {@link #query(FilterCriteria, String)} should be overriden as well.
+     * implementation of {@link #query(FilterCriteria, String)} should be overridden as well.
      *
      * @param filter the filter to apply to the query
      * @return a time series of items
@@ -49,7 +49,7 @@ public interface QueryablePersistenceService extends PersistenceService {
     /**
      * Queries the {@link PersistenceService} for historic data with a given {@link FilterCriteria}.
      * If the persistence service implementing this interface supports aliases and relies on item registry lookups, the
-     * default implementation should be overriden to query the database with the aliased name.
+     * default implementation should be overridden to query the database with the aliased name.
      *
      * @param filter the filter to apply to the query
      * @param alias for item name in database
@@ -105,17 +105,21 @@ public interface QueryablePersistenceService extends PersistenceService {
      * persisted state. Persistence services can override this default implementation with a more specific or efficient
      * algorithm.
      *
+     * @param itemName name of item
+     * @param alias alias of item
+     *
      * @return a {@link PersistedItem} or null if the item has not been persisted
      */
-    default @Nullable PersistedItem persistedItem(String itemName) {
+    default @Nullable PersistedItem persistedItem(String itemName, @Nullable String alias) {
         State currentState = UnDefType.NULL;
         State previousState = null;
         ZonedDateTime lastUpdate = null;
         ZonedDateTime lastChange = null;
 
         int pageNumber = 0;
-        FilterCriteria filter = new FilterCriteria().setItemName(itemName).setEndDate(ZonedDateTime.now())
-                .setOrdering(Ordering.DESCENDING).setPageSize(1000).setPageNumber(pageNumber);
+        FilterCriteria filter = new FilterCriteria().setItemName(alias != null ? alias : itemName)
+                .setEndDate(ZonedDateTime.now()).setOrdering(Ordering.DESCENDING).setPageSize(1000)
+                .setPageNumber(pageNumber);
         Iterable<HistoricItem> items = query(filter);
         while (items != null) {
             Iterator<HistoricItem> it = items.iterator();

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
@@ -117,10 +117,9 @@ public interface QueryablePersistenceService extends PersistenceService {
         ZonedDateTime lastChange = null;
 
         int pageNumber = 0;
-        FilterCriteria filter = new FilterCriteria().setItemName(alias != null ? alias : itemName)
-                .setEndDate(ZonedDateTime.now()).setOrdering(Ordering.DESCENDING).setPageSize(1000)
-                .setPageNumber(pageNumber);
-        Iterable<HistoricItem> items = query(filter);
+        FilterCriteria filter = new FilterCriteria().setItemName(itemName).setEndDate(ZonedDateTime.now())
+                .setOrdering(Ordering.DESCENDING).setPageSize(1000).setPageNumber(pageNumber);
+        Iterable<HistoricItem> items = query(filter, alias);
         while (items != null) {
             Iterator<HistoricItem> it = items.iterator();
             int itemCount = 0;

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
@@ -15,6 +15,8 @@ package org.openhab.core.persistence;
 import java.time.ZonedDateTime;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -29,12 +31,15 @@ import org.openhab.core.types.UnDefType;
  * @author Kai Kreuzer - Initial contribution
  * @author Chris Jackson - Added getItems method
  * @author Mark Herwege - Added methods to retrieve lastUpdate, lastChange and lastState from persistence
+ * @author Mark Herwege - Implement aliases
  */
 @NonNullByDefault
 public interface QueryablePersistenceService extends PersistenceService {
 
     /**
      * Queries the {@link PersistenceService} for historic data with a given {@link FilterCriteria}.
+     * If the persistence service implementing this class supports using aliases for item names, the default
+     * implementation of {@link #query(FilterCriteria, String)} should be overriden as well.
      *
      * @param filter the filter to apply to the query
      * @return a time series of items
@@ -42,10 +47,52 @@ public interface QueryablePersistenceService extends PersistenceService {
     Iterable<HistoricItem> query(FilterCriteria filter);
 
     /**
+     * Queries the {@link PersistenceService} for historic data with a given {@link FilterCriteria}.
+     * If the persistence service implementing this interface supports aliases and relies on item registry lookups, the
+     * default implementation should be overriden to query the database with the aliased name.
+     *
+     * @param filter the filter to apply to the query
+     * @param alias for item name in database
+     * @return a time series of items
+     */
+    default Iterable<HistoricItem> query(FilterCriteria filter, @Nullable String alias) {
+        // Default implementation changes the filter to have the alias as itemName and sets it back in the returned
+        // result.
+        // This gives correct results as long as the persistence service does not rely on a lookup in the item registry
+        // (in which case the item will not be found).
+        String itemName = filter.getItemName();
+        if (itemName != null && alias != null) {
+            FilterCriteria aliasFilter = new FilterCriteria(filter).setItemName(alias);
+            return StreamSupport.stream(query(aliasFilter).spliterator(), false).map(hi -> new HistoricItem() {
+
+                @Override
+                public ZonedDateTime getTimestamp() {
+                    return hi.getTimestamp();
+                }
+
+                @Override
+                public State getState() {
+                    return hi.getState();
+                }
+
+                @Override
+                public String getName() {
+                    return itemName;
+                }
+            }).collect(Collectors.toList());
+        }
+        return query(filter);
+    }
+
+    /**
      * Returns a set of {@link PersistenceItemInfo} about items that are stored in the persistence service. This allows
      * the persistence service to return information about items that are no long available as an
-     * {@link org.openhab.core.items.Item} in
-     * openHAB. If it is not possible to retrieve the information an empty set should be returned.
+     * {@link org.openhab.core.items.Item} in openHAB. If it is not possible to retrieve the information an empty set
+     * should be returned.
+     *
+     * Note that implementations for method callers that this method may return an alias for an existing item if the
+     * database does not store the mapping between item name and alias or the reverse mapping is not implemented in the
+     * persistence service.
      *
      * @return a set of information about the persisted items
      */

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceItemConfigurationDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceItemConfigurationDTO.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * The {@link org.openhab.core.persistence.dto.PersistenceItemConfigurationDTO} is used for transferring persistence
@@ -29,5 +28,4 @@ public class PersistenceItemConfigurationDTO {
     public Collection<String> items = List.of();
     public Collection<String> strategies = List.of();
     public Collection<String> filters = List.of();
-    public @Nullable String alias;
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
@@ -14,6 +14,7 @@ package org.openhab.core.persistence.dto;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
@@ -26,6 +27,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 public class PersistenceServiceConfigurationDTO {
     public String serviceId = "";
     public Collection<PersistenceItemConfigurationDTO> configs = List.of();
+    public Map<String, String> aliases = Map.of();
     public Collection<String> defaults = List.of();
     public Collection<PersistenceCronStrategyDTO> cronStrategies = List.of();
     public Collection<PersistenceFilterDTO> thresholdFilters = List.of();

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -564,14 +564,9 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                     .onException(e -> logger.error(
                             "Exception occurred while querying persistence service '{}' to restore '{}': {}",
                             queryService.getId(), item.getName(), e.getMessage(), e))
-<<<<<<< Upstream, based on origin/main
-                    .build().persistedItem(item.getName());
+                    .build().persistedItem(item.getName(), alias);
             if (persistedItem == null) {
-=======
-                    .build().query(filter, alias);
-            if (result == null) {
                 // in case of an exception or timeout, the safe caller returns null
->>>>>>> 80a9bbc persistence aliases
                 return;
             }
             GenericItem genericItem = (GenericItem) item;

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -188,7 +188,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                         .filter(itemConfig -> itemConfig.filters().stream().allMatch(filter -> filter.apply(item)))
                         .forEach(itemConfig -> {
                             itemConfig.filters().forEach(filter -> filter.persisted(item));
-                            container.getPersistenceService().store(item, itemConfig.alias());
+                            container.getPersistenceService().store(item, container.getAlias(item));
                         }));
     }
 
@@ -353,7 +353,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                                 ZonedDateTime end = timeSeries.getEnd().atZone(ZoneId.systemDefault());
                                 FilterCriteria removeFilter = new FilterCriteria().setItemName(item.getName())
                                         .setBeginDate(begin).setEndDate(end);
-                                service.remove(removeFilter);
+                                service.remove(removeFilter, container.getAlias(item));
                                 ScheduledCompletableFuture<?> forecastJob = container.forecastJobs.get(item.getName());
                                 if (forecastJob != null && forecastJob.getScheduledTime().isAfter(begin)
                                         && forecastJob.getScheduledTime().isBefore(end)) {
@@ -478,12 +478,17 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
             }).stream());
         }
 
+        public @Nullable String getAlias(Item item) {
+            return configuration.getAliases().get(item.getName());
+        }
+
         private PersistenceServiceConfiguration getDefaultConfig() {
             List<PersistenceStrategy> strategies = persistenceService.getDefaultStrategies();
             List<PersistenceItemConfiguration> configs = List
-                    .of(new PersistenceItemConfiguration(List.of(new PersistenceAllConfig()), null, strategies, null));
-            return new PersistenceServiceConfiguration(persistenceService.getId(), configs, strategies, strategies,
-                    List.of());
+                    .of(new PersistenceItemConfiguration(List.of(new PersistenceAllConfig()), strategies, null));
+            Map<String, String> aliases = Map.of();
+            return new PersistenceServiceConfiguration(persistenceService.getId(), configs, aliases, strategies,
+                    strategies, List.of());
         }
 
         /**
@@ -550,6 +555,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
 
         private void restoreItemStateIfPossible(Item item) {
             QueryablePersistenceService queryService = (QueryablePersistenceService) persistenceService;
+            String alias = getAlias(item);
 
             PersistedItem persistedItem = safeCaller.create(queryService, QueryablePersistenceService.class)
                     .onTimeout(
@@ -558,8 +564,14 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                     .onException(e -> logger.error(
                             "Exception occurred while querying persistence service '{}' to restore '{}': {}",
                             queryService.getId(), item.getName(), e.getMessage(), e))
+<<<<<<< Upstream, based on origin/main
                     .build().persistedItem(item.getName());
             if (persistedItem == null) {
+=======
+                    .build().query(filter, alias);
+            if (result == null) {
+                // in case of an exception or timeout, the safe caller returns null
+>>>>>>> 80a9bbc persistence aliases
                 return;
             }
             GenericItem genericItem = (GenericItem) item;
@@ -590,6 +602,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         public void scheduleNextPersistedForecastForItem(String itemName) {
             Item item = itemRegistry.get(itemName);
             if (item instanceof GenericItem) {
+                String alias = getAlias(item);
                 QueryablePersistenceService queryService = (QueryablePersistenceService) persistenceService;
                 FilterCriteria filter = new FilterCriteria().setItemName(itemName).setBeginDate(ZonedDateTime.now())
                         .setOrdering(ASCENDING);
@@ -598,7 +611,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                                 queryService.getId(), SafeCaller.DEFAULT_TIMEOUT))
                         .onException(e -> logger.error("Exception occurred while querying persistence service '{}': {}",
                                 queryService.getId(), e.getMessage(), e))
-                        .build().query(filter).iterator();
+                        .build().query(filter, alias).iterator();
                 while (result.hasNext()) {
                     HistoricItem next = result.next();
                     Instant timestamp = next.getInstant();
@@ -624,7 +637,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                     if (itemConfig.filters().stream().allMatch(filter -> filter.apply(item))) {
                         long startTime = System.nanoTime();
                         itemConfig.filters().forEach(filter -> filter.persisted(item));
-                        persistenceService.store(item, itemConfig.alias());
+                        persistenceService.store(item, getAlias(item));
                         logger.trace("Storing item '{}' with persistence service '{}' took {}ms", item.getName(),
                                 configuration.getUID(), TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime));
                     }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
@@ -14,6 +14,7 @@ package org.openhab.core.persistence.registry;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.common.registry.Identifiable;
@@ -25,20 +26,23 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  * The {@link PersistenceServiceConfiguration} represents the configuration for a persistence service.
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Mark Herwege - Implement aliases
  */
 @NonNullByDefault
 public class PersistenceServiceConfiguration implements Identifiable<String> {
     private final String serviceId;
     private final List<PersistenceItemConfiguration> configs;
+    private final Map<String, String> aliases;
     private final List<PersistenceStrategy> defaults;
     private final List<PersistenceStrategy> strategies;
     private final List<PersistenceFilter> filters;
 
     public PersistenceServiceConfiguration(String serviceId, Collection<PersistenceItemConfiguration> configs,
-            Collection<PersistenceStrategy> defaults, Collection<PersistenceStrategy> strategies,
-            Collection<PersistenceFilter> filters) {
+            Map<String, String> aliases, Collection<PersistenceStrategy> defaults,
+            Collection<PersistenceStrategy> strategies, Collection<PersistenceFilter> filters) {
         this.serviceId = serviceId;
         this.configs = List.copyOf(configs);
+        this.aliases = Map.copyOf(aliases);
         this.defaults = List.copyOf(defaults);
         this.strategies = List.copyOf(strategies);
         this.filters = List.copyOf(filters);
@@ -56,6 +60,15 @@ public class PersistenceServiceConfiguration implements Identifiable<String> {
      */
     public List<PersistenceItemConfiguration> getConfigs() {
         return configs;
+    }
+
+    /**
+     * Get the item aliases.
+     *
+     * @return a map of items to aliases
+     */
+    public Map<String, String> getAliases() {
+        return aliases;
     }
 
     /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -46,6 +46,7 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  * The {@link PersistenceServiceConfigurationDTOMapper} is a utility class to map persistence configurations for storage
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Mark Herwege - Implement aliases
  */
 @NonNullByDefault
 public class PersistenceServiceConfigurationDTOMapper {
@@ -60,6 +61,7 @@ public class PersistenceServiceConfigurationDTOMapper {
         dto.serviceId = persistenceServiceConfiguration.getUID();
         dto.configs = persistenceServiceConfiguration.getConfigs().stream()
                 .map(PersistenceServiceConfigurationDTOMapper::mapPersistenceItemConfig).toList();
+        dto.aliases = Map.copyOf(persistenceServiceConfiguration.getAliases());
         dto.defaults = persistenceServiceConfiguration.getDefaults().stream().map(PersistenceStrategy::getName)
                 .toList();
         dto.cronStrategies = filterList(persistenceServiceConfiguration.getStrategies(), PersistenceCronStrategy.class,
@@ -100,10 +102,12 @@ public class PersistenceServiceConfigurationDTOMapper {
                     .map(str -> stringToPersistenceStrategy(str, strategyMap, dto.serviceId)).toList();
             List<PersistenceFilter> filters = config.filters.stream()
                     .map(str -> stringToPersistenceFilter(str, filterMap, dto.serviceId)).toList();
-            return new PersistenceItemConfiguration(items, config.alias, strategies, filters);
+            return new PersistenceItemConfiguration(items, strategies, filters);
         }).toList();
 
-        return new PersistenceServiceConfiguration(dto.serviceId, configs, defaults, strategyMap.values(),
+        Map<String, String> aliases = Map.copyOf(dto.aliases);
+
+        return new PersistenceServiceConfiguration(dto.serviceId, configs, aliases, defaults, strategyMap.values(),
                 filterMap.values());
     }
 
@@ -171,7 +175,6 @@ public class PersistenceServiceConfigurationDTOMapper {
                 .toList();
         itemDto.strategies = config.strategies().stream().map(PersistenceStrategy::getName).toList();
         itemDto.filters = config.filters().stream().map(PersistenceFilter::getName).toList();
-        itemDto.alias = config.alias();
         return itemDto;
     }
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.openhab.core.persistence.extensions.TestPersistenceService.*;
 
@@ -52,6 +53,7 @@ import org.openhab.core.library.unit.Units;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
+import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.types.State;
 
 /**
@@ -64,6 +66,7 @@ import org.openhab.core.types.State;
  * @author Mark Herwege - lastChange and nextChange methods
  * @author Mark Herwege - handle persisted GroupItem with QuantityType
  * @author Mark Herwege - add median methods
+ * @author Mark Herwege - Implement aliases
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -80,6 +83,8 @@ public class PersistenceExtensionsTest {
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
     private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
+
+    private @Mock @NonNullByDefault({}) PersistenceServiceConfigurationRegistry persistenceServiceConfigurationRegistryMock;
 
     private @NonNullByDefault({}) GenericItem numberItem, quantityItem, groupQuantityItem, switchItem;
 
@@ -109,6 +114,7 @@ public class PersistenceExtensionsTest {
         when(itemRegistryMock.get(TEST_SWITCH)).thenReturn(switchItem);
         when(itemRegistryMock.get(TEST_GROUP_QUANTITY_NUMBER)).thenReturn(groupQuantityItem);
 
+        when(persistenceServiceConfigurationRegistryMock.get(anyString())).thenReturn(null);
         when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.systemDefault());
 
         new PersistenceExtensions(new PersistenceServiceRegistry() {
@@ -135,7 +141,7 @@ public class PersistenceExtensionsTest {
             public @Nullable PersistenceService get(@Nullable String serviceId) {
                 return TestPersistenceService.SERVICE_ID.equals(serviceId) ? testPersistenceService : null;
             }
-        }, timeZoneProviderMock);
+        }, persistenceServiceConfigurationRegistryMock, timeZoneProviderMock);
     }
 
     @Test
@@ -3397,7 +3403,7 @@ public class PersistenceExtensionsTest {
             public @Nullable PersistenceService get(@Nullable String serviceId) {
                 return TestCachedValuesPersistenceService.ID.equals(serviceId) ? persistenceService : null;
             }
-        }, timeZoneProviderMock);
+        }, persistenceServiceConfigurationRegistryMock, timeZoneProviderMock);
 
         if (historicHours > 0) {
             ZonedDateTime beginHistory = now.minusHours(historicHours);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -86,6 +86,7 @@ import org.openhab.core.types.UnDefType;
  * The {@link PersistenceManagerTest} contains tests for the {@link PersistenceManagerImpl}
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Mark Herwege - Implement aliases
  */
 @NonNullByDefault
 @ExtendWith(MockitoExtension.class)
@@ -185,7 +186,7 @@ public class PersistenceManagerTest {
         when(itemRegistryMock.getItems()).thenReturn(List.of(TEST_ITEM, TEST_ITEM2, TEST_ITEM3, TEST_GROUP_ITEM));
         when(persistenceServiceMock.getId()).thenReturn(TEST_PERSISTENCE_SERVICE_ID);
         when(queryablePersistenceServiceMock.getId()).thenReturn(TEST_QUERYABLE_PERSISTENCE_SERVICE_ID);
-        when(queryablePersistenceServiceMock.query(any())).thenReturn(List.of(TEST_HISTORIC_ITEM));
+        when(queryablePersistenceServiceMock.query(any(), any())).thenReturn(List.of(TEST_HISTORIC_ITEM));
         when(queryablePersistenceServiceMock.persistedItem(any())).thenReturn(TEST_PERSISTED_ITEM);
         when(modifiablePersistenceServiceMock.getId()).thenReturn(TEST_MODIFIABLE_PERSISTENCE_SERVICE_ID);
 
@@ -367,7 +368,7 @@ public class PersistenceManagerTest {
         assertThat(TEST_GROUP_ITEM.getState(), is(TEST_STATE));
         assertThat(TEST_GROUP_ITEM.getLastState(), is(TEST_LAST_STATE));
 
-        verify(queryablePersistenceServiceMock, times(3)).persistedItem(any());
+        verify(queryablePersistenceServiceMock, times(3)).query(any(), any());
 
         ZonedDateTime lastStateUpdate = TEST_ITEM.getLastStateUpdate();
         assertNotNull(lastStateUpdate);
@@ -398,7 +399,7 @@ public class PersistenceManagerTest {
         assertThat(TEST_GROUP_ITEM.getState(), is(TEST_STATE));
         assertThat(TEST_GROUP_ITEM.getLastState(), is(TEST_LAST_STATE));
 
-        verify(queryablePersistenceServiceMock, times(2)).persistedItem(any());
+        verify(queryablePersistenceServiceMock, times(2)).query(any(), any());
 
         ZonedDateTime lastStateUpdate = TEST_ITEM.getLastStateUpdate();
         assertNotNull(lastStateUpdate);
@@ -578,7 +579,7 @@ public class PersistenceManagerTest {
             PersistenceStrategy strategy, @Nullable PersistenceFilter filter) {
         List<PersistenceFilter> filters = filter != null ? List.of(filter) : List.of();
 
-        PersistenceItemConfiguration itemConfiguration = new PersistenceItemConfiguration(itemConfigs, null,
+        PersistenceItemConfiguration itemConfiguration = new PersistenceItemConfiguration(itemConfigs,
                 List.of(strategy), filters);
 
         List<PersistenceStrategy> strategies = PersistenceStrategy.Globals.STRATEGIES.containsValue(strategy)
@@ -586,7 +587,7 @@ public class PersistenceManagerTest {
                 : List.of(strategy);
 
         PersistenceServiceConfiguration serviceConfiguration = new PersistenceServiceConfiguration(serviceId,
-                List.of(itemConfiguration), List.of(), strategies, filters);
+                List.of(itemConfiguration), Map.of(), List.of(), strategies, filters);
         manager.added(serviceConfiguration);
 
         return serviceConfiguration;

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -187,7 +187,7 @@ public class PersistenceManagerTest {
         when(persistenceServiceMock.getId()).thenReturn(TEST_PERSISTENCE_SERVICE_ID);
         when(queryablePersistenceServiceMock.getId()).thenReturn(TEST_QUERYABLE_PERSISTENCE_SERVICE_ID);
         when(queryablePersistenceServiceMock.query(any(), any())).thenReturn(List.of(TEST_HISTORIC_ITEM));
-        when(queryablePersistenceServiceMock.persistedItem(any())).thenReturn(TEST_PERSISTED_ITEM);
+        when(queryablePersistenceServiceMock.persistedItem(any(), any())).thenReturn(TEST_PERSISTED_ITEM);
         when(modifiablePersistenceServiceMock.getId()).thenReturn(TEST_MODIFIABLE_PERSISTENCE_SERVICE_ID);
 
         manager = new PersistenceManagerImpl(cronSchedulerMock, schedulerMock, itemRegistryMock, safeCallerMock,
@@ -368,7 +368,7 @@ public class PersistenceManagerTest {
         assertThat(TEST_GROUP_ITEM.getState(), is(TEST_STATE));
         assertThat(TEST_GROUP_ITEM.getLastState(), is(TEST_LAST_STATE));
 
-        verify(queryablePersistenceServiceMock, times(3)).query(any(), any());
+        verify(queryablePersistenceServiceMock, times(3)).persistedItem(any(), any());
 
         ZonedDateTime lastStateUpdate = TEST_ITEM.getLastStateUpdate();
         assertNotNull(lastStateUpdate);
@@ -399,7 +399,7 @@ public class PersistenceManagerTest {
         assertThat(TEST_GROUP_ITEM.getState(), is(TEST_STATE));
         assertThat(TEST_GROUP_ITEM.getLastState(), is(TEST_LAST_STATE));
 
-        verify(queryablePersistenceServiceMock, times(2)).query(any(), any());
+        verify(queryablePersistenceServiceMock, times(2)).persistedItem(any(), any());
 
         ZonedDateTime lastStateUpdate = TEST_ITEM.getLastStateUpdate();
         assertNotNull(lastStateUpdate);


### PR DESCRIPTION
See discussion https://github.com/openhab/openhab-core/issues/4359

At its current state, defining and using aliases for persistence is largely broken.

1. At the point of definining aliases, one can define an alias in the syntax for an item, item group or all items. There are several issues with this way of defining:
- The last two options obviously don't make sense.
- One has to define with all parameters (strategy, filters) for each item you want to define an alias for (otherwise the default will be used). It becomes impossible to use a group definition for the strategy and filters.
- It is not possible to define an alias for an item without a strategy (once you define it, the default strategy will be applied). This can be useful if an item is persisted manually through a rule, and not through a strategy.
2. There are methods to store items with aliases. However, on retrieval (`query`), it is assumed the `itemName` in the `FilterCriteria` is the alias. Many persistence services use this filter `itemName` to look up the item in the item registry (e.g. to find the unit). This does not work if an alias is passed in the filter criteria.

This PR does 2 things:
1. Redefine syntax to have a separate section to define aliases. This is a breaking change, but allows defining aliases in a proper and consistent way, and is easy enough to apply.
2. Add interface methods (with default implemention) `QueryablePersistenceService.query(FilterCriteria, String)` and `ModifiablePersistenceService.remove(FilterCriteria, String)`. The second argument defaults to `null` in its default implementation. Persistence services implementing support for aliases and using item registry lookups, should implement these new methods to make querying with aliases work. However, as there is a default implementation, if the persistence service is not changed, it will behave as it does now (failing if the persistence service tries to do a lookup in the item registry). All core calls to the `query` and `remove` methods are also changed to add the alias if one exists. I expect some classes in the ui repo (and maybe some scripting addons) will need limited changes as well to properly support aliases. (I have not done this, but the methods without alias could be annotated `@Deprecated` to make it clear to the consumer they should use the methods with alias arguments).

For 2, the better approach would probably be to make the individual persistence services completely independent of the item registry. The interface should then have `store`, `query` and `remove` methods that are only concerned about the storage key and values, whereby the storage key is the item name or alias. The core persistence layer would be responsible for using item name or alias when calling these methods, and then also for all actions currently done in the individual persistence services where the lookup in the item registry is required (e.g. unit lookup and conversion). Also ChartServlets would be impacted by this. As this is obviously a major API change, I have refrained from doing that. With the current proposal, the interaction with persistence services should keep on working as before, and persistence services that support aliases (that is a limited number) can easily be enhanced to properly support them (instead of the broken support in the current implementation without applying required changes).

Another option would be to completely remove support for aliases from openHAB core, and leave it to individual persistence services if they want to implement something, marking the `store` methods with `alias` parameters as deprecated. I also think that would be a step back and is not needed. But it may simplify code and, as it stands, I don't have the impression aliases are used a lot (if they where, I would expect to see many more issues being created as they don't work).

This PR is offered as a starting point and open for discussion. My design premises have been to try to fix it while not breaking the interface with persistence addons. I would very much appreciate feedback if this approach makes sense, and would be accepted before I invest further time in it.

@jpg0 FYI and evaluation.

EDIT: changed the default query method implementations to do an alias lookup, so the returned results are correct as long as the implementing persistence service does not do an item registry lookup. This again limits impact on persistence service implementations.
