### PR TITLE
Make DateTimeType Comparable

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -37,9 +37,10 @@ import org.openhab.core.types.State;
  * @author Wouter Born - increase parsing and formatting precision
  * @author Laurent Garnier - added methods toLocaleZone and toZone
  * @author Gaël L'hopital - added ability to use second and milliseconds unix time
+ * @author Jimmy Tanagra - implement Comparable
  */
 @NonNullByDefault
-public class DateTimeType implements PrimitiveType, State, Command {
+public class DateTimeType implements PrimitiveType, State, Command, Comparable<DateTimeType> {
 
     // external format patterns for output
     public static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
@@ -227,6 +228,11 @@ public class DateTimeType implements PrimitiveType, State, Command {
         }
         DateTimeType other = (DateTimeType) obj;
         return zonedDateTime.compareTo(other.zonedDateTime) == 0;
+    }
+
+    @Override
+    public int compareTo(DateTimeType o) {
+        return zonedDateTime.compareTo(o.getZonedDateTime());
     }
 
     private ZonedDateTime parse(String value) throws DateTimeParseException {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -249,6 +249,18 @@ public class DateTimeTypeTest {
     }
 
     @Test
+    public void comparabilityTest() {
+        ZonedDateTime zoned = ZonedDateTime.now();
+        DateTimeType dt1 = new DateTimeType(zoned);
+        DateTimeType dt2 = new DateTimeType(zoned.plusSeconds(1));
+        DateTimeType dt3 = new DateTimeType(zoned.minusSeconds(1));
+
+        assertTrue(dt1.compareTo(dt2) < 0);
+        assertTrue(dt1.compareTo(dt3) > 0);
+        assertTrue(dt1.compareTo(dt1) == 0);
+    }
+
+    @Test
     public void zonedParsingTest() {
         DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
         DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");


### PR DESCRIPTION
While working on the [State Profile PR](https://github.com/openhab/openhab-addons/pull/17323), I came across the issue that DateTimeType is not comparable. Making it comparable will enable inequality comparisons in the profile without having to resort to special handling for DateTimeType.

