### PR TITLE
Support space-separated date/time format for DateTimeType

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -88,7 +88,11 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
         try {
             // direct parsing (date and time)
             try {
-                date = parse(zonedValue);
+                if (DATE_PARSE_PATTERN_WITH_SPACE.matcher(zonedValue).matches()) {
+                    date = parse(zonedValue.substring(0, 10) + "T" + zonedValue.substring(11));
+                } else {
+                    date = parse(zonedValue);
+                }
             } catch (DateTimeParseException fullDtException) {
                 // time only
                 try {
@@ -250,17 +254,8 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
                 try {
                     date = ZonedDateTime.parse(value, PARSER_TZ);
                 } catch (DateTimeParseException tzException) {
-                    try {
-                        LocalDateTime localDateTime = LocalDateTime.parse(value, PARSER);
-                        date = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
-                    } catch (DateTimeParseException noTzException) {
-                        if (DATE_PARSE_PATTERN_WITH_SPACE.matcher(value).matches()) {
-                            value = value.substring(0, 10) + "T" + value.substring(11);
-                            date = parse(value);
-                        } else {
-                            throw noTzException;
-                        }
-                    }
+                    LocalDateTime localDateTime = LocalDateTime.parse(value, PARSER);
+                    date = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
                 }
             }
         }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @author Thomas Eichstaedt-Engelen - Initial contribution
@@ -258,6 +259,22 @@ public class DateTimeTypeTest {
         assertTrue(dt1.compareTo(dt2) < 0);
         assertTrue(dt1.compareTo(dt3) > 0);
         assertTrue(dt1.compareTo(dt1) == 0);
+    }
+
+    // This can only test explicit time zones, as we cannot mock the system default time zone
+    @ParameterizedTest
+    @ValueSource(strings = { //
+            "2024-09-05T15:30:00Z", //
+            "2024-09-05 15:30Z", //
+            "2024-09-05 16:30+0100", //
+            "2024-09-05T17:30:00.000+0200", //
+            "2024-09-05T17:30:00.000+02:00" //
+    })
+    public void parserTest(String input) {
+        ZonedDateTime zdtReference = ZonedDateTime.parse("2024-09-05T15:30:00Z");
+
+        ZonedDateTime zdt = new DateTimeType(input).getZonedDateTime().withZoneSameInstant(zdtReference.getZone());
+        assertThat(zdt, is(zdtReference));
     }
 
     @Test


### PR DESCRIPTION
Support `yyyy-MM-dd HH:mm`  syntax in addition to `yyyy-MM-ddTHH:mm`.

The syntax with space often appears in incoming data, e.g. mqtt. By supporting this, we won't need to run the input data through a transformation.