### PR TITLE
Insert context keys before compiling UI scripts

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -105,6 +105,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
             ScriptEngine scriptEngine = engine.get();
             if (scriptEngine instanceof Compilable) {
                 logger.debug("Pre-compiling script of rule with UID '{}'", ruleUID);
+                setExecutionContext(scriptEngine, Map.of()); // JRuby script engine needs this before compiling
                 compiledScript = Optional.ofNullable(((Compilable) scriptEngine).compile(script));
             }
         }
@@ -211,7 +212,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         try {
             if (compiledScript.isPresent()) {
                 logger.debug("Executing pre-compiled script of rule with UID '{}'", ruleUID);
-                return compiledScript.get().eval(engine.getContext());
+                return compiledScript.get().eval();
             }
             logger.debug("Executing script of rule with UID '{}'", ruleUID);
             return engine.eval(script);


### PR DESCRIPTION
Regression from #4289

This is needed, similar to #3464, except in this case, JRuby would throw an `ArrayIndexOutOfBounds` exception without this fix. This is possibly a bug in JRuby script engine, but this PR avoids encountering that problem.

The error was:

```
javax.script.ScriptException: java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at org.jruby.embed.jsr223.JRubyEngine.wrapException(JRubyEngine.java:263) ~[?:?]
	at org.jruby.embed.jsr223.JRubyEngine.doEval(JRubyEngine.java:104) ~[?:?]
	at org.jruby.embed.jsr223.JRubyCompiledScript.eval(JRubyCompiledScript.java:78) ~[?:?]
	at org.openhab.core.automation.module.script.internal.handler.AbstractScriptModuleHandler.eval(AbstractScriptModuleHandler.java:214) ~[?:?]
	at org.openhab.core.automation.module.script.internal.handler.ScriptActionHandler.lambda$0(ScriptActionHandler.java:80) ~[?:?]
	at java.util.Optional.ifPresent(Optional.java:178) [?:?]
	at org.openhab.core.automation.module.script.internal.handler.ScriptActionHandler.execute(ScriptActionHandler.java:78) [bundleFile:?]
	at org.openhab.core.automation.internal.RuleEngineImpl.executeActions(RuleEngineImpl.java:1299) [bundleFile:?]
	at org.openhab.core.automation.internal.RuleEngineImpl.runRule(RuleEngineImpl.java:1057) [bundleFile:?]
	at org.openhab.core.automation.internal.TriggerHandlerCallbackImpl$TriggerData.run(TriggerHandlerCallbackImpl.java:86) [bundleFile:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at org.jruby.runtime.scope.ManyVarsDynamicScope.setValueDepthZeroVoid(ManyVarsDynamicScope.java:190) ~[?:?]
	at org.jruby.runtime.scope.ManyVarsDynamicScope.setValueVoid(ManyVarsDynamicScope.java:181) ~[?:?]
	at org.jruby.runtime.DynamicScope.setValue(DynamicScope.java:337) ~[?:?]
	at org.jruby.embed.variable.VariableInterceptor.inject(VariableInterceptor.java:144) ~[?:?]
	at org.jruby.embed.internal.BiVariableMap.inject(BiVariableMap.java:380) ~[?:?]
	at org.jruby.embed.internal.EmbedEvalUnitImpl.run(EmbedEvalUnitImpl.java:111) ~[?:?]
	at org.jruby.embed.jsr223.JRubyEngine.doEval(JRubyEngine.java:99) ~[?:?]
	... 14 more
```

Note that line 215 is changed not because it fixes this problem, but because it's unnecessary to pass the engine context. 

```
return compiledScript.get().eval();
```

See https://docs.oracle.com/en/java/javase/17/docs/api/java.scripting/javax/script/CompiledScript.html#eval()

> The effect of calling this method is same as that of eval(getEngine().getContext()).