### PR TITLE
Revert "Insert context keys before compiling UI scripts (#4372)"

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -105,7 +105,6 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
             ScriptEngine scriptEngine = engine.get();
             if (scriptEngine instanceof Compilable) {
                 logger.debug("Pre-compiling script of rule with UID '{}'", ruleUID);
-                setExecutionContext(scriptEngine, Map.of()); // JRuby script engine needs this before compiling
                 compiledScript = Optional.ofNullable(((Compilable) scriptEngine).compile(script));
             }
         }
@@ -212,7 +211,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         try {
             if (compiledScript.isPresent()) {
                 logger.debug("Executing pre-compiled script of rule with UID '{}'", ruleUID);
-                return compiledScript.get().eval();
+                return compiledScript.get().eval(engine.getContext());
             }
             logger.debug("Executing script of rule with UID '{}'", ruleUID);
             return engine.eval(script);


### PR DESCRIPTION
This reverts #4372
commit 6e6f000800dec137e14763eaeb595a5fce67fe15.

See https://github.com/openhab/openhab-core/pull/4372#issuecomment-2339408866