### PR TITLE
Extend NetUtils for network range scanning

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -175,7 +175,13 @@ public class ScriptEngineManagerImpl implements ScriptEngineManager {
                 return true;
             } catch (Exception ex) {
                 logger.error("Error during evaluation of script '{}': {}", engineIdentifier, ex.getMessage());
-                logger.debug("", ex);
+                // Only call logger if debug level is actually enabled, because OPS4J Pax Logging holds (at least for
+                // some time) a reference to the exception and its cause, which may hold a reference to the script
+                // engine.
+                // This prevents garbage collection (at least for some time) to remove the script engine from heap.
+                if (logger.isDebugEnabled()) {
+                    logger.debug("", ex);
+                }
             }
         }
         return false;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -662,6 +662,7 @@ public class NetUtil implements NetworkAddressService {
      * 
      * @param address IPv4 address in byte array form (i.e. 127.0.0.1 = 01111111 00000000 00000000 00000001)
      * @param maskLength Network mask length (i.e. the number after the forward-slash, '/', in CIDR notation)
+     * @return A list of all possible IP addresses in byte array form
      */
     private static List<byte[]> getAddressesInSubnet(byte[] address, int maskLength) {
         byte[] lowestAddress = address.clone();

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -388,7 +388,7 @@ public class NetUtil implements NetworkAddressService {
     /**
      * Get the network address a specific ip address is in
      *
-     * @param ipAddressString ipv4 address of the device (i.e. 192.168.5.1)
+     * @param ipAddressString IPv4 address of the device (i.e. 192.168.5.1)
      * @param netMask netmask in bits (i.e. 24)
      * @return network a device is in (i.e. 192.168.5.0)
      * @throws IllegalArgumentException if parameters are wrong
@@ -424,7 +424,7 @@ public class NetUtil implements NetworkAddressService {
     /**
      * Get the network broadcast address of the subnet a specific ip address is in
      *
-     * @param ipAddressString ipv4 address of the device (i.e. 192.168.5.1)
+     * @param ipAddressString IPv4 address of the device (i.e. 192.168.5.1)
      * @param prefix network prefix in bits (i.e. 24)
      * @return network broadcast address of the network the device is in (i.e. 192.168.5.255)
      * @throws IllegalArgumentException if parameters are wrong
@@ -599,7 +599,7 @@ public class NetUtil implements NetworkAddressService {
     }
 
     /**
-     * For all network interfaces (except loopback) all Ipv4 addresses are returned.
+     * For all network interfaces (except loopback) all IPv4 addresses are returned.
      * This list can for example, be used to scan the network for available devices.
      * 
      * @return A full list of IP {@link InetAddress} (except network and broadcast)
@@ -616,15 +616,17 @@ public class NetUtil implements NetworkAddressService {
     }
 
     /**
-     * For the given {@link CidrAddress} all Ipv4 addresses are returned.
-     * This list can for example, be used to scan the network for available devices.
+     * For the given {@link CidrAddress} all IPv4 addresses are returned.
+     * This list can, for example, be used to scan the network for available devices.
      * 
      * @param iFaceAddress The {@link CidrAddress} of the network interface
-     * @param maxPrefixLength Control the prefix length of the network (e.g. 24 for class C)
+     * @param maxAllowedPrefixLength Control the maximum allowed prefix length of the network (e.g. 24 for class C).
+     *            iFaceAddress's with a larger prefix are ignored and return an empty result.
      * @return A full list of IP {@link InetAddress} (except network and broadcast)
      */
-    public static List<InetAddress> getAddressesRangeByCidrAddress(CidrAddress iFaceAddress, int maxPrefixLength) {
-        if (!(iFaceAddress.getAddress() instanceof Inet4Address) || iFaceAddress.getPrefix() < maxPrefixLength) {
+    public static List<InetAddress> getAddressesRangeByCidrAddress(CidrAddress iFaceAddress,
+            int maxAllowedPrefixLength) {
+        if (!(iFaceAddress.getAddress() instanceof Inet4Address) || iFaceAddress.getPrefix() < maxAllowedPrefixLength) {
             return List.of();
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -610,7 +610,7 @@ public class NetUtil implements NetworkAddressService {
                 .filter(a -> a.getAddress() instanceof Inet4Address).collect(Collectors.toList());
 
         for (CidrAddress i : ipV4InterfaceAddresses) {
-            addressesToScan.addAll(getAddressesRangeByCidrAddress(i, 24));
+            addressesToScan.addAll(getAddressesRangeByCidrAddress(i, i.getPrefix()));
         }
         return addressesToScan;
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -55,6 +56,7 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Triller - Converted to OSGi service with primary ipv4 conf
  * @author Gary Tse - Network address change listener
  * @author Tim Roberts - Added primary address change to network address change listener
+ * @author Leo Siepel - Added methods to imrpove support for network scanning
  */
 @Component(configurationPid = "org.openhab.network", property = { "service.pid=org.openhab.network",
         "service.config.description.uri=system:network", "service.config.label=Network Settings",
@@ -594,5 +596,117 @@ public class NetUtil implements NetworkAddressService {
         } else {
             return defaultValue;
         }
+    }
+
+    /**
+     * For all network interfaces (except loopback) all Ipv4 addresses are returned.
+     * This list can for example, be used to scan the network for available devices.
+     * 
+     * @return A full list of IP {@link InetAddress} (except network and broadcast)
+     */
+    public static List<InetAddress> getFullRangeOfAddressesToScan() {
+        List<InetAddress> addressesToScan = List.of();
+        List<CidrAddress> ipV4InterfaceAddresses = NetUtil.getAllInterfaceAddresses().stream()
+                .filter(a -> a.getAddress() instanceof Inet4Address).collect(Collectors.toList());
+
+        for (CidrAddress i : ipV4InterfaceAddresses) {
+            addressesToScan.addAll(getAddressesRangeByCidrAddress(i, 24));
+        }
+        return addressesToScan;
+    }
+
+    /**
+     * For the given {@link CidrAddress} all Ipv4 addresses are returned.
+     * This list can for example, be used to scan the network for available devices.
+     * 
+     * @param iFaceAddress The {@link CidrAddress} of the network interface
+     * @param maxPrefixLength Control the prefix length of the network (e.g. 24 for class C)
+     * @return A full list of IP {@link InetAddress} (except network and broadcast)
+     */
+    public static List<InetAddress> getAddressesRangeByCidrAddress(CidrAddress iFaceAddress, int maxPrefixLength) {
+        if (!(iFaceAddress.getAddress() instanceof Inet4Address) || iFaceAddress.getPrefix() < maxPrefixLength) {
+            return List.of();
+        }
+
+        List<byte[]> addresses = getAddressesInSubnet(iFaceAddress.getAddress().getAddress(), iFaceAddress.getPrefix(),
+                true);
+        if (addresses.size() > 2) {
+            addresses.remove(0); // remove network address
+            addresses.remove(addresses.size() - 1); // remove broadcast address
+        }
+
+        return addresses.stream().map(m -> {
+            try {
+                return InetAddress.getByAddress(m);
+            } catch (UnknownHostException e) {
+                return null;
+            }
+        }).filter(f -> f != null).sorted((a, b) -> {
+            byte[] aOct = a.getAddress();
+            byte[] bOct = b.getAddress();
+            int r = 0;
+            for (int i = 0; i < aOct.length && i < bOct.length; i++) {
+                r = Integer.compare(aOct[i] & 0xff, bOct[i] & 0xff);
+                if (r != 0) {
+                    return r;
+                }
+            }
+            return r;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Recursively calculate each IP address within a subnet
+     * 
+     * @param address IP address in byte array form (i.e. 127.0.0.1 = 01111111 00000000 00000000 00000001)
+     * @param maskLength Network mask length (i.e. the number after the forward-slash, '/', in CIDR notation)
+     * @param scrub Whether or not to scrub the unmasked bits of the address
+     * @return All possible IP addresses
+     * 
+     * @author: https://gist.github.com/ssttevee/b0e2b431f4b23d289537
+     */
+    private static List<byte[]> getAddressesInSubnet(byte[] address, int maskLength, boolean scrub) {
+        if (scrub) {
+            scrubAddress(address, maskLength);
+        }
+
+        if (maskLength >= address.length * 8) {
+            return Collections.singletonList(address);
+        }
+
+        List<byte[]> addresses = new ArrayList<byte[]>();
+
+        int set = maskLength / 8;
+        int pos = maskLength % 8;
+
+        byte[] addressLeft = address.clone();
+        addressLeft[set] |= 1 << pos;
+        addresses.addAll(getAddressesInSubnet(addressLeft, maskLength + 1, false));
+
+        byte[] addressRight = address.clone();
+        addressRight[set] &= ~(1 << pos);
+        addresses.addAll(getAddressesInSubnet(addressRight, maskLength + 1, false));
+
+        return addresses;
+    }
+
+    /**
+     * Set the unmasked bits of the IP address to 0
+     * 
+     * @param address IP address in byte array form (i.e. 127.0.0.1 = 01111111 00000000 00000000 00000001)
+     * @param maskLength Network mask length (i.e. the number after the forward-slash, '/', in CIDR notation)
+     * @return The scrubbed IP address
+     * 
+     * @author: https://gist.github.com/ssttevee/b0e2b431f4b23d289537
+     */
+    private static byte[] scrubAddress(byte[] address, int maskLength) {
+        for (int i = 0; i < address.length * 8; i++) {
+            if (i < maskLength)
+                continue;
+
+            address[i / 8] &= ~(1 << (i % 8));
+        }
+
+        return address;
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
@@ -123,7 +123,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void checkValidRangeCount() throws UnknownHostException {
+    public void checkValidRangeCountAndSort() throws UnknownHostException {
         InetAddress testableAddress = InetAddress.getByName("192.168.1.4");
         List<InetAddress> addresses = NetUtil
                 .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 24), 24);
@@ -134,7 +134,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void checkValidLargeRangeCount() throws UnknownHostException {
+    public void checkValidLargeRangeCountAndSort() throws UnknownHostException {
         InetAddress testableAddress = InetAddress.getByName("127.0.1.12");
         List<InetAddress> addresses = NetUtil
                 .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 16), 16);
@@ -145,7 +145,7 @@ public class NetUtilTest {
     }
 
     @Test
-    public void checkInvalidPrefixLength() throws UnknownHostException {
+    public void checkNotAllowedPrefixLength() throws UnknownHostException {
         InetAddress testableAddress = InetAddress.getByName("192.168.1.0");
         List<InetAddress> addresses = NetUtil
                 .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 16), 24);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
@@ -124,7 +124,7 @@ public class NetUtilTest {
 
     @Test
     public void checkValidRangeCount() throws UnknownHostException {
-        InetAddress testableAddress = InetAddress.getByName("192.168.1.0");
+        InetAddress testableAddress = InetAddress.getByName("192.168.1.4");
         List<InetAddress> addresses = NetUtil
                 .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 24), 24);
 
@@ -135,7 +135,7 @@ public class NetUtilTest {
 
     @Test
     public void checkValidLargeRangeCount() throws UnknownHostException {
-        InetAddress testableAddress = InetAddress.getByName("127.0.0.0");
+        InetAddress testableAddress = InetAddress.getByName("127.0.1.12");
         List<InetAddress> addresses = NetUtil
                 .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 16), 16);
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
@@ -14,6 +14,11 @@ package org.openhab.core.net;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;
@@ -115,5 +120,36 @@ public class NetUtilTest {
         } catch (IllegalArgumentException iae) {
             assertThat(iae.getMessage(), is("IP 'SOME_TEXT' is not a valid IPv4 address"));
         }
+    }
+
+    @Test
+    public void checkValidRangeCount() throws UnknownHostException {
+        InetAddress testableAddress = InetAddress.getByName("192.168.1.0");
+        List<InetAddress> addresses = NetUtil
+                .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 24), 24);
+
+        assertEquals(254, addresses.size());
+        assertEquals("192.168.1.1", addresses.get(0).getHostAddress());
+        assertEquals("192.168.1.254", addresses.get(253).getHostAddress());
+    }
+
+    @Test
+    public void checkValidLargeRangeCount() throws UnknownHostException {
+        InetAddress testableAddress = InetAddress.getByName("127.0.0.0");
+        List<InetAddress> addresses = NetUtil
+                .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 16), 16);
+
+        assertEquals(65534, addresses.size());
+        assertEquals("127.0.0.1", addresses.get(0).getHostAddress());
+        assertEquals("127.0.255.254", addresses.get(65533).getHostAddress());
+    }
+
+    @Test
+    public void checkInvalidPrefixLength() throws UnknownHostException {
+        InetAddress testableAddress = InetAddress.getByName("192.168.1.0");
+        List<InetAddress> addresses = NetUtil
+                .getAddressesRangeByCidrAddress(new CidrAddress(testableAddress, (short) 16), 24);
+
+        assertEquals(0, addresses.size());
     }
 }


### PR DESCRIPTION
Multiple bindings scan the network for devices by looping though all ip addresses. When trying to get rid of the apache libs, i also noticed the code is similar and it would be better to deduplicate this.

In future we can discuss if this scanning should be limited to the openHAB network setting or to all interfaces, but that is beyond the scope of this PR. Atleast we then have a central place to control that behaviour.

Reference: https://github.com/openhab/openhab-core/issues/3965