### PR TITLE
Extend HistoricItem to work with Instant instead of ZonedDateTime

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -449,7 +449,7 @@ public class PersistenceResource implements RESTResource {
         while (it.hasNext()) {
             HistoricItem historicItem = it.next();
             State state = historicItem.getState();
-            long timestamp = historicItem.getTimestamp().toInstant().toEpochMilli();
+            long timestamp = historicItem.getInstant().toEpochMilli();
 
             // For 'binary' states, we need to replicate the data
             // to avoid diagonal lines

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/HistoricItem.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/HistoricItem.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.persistence;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -37,6 +38,15 @@ public interface HistoricItem {
      * @return the timestamp of the item
      */
     ZonedDateTime getTimestamp();
+
+    /**
+     * returns the timestamp of the persisted item
+     *
+     * @return the timestamp of the item
+     */
+    default Instant getInstant() {
+        return getTimestamp().toInstant();
+    }
 
     /**
      * returns the current state of the item

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -577,8 +577,9 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                         .build().query(filter).iterator();
                 while (result.hasNext()) {
                     HistoricItem next = result.next();
-                    if (next.getTimestamp().isAfter(ZonedDateTime.now())) {
-                        scheduleNextForecastForItem(itemName, next.getTimestamp().toInstant(), next.getState());
+                    Instant timestamp = next.getInstant();
+                    if (timestamp.isAfter(Instant.now())) {
+                        scheduleNextForecastForItem(itemName, timestamp, next.getState());
                         break;
                     }
                 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -359,12 +359,12 @@ public class DefaultChartProvider implements ChartProvider {
             // For 'binary' states, we need to replicate the data
             // to avoid diagonal lines
             if (state instanceof OnOffType || state instanceof OpenClosedType) {
-                xData.add(Date.from(historicItem.getTimestamp().toInstant().minus(1, ChronoUnit.MILLIS)));
+                xData.add(Date.from(historicItem.getInstant().minus(1, ChronoUnit.MILLIS)));
                 yData.add(convertData(state));
             }
 
             state = historicItem.getState();
-            xData.add(Date.from(historicItem.getTimestamp().toInstant()));
+            xData.add(Date.from(historicItem.getInstant()));
             yData.add(convertData(state));
         }
 


### PR DESCRIPTION
This PR will add a new `default` method to the HistoricItem interface, to get the timestamp as `Instant`.
The most areas using the `HistoricItem` must transform the internal `Instant` to a `ZonedDateTime` (e.g. [all the persistence implementations](https://github.com/joerg1985/openhab-addons/commit/e400f7352cc8151db25304e33fce256c025b6e9f)) or need to transform the returned `ZonedDateTime` to an `Instant` (e.g. see the below).

So i my mind it does make sense to use a `Instant` here and not transform the data.
The link to the persistence implementations above does show the changes needed to the addons.

Signed-off-by: Jörg Sautter <joerg.sautter@gmx.net>
