### PR TITLE
Fix discovery input parameter not enabled if label/description provided

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -164,7 +164,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     @Override
     public boolean isScanInputSupported() {
-        return scanInputLabel != null && scanInputDescription != null;
+        return getScanInputLabel() != null && getScanInputDescription() != null;
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue from #4389.
For more details/explanation see https://github.com/openhab/openhab-core/pull/4389#discussion_r1781097842.