### PR TITLE
[rest] Persistence: Optionally add current Item state to response

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -13,6 +13,7 @@
 package org.openhab.core.io.rest.core.internal.persistence;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
@@ -165,6 +166,7 @@ public class PersistenceResourceTest {
 
         assertThat(Integer.parseInt(dto.datapoints), is(6));
         assertThat(dto.data, hasSize(6));
+        assertThat(dto.data.get(dto.data.size() - 1).state, is("0"));
     }
 
     @Test
@@ -176,6 +178,30 @@ public class PersistenceResourceTest {
 
         assertThat(Integer.parseInt(dto.datapoints), is(5));
         assertThat(dto.data, hasSize(5));
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithItemStateNull() throws ItemNotFoundException {
+        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+        when(itemMock.getState()).thenReturn(UnDefType.NULL);
+
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, false, true);
+
+        assertThat(Integer.parseInt(dto.datapoints), is(5));
+        assertThat(dto.data, hasSize(5));
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithBoundaryAndItemStateButNoItemStateRequired()
+            throws ItemNotFoundException {
+        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+        when(itemMock.getState()).thenReturn(DecimalType.ZERO);
+
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, true, true);
+
+        assertThat(Integer.parseInt(dto.datapoints), is(7));
+        assertThat(dto.data, hasSize(7));
+        assertThat(dto.data.get(dto.data.size() - 1).state, not("0"));
     }
 
     @Test

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -40,6 +40,7 @@ import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.ModifiablePersistenceService;
@@ -50,6 +51,7 @@ import org.openhab.core.persistence.internal.PersistenceManagerImpl;
 import org.openhab.core.persistence.registry.ManagedPersistenceServiceConfigurationProvider;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.types.State;
+import org.openhab.core.types.UnDefType;
 
 /**
  * Tests for PersistenceItem Restresource
@@ -74,6 +76,7 @@ public class PersistenceResourceTest {
     private @Mock @NonNullByDefault({}) PersistenceServiceConfigurationRegistry persistenceServiceConfigurationRegistryMock;
     private @Mock @NonNullByDefault({}) ManagedPersistenceServiceConfigurationProvider managedPersistenceServiceConfigurationProviderMock;
     private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
+    private @Mock @NonNullByDefault({}) Item itemMock;
 
     @BeforeEach
     public void beforeEach() {
@@ -116,7 +119,7 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemData() {
-        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, false);
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, false, false);
 
         assertThat(Integer.parseInt(dto.datapoints), is(5));
         assertThat(dto.data, hasSize(5));
@@ -147,10 +150,32 @@ public class PersistenceResourceTest {
 
     @Test
     public void testGetPersistenceItemDataWithBoundery() {
-        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, true);
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, true, false);
 
         assertThat(Integer.parseInt(dto.datapoints), is(7));
         assertThat(dto.data, hasSize(7));
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithItemState() throws ItemNotFoundException {
+        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+        when(itemMock.getState()).thenReturn(DecimalType.ZERO);
+
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, false, true);
+
+        assertThat(Integer.parseInt(dto.datapoints), is(6));
+        assertThat(dto.data, hasSize(6));
+    }
+
+    @Test
+    public void testGetPersistenceItemDataWithItemStateUndefined() throws ItemNotFoundException {
+        when(itemRegistryMock.getItem("testItem")).thenReturn(itemMock);
+        when(itemMock.getState()).thenReturn(UnDefType.UNDEF);
+
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 10, false, true);
+
+        assertThat(Integer.parseInt(dto.datapoints), is(5));
+        assertThat(dto.data, hasSize(5));
     }
 
     @Test

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
@@ -13,6 +13,7 @@
 package org.openhab.core.persistence.dto;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.openhab.core.library.types.DecimalType;
@@ -55,6 +56,13 @@ public class ItemHistoryDTO {
             newVal.state = state.toString();
         }
         data.add(newVal);
+    }
+
+    /**
+     * Sort the data history by time.
+     */
+    public void sortData() {
+        data.sort(Comparator.comparingLong(o -> o.time));
     }
 
     public static class HistoryDataBean {


### PR DESCRIPTION
This adds a new query param `itemState` to the GET `/rest/persistence/items/{itemname}` endpoint.

This new parameter allows to add the current Item state to the data returned from persistence, which is a huge improvement for charts in the UI:

- "normal" charts range until the end of the requested time range
- "aggregate" charts such as a monthly chart are able to display the values of the current month even if the monthly value is only persisted at the end of the month

There are two special cases where the Item state is not added with the current time to the response:

- If the `boundary` query param is also set to true and a state was already added to the requested end time, there is no need to include the current Item state as there already is a state at the end of the time range.
- If the current time is after the requested end time and no end state was added, add the current state as the end state.