### PR TITLE
Ensure timeseries entries have unique timestamps

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -358,8 +358,10 @@ public class ScriptProfileTest extends JavaTest {
 
     private TimeSeries createTimeSeries(State... states) {
         TimeSeries timeSeries = new TimeSeries(TimeSeries.Policy.ADD);
+        Instant instant = Instant.now();
         for (State state : states) {
-            timeSeries.add(Instant.now(), state);
+            timeSeries.add(instant, state);
+            instant = instant.plusMillis(100);
         }
         return timeSeries;
     }


### PR DESCRIPTION
In Windows, successive invocations of Instant.now() may return the same instant, thus not creating new TimeSeries entries

Regression introduced in #4365
Resolve #4391