### PR TITLE
Add ColorUtil.xyToDuv

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
@@ -539,24 +539,24 @@ public class ColorUtil {
      * Duv describes the distance of a color point from the black body curve. It's useful for calculating
      * if a color is near to "white", at any color temperature.
      * 
-     * @param xy array of double with CIE 1931 x,y[,Y] in the range 0.0000 to 1.0000 <code>Y</code> value is optional.
+     * @param xy array of double with CIE 1931 x,y in the range 0.0000 to 1.0000
      * @return the calculated Duv metric
      * @throws IllegalArgumentException when input array has wrong size or exceeds allowed value range.
      */
-    public static double xyToDuv(double[] xyY) throws IllegalArgumentException {
-        if (xyY.length < 2 || xyY.length > 4) {
-            throw new IllegalArgumentException("xyToHsb() requires 2, 3 or 4 arguments");
+    public static double xyToDuv(double[] xy) throws IllegalArgumentException {
+        if (xy.length != 2) {
+            throw new IllegalArgumentException("xyToDuv() requires 2 arguments");
         }
 
-        for (int i = 0; i < xyY.length; i++) {
-            if (xyY[i] < 0 || xyY[i] > 1) {
+        for (int i = 0; i < xy.length; i++) {
+            if (xy[i] < 0 || xy[i] > 1) {
                 throw new IllegalArgumentException(
-                        String.format("xyToHsb() argument %d value '%f' out of range [0..1.0]", i, xyY[i]));
+                        String.format("xyToDuv() argument %d value '%f' out of range [0..1.0]", i, xy[i]));
             }
         }
 
-        var x = BigDecimal.valueOf(xyY[0]);
-        var y = BigDecimal.valueOf(xyY[1]);
+        var x = BigDecimal.valueOf(xy[0]);
+        var y = BigDecimal.valueOf(xy[1]);
         var u = BIG_DECIMAL_4.multiply(x).divide(
                 BIG_DECIMAL_2.multiply(x).negate().add(BIG_DECIMAL_12.multiply(y).add(BIG_DECIMAL_3)),
                 MathContext.DECIMAL128);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
@@ -1225,11 +1225,20 @@ public class ColorUtil {
         return (437 * Math.pow(n, 3)) + (3601 * Math.pow(n, 2)) + (6861 * n) + 5517;
     }
 
+    /**
+     * Calculates a polynomial regression.
+     *
+     * This calculates the equation K[4]*x^0 + K[3]*x^1 + K[2]*x^2 + K[1]*x^3 + K[0]*x^4
+     *
+     * @param x The independent variable distributed through each term of the polynomial
+     * @param coefficients The coefficients of the polynomial. Note that the terms are in
+     *            order from largest exponent to smallest exponent, which is the reverse order
+     *            of the usual way of writing it in academic papers
+     * @return the result of substituting x into the regression polynomial
+     */
     private static BigDecimal polynomialFit(BigDecimal x, BigDecimal[] coefficients) {
         var result = BigDecimal.ZERO;
         var xAccumulator = BigDecimal.ONE;
-        // forms K[4]*x^0 + K[3]*x^1 + K[2]*x^2 + K[1]*x^3 + K[0]*x^4
-        // (or reverse the order of terms for the usual way of writing it in academic papers)
         for (int i = coefficients.length - 1; i >= 0; i--) {
             result = result.add(coefficients[i].multiply(xAccumulator));
             xAccumulator = xAccumulator.multiply(x);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/ColorUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/ColorUtilTest.java
@@ -274,6 +274,20 @@ public class ColorUtilTest {
         assertTrue(hsbType.closeTo(new HSBType(expected), 0.01));
     }
 
+    @Test
+    public void testXyToDuv() {
+        // Black
+        assertEquals(-0.0017d, ColorUtil.xyToDuv(new double[] { 0.3227d, 0.3290d }), 0.0001);
+        // 2700K
+        assertEquals(0.0000d, ColorUtil.xyToDuv(new double[] { 0.4599d, 0.4106d }), 0.0001);
+        // 3000K
+        assertEquals(0.0000d, ColorUtil.xyToDuv(new double[] { 0.4369d, 0.4041d }), 0.0001);
+        // Red
+        assertEquals(0.2727d, ColorUtil.xyToDuv(new double[] { 0.6987d, 0.2974d }), 0.0001);
+        // Yellow
+        assertEquals(0.0387d, ColorUtil.xyToDuv(new double[] { 0.4442d, 0.5166d }), 0.0001);
+    }
+
     private void xyToXY(double[] xy, Gamut gamut) {
         assertTrue(xy.length > 1);
         HSBType hsb = ColorUtil.xyToHsb(xy, gamut);


### PR DESCRIPTION
This adds a new helper method to calculate the Duv (Delta u, v) of a color. The code is taken almost literally from the mqtt.espmilighthub binding, but changed slightly to fit in with other functions in ColorUtil. I intend to use this from espmilighthub, but also the HomeKit add-on. HomeKit doesn't allow linking both HSB _and_ Color Temperature characteristics to a single accessory, even though the iOS Home App will present a Color Temperature picker for any HSB light. So I want to allow linking devices that support both RGB+CCT to HomeKit, and if the Duv is within threshold, send a command to the Color Temperature channel instead.

I also think it might be useful to add a profile to apply to a Color channel link that does the same thing - if a color is close enough to "white", send a command to the color temperature item instead. This would cover all other use cases, such as BasicUI and MainUI.

This can also be useful for user rules dealing with RGB+CCT light.