### PR TITLE
[automation] Add support for synchronized execution of compiled scripts

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -218,7 +218,8 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
                 Object result;
                 try {
                     result = compiledScript.get().eval(engine.getContext());
-                } finally {
+                } finally { // Make sure that Lock is unlocked regardless of an exception being thrown or not to avoid
+                            // deadlocks
                     if (engine instanceof Lock lock) {
                         lock.unlock();
                     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -212,33 +212,29 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     protected @Nullable Object eval(ScriptEngine engine, String script) {
         try {
             if (compiledScript.isPresent()) {
-                if (engine instanceof Lock lock) {
-                    if (!lock.tryLock(1, TimeUnit.MINUTES)) {
-                        logger.error("Failed to acquire lock within one minute for script module of rule with UID '{}'",
-                                ruleUID);
-                        return null;
-                    }
+                if (engine instanceof Lock lock && !lock.tryLock(1, TimeUnit.MINUTES)) {
+                    logger.error("Failed to acquire lock within one minute for script module of rule with UID '{}'",
+                            ruleUID);
+                    return null;
                 }
                 logger.debug("Executing pre-compiled script of rule with UID '{}'", ruleUID);
-                Object result;
                 try {
-                    result = compiledScript.get().eval(engine.getContext());
+                    return compiledScript.get().eval(engine.getContext());
                 } finally { // Make sure that Lock is unlocked regardless of an exception being thrown or not to avoid
                             // deadlocks
                     if (engine instanceof Lock lock) {
                         lock.unlock();
                     }
                 }
-                return result;
             }
             logger.debug("Executing script of rule with UID '{}'", ruleUID);
             return engine.eval(script);
         } catch (ScriptException e) {
             logger.error("Script execution of rule with UID '{}' failed: {}", ruleUID, e.getMessage(),
                     logger.isDebugEnabled() ? e : null);
-            return null;
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+        return null;
     }
 }


### PR DESCRIPTION
If the ScriptEngine implements the Lock interface, the execution of the CompiledScript is synced by acquisition and release of the log.
This is required for add-ons like JS Scripting.