### PR TITLE
Upgrade Jollyday to 0.32.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -365,7 +365,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.30.0</version>
+      <version>0.32.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -950,7 +950,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.30.0</version>
+      <version>0.32.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -174,12 +174,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.30.0</capability>
+		<capability>openhab.tp;feature=jollyday;version=0.32.0</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/0.30.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/0.30.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/0.32.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/0.32.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -77,5 +77,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -75,5 +75,5 @@ feature.openhab-config: \
 	org.openhab.core.ephemeris.tests;version='[4.3.0,4.3.1)',\
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -58,7 +58,6 @@ Fragment-Host: org.openhab.core.model.item
 	com.fasterxml.jackson.core.jackson-core;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.17.1,2.17.2)',\
-	com.google.guava;version='[33.3.0,33.4.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	io.github.classgraph.classgraph;version='[4.8.174,4.8.175)',\
@@ -126,6 +125,7 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'
+	com.google.guava;version='[33.3.0,33.3.1)',\
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.3.0,4.3.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -62,7 +62,6 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.fasterxml.jackson.core.jackson-core;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.17.1,2.17.2)',\
-	com.google.guava;version='[33.3.0,33.4.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	io.github.classgraph.classgraph;version='[4.8.174,4.8.175)',\
@@ -129,5 +128,7 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)'
+	com.google.guava;version='[33.3.0,33.3.1)',\
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.3.0,4.3.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -67,7 +67,6 @@ Fragment-Host: org.openhab.core.model.script
 	com.fasterxml.jackson.core.jackson-core;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.17.1,2.17.2)',\
-	com.google.guava;version='[33.3.0,33.4.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	io.github.classgraph.classgraph;version='[4.8.174,4.8.175)',\
@@ -133,6 +132,7 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'
+	com.google.guava;version='[33.3.0,33.3.1)',\
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.3.0,4.3.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -65,7 +65,6 @@ Fragment-Host: org.openhab.core.model.thing
 	com.fasterxml.jackson.core.jackson-core;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.17.1,2.17.2)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-xml;version='[2.17.1,2.17.2)',\
-	com.google.guava;version='[33.3.0,33.4.1)',\
 	com.google.guava.failureaccess;version='[1.0.2,1.0.3)',\
 	com.sun.jna;version='[5.14.0,5.14.1)',\
 	io.github.classgraph.classgraph;version='[4.8.174,4.8.175)',\
@@ -135,6 +134,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.30.0,0.30.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.30.0,0.30.1)',\
-	org.openhab.core.model.rule.runtime;version='[4.3.0,4.3.1)'
+	com.google.guava;version='[33.3.0,33.3.1)',\
+	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
+	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
+	org.openhab.core.model.persistence.runtime;version='[4.3.0,4.3.1)'


### PR DESCRIPTION
Upgrades Jollyday from 0.30.0 to 0.32.0.

For release notes, see:

* https://github.com/focus-shift/jollyday/releases/tag/v0.31.0
* https://github.com/focus-shift/jollyday/releases/tag/v0.32.0