### PR TITLE
Add Apache  commons-codec feature

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -87,6 +87,12 @@
       <version>3.14.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.17.0</version>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Californium -->
     <dependency>

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -418,6 +418,12 @@
       <version>3.9.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.17.0</version>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- Californium -->
     <dependency>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -54,6 +54,11 @@
 		<bundle dependency="true">mvn:commons-net/commons-net/3.9.0</bundle>
 	</feature>
 
+	<feature name="openhab.tp-commons-codec" description="The Apache Commons Codec library" version="${project.version}">
+		<capability>openhab.tp;feature=commons-codec;version=1.17.0</capability>
+		<bundle dependency="true">mvn:commons-codec/commons-codec/1.17.0</bundle>
+	</feature>
+
 	<feature name="openhab.tp-gson" description="Gson" version="${project.version}">
 		<capability>openhab.tp;feature=gson;version=2.10.1</capability>
 		<bundle>mvn:org.eclipse.orbit.bundles/com.google.gson/2.10.1.v20230109-0753</bundle>


### PR DESCRIPTION
# Title

Add Apache commons-codec library to openhab-core

# Description

The goal of this PR is to add  Apache commons codec library [https://commons.apache.org/proper/commons-codec/](url) as an OSGi feature  to Openhab-core in order to be used in Openhab-addons. With the aim to integrate  the Meross Internet  things [https://www.meross.com/en-gc](url)  in openhab; the library will consent to the upcoming binding to achieve  the ability of generating   MD5 hashes  required to perform Http and Mqtt  requests/messages to the Meross host and broker. In fact,  I I didn't find any library in openab to perform this task and I believe   the whole openhab ecosystem could benefit from it. That said,  I already posted about my intention to go  with  manufectoring a binding for Meross IOT:
[Unsatisfied Requirements: Declarative Services and multiple OSGi dependences](https://community.openhab.org/t/unsatisfied-requirements-declarative-services-and-multiple-osgi-dependences/159376)

Unfortunatelly,  OSGi is "a strange beast" so it took time for me to comprehend the framework and  how it menages dependencies which turned out to be way different from maven's fashion.

I kindly request support by the reviewer(s) for this P.R  as I have a limited background  in  OSGi and Openhab Core as well! 