### PR TITLE
ActionOutput: Document QR code rendering & Fix action REST doc

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -149,7 +149,7 @@ public class ThingActionsResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getAvailableActionsForThing", summary = "Get all available actions for provided thing UID", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ThingActionDTO.class), uniqueItems = true))),
-            @ApiResponse(responseCode = "204", description = "No actions found.") })
+            @ApiResponse(responseCode = "404", description = "No actions found.") })
     public Response getActions(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
@@ -29,8 +29,28 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface ActionOutput {
 
+    /**
+     * Name of the output parameter
+     * <p>
+     * There are some reserved names that make the UI render the output pretty and not just as a text field:
+     * <ul>
+     * <li>qrCode: Render the output as a QR code.</li>
+     * </ul>
+     *
+     * @return the name of the output parameter
+     */
     String name();
 
+    /**
+     * Type of the output parameter
+     * <p>
+     * There are some special types that make the UI render the output pretty and not just as a text field:
+     * <ul>
+     * <li>qrCode: Render the output as a QR code.</li>
+     * </ul>
+     *
+     * @return the type of the output parameter
+     */
     String type();
 
     String label() default "";


### PR DESCRIPTION
This documents how to make the UI render an action output as QR code and fixes a wrong API response annotation in `ThingActionsResource`.

Refs https://github.com/openhab/openhab-webui/pull/2818 for the QR code rendering.