### PR TITLE
ConfigDescriptionParameter: Change default format for datetime & Update context docs

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
@@ -21,7 +21,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -258,11 +257,11 @@ public class ActionInputsHelper {
                             // Accepted format is: 10:15:30
                             LocalTime.parse(valueString);
                         case "java.time.LocalDateTime" ->
-                            // Accepted format is: 2007-12-03 10:15:30
-                            LocalDateTime.parse(valueString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                            // Accepted format is: 2007-12-03T10:15:30
+                            LocalDateTime.parse(valueString);
                         case "java.util.Date" ->
-                            // Accepted format is: 2007-12-03 10:15:30
-                            new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(valueString);
+                            // Accepted format is: 2007-12-03T10:15:30
+                            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(valueString);
                         case "java.time.ZonedDateTime" ->
                             // Accepted format is: 2007-12-03T10:15:30+01:00[Europe/Paris]
                             ZonedDateTime.parse(valueString);

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
@@ -24,7 +24,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -411,13 +410,13 @@ public class ActionInputHelperTest {
 
     @Test
     public void testMapSerializedInputToActionInputWhenLocalDateTime() {
-        String valAsString = "2024-07-01 20:30:45";
-        LocalDateTime val = LocalDateTime.parse(valAsString, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        String valAsString = "2024-07-01T20:30:45";
+        LocalDateTime val = LocalDateTime.parse(valAsString);
         Input input = buildInput("java.time.LocalDateTime");
         assertThat(helper.mapSerializedInputToActionInput(input, val), is(val));
         assertThat(helper.mapSerializedInputToActionInput(input, valAsString), is(val));
         assertThrows(IllegalArgumentException.class,
-                () -> helper.mapSerializedInputToActionInput(input, valAsString.replaceAll(" ", "T")));
+                () -> helper.mapSerializedInputToActionInput(input, valAsString.replaceAll("T", " ")));
     }
 
     @Test
@@ -433,10 +432,10 @@ public class ActionInputHelperTest {
 
     @Test
     public void testMapSerializedInputToActionInputWhenDate() {
-        String valAsString = "2024-11-05 09:45:12";
+        String valAsString = "2024-11-05T09:45:12";
         Date val;
         try {
-            val = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(valAsString);
+            val = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(valAsString);
         } catch (IllegalArgumentException | ParseException e) {
             val = null;
         }
@@ -445,7 +444,7 @@ public class ActionInputHelperTest {
         assertThat(helper.mapSerializedInputToActionInput(input, val), is(val));
         assertThat(helper.mapSerializedInputToActionInput(input, valAsString), is(val));
         assertThrows(IllegalArgumentException.class,
-                () -> helper.mapSerializedInputToActionInput(input, valAsString.replaceAll(" ", "T")));
+                () -> helper.mapSerializedInputToActionInput(input, valAsString.replaceAll("T", " ")));
     }
 
     @Test

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
@@ -309,31 +309,35 @@ public class ConfigDescriptionParameter {
      * Any string can be used, but the following have a special meaning:
      * </p>
      *
-     * - network-address: The configuration value represents an IPv4 or IPv6 address.
-     * - password: A password value (a user-interface might obscure the visible value)
-     * - password-create: A passwort generator widget might be shown
-     * - color: This value represents an RGB color value like #ffffff or 12,12,12.
-     * - date: A date string
-     * - time: A time string
-     * - cronexpression: A cron expression like "* * * * *". A user interface would probably show a cron expression
-     * generator.
-     * - datetime: A date and time string
-     * - email: The configuration value represents an email address
-     * - month: A number [1-12]
-     * - week: A week [0-52]
-     * - tel: A tel no
+     * - network-address: The configuration value represents an IPv4 or IPv6 address or domain name.
+     * - network-interface: The configuration value represents a network interface name, e.g. eth0, wlan0.
+     * - serial-port: The configuration value represents a serial port name, e.g. COM1, /dev/ttyS0.
+     * - password: A alphanumeric password value (a user-interface might obscure the visible value)
+     * - password-create: A alphanumeric passwort generator widget might be shown
+     * - color: This value represents an RGB color value like #000000 - #ffffff or 12,12,12.
+     * - date: A date string in the format "YYYY-MM-DD"
+     * - datetime: A date and time string in the format "YYYY-MM-DD'T'hh:mm:ss", e.g. "2019-12-31T23:59:59"
+     * - cronexpression: A cron expression like "* * * * *". A user interface would probably show a cron expression generator.
+     * - email: The configuration value represents an email address, e.g. username@domain.com
+     * - month: A month of year [1-12]
+     * - week: A week of year [0-52]
+     * - dayOfWeek: A day of week [MON, TUE, WED, THU, FRI, SAT, SUN]
+     * - time: A time string in the format "hh:mm:ss" or as milliseconds since epoch
+     * - telephone: A tel no
      * - url: A web address
-     * - script: The configuration value represents a script (javascript, python etc). A user-interface would probably
-     * render a multi line editor.
-     * - location: A lat,long,alt GPS location. A user-interface would probably render a world map for selection.
      * - tag: One tag or multiple tags separated by comma.
      * - item: A valid item "name". A user-interface would probably show an item selection widget.
      * - thing: A valid thing UID. A user-interface would probably show a thing selection widget.
-     * - channel: A valid channel UID.
-     * - channeltype: A valid channel type UID. A user-interface would probably show a channel type selection widget.
      * - group: A valid group item "name". A user-interface would probably show an item selection widget.
      * - service: A valid service ID. A user-interface would probably show a service selection widget.
+     * - persistenceService: A valid persistence service ID. A user-interface would probably show a persistence service selection widget.
+     * - channel: A valid channel UID. A user-interface would probably show a channel selection widget.
+     * - channeltype: A valid channel type UID. A user-interface would probably show a channel type selection widget.
      * - rule: A valid rule uid. A user-interface would probably show a rule selection widget.
+     * - script: The configuration value represents a script (javascript, python etc). A user-interface would probably render a multi line editor.
+     * - page: A valid page UID. A user-interface would probably show a page selection widget.
+     * - widget: A valid widget UID. A user-interface would probably show a widget selection widget.
+     * - location: A latitude,longitude[,altitude] GPS location. A user-interface would probably render a world map for selection.
      *
      * @return the context of the configuration parameter (could be null or
      *         empty)

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
@@ -317,7 +317,8 @@ public class ConfigDescriptionParameter {
      * - color: This value represents an RGB color value like #000000 - #ffffff or 12,12,12.
      * - date: A date string in the format "YYYY-MM-DD"
      * - datetime: A date and time string in the format "YYYY-MM-DD'T'hh:mm:ss", e.g. "2019-12-31T23:59:59"
-     * - cronexpression: A cron expression like "* * * * *". A user interface would probably show a cron expression generator.
+     * - cronexpression: A cron expression like "* * * * *". A user interface would probably show a cron expression
+     * generator.
      * - email: The configuration value represents an email address, e.g. username@domain.com
      * - month: A month of year [1-12]
      * - week: A week of year [0-52]
@@ -330,14 +331,17 @@ public class ConfigDescriptionParameter {
      * - thing: A valid thing UID. A user-interface would probably show a thing selection widget.
      * - group: A valid group item "name". A user-interface would probably show an item selection widget.
      * - service: A valid service ID. A user-interface would probably show a service selection widget.
-     * - persistenceService: A valid persistence service ID. A user-interface would probably show a persistence service selection widget.
+     * - persistenceService: A valid persistence service ID. A user-interface would probably show a persistence service
+     * selection widget.
      * - channel: A valid channel UID. A user-interface would probably show a channel selection widget.
      * - channeltype: A valid channel type UID. A user-interface would probably show a channel type selection widget.
      * - rule: A valid rule uid. A user-interface would probably show a rule selection widget.
-     * - script: The configuration value represents a script (javascript, python etc). A user-interface would probably render a multi line editor.
+     * - script: The configuration value represents a script (javascript, python etc). A user-interface would probably
+     * render a multi line editor.
      * - page: A valid page UID. A user-interface would probably show a page selection widget.
      * - widget: A valid widget UID. A user-interface would probably show a widget selection widget.
-     * - location: A latitude,longitude[,altitude] GPS location. A user-interface would probably render a world map for selection.
+     * - location: A latitude,longitude[,altitude] GPS location. A user-interface would probably render a world map for
+     * selection.
      *
      * @return the context of the configuration parameter (could be null or
      *         empty)


### PR DESCRIPTION
This changes the default format for the datetime context to the ISO standard. This context is not used by add-ons and supported by the UI, so it should be possible to change it (again after #4392.)

Also update the context docs from https://next.openhab.org/docs/developer/addons/config-xml.html#supported-contexts and the UI code.