### PR TITLE
Thing actions: Support `@ActionOutput` for single return values

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
@@ -13,6 +13,7 @@
 package org.openhab.core.automation.annotation;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.openhab.core.automation.internal.module.handler.AnnotationActionHandler.MODULE_RESULT;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
@@ -39,7 +40,7 @@ public @interface ActionOutput {
      *
      * @return the name of the output parameter
      */
-    String name();
+    String name() default MODULE_RESULT;
 
     /**
      * Type of the output parameter

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class AnnotationActionHandler extends BaseActionModuleHandler {
 
-    private static final String MODULE_RESULT = "result";
+    public static final String MODULE_RESULT = "result";
 
     private final Logger logger = LoggerFactory.getLogger(AnnotationActionHandler.class);
 


### PR DESCRIPTION
See discussion in https://github.com/openhab/openhab-addons/issues/17504#issuecomment-2439906483.

This adds processing of the ActionOutput annotation for Thing actions with a single return value, which allows providing a label for use in the UI. The output name for those actions is "result", which is now the default value in the @ActionOutput annotation. If a binding overrides the default name, a warning is logged.

If a Thing action returns a Map<String, Object> but does not provide the @ActionOutputs annotation, a warning is logged.