### PR TITLE
[automation] ActionInputsHelper: Enable seconds for time & datetime

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
@@ -102,9 +102,11 @@ public class ActionInputsHelper {
         Unit<?> unit = null;
         boolean required = false;
         String context = null;
+        BigDecimal step = null;
         Matcher matcher = QUANTITY_TYPE_PATTERN.matcher(input.getType());
         if (matcher.matches()) {
             parameterType = ConfigDescriptionParameter.Type.DECIMAL;
+            step = BigDecimal.ZERO;
             try {
                 unit = getDefaultUnit(matcher.group("dimension"));
             } catch (IllegalArgumentException e) {
@@ -140,6 +142,7 @@ public class ActionInputsHelper {
                 case "java.lang.Number":
                 case "org.openhab.core.library.types.DecimalType":
                     parameterType = ConfigDescriptionParameter.Type.DECIMAL;
+                    step = BigDecimal.ZERO;
                     break;
                 case "java.lang.String":
                     break;
@@ -148,10 +151,12 @@ public class ActionInputsHelper {
                     break;
                 case "java.time.LocalTime":
                     context = "time";
+                    step = BigDecimal.ONE;
                     break;
                 case "java.time.LocalDateTime":
                 case "java.util.Date":
                     context = "datetime";
+                    step = BigDecimal.ONE;
                     break;
                 case "java.time.ZonedDateTime":
                 case "java.time.Instant":
@@ -178,8 +183,8 @@ public class ActionInputsHelper {
         if (unit != null) {
             builder = builder.withUnit(unit.getSymbol());
         }
-        if (parameterType == ConfigDescriptionParameter.Type.DECIMAL) {
-            builder = builder.withStepSize(BigDecimal.ZERO);
+        if (step != null) {
+            builder = builder.withStepSize(step);
         }
         return builder.build();
     }

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
@@ -152,19 +152,19 @@ public class ActionInputHelperTest {
     @Test
     public void testMapActionInputToConfigDescriptionParameterWhenLocalTime() {
         checkParameter(helper.mapActionInputToConfigDescriptionParameter(buildInput("java.time.LocalTime")),
-                ConfigDescriptionParameter.Type.TEXT, false, null, "time", null, null);
+                ConfigDescriptionParameter.Type.TEXT, false, null, "time", null, BigDecimal.ONE);
     }
 
     @Test
     public void testMapActionInputToConfigDescriptionParameterWhenLocalDateTime() {
         checkParameter(helper.mapActionInputToConfigDescriptionParameter(buildInput("java.time.LocalDateTime")),
-                ConfigDescriptionParameter.Type.TEXT, false, null, "datetime", null, null);
+                ConfigDescriptionParameter.Type.TEXT, false, null, "datetime", null, BigDecimal.ONE);
     }
 
     @Test
     public void testMapActionInputToConfigDescriptionParameterWhenDate() {
         checkParameter(helper.mapActionInputToConfigDescriptionParameter(buildInput("java.util.Date")),
-                ConfigDescriptionParameter.Type.TEXT, false, null, "datetime", null, null);
+                ConfigDescriptionParameter.Type.TEXT, false, null, "datetime", null, BigDecimal.ONE);
     }
 
     @Test


### PR DESCRIPTION
By setting the step size to 1 for time and datetime, seconds are enabled in the UI.

Refs https://github.com/openhab/openhab-webui/pull/2848.
Discussion in https://github.com/openhab/openhab-webui/issues/2847#issuecomment-2446426478