### PR TITLE
ScriptProfile: Recover from closed context for JS Scripting

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -215,6 +215,7 @@ public class ScriptTransformationService implements TransformationService, Confi
             } catch (ScriptException e) {
                 throw new TransformationException("Failed to execute script.", e);
             } catch (IllegalStateException e) {
+                // ISE thrown by JS Scripting if script engine already closed
                 if ("The Context is already closed.".equals(e.getMessage())) {
                     logger.warn(
                             "Script engine context {} is already closed, this should not happen. Recreating script engine.",

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -214,6 +214,18 @@ public class ScriptTransformationService implements TransformationService, Confi
                 return result == null ? null : result.toString();
             } catch (ScriptException e) {
                 throw new TransformationException("Failed to execute script.", e);
+            } catch (IllegalStateException e) {
+                String message = e.getMessage();
+                if (message != null && message.equals("The Context is already closed.")) {
+                    logger.warn(
+                            "Script engine context {} is already closed, this should not happen. Recreating script engine.",
+                            scriptUid);
+                    scriptCache.remove(scriptUid);
+                    return transform(function, source);
+                } else {
+                    // rethrow
+                    throw e;
+                }
             }
         } finally {
             scriptRecord.lock.unlock();

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -215,8 +215,7 @@ public class ScriptTransformationService implements TransformationService, Confi
             } catch (ScriptException e) {
                 throw new TransformationException("Failed to execute script.", e);
             } catch (IllegalStateException e) {
-                String message = e.getMessage();
-                if (message != null && message.equals("The Context is already closed.")) {
+                if ("The Context is already closed.".equals(e.getMessage())) {
                     logger.warn(
                             "Script engine context {} is already closed, this should not happen. Recreating script engine.",
                             scriptUid);


### PR DESCRIPTION
From time to time, I can see the following exception in my logs:

```
... AbstractInvocationHandler] - An exception occurred while calling method 'Profile.onStateUpdateFromItem()' on '...ScriptProfile@...': The Context is already closed.
java.lang.IllegalStateException: The Context is already closed.
        at com.oracle.truffle.polyglot.PolyglotEngineException.illegalState(PolyglotEngineException.java:129) ~[?:?]
        at com.oracle.truffle.polyglot.PolyglotContextImpl.checkClosed(PolyglotContextImpl.java:1103) ~[?:?]
        at com.oracle.truffle.polyglot.PolyglotContextImpl.enterThreadChanged(PolyglotContextImpl.java:702) ~[?:?]
        at com.oracle.truffle.polyglot.PolyglotEngineImpl.enterCached(PolyglotEngineImpl.java:1991) ~[?:?]
        at com.oracle.truffle.polyglot.HostToGuestRootNode.execute(HostToGuestRootNode.java:110) ~[?:?]
        at com.oracle.truffle.api.impl.DefaultCallTarget.callDirectOrIndirect(DefaultCallTarget.java:85) ~[?:?]
        at com.oracle.truffle.api.impl.DefaultCallTarget.call(DefaultCallTarget.java:102) ~[?:?]
        at com.oracle.truffle.polyglot.PolyglotMap.get(PolyglotMap.java:127) ~[?:?]
        at com.oracle.truffle.polyglot.PolyglotMap.put(PolyglotMap.java:133) ~[?:?]
        at com.oracle.truffle.js.scriptengine.GraalJSBindings.put(GraalJSBindings.java:130) ~[?:?]
        at javax.script.SimpleScriptContext.setAttribute(SimpleScriptContext.java:246) ~[java.scripting:?]
        at org.openhab.core.automation.module.script.ScriptTransformationService.transform(ScriptTransformationService.java:187) ~[?:?]
        at org.openhab.core.automation.module.script.profile.ScriptProfile.executeScript(ScriptProfile.java:185) ~[?:?]
        at org.openhab.core.automation.module.script.profile.ScriptProfile.transformState(ScriptProfile.java:173) ~[?:?]
        at org.openhab.core.automation.module.script.profile.ScriptProfile.onStateUpdateFromHandler(ScriptProfile.java:153) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.lambda$14(CommunicationManager.java:508) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.lambda$17(CommunicationManager.java:543) ~[?:?]
        at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.handleCallFromHandler(CommunicationManager.java:539) ~[?:?]
        at org.openhab.core.thing.internal.CommunicationManager.stateUpdated(CommunicationManager.java:506) ~[?:?]
        at org.openhab.core.thing.internal.ThingHandlerCallbackImpl.stateUpdated(ThingHandlerCallbackImpl.java:66) ~[?:?]
        at org.openhab.core.thing.binding.BaseThingHandler.updateState(BaseThingHandler.java:270) ~[?:?]
        at org.openhab.binding.astro.internal.handler.AstroThingHandler.publishChannelIfLinked(AstroThingHandler.java:178) ~[?:?]
        at org.openhab.binding.astro.internal.handler.AstroThingHandler.publishPlanet(AstroThingHandler.java:160) ~[?:?]
        at org.openhab.binding.astro.internal.handler.SunHandler.publishPositionalInfo(SunHandler.java:66) ~[?:?]
        at org.openhab.binding.astro.internal.job.PositionalJob.run(PositionalJob.java:43) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[?:?]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: com.oracle.truffle.api.TruffleStackTrace$LazyStackTrace
```
