### PR TITLE
[automation] Ensure unique module IDs for overloaded `@RuleAction` methods

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -120,13 +120,14 @@ public class ThingActionsResource implements RESTResource {
         String scope = getScope(thingActions);
         if (handler != null && scope != null) {
             ThingUID thingUID = handler.getThing().getUID();
-            Method[] methods = thingActions.getClass().getDeclaredMethods();
+            Class<?> clazz = thingActions.getClass();
+            Method[] methods = clazz.getDeclaredMethods();
             List<String> actionUIDs = new ArrayList<>();
             for (Method method : methods) {
                 if (!method.isAnnotationPresent(RuleAction.class)) {
                     continue;
                 }
-                actionUIDs.add(annotationActionModuleTypeHelper.getModuleIdFromMethod(scope, method));
+                actionUIDs.add(annotationActionModuleTypeHelper.getModuleIdFromClassAndMethod(scope, clazz, method));
             }
             if (actionUIDs.isEmpty()) {
                 return;

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -120,14 +120,13 @@ public class ThingActionsResource implements RESTResource {
         String scope = getScope(thingActions);
         if (handler != null && scope != null) {
             ThingUID thingUID = handler.getThing().getUID();
-            Class<?> clazz = thingActions.getClass();
-            Method[] methods = clazz.getDeclaredMethods();
+            Method[] methods = thingActions.getClass().getDeclaredMethods();
             List<String> actionUIDs = new ArrayList<>();
             for (Method method : methods) {
                 if (!method.isAnnotationPresent(RuleAction.class)) {
                     continue;
                 }
-                actionUIDs.add(annotationActionModuleTypeHelper.getModuleIdFromClassAndMethod(scope, clazz, method));
+                actionUIDs.add(annotationActionModuleTypeHelper.getModuleIdFromMethod(scope, method));
             }
             if (actionUIDs.isEmpty()) {
                 return;

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Role;
 import org.openhab.core.automation.Action;
+import org.openhab.core.automation.Visibility;
 import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.automation.handler.ActionHandler;
 import org.openhab.core.automation.handler.ModuleHandlerFactory;
@@ -203,6 +204,7 @@ public class ThingActionsResource implements RESTResource {
                 actionDTO.inputConfigDescriptions = inputParameters == null ? null
                         : ConfigDescriptionDTOMapper.mapParameters(inputParameters);
                 actionDTO.outputs = actionType.getOutputs();
+                actionDTO.visibility = actionType.getVisibility();
                 actions.add(actionDTO);
             }
         }
@@ -271,6 +273,7 @@ public class ThingActionsResource implements RESTResource {
 
         public @Nullable String label;
         public @Nullable String description;
+        public @Nullable Visibility visibility;
 
         public List<Input> inputs = new ArrayList<>();
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
@@ -100,7 +100,7 @@ public class AnnotationActionModuleTypeHelper {
                 List<Output> outputs = getOutputsFromAction(method);
 
                 RuleAction ruleAction = method.getAnnotation(RuleAction.class);
-                String uid = getModuleIdFromClassAndMethod(name, clazz, method);
+                String uid = getModuleIdFromMethod(name, method);
                 Set<String> tags = new HashSet<>(Arrays.asList(ruleAction.tags()));
 
                 ModuleInformation mi = new ModuleInformation(uid, actionProvider, method);
@@ -117,7 +117,7 @@ public class AnnotationActionModuleTypeHelper {
         return moduleInformation;
     }
 
-    public String getModuleIdFromClassAndMethod(String actionScope, Class<?> clazz, Method method) {
+    public String getModuleIdFromMethod(String actionScope, Method method) {
         String uid = actionScope + "." + method.getName() + "#";
         MessageDigest md5 = null;
         try {
@@ -125,7 +125,6 @@ public class AnnotationActionModuleTypeHelper {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        md5.update(clazz.getName().getBytes());
         for (Class<?> parameter : method.getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
@@ -100,7 +100,7 @@ public class AnnotationActionModuleTypeHelper {
                 List<Output> outputs = getOutputsFromAction(method);
 
                 RuleAction ruleAction = method.getAnnotation(RuleAction.class);
-                String uid = getModuleIdFromMethod(name, method);
+                String uid = getModuleIdFromClassAndMethod(name, clazz, method);
                 Set<String> tags = new HashSet<>(Arrays.asList(ruleAction.tags()));
 
                 ModuleInformation mi = new ModuleInformation(uid, actionProvider, method);
@@ -117,7 +117,7 @@ public class AnnotationActionModuleTypeHelper {
         return moduleInformation;
     }
 
-    public String getModuleIdFromMethod(String actionScope, Method method) {
+    public String getModuleIdFromClassAndMethod(String actionScope, Class<?> clazz, Method method) {
         String uid = actionScope + "." + method.getName() + "#";
         MessageDigest md5 = null;
         try {
@@ -125,6 +125,7 @@ public class AnnotationActionModuleTypeHelper {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+        md5.update(clazz.getName().getBytes());
         for (Class<?> parameter : method.getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -16,6 +16,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +36,7 @@ import org.openhab.core.automation.AnnotatedActions;
 import org.openhab.core.automation.Visibility;
 import org.openhab.core.automation.annotation.ActionInput;
 import org.openhab.core.automation.annotation.ActionOutput;
+import org.openhab.core.automation.annotation.ActionOutputs;
 import org.openhab.core.automation.annotation.ActionScope;
 import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.automation.module.provider.AnnotationActionModuleTypeHelper;
@@ -55,7 +59,20 @@ import org.openhab.core.test.java.JavaTest;
 @NonNullByDefault
 public class AnnotationActionModuleTypeProviderTest extends JavaTest {
 
-    private static final String TEST_ACTION_TYPE_ID = "binding.test.testMethod";
+    private static final String TEST_ACTION_SIGNATURE_HASH;
+    static {
+        MessageDigest md5 = null;
+        try {
+            md5 = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        for (Class<?> parameter : TestActionProvider.class.getDeclaredMethods()[0].getParameterTypes()) {
+            md5.update(parameter.getName().getBytes());
+        }
+        TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));
+    }
+    private static final String TEST_ACTION_TYPE_ID = "binding.test.testMethod#" + TEST_ACTION_SIGNATURE_HASH;
     private static final String ACTION_LABEL = "Test Label";
     private static final String ACTION_DESCRIPTION = "My Description";
 
@@ -195,9 +212,10 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
 
         @RuleAction(label = ACTION_LABEL, description = ACTION_DESCRIPTION, visibility = Visibility.HIDDEN, tags = {
                 "tag1", "tag2" })
-        public @ActionOutput(name = ACTION_OUTPUT1, type = ACTION_OUTPUT1_TYPE, description = ACTION_OUTPUT1_DESCRIPTION, label = ACTION_OUTPUT1_LABEL, defaultValue = ACTION_OUTPUT1_DEFAULT_VALUE, reference = ACTION_OUTPUT1_REFERENCE, tags = {
-                "tagOut11",
-                "tagOut12" }) @ActionOutput(name = ACTION_OUTPUT2, type = ACTION_OUTPUT2_TYPE) Map<String, Object> testMethod(
+        public @ActionOutputs({
+                @ActionOutput(name = ACTION_OUTPUT1, type = ACTION_OUTPUT1_TYPE, description = ACTION_OUTPUT1_DESCRIPTION, label = ACTION_OUTPUT1_LABEL, defaultValue = ACTION_OUTPUT1_DEFAULT_VALUE, reference = ACTION_OUTPUT1_REFERENCE, tags = {
+                        "tagOut11", "tagOut12" }),
+                @ActionOutput(name = ACTION_OUTPUT2, type = ACTION_OUTPUT2_TYPE) }) Map<String, Object> testMethod(
                         @ActionInput(name = ACTION_INPUT1, label = ACTION_INPUT1_LABEL, defaultValue = ACTION_INPUT1_DEFAULT_VALUE, description = ACTION_INPUT1_DESCRIPTION, reference = ACTION_INPUT1_REFERENCE, required = true, type = "Item", tags = {
                                 "tagIn11", "tagIn12" }) String input1,
                         @ActionInput(name = ACTION_INPUT2) String input2) {

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -67,9 +67,7 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        Class<?> clazz = AnnotationActionModuleTypeProviderTest.TestActionProvider.class;
-        md5.update(clazz.getName().getBytes());
-        for (Class<?> parameter : clazz.getDeclaredMethods()[0].getParameterTypes()) {
+        for (Class<?> parameter : TestActionProvider.class.getDeclaredMethods()[0].getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -16,9 +16,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +69,9 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        for (Class<?> parameter : TestActionProvider.class.getDeclaredMethods()[0].getParameterTypes()) {
+        Method method = Arrays.stream(TestActionProvider.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals("testMethod")).findFirst().orElseThrow();
+        for (Class<?> parameter : method.getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -67,7 +67,9 @@ public class AnnotationActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        for (Class<?> parameter : TestActionProvider.class.getDeclaredMethods()[0].getParameterTypes()) {
+        Class<?> clazz = AnnotationActionModuleTypeProviderTest.TestActionProvider.class;
+        md5.update(clazz.getName().getBytes());
+        for (Class<?> parameter : clazz.getDeclaredMethods()[0].getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -16,9 +16,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -71,8 +73,9 @@ public class AnnotatedThingActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        for (Class<?> parameter : AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class
-                .getDeclaredMethods()[0].getParameterTypes()) {
+        Method method = Arrays.stream(TestThingActionProvider.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals("testMethod")).findFirst().orElseThrow();
+        for (Class<?> parameter : method.getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -16,6 +16,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +63,21 @@ public class AnnotatedThingActionModuleTypeProviderTest extends JavaTest {
 
     private static final ThingTypeUID TEST_THING_TYPE_UID = new ThingTypeUID("binding", "thing-type");
 
-    private static final String TEST_ACTION_TYPE_ID = "test.testMethod";
+    private static final String TEST_ACTION_SIGNATURE_HASH;
+    static {
+        MessageDigest md5 = null;
+        try {
+            md5 = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        for (Class<?> parameter : AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class
+                .getDeclaredMethods()[0].getParameterTypes()) {
+            md5.update(parameter.getName().getBytes());
+        }
+        TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));
+    }
+    private static final String TEST_ACTION_TYPE_ID = "test.testMethod#" + TEST_ACTION_SIGNATURE_HASH;
     private static final String ACTION_LABEL = "Test Label";
     private static final String ACTION_DESCRIPTION = "My Description";
 

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -71,8 +71,9 @@ public class AnnotatedThingActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        for (Class<?> parameter : AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class
-                .getDeclaredMethods()[0].getParameterTypes()) {
+        Class<?> clazz = AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class;
+        md5.update(clazz.getName().getBytes());
+        for (Class<?> parameter : clazz.getDeclaredMethods()[0].getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -71,9 +71,8 @@ public class AnnotatedThingActionModuleTypeProviderTest extends JavaTest {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-        Class<?> clazz = AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class;
-        md5.update(clazz.getName().getBytes());
-        for (Class<?> parameter : clazz.getDeclaredMethods()[0].getParameterTypes()) {
+        for (Class<?> parameter : AnnotatedThingActionModuleTypeProviderTest.TestThingActionProvider.class
+                .getDeclaredMethods()[0].getParameterTypes()) {
             md5.update(parameter.getName().getBytes());
         }
         TEST_ACTION_SIGNATURE_HASH = String.format("%032x", new BigInteger(1, md5.digest()));


### PR DESCRIPTION
Supersedes #4438.

This appends a method signature hash to `@RuleAction` methods which have overloades to ensure module IDs are unique.
It also returns the visibility for Thing actions from the REST API.