### PR TITLE
Improve FolderObserver

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -96,6 +96,14 @@ public class FolderObserver implements WatchService.WatchEventListener {
         logger.debug("Adding parser for '{}' extension", extension);
         parsers.add(extension);
 
+        // check if the desired directory exists and create it if it's missing
+        try {
+            Path extensionPath = watchService.getWatchPath().resolve(extension);
+            Files.createDirectories(extensionPath);
+        } catch (IOException e) {
+            logger.error("Model path for extension '{}' is missing and creation failed: {}", extension, e.getMessage());
+        }
+
         if (activated) {
             processIgnoredPaths(extension);
             readyService.markReady(new ReadyMarker(READYMARKER_TYPE, extension));


### PR DESCRIPTION
Party fixes #3823

It has been reported that missing model directories cause issued during startup. With this PR a directory is created when it is missing.
