### PR TITLE
First part

### DIFF
--- a/bundles/org.openhab.core.thing/schema/thing/thing-description-1.0.0.xsd
+++ b/bundles/org.openhab.core.thing/schema/thing/thing-description-1.0.0.xsd
@@ -226,6 +226,7 @@
 		<xs:attribute name="min" type="xs:decimal" use="optional"/>
 		<xs:attribute name="max" type="xs:decimal" use="optional"/>
 		<xs:attribute name="step" type="xs:decimal" use="optional"/>
+		<xs:attribute name="rangeUnit" type="xs:string" use="optional"/>
 		<xs:attribute name="pattern" type="xs:string" use="optional"/>
 		<xs:attribute name="readOnly" type="xs:boolean" default="false" use="optional"/>
 	</xs:complexType>

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
@@ -271,6 +271,7 @@ public abstract class AbstractStorageBasedTypeProvider
         entity.maximum = fragment.getMaximum();
         entity.minimum = fragment.getMinimum();
         entity.step = fragment.getStep();
+        entity.rangeUnit = fragment.getRangeUnit();
         entity.options = fragment.getOptions();
         entity.pattern = fragment.getPattern();
         entity.isReadOnly = fragment.isReadOnly();
@@ -371,6 +372,9 @@ public abstract class AbstractStorageBasedTypeProvider
         if (entity.step != null) {
             builder.withStep(Objects.requireNonNull(entity.step));
         }
+        if (entity.rangeUnit != null) {
+            builder.withRangeUnit(Objects.requireNonNull(entity.rangeUnit));
+        }
         if (entity.options != null) {
             builder.withOptions(Objects.requireNonNull(entity.options));
         }
@@ -444,6 +448,7 @@ public abstract class AbstractStorageBasedTypeProvider
         public @Nullable BigDecimal maximum;
         public @Nullable BigDecimal minimum;
         public @Nullable BigDecimal step;
+        public @Nullable String rangeUnit;
         public @Nullable List<StateOption> options;
         public @Nullable String pattern;
         public boolean isReadOnly = false;

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
@@ -51,8 +51,9 @@ public class StateDescriptionConverter extends GenericUnmarshaller<StateDescript
     public StateDescriptionConverter() {
         super(StateDescription.class);
 
-        this.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "min", "false" },
-                { "max", "false" }, { "step", "false" }, { "pattern", "false" }, { "readOnly", "false" } });
+        this.attributeMapValidator = new ConverterAttributeMapValidator(
+                new String[][] { { "min", "false" }, { "max", "false" }, { "step", "false" }, { "rangeUnit", "false" },
+                        { "pattern", "false" }, { "readOnly", "false" } });
     }
 
     private @Nullable BigDecimal toBigDecimal(Map<String, String> attributes, String attribute,
@@ -121,6 +122,11 @@ public class StateDescriptionConverter extends GenericUnmarshaller<StateDescript
         BigDecimal step = toBigDecimal(attributes, "step", null);
         if (step != null) {
             builder.withStep(step);
+        }
+
+        String rangeUnit = attributes.get("pattern");
+        if (rangeUnit != null) {
+            builder.withRangeUnit(rangeUnit);
         }
 
         String pattern = attributes.get("pattern");

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
@@ -107,6 +107,7 @@ public class ThingEventFactoryTest {
                     .withMinimum(BigDecimal.ZERO) //
                     .withMaximum(new BigDecimal(1000)) //
                     .withStep(new BigDecimal(100)) //
+                    .withRangeUnit("K") //
                     .withPattern("%.0f K") //
                     .build());
     private static final String CHANNEL_DESCRIPTION_OLD_STATE_DESCRIPTION_PAYLOAD = JSONCONVERTER
@@ -114,6 +115,7 @@ public class ThingEventFactoryTest {
                     .withMinimum(BigDecimal.ZERO) //
                     .withMaximum(new BigDecimal(6000)) //
                     .withStep(new BigDecimal(100)) //
+                    .withRangeUnit("K") //
                     .withPattern("%.0f K") //
                     .build());
     private static final String CHANNEL_DESCRIPTION_CHANGED_EVENT_PAYLOAD_NEW_AND_OLD_DESCRIPTION = JSONCONVERTER
@@ -340,12 +342,14 @@ public class ThingEventFactoryTest {
                 .withMinimum(BigDecimal.ZERO) //
                 .withMaximum(new BigDecimal(1000)) //
                 .withStep(new BigDecimal(100)) //
+                .withRangeUnit("K") //
                 .withPattern("%.0f K") //
                 .build();
         StateDescriptionFragment oldStateDescriptionFragment = StateDescriptionFragmentBuilder.create() //
                 .withMinimum(BigDecimal.ZERO) //
                 .withMaximum(new BigDecimal(6000)) //
                 .withStep(new BigDecimal(100)) //
+                .withRangeUnit("K") //
                 .withPattern("%.0f K") //
                 .build();
         ChannelDescriptionChangedEvent event = ThingEventFactory.createChannelDescriptionChangedEvent(CHANNEL_UID,

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
@@ -96,6 +96,11 @@ public class MetadataStateDescriptionFragmentProvider implements StateDescriptio
                     builder.withStep(getBigDecimal(step));
                 }
 
+                Object rangeUnit = metadata.getConfiguration().get("rangeUnit");
+                if (rangeUnit != null) {
+                    builder.withRangeUnit((String) rangeUnit);
+                }
+
                 Object readOnly = metadata.getConfiguration().get("readOnly");
                 if (readOnly != null) {
                     builder.withReadOnly(getBoolean(readOnly));

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -34,14 +34,16 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     private static class StateDescriptionImpl extends StateDescription {
         StateDescriptionImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-                @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
-            super(minimum, maximum, step, pattern, readOnly, options);
+                @Nullable String rangeUnit, @Nullable String pattern, boolean readOnly,
+                @Nullable List<StateOption> options) {
+            super(minimum, maximum, step, rangeUnit, pattern, readOnly, options);
         }
     }
 
     private @Nullable BigDecimal minimum;
     private @Nullable BigDecimal maximum;
     private @Nullable BigDecimal step;
+    private @Nullable String rangeUnit;
     private @Nullable String pattern;
     private @Nullable Boolean readOnly;
     private @Nullable List<StateOption> options;
@@ -59,6 +61,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
      * @param minimum minimum value of the state
      * @param maximum maximum value of the state
      * @param step step size
+     * @param rangeUnit unit that applies to the min, max and step value
      * @param pattern pattern to render the state
      * @param readOnly if the state can be changed by the system
      * @param options predefined list of options
@@ -66,11 +69,12 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
      */
     @Deprecated
     public StateDescriptionFragmentImpl(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum,
-            @Nullable BigDecimal step, @Nullable String pattern, @Nullable Boolean readOnly,
+            @Nullable BigDecimal step, @Nullable String rangeUnit, @Nullable String pattern, @Nullable Boolean readOnly,
             @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
+        this.rangeUnit = rangeUnit;
         this.pattern = pattern;
         this.readOnly = readOnly;
         this.options = options == null || options.isEmpty() ? List.of() : Collections.unmodifiableList(options);
@@ -88,6 +92,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         this.minimum = legacy.getMinimum();
         this.maximum = legacy.getMaximum();
         this.step = legacy.getStep();
+        this.rangeUnit = legacy.getRangeUnit();
         this.pattern = legacy.getPattern();
         this.readOnly = Boolean.valueOf(legacy.isReadOnly());
         if (!legacy.getOptions().isEmpty()) {
@@ -104,6 +109,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         this.minimum = source.getMinimum();
         this.maximum = source.getMaximum();
         this.step = source.getStep();
+        this.rangeUnit = source.getRangeUnit();
         this.pattern = source.getPattern();
         this.readOnly = source.isReadOnly();
         this.options = source.getOptions();
@@ -137,6 +143,15 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
     }
 
     @Override
+    public @Nullable String getRangeUnit() {
+        return rangeUnit;
+    }
+
+    public void setRangeUnit(String rangeUnit) {
+        this.rangeUnit = rangeUnit;
+    }
+
+    @Override
     public @Nullable String getPattern() {
         return pattern;
     }
@@ -165,12 +180,13 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
 
     @Override
     public @Nullable StateDescription toStateDescription() {
-        if (minimum == null && maximum == null && step == null && readOnly == null && pattern == null
-                && options == null) {
+        if (minimum == null && maximum == null && step == null && rangeUnit == null && readOnly == null
+                && pattern == null && options == null) {
             return null;
         }
         final Boolean ro = readOnly;
-        return new StateDescriptionImpl(minimum, maximum, step, pattern, ro != null && ro.booleanValue(), options);
+        return new StateDescriptionImpl(minimum, maximum, step, rangeUnit, pattern, ro != null && ro.booleanValue(),
+                options);
     }
 
     /**
@@ -189,6 +205,9 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         }
         if (step == null) {
             step = fragment.getStep();
+        }
+        if (rangeUnit == null) {
+            rangeUnit = fragment.getRangeUnit();
         }
         if (pattern == null) {
             pattern = fragment.getPattern();
@@ -209,6 +228,7 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         result = prime * result + (minimum != null ? minimum.hashCode() : 0);
         result = prime * result + (maximum != null ? maximum.hashCode() : 0);
         result = prime * result + (step != null ? step.hashCode() : 0);
+        result = prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
         result = prime * result + (pattern != null ? pattern.hashCode() : 0);
         result = prime * result + (readOnly ? 1231 : 1237);
         result = prime * result + (options != null ? options.hashCode() : 0);
@@ -228,13 +248,15 @@ public class StateDescriptionFragmentImpl implements StateDescriptionFragment {
         }
         StateDescriptionFragmentImpl other = (StateDescriptionFragmentImpl) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
-                && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
-                && Objects.equals(readOnly, other.readOnly) && Objects.equals(options, other.options);
+                && Objects.equals(step, other.step) && Objects.equals(rangeUnit, other.rangeUnit)
+                && Objects.equals(pattern, other.pattern) && Objects.equals(readOnly, other.readOnly)
+                && Objects.equals(options, other.options);
     }
 
     @Override
     public String toString() {
-        return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+        return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", rangeUnit="
+                + rangeUnit + ", pattern=" + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options
+                + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
@@ -31,6 +31,7 @@ public class StateDescription {
     protected @Nullable final BigDecimal minimum;
     protected @Nullable final BigDecimal maximum;
     protected @Nullable final BigDecimal step;
+    protected @Nullable final String rangeUnit;
     protected @Nullable final String pattern;
     protected final boolean readOnly;
     protected final List<StateOption> options;
@@ -41,15 +42,18 @@ public class StateDescription {
      * @param minimum minimum value of the state
      * @param maximum maximum value of the state
      * @param step step size
+     * @param rangeUnit unit that applies to the min, max and step value
      * @param pattern pattern to render the state
      * @param readOnly if the state can be changed by the system
      * @param options predefined list of options
      */
     protected StateDescription(@Nullable BigDecimal minimum, @Nullable BigDecimal maximum, @Nullable BigDecimal step,
-            @Nullable String pattern, boolean readOnly, @Nullable List<StateOption> options) {
+            @Nullable String rangeUnit, @Nullable String pattern, boolean readOnly,
+            @Nullable List<StateOption> options) {
         this.minimum = minimum;
         this.maximum = maximum;
         this.step = step;
+        this.rangeUnit = rangeUnit;
         this.pattern = pattern;
         this.readOnly = readOnly;
         this.options = options == null ? List.of() : Collections.unmodifiableList(options);
@@ -80,6 +84,15 @@ public class StateDescription {
      */
     public @Nullable BigDecimal getStep() {
         return step;
+    }
+
+    /**
+     * Returns the unit that applies to the min, max and step
+     *
+     * @return range unit
+     */
+    public @Nullable String getRangeUnit() {
+        return rangeUnit;
     }
 
     /**
@@ -119,6 +132,7 @@ public class StateDescription {
         result = prime * result + (minimum != null ? minimum.hashCode() : 0);
         result = prime * result + (maximum != null ? maximum.hashCode() : 0);
         result = prime * result + (step != null ? step.hashCode() : 0);
+        result = prime * result + (rangeUnit != null ? rangeUnit.hashCode() : 0);
         result = prime * result + (pattern != null ? pattern.hashCode() : 0);
         result = prime * result + (readOnly ? 1231 : 1237);
         result = prime * result + options.hashCode();
@@ -138,14 +152,15 @@ public class StateDescription {
         }
         StateDescription other = (StateDescription) obj;
         return Objects.equals(minimum, other.minimum) && Objects.equals(maximum, other.maximum)
-                && Objects.equals(step, other.step) && Objects.equals(pattern, other.pattern)
-                && readOnly == other.readOnly //
+                && Objects.equals(step, other.step) && Objects.equals(rangeUnit, other.rangeUnit)
+                && Objects.equals(pattern, other.pattern) && readOnly == other.readOnly //
                 && options.equals(other.options);
     }
 
     @Override
     public String toString() {
-        return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", pattern="
-                + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options + "]";
+        return "StateDescription [minimum=" + minimum + ", maximum=" + maximum + ", step=" + step + ", rangeUnit="
+                + rangeUnit + ", pattern=" + pattern + ", readOnly=" + readOnly + ", channelStateOptions=" + options
+                + "]";
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
@@ -52,6 +52,14 @@ public interface StateDescriptionFragment {
     BigDecimal getStep();
 
     /**
+     * Returns the unit that applies to the min, max and step
+     *
+     * @return range unit
+     */
+    @Nullable
+    String getRangeUnit();
+
+    /**
      * Returns the pattern to render the state to a string.
      *
      * @return pattern

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
@@ -31,6 +31,7 @@ public class StateDescriptionFragmentBuilder {
     private @Nullable BigDecimal minimum;
     private @Nullable BigDecimal maximum;
     private @Nullable BigDecimal step;
+    private @Nullable String rangeUnit;
     private @Nullable String pattern;
     private @Nullable Boolean readOnly;
     private @Nullable List<StateOption> options;
@@ -43,6 +44,7 @@ public class StateDescriptionFragmentBuilder {
         this.minimum = fragment.getMinimum();
         this.maximum = fragment.getMaximum();
         this.step = fragment.getStep();
+        this.rangeUnit = fragment.getRangeUnit();
         this.pattern = fragment.getPattern();
         this.readOnly = fragment.isReadOnly();
         final List<StateOption> stateOptions = fragment.getOptions();
@@ -55,6 +57,7 @@ public class StateDescriptionFragmentBuilder {
         this.minimum = legacy.getMinimum();
         this.maximum = legacy.getMaximum();
         this.step = legacy.getStep();
+        this.rangeUnit = legacy.getRangeUnit();
         this.pattern = legacy.getPattern();
         this.readOnly = Boolean.valueOf(legacy.isReadOnly());
         if (!legacy.getOptions().isEmpty()) {
@@ -100,7 +103,7 @@ public class StateDescriptionFragmentBuilder {
      */
     @SuppressWarnings("deprecation")
     public StateDescriptionFragment build() {
-        return new StateDescriptionFragmentImpl(minimum, maximum, step, pattern, readOnly, options);
+        return new StateDescriptionFragmentImpl(minimum, maximum, step, rangeUnit, pattern, readOnly, options);
     }
 
     /**
@@ -133,6 +136,17 @@ public class StateDescriptionFragmentBuilder {
      */
     public StateDescriptionFragmentBuilder withStep(BigDecimal step) {
         this.step = step;
+        return this;
+    }
+
+    /**
+     * Set the range unit for the resulting {@link StateDescriptionFragment}.
+     *
+     * @param rangeUnit the range unit for the resulting {@link StateDescriptionFragment}.
+     * @return this builder.
+     */
+    public StateDescriptionFragmentBuilder withRangeUnit(String rangeUnit) {
+        this.rangeUnit = rangeUnit;
         return this;
     }
 

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -94,6 +94,7 @@ public class MetadataStateDescriptionFragmentProviderTest {
         metadataConfig.put("min", 18.5);
         metadataConfig.put("max", "34");
         metadataConfig.put("step", 3);
+        metadataConfig.put("rangeUnit", "°C");
         metadataConfig.put("readOnly", "true");
         metadataConfig.put("options", "OPTION1,OPTION2 , 3 =Option 3 ,\"4=4\"=\" Option=4 \" ");
         Metadata metadata = new Metadata(metadataKey, "N/A", metadataConfig);
@@ -106,6 +107,7 @@ public class MetadataStateDescriptionFragmentProviderTest {
         assertEquals(new BigDecimal(18.5), stateDescriptionFragment.getMinimum());
         assertEquals(new BigDecimal(34), stateDescriptionFragment.getMaximum());
         assertEquals(new BigDecimal(3), stateDescriptionFragment.getStep());
+        assertEquals("°C", stateDescriptionFragment.getRangeUnit());
         assertEquals(true, stateDescriptionFragment.isReadOnly());
         assertNotNull(stateDescriptionFragment.getOptions());
         Iterator<StateOption> it = stateDescriptionFragment.getOptions().iterator();

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
@@ -43,6 +43,7 @@ public class StateDescriptionServiceImplTest {
     private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE = BigDecimal.ZERO;
     private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE = BigDecimal.ZERO;
     private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP = BigDecimal.ZERO;
+    private static final String STATE_DESCRIPTION_PROVIDER_DEFAULT_RANGE_UNIT = "x";
     private static final String STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN = "pattern1";
     private static final Boolean STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY = Boolean.FALSE;
     private static final List<StateOption> STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS = List.of();
@@ -64,6 +65,7 @@ public class StateDescriptionServiceImplTest {
                 .withMinimum(STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE)
                 .withMaximum(STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE)
                 .withStep(STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP)
+                .withRangeUnit(STATE_DESCRIPTION_PROVIDER_DEFAULT_RANGE_UNIT)
                 .withPattern(STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN)
                 .withReadOnly(STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY)
                 .withOptions(STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS).build();
@@ -74,6 +76,7 @@ public class StateDescriptionServiceImplTest {
         assertThat(stateDescription.getMinimum(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE));
         assertThat(stateDescription.getMaximum(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE));
         assertThat(stateDescription.getStep(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP));
+        assertThat(stateDescription.getRangeUnit(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_RANGE_UNIT));
         assertThat(stateDescription.getPattern(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN));
         assertThat(stateDescription.isReadOnly(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY));
         assertThat(stateDescription.getOptions(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS));
@@ -85,6 +88,7 @@ public class StateDescriptionServiceImplTest {
                 .withMinimum(new BigDecimal(-1)) //
                 .withMaximum(new BigDecimal(-1)) //
                 .withStep(new BigDecimal(-1)) //
+                .withRangeUnit("x") //
                 .withPattern("pattern1").build();
         registerStateDescriptionFragmentProvider(stateDescriptionFragment1, -1);
 
@@ -92,6 +96,7 @@ public class StateDescriptionServiceImplTest {
                 .withMinimum(new BigDecimal(-2)) //
                 .withMaximum(new BigDecimal(-2)) //
                 .withStep(new BigDecimal(-2)) //
+                .withRangeUnit("y") //
                 .withPattern("pattern2").build();
         registerStateDescriptionFragmentProvider(stateDescriptionFragment2, -2);
 
@@ -100,6 +105,7 @@ public class StateDescriptionServiceImplTest {
         assertThat(stateDescription.getMinimum(), is(stateDescriptionFragment1.getMinimum()));
         assertThat(stateDescription.getMaximum(), is(stateDescriptionFragment1.getMaximum()));
         assertThat(stateDescription.getStep(), is(stateDescriptionFragment1.getStep()));
+        assertThat(stateDescription.getRangeUnit(), is(stateDescriptionFragment1.getRangeUnit()));
         assertThat(stateDescription.getPattern(), is(stateDescriptionFragment1.getPattern()));
     }
 
@@ -188,6 +194,7 @@ public class StateDescriptionServiceImplTest {
                 .withMinimum(BigDecimal.ONE) //
                 .withMaximum(BigDecimal.ONE) //
                 .withStep(BigDecimal.ONE) //
+                .withRangeUnit("x") //
                 .withPattern("base_pattern") //
                 .withOptions(options).build();
         registerStateDescriptionFragmentProvider(stateDescriptionFragment2, -2);
@@ -197,6 +204,7 @@ public class StateDescriptionServiceImplTest {
         assertThat(stateDescription.getMinimum(), is(BigDecimal.ZERO));
         assertThat(stateDescription.getMaximum(), is(BigDecimal.TEN));
         assertThat(stateDescription.getStep(), is(BigDecimal.ONE));
+        assertThat(stateDescription.getRangeUnit(), is("x"));
         assertThat(stateDescription.getPattern(), is("pattern"));
         assertThat(stateDescription.isReadOnly(), is(true));
         assertThat(stateDescription.getOptions(), is(options));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/types/StateDescriptionFragmentImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/types/StateDescriptionFragmentImplTest.java
@@ -42,6 +42,7 @@ public class StateDescriptionFragmentImplTest {
         source.setMinimum(BigDecimal.ZERO);
         source.setMaximum(BigDecimal.TEN);
         source.setStep(BigDecimal.ONE);
+        source.setRangeUnit("x");
         source.setPattern("pattern");
         source.setReadOnly(Boolean.TRUE);
         source.setOptions(List.of());
@@ -54,6 +55,7 @@ public class StateDescriptionFragmentImplTest {
         assertThat(fragment.getMinimum(), is(source.getMinimum()));
         assertThat(fragment.getMaximum(), is(source.getMaximum()));
         assertThat(fragment.getStep(), is(source.getStep()));
+        assertThat(fragment.getRangeUnit(), is(source.getRangeUnit()));
         assertThat(fragment.getPattern(), is(source.getPattern()));
         assertThat(fragment.isReadOnly(), is(source.isReadOnly()));
         assertThat(fragment.getOptions(), is(source.getOptions()));
@@ -82,6 +84,7 @@ public class StateDescriptionFragmentImplTest {
         assertThat(stateDescription.getMinimum(), is(source.getMinimum()));
         assertThat(stateDescription.getMaximum(), is(source.getMaximum()));
         assertThat(stateDescription.getStep(), is(source.getStep()));
+        assertThat(stateDescription.getRangeUnit(), is(source.getRangeUnit()));
         assertThat(stateDescription.getPattern(), is(source.getPattern()));
         assertThat(stateDescription.isReadOnly(), is(source.isReadOnly()));
         assertThat(stateDescription.getOptions(), is(source.getOptions()));

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
@@ -53,6 +53,11 @@ public class StateDescriptionFragmentBuilderTest {
     }
 
     @Test
+    public void builderWithRangeUnit() {
+        assertThat(builder.withRangeUnit("x").build().getRangeUnit(), is("x"));
+    }
+
+    @Test
     public void builderWithPattern() {
         assertThat(builder.withPattern("pattern").build().getPattern(), is("pattern"));
     }
@@ -82,14 +87,15 @@ public class StateDescriptionFragmentBuilderTest {
 
     @Test
     public void builderWithStateDescription() {
-        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "pattern", true,
-                List.of(new StateOption("value", "label")));
+        StateDescription source = new StateDescription(BigDecimal.ZERO, BigDecimal.TEN, BigDecimal.ONE, "rangeUnit",
+                "pattern", true, List.of(new StateOption("value", "label")));
         StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create(source);
         StateDescriptionFragment fragment = builder.build();
 
         assertThat(fragment.getMinimum(), is(source.getMinimum()));
         assertThat(fragment.getMaximum(), is(source.getMaximum()));
         assertThat(fragment.getStep(), is(source.getStep()));
+        assertThat(fragment.getRangeUnit(), is(source.getRangeUnit()));
         assertThat(fragment.getPattern(), is(source.getPattern()));
         assertThat(fragment.isReadOnly(), is(source.isReadOnly()));
         assertThat(fragment.getOptions(), is(source.getOptions()));
@@ -100,15 +106,16 @@ public class StateDescriptionFragmentBuilderTest {
     @Test
     public void subsequentBuildsCreateIndependentFragments() {
         StateDescriptionFragment fragment1 = builder.withMinimum(BigDecimal.ZERO).withMaximum(BigDecimal.TEN)
-                .withStep(BigDecimal.ONE).withPattern("pattern").withReadOnly(Boolean.FALSE)
+                .withStep(BigDecimal.ONE).withRangeUnit("x").withPattern("pattern").withReadOnly(Boolean.FALSE)
                 .withOptions(List.of(new StateOption("value", "label"))).build();
         StateDescriptionFragment fragment2 = builder.withMinimum(BigDecimal.ONE).withMaximum(BigDecimal.ONE)
-                .withStep(BigDecimal.ZERO).withPattern("pattern_new").withReadOnly(Boolean.TRUE).withOptions(List.of())
-                .build();
+                .withStep(BigDecimal.ZERO).withRangeUnit("y").withPattern("pattern_new").withReadOnly(Boolean.TRUE)
+                .withOptions(List.of()).build();
 
         assertThat(fragment1.getMinimum(), is(not(fragment2.getMinimum())));
         assertThat(fragment1.getMaximum(), is(not(fragment2.getMaximum())));
         assertThat(fragment1.getStep(), is(not(fragment2.getStep())));
+        assertThat(fragment1.getRangeUnit(), is(not(fragment2.getRangeUnit())));
         assertThat(fragment1.getPattern(), is(not(fragment2.getPattern())));
         assertThat(fragment1.isReadOnly(), is(not(fragment2.isReadOnly())));
         assertThat(fragment1.getOptions(), is(not(fragment2.getOptions())));


### PR DESCRIPTION
A common scenario for a thermostat's is that they have a limited operation range. To support these ranges the xml thing type structure has min, max and step xml attributes. After the introduction of UoM, these attributes where not adapted. Binding's now typically have a state pattern of %unit% and a unitHint set. The min/max/step lack a unit so it is not known to what unit it relates.

[x] Adapt XML
[x] Adapt tests
[ ] Validation

Fixes: https://github.com/openhab/openhab-core/issues/4432