### PR TITLE
Persistence Extensions: Riemann Sums

### DIFF
--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -53,8 +53,8 @@ import org.openhab.core.library.unit.Units;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
-import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.persistence.extensions.PersistenceExtensions.RiemannType;
+import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
 import org.openhab.core.types.State;
 
 /**
@@ -892,7 +892,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceSinceDecimalType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -914,7 +914,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceUntilDecimalType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -939,7 +939,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage1 = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
@@ -953,7 +953,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -967,7 +967,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -990,7 +990,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceSinceQuantityType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -1013,7 +1013,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceUntilQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -1039,7 +1039,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage1 = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
@@ -1054,7 +1054,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -1069,7 +1069,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -1093,7 +1093,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceSinceGroupQuantityType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -1116,7 +1116,7 @@ public class PersistenceExtensionsTest {
     public void testVarianceUntilGroupQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -1142,7 +1142,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage1 = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
@@ -1157,7 +1157,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -1172,7 +1172,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -1196,7 +1196,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationSinceDecimalType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -1218,7 +1218,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationUntilDecimalType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -1243,7 +1243,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
@@ -1256,7 +1256,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -1270,7 +1270,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -1293,7 +1293,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationSinceQuantityType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -1316,7 +1316,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationUntilQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -1342,7 +1342,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
@@ -1356,7 +1356,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -1371,7 +1371,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -1395,7 +1395,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationSinceGroupQuantityType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
@@ -1418,7 +1418,7 @@ public class PersistenceExtensionsTest {
     public void testDeviationUntilGroupQuantityType() {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
 
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
@@ -1444,7 +1444,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expectedAverage = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
 
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
@@ -1458,7 +1458,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage2 = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
@@ -1473,7 +1473,7 @@ public class PersistenceExtensionsTest {
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expectedAverage3 = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
@@ -1498,7 +1498,7 @@ public class PersistenceExtensionsTest {
         RiemannType type = RiemannType.LEFT;
 
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = riemannSum(BEFORE_START, null, type);
+        double expected = testRiemannSum(BEFORE_START, null, type);
         State sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         DecimalType dt = sum.as(DecimalType.class);
@@ -1507,7 +1507,7 @@ public class PersistenceExtensionsTest {
         // now from system
         assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1523,7 +1523,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.RIGHT;
 
         start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(BEFORE_START, null, type);
+        expected = testRiemannSum(BEFORE_START, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1532,7 +1532,7 @@ public class PersistenceExtensionsTest {
         // now from system
         assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1548,7 +1548,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.TRAPEZOIDAL;
 
         start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(BEFORE_START, null, type);
+        expected = testRiemannSum(BEFORE_START, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1557,7 +1557,7 @@ public class PersistenceExtensionsTest {
         // now
         assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1573,7 +1573,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.MIDPOINT;
 
         start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(BEFORE_START, null, type);
+        expected = testRiemannSum(BEFORE_START, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1582,7 +1582,7 @@ public class PersistenceExtensionsTest {
         // now from system
         assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
         sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1601,7 +1601,7 @@ public class PersistenceExtensionsTest {
         RiemannType type = RiemannType.LEFT;
 
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        double expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
         State sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
         assertNotNull(sum);
         DecimalType dt = sum.as(DecimalType.class);
@@ -1616,7 +1616,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.RIGHT;
 
         end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
         sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1631,7 +1631,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.TRAPEZOIDAL;
 
         end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
         sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1646,7 +1646,7 @@ public class PersistenceExtensionsTest {
         type = RiemannType.MIDPOINT;
 
         end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
         sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1667,7 +1667,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        double expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
         State sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         DecimalType dt = sum.as(DecimalType.class);
@@ -1676,7 +1676,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+        expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1686,7 +1686,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1702,7 +1702,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1711,7 +1711,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+        expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1721,7 +1721,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1737,7 +1737,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1746,7 +1746,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+        expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1756,7 +1756,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1772,7 +1772,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1781,7 +1781,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+        expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1791,7 +1791,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
 
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
@@ -1811,7 +1811,7 @@ public class PersistenceExtensionsTest {
                     ZoneId.systemDefault());
             ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                     ZoneId.systemDefault());
-            double expected = riemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+            double expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
             State sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
 
             assertNotNull(sum);
@@ -1822,7 +1822,7 @@ public class PersistenceExtensionsTest {
 
             beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-            expected = riemannSumCelsius(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+            expected = testRiemannSumCelsius(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
 
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
@@ -1833,7 +1833,7 @@ public class PersistenceExtensionsTest {
 
             beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-            expected = riemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+            expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
 
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
@@ -1856,8 +1856,15 @@ public class PersistenceExtensionsTest {
         int historicHours = 27;
         int futureHours = 0;
 
+        // Persistence will contain following entries:
+        // 0 - 27 hours back in time
+        // 100 - 26 hours back in time
+        // 0 - 25 hours back in time
+        // 50 - 2 hours back in time
+        // 0 - 1 hour back in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
+        // Testing that riemannSum calculates the correct Riemann sum over the last 27 hours
         State sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusHours(historicHours), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1865,6 +1872,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(100.0 * 3600 + 50.0 * 3600, 0.01)));
 
+        // Testing that riemannSum calculates the correct Riemann sum over the last 24 hours
         sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusHours(historicHours).plusHours(3), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1872,6 +1880,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 * 3600, 0.01)));
 
+        // Testing that riemannSum calculates the correct Riemann sum over the last 30 minutes
         sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusMinutes(30), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1888,8 +1897,15 @@ public class PersistenceExtensionsTest {
         int historicHours = 0;
         int futureHours = 27;
 
+        // Persistence will contain following entries:
+        // 0 - 1 hour forward in time
+        // 50 - 2 hours forward in time
+        // 0 - 3 hours forward in time
+        // 100 - 25 hours forward in time
+        // 0 - 26 hour forward in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
+        // Testing that riemannSum calculates the correct Riemann sum over the next 27 hours
         State sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusHours(futureHours), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1897,6 +1913,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(100.0 * 3600 + 50.0 * 3600, 0.01)));
 
+        // Testing that riemannSum calculates the correct Riemann sum over the next 25 hours
         sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusHours(futureHours).minusHours(2), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1904,6 +1921,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 * 3600, 0.01)));
 
+        // Testing that riemannSum calculates the correct Riemann sum over the next 30 minutes hours
         sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusMinutes(30), type,
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(sum);
@@ -1925,7 +1943,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSinceDecimalType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(BEFORE_START, null);
+        double expected = testAverage(BEFORE_START, null);
         State average = PersistenceExtensions.averageSince(numberItem, start, SERVICE_ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
@@ -1933,7 +1951,7 @@ public class PersistenceExtensionsTest {
         assertEquals(expected, dt.doubleValue(), 0.01);
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
         average = PersistenceExtensions.averageSince(numberItem, start, SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
@@ -1948,7 +1966,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageUntilDecimalType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
         State average = PersistenceExtensions.averageUntil(numberItem, end, SERVICE_ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
@@ -1967,7 +1985,7 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
 
-        double expected = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         DecimalType dt = average.as(DecimalType.class);
@@ -1976,7 +1994,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -1986,7 +2004,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -2002,7 +2020,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSinceQuantityType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(BEFORE_START, null);
+        double expected = testAverage(BEFORE_START, null);
         State average = PersistenceExtensions.averageSince(quantityItem, start, SERVICE_ID);
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
@@ -2011,7 +2029,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
         average = PersistenceExtensions.averageSince(quantityItem, start, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2027,7 +2045,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageUntilQuantityType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
         State average = PersistenceExtensions.averageUntil(quantityItem, end, SERVICE_ID);
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
@@ -2046,7 +2064,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expected = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
 
         assertNotNull(average);
@@ -2057,7 +2075,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -2068,7 +2086,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -2085,7 +2103,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSinceGroupQuantityType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(BEFORE_START, null);
+        double expected = testAverage(BEFORE_START, null);
         State average = PersistenceExtensions.averageSince(groupQuantityItem, start, SERVICE_ID);
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
@@ -2094,7 +2112,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
         average = PersistenceExtensions.averageSince(groupQuantityItem, start, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2110,7 +2128,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageUntilGroupQuantityType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = average(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
         State average = PersistenceExtensions.averageUntil(groupQuantityItem, end, SERVICE_ID);
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
@@ -2129,7 +2147,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expected = average(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
 
         assertNotNull(average);
@@ -2140,7 +2158,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -2151,7 +2169,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = average(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -2252,8 +2270,15 @@ public class PersistenceExtensionsTest {
         int historicHours = 27;
         int futureHours = 0;
 
+        // Persistence will contain following entries:
+        // 0 - 27 hours back in time
+        // 100 - 26 hours back in time
+        // 0 - 25 hours back in time
+        // 50 - 2 hours back in time
+        // 0 - 1 hour back in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
+        // Testing that riemannSum calculates the correct average over the last 27 hours
         State average = PersistenceExtensions.averageSince(numberItem, now.minusHours(historicHours),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2261,6 +2286,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / historicHours, 0.01)));
 
+        // Testing that riemannSum calculates the correct average over the last 24 hours
         average = PersistenceExtensions.averageSince(numberItem, now.minusHours(historicHours).plusHours(3),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2268,6 +2294,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 / (historicHours - 3.0), 0.01)));
 
+        // Testing that riemannSum calculates the correct average over the last 30 minutes
         average = PersistenceExtensions.averageSince(numberItem, now.minusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2282,8 +2309,15 @@ public class PersistenceExtensionsTest {
         int historicHours = 0;
         int futureHours = 27;
 
+        // Persistence will contain following entries:
+        // 0 - 1 hour forward in time
+        // 50 - 2 hours forward in time
+        // 0 - 3 hours forward in time
+        // 100 - 25 hours forward in time
+        // 0 - 26 hour forward in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
+        // Testing that riemannSum calculates the correct average over the next 27 hours
         State average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2291,6 +2325,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / futureHours, 0.01)));
 
+        // Testing that riemannSum calculates the correct average over the next 25 hours
         average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours).minusHours(2),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2298,6 +2333,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 / (futureHours - 2.0), 0.01)));
 
+        // Testing that riemannSum calculates the correct average over the next 30 minutes hours
         average = PersistenceExtensions.averageUntil(numberItem, now.plusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2320,7 +2356,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianSinceDecimalType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(BEFORE_START, null);
+        double expected = testMedian(BEFORE_START, null);
         State median = PersistenceExtensions.medianSince(numberItem, start, SERVICE_ID);
         assertNotNull(median);
         DecimalType dt = median.as(DecimalType.class);
@@ -2328,7 +2364,7 @@ public class PersistenceExtensionsTest {
         assertEquals(expected, dt.doubleValue(), 0.01);
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, null);
         median = PersistenceExtensions.medianSince(numberItem, start, SERVICE_ID);
         assertNotNull(median);
         dt = median.as(DecimalType.class);
@@ -2343,7 +2379,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianUntilDecimalType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testMedian(null, FUTURE_INTERMEDIATE_VALUE_3);
         State median = PersistenceExtensions.medianUntil(numberItem, end, SERVICE_ID);
         assertNotNull(median);
         DecimalType dt = median.as(DecimalType.class);
@@ -2362,7 +2398,7 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
 
-        double expected = median(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         DecimalType dt = median.as(DecimalType.class);
@@ -2371,7 +2407,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2381,7 +2417,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2397,7 +2433,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianSinceQuantityType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(BEFORE_START, null);
+        double expected = testMedian(BEFORE_START, null);
         State median = PersistenceExtensions.medianSince(quantityItem, start, SERVICE_ID);
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
@@ -2406,7 +2442,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, null);
         median = PersistenceExtensions.medianSince(quantityItem, start, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);
@@ -2422,7 +2458,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianUntilQuantityType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testMedian(null, FUTURE_INTERMEDIATE_VALUE_3);
         State median = PersistenceExtensions.medianUntil(quantityItem, end, SERVICE_ID);
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
@@ -2441,7 +2477,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expected = median(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
 
         assertNotNull(median);
@@ -2452,7 +2488,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2463,7 +2499,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2480,7 +2516,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianSinceGroupQuantityType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(BEFORE_START, null);
+        double expected = testMedian(BEFORE_START, null);
         State median = PersistenceExtensions.medianSince(groupQuantityItem, start, SERVICE_ID);
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
@@ -2489,7 +2525,7 @@ public class PersistenceExtensionsTest {
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, null);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, null);
         median = PersistenceExtensions.medianSince(groupQuantityItem, start, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);
@@ -2505,7 +2541,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testMedianUntilGroupQuantityType() {
         ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = median(null, FUTURE_INTERMEDIATE_VALUE_3);
+        double expected = testMedian(null, FUTURE_INTERMEDIATE_VALUE_3);
         State median = PersistenceExtensions.medianUntil(groupQuantityItem, end, SERVICE_ID);
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
@@ -2524,7 +2560,7 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-        double expected = median(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
 
         assertNotNull(median);
@@ -2535,7 +2571,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
+        expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
 
         median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2546,7 +2582,7 @@ public class PersistenceExtensionsTest {
 
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = median(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
+        expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
 
         median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -2278,7 +2278,7 @@ public class PersistenceExtensionsTest {
         // 0 - 1 hour back in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
-        // Testing that riemannSum calculates the correct average over the last 27 hours
+        // Testing that average calculates the correct average over the last 27 hours
         State average = PersistenceExtensions.averageSince(numberItem, now.minusHours(historicHours),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2286,7 +2286,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / historicHours, 0.01)));
 
-        // Testing that riemannSum calculates the correct average over the last 24 hours
+        // Testing that average calculates the correct average over the last 24 hours
         average = PersistenceExtensions.averageSince(numberItem, now.minusHours(historicHours).plusHours(3),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2294,7 +2294,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 / (historicHours - 3.0), 0.01)));
 
-        // Testing that riemannSum calculates the correct average over the last 30 minutes
+        // Testing that average calculates the correct average over the last 30 minutes
         average = PersistenceExtensions.averageSince(numberItem, now.minusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2317,7 +2317,7 @@ public class PersistenceExtensionsTest {
         // 0 - 26 hour forward in time
         createTestCachedValuesPersistenceService(now, historicHours, futureHours);
 
-        // Testing that riemannSum calculates the correct average over the next 27 hours
+        // Testing that average calculates the correct average over the next 27 hours
         State average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2325,7 +2325,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo((100.0 + 50.0) / futureHours, 0.01)));
 
-        // Testing that riemannSum calculates the correct average over the next 25 hours
+        // Testing that average calculates the correct average over the next 25 hours
         average = PersistenceExtensions.averageUntil(numberItem, now.plusHours(futureHours).minusHours(2),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);
@@ -2333,7 +2333,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(50.0 / (futureHours - 2.0), 0.01)));
 
-        // Testing that riemannSum calculates the correct average over the next 30 minutes hours
+        // Testing that average calculates the correct average over the next 30 minutes hours
         average = PersistenceExtensions.averageUntil(numberItem, now.plusMinutes(30),
                 TestCachedValuesPersistenceService.ID);
         assertNotNull(average);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -54,6 +54,7 @@ import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.PersistenceServiceRegistry;
 import org.openhab.core.persistence.registry.PersistenceServiceConfigurationRegistry;
+import org.openhab.core.persistence.extensions.PersistenceExtensions.RiemannType;
 import org.openhab.core.types.State;
 
 /**
@@ -67,6 +68,7 @@ import org.openhab.core.types.State;
  * @author Mark Herwege - handle persisted GroupItem with QuantityType
  * @author Mark Herwege - add median methods
  * @author Mark Herwege - Implement aliases
+ * @author Mark Herwege - add Riemann sum methods
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -1492,6 +1494,435 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testRiemannSumSinceDecimalType() {
+        RiemannType type = RiemannType.LEFT;
+
+        ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = riemannSum(BEFORE_START, null, type);
+        State sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
+        assertNull(sum);
+
+        type = RiemannType.RIGHT;
+
+        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(BEFORE_START, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
+        assertNull(sum);
+
+        type = RiemannType.TRAPEZOIDAL;
+
+        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(BEFORE_START, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
+        assertNull(sum);
+
+        type = RiemannType.MIDPOINT;
+
+        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(BEFORE_START, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 1 min difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 60.0);
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
+        assertNull(sum);
+    }
+
+    @Test
+    public void testRiemannSumUntilDecimalType() {
+        RiemannType type = RiemannType.LEFT;
+
+        ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        double expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        State sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
+        assertNull(sum);
+
+        type = RiemannType.RIGHT;
+
+        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
+        assertNull(sum);
+
+        type = RiemannType.TRAPEZOIDAL;
+
+        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
+        assertNull(sum);
+
+        type = RiemannType.MIDPOINT;
+
+        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
+        // now from system
+        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
+        assertNull(sum);
+    }
+
+    @Test
+    public void testRiemannSumBetweenDecimalType() {
+        RiemannType type = RiemannType.LEFT;
+
+        ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        State sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type);
+        assertNull(sum);
+
+        type = RiemannType.RIGHT;
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type);
+        assertNull(sum);
+
+        type = RiemannType.TRAPEZOIDAL;
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type);
+        assertNull(sum);
+
+        type = RiemannType.MIDPOINT;
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertEquals(expected, dt.doubleValue(), 0.01);
+
+        beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+        expected = riemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
+
+        // default persistence service
+        sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type);
+        assertNull(sum);
+    }
+
+    @Test
+    public void testRiemannSumBetweenQuantityType() {
+        for (RiemannType type : RiemannType.values()) {
+            ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                    ZoneId.systemDefault());
+            ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                    ZoneId.systemDefault());
+            double expected = riemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+            State sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
+
+            assertNotNull(sum);
+            QuantityType<?> qt = sum.as(QuantityType.class);
+            assertNotNull(qt);
+            assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+
+            beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+            endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+            expected = riemannSumCelsius(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+
+            sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
+            assertNotNull(sum);
+            qt = sum.as(QuantityType.class);
+            assertNotNull(qt);
+            assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+
+            beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+            endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
+            expected = riemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+
+            sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
+            assertNotNull(sum);
+            qt = sum.as(QuantityType.class);
+            assertNotNull(qt);
+            assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+
+            // default persistence service
+            sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type);
+            assertNull(sum);
+        }
+    }
+
+    @Test
+    public void testRiemannSumSinceDecimalTypeIrregularTimespans() {
+        RiemannType type = RiemannType.LEFT;
+
+        ZonedDateTime now = ZonedDateTime.now();
+        int historicHours = 27;
+        int futureHours = 0;
+
+        createTestCachedValuesPersistenceService(now, historicHours, futureHours);
+
+        State sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusHours(historicHours), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(100.0 * 3600 + 50.0 * 3600, 0.01)));
+
+        sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusHours(historicHours).plusHours(3), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(50.0 * 3600, 0.01)));
+
+        sum = PersistenceExtensions.riemannSumSince(numberItem, now.minusMinutes(30), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
+    }
+
+    @Test
+    public void testRiemannSumUntilDecimalTypeIrregularTimespans() {
+        RiemannType type = RiemannType.LEFT;
+
+        ZonedDateTime now = ZonedDateTime.now();
+        int historicHours = 0;
+        int futureHours = 27;
+
+        createTestCachedValuesPersistenceService(now, historicHours, futureHours);
+
+        State sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusHours(futureHours), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(100.0 * 3600 + 50.0 * 3600, 0.01)));
+
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusHours(futureHours).minusHours(2), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(50.0 * 3600, 0.01)));
+
+        sum = PersistenceExtensions.riemannSumUntil(numberItem, now.plusMinutes(30), type,
+                TestCachedValuesPersistenceService.ID);
+        assertNotNull(sum);
+        dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
+    }
+
+    @Test
+    public void testRiemannSumBetweenZeroDuration() {
+        ZonedDateTime now = ZonedDateTime.now();
+        State sum = PersistenceExtensions.riemannSumBetween(numberItem, now, now, SERVICE_ID);
+        assertNotNull(sum);
+        DecimalType dt = sum.as(DecimalType.class);
+        assertNotNull(dt);
+        assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
+    }
+
+    @Test
     public void testAverageSinceDecimalType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expected = average(BEFORE_START, null);
@@ -1564,7 +1995,7 @@ public class PersistenceExtensionsTest {
         assertThat(dt.doubleValue(), is(closeTo(expected, 0.01)));
 
         // default persistence service
-        average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored);
+        average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored);
         assertNull(average);
     }
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -41,6 +41,7 @@ import org.openhab.core.persistence.FilterCriteria.Ordering;
 import org.openhab.core.persistence.HistoricItem;
 import org.openhab.core.persistence.PersistenceItemInfo;
 import org.openhab.core.persistence.QueryablePersistenceService;
+import org.openhab.core.persistence.extensions.PersistenceExtensions.RiemannType;
 import org.openhab.core.persistence.strategy.PersistenceStrategy;
 import org.openhab.core.types.State;
 
@@ -49,6 +50,7 @@ import org.openhab.core.types.State;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Mark Herwege - Allow future values
+ * @author Mark Herwege - Adapt test expected value logic for Riemann sums
  */
 @NonNullByDefault
 public class TestPersistenceService implements QueryablePersistenceService {
@@ -86,6 +88,8 @@ public class TestPersistenceService implements QueryablePersistenceService {
     static final int FUTURE_END = 2100;
     static final int AFTER_END = 2110;
     static final DecimalType STATE = new DecimalType(HISTORIC_END);
+
+    static final double KELVIN_OFFSET = 273.15;
 
     private final ItemRegistry itemRegistry;
 
@@ -176,6 +180,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 }
                 final int year = i;
                 results.add(new HistoricItem() {
+
                     @Override
                     public ZonedDateTime getTimestamp() {
                         return ZonedDateTime.of(year, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -201,6 +206,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
             if (filter.getOrdering() == Ordering.DESCENDING) {
                 Collections.reverse(results);
             }
+
             Stream<HistoricItem> stream = results.stream();
             if (filter.getPageNumber() > 0) {
                 stream = stream.skip(filter.getPageSize() * filter.getPageNumber());
@@ -234,17 +240,168 @@ public class TestPersistenceService implements QueryablePersistenceService {
     }
 
     static DecimalType value(long year) {
+        return value(year, false);
+    }
+
+    private static DecimalType value(long year, boolean kelvinOffset) {
         if (year < HISTORIC_START) {
             return DecimalType.ZERO;
         } else if (year <= HISTORIC_END) {
-            return new DecimalType(year);
+            return new DecimalType(year + (kelvinOffset ? KELVIN_OFFSET : 0));
         } else if (year < FUTURE_START) {
-            return new DecimalType(HISTORIC_END);
+            return new DecimalType(HISTORIC_END + (kelvinOffset ? KELVIN_OFFSET : 0));
         } else if (year <= FUTURE_END) {
-            return new DecimalType(year);
+            return new DecimalType(year + (kelvinOffset ? KELVIN_OFFSET : 0));
         } else {
-            return new DecimalType(FUTURE_END);
+            return new DecimalType(FUTURE_END + (kelvinOffset ? KELVIN_OFFSET : 0));
         }
+    }
+
+    static double riemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
+        return riemannSumInternal(beginYear, endYear, type, false);
+    }
+
+    static double riemannSumCelsius(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
+        return riemannSumInternal(beginYear, endYear, type, true);
+    }
+
+    private static double riemannSumInternal(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type,
+            boolean kelvinOffset) {
+        ZonedDateTime now = ZonedDateTime.now();
+        int begin = beginYear != null ? (beginYear < HISTORIC_START ? HISTORIC_START : beginYear) : now.getYear() + 1;
+        int end = endYear != null ? endYear : now.getYear();
+        double sum = 0;
+        int index = begin;
+        long duration = 0;
+        long nextDuration = 0;
+        switch (type) {
+            case LEFT:
+                if (beginYear == null) {
+                    duration = Duration
+                            .between(now, ZonedDateTime.of(now.getYear() + 1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                }
+                while (index < end) {
+                    int bucketStart = index;
+                    double value = value(index, kelvinOffset).doubleValue();
+                    while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
+                        index++;
+                    }
+                    index++;
+                    duration += Duration
+                            .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                                    ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                    if (endYear == null && index == end) {
+                        duration += Duration
+                                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now)
+                                .toSeconds();
+                    }
+                    sum += value * duration;
+                    duration = 0;
+                }
+                break;
+            case RIGHT:
+                if (beginYear == null) {
+                    duration = Duration
+                            .between(now, ZonedDateTime.of(now.getYear() + 1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                }
+                while (index < end) {
+                    int bucketStart = index;
+                    while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
+                        index++;
+                    }
+                    index++;
+                    double value = value(index, kelvinOffset).doubleValue();
+                    duration += Duration
+                            .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                                    ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                    if (endYear == null && index == end) {
+                        duration += Duration
+                                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now)
+                                .toSeconds();
+                    }
+                    sum += value * duration;
+                    duration = 0;
+                }
+                break;
+            case TRAPEZOIDAL:
+                if (beginYear == null) {
+                    duration = Duration
+                            .between(now, ZonedDateTime.of(now.getYear() + 1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                }
+                while (index < end) {
+                    int bucketStart = index;
+                    double value = value(index, kelvinOffset).doubleValue();
+                    while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
+                        index++;
+                    }
+                    index++;
+                    value = (value + value(index, kelvinOffset).doubleValue()) / 2.0;
+                    duration += Duration
+                            .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                                    ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                    if (endYear == null && index == end) {
+                        duration += Duration
+                                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now)
+                                .toSeconds();
+                    }
+                    sum += value * duration;
+                    duration = 0;
+                }
+                break;
+            case MIDPOINT:
+                int nextIndex = begin;
+                boolean startBucket = true;
+                double startValue = value(begin, kelvinOffset).doubleValue();
+                if (beginYear == null) {
+                    duration = Duration.between(now, ZonedDateTime.of(begin, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                }
+                while (index < end - 1 && nextIndex < end) {
+                    int bucketStart = index;
+                    while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
+                        index++;
+                    }
+                    index++;
+                    double value = value(index, kelvinOffset).doubleValue();
+                    duration += Duration
+                            .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                                    ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                    if (startBucket) {
+                        sum += startValue * duration / 2.0;
+                        startBucket = false;
+                    }
+                    bucketStart = index;
+                    nextIndex = index;
+                    while ((nextIndex < end - 1)
+                            && (value(nextIndex).longValue() == value(nextIndex + 1).longValue())) {
+                        nextIndex++;
+                    }
+                    nextIndex++;
+                    nextDuration = Duration
+                            .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                                    ZonedDateTime.of(nextIndex, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
+                            .toSeconds();
+                    if (endYear == null && nextIndex == end) {
+                        nextDuration += Duration
+                                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now)
+                                .toSeconds();
+                    }
+                    sum += value * (duration + nextDuration) / 2.0;
+                    duration = 0;
+                }
+                double endValue = value(end, kelvinOffset).doubleValue();
+                long endDuration = nextDuration;
+                sum += endValue * endDuration / 2.0;
+                break;
+        }
+        return sum;
     }
 
     static double average(@Nullable Integer beginYear, @Nullable Integer endYear) {
@@ -255,18 +412,8 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 : now;
         ZonedDateTime endDate = endYear != null ? ZonedDateTime.of(endYear, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
                 : now;
-        int begin = beginYear != null ? beginYear : now.getYear() + 1;
-        int end = endYear != null ? endYear : now.getYear();
-        long sum = LongStream.range(begin, end).map(y -> value(y).longValue() * Duration
-                .between(ZonedDateTime.of(Long.valueOf(y).intValue(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
-                        ZonedDateTime.of(Long.valueOf(y + 1).intValue(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
-                .toMillis()).sum();
-        sum += beginYear == null ? value(now.getYear()).longValue() * Duration
-                .between(now, ZonedDateTime.of(now.getYear() + 1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())).toMillis()
-                : 0;
-        sum += endYear == null ? value(now.getYear()).longValue() * Duration
-                .between(ZonedDateTime.of(now.getYear(), 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), now).toMillis() : 0;
-        long duration = Duration.between(beginDate, endDate).toMillis();
+        double sum = riemannSum(beginYear, endYear, RiemannType.LEFT);
+        long duration = Duration.between(beginDate, endDate).toSeconds();
         return 1.0 * sum / duration;
     }
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -257,15 +257,15 @@ public class TestPersistenceService implements QueryablePersistenceService {
         }
     }
 
-    static double riemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
-        return riemannSumInternal(beginYear, endYear, type, false);
+    static double testRiemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
+        return testRiemannSum(beginYear, endYear, type, false);
     }
 
-    static double riemannSumCelsius(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
-        return riemannSumInternal(beginYear, endYear, type, true);
+    static double testRiemannSumCelsius(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
+        return testRiemannSum(beginYear, endYear, type, true);
     }
 
-    private static double riemannSumInternal(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type,
+    private static double testRiemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type,
             boolean kelvinOffset) {
         ZonedDateTime now = ZonedDateTime.now();
         int begin = beginYear != null ? (beginYear < HISTORIC_START ? HISTORIC_START : beginYear) : now.getYear() + 1;
@@ -404,7 +404,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
         return sum;
     }
 
-    static double average(@Nullable Integer beginYear, @Nullable Integer endYear) {
+    static double testAverage(@Nullable Integer beginYear, @Nullable Integer endYear) {
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime beginDate = beginYear != null
                 ? ZonedDateTime.of(beginYear >= HISTORIC_START ? beginYear : HISTORIC_START, 1, 1, 0, 0, 0, 0,
@@ -412,12 +412,12 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 : now;
         ZonedDateTime endDate = endYear != null ? ZonedDateTime.of(endYear, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
                 : now;
-        double sum = riemannSum(beginYear, endYear, RiemannType.LEFT);
+        double sum = testRiemannSum(beginYear, endYear, RiemannType.LEFT);
         long duration = Duration.between(beginDate, endDate).toSeconds();
         return 1.0 * sum / duration;
     }
 
-    static double median(@Nullable Integer beginYear, @Nullable Integer endYear) {
+    static double testMedian(@Nullable Integer beginYear, @Nullable Integer endYear) {
         ZonedDateTime now = ZonedDateTime.now();
         int begin = beginYear != null ? beginYear : now.getYear() + 1;
         int end = endYear != null ? endYear : now.getYear();


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4439

At the moment, it is not possible to easily calculate the integral value of the curve represented by persisted values. This is useful for calculating e.g. total energy consumed (in kWh) from instantaneous power meter readings (in W).

The current `sum` persistence actions calculate a sum without considering the time dimension, and therefore are only useful when we have a guaranteed constant interval between persisted values for this.

The `average` actions do use a time weighting in their calculation. Multiplying the average with the total duration considered would give an approximation. However, the `average` calculations assume a constant value over the bucket and take the value at the start of the bucket. Using this average to calculate an integration would also mean an extra calculation (already divided in the action code and multiplied again in the rule).
An alternative approach to get an integral value is by setting up an integrated item and a rule that adds value * duration since previous change/upate, triggered on base item change. This works and is flexible in its calculation (value can be approximated based on previous and new item state). It suffers from things like unexpected shutdowns, where the base item and its aggretation may run out of sync.

This PR proposes to create a group of new actions, `riemannSum` , that will calculate the RiemannSum as an approximation for the integral value. Analoguous to the other actions, there are variants taking (or not) `startDate`, `endDate` and `serviceId` as input.
There is one extra key parameter, the Riemann type, representing the type of approximation used. Valid values are:

- `RiemannType.left`: takes the persisted value at the start of the bucket to represent the value for the whole bucket. This is most useful when there is a `persistOnChange` strategy and the values represent a step function. An example would be dynamic electricity rates, as they will  effectively be constant inside the bucket.
- `RiemannType.right`: takes the persisted value at the end of the bucket.
- `RiemannType.trapezoidal`: takes the average of the persisted value at the start end the end of the bucket, effectively making a linear interpolation to fit the curve. This type is most useful when the real values change continuously. It can be used for any persistence strategy and any interval.
- `RiemannType.midpoint`: uses 3 persisted values and uses the middle of the values as an approximation for the value halfway in the interval between the middle of point 1 and 2 and the middle of point 2 and 3. This is the best approximation when the real values change continuously, the persistence intervals are short and the bucket sizes between persisted values are relatively constant.

The existing `average`, `variance` and `deviation` actions have been enhanced to use the results of the Riemann sum calculations. They now have variants with an extra parameter where this type can be selected.
For backward compatibility and consistency between defaults of the different actions, the action versions for `riemannSum`, `average`, `variance` and `deviation` without a Riemann type parameter all use `RiemannType.left` as a default.

Tests have been enhanced end confirmed the existing actions with the existing parameters still behave as before.

If this PR is accepted the scripting libraries should be enhanced to cover these new actions and the new parameters in the existing actions.

For testing, a compiled jar can be downloaded from [here](https://www.dropbox.com/scl/fi/xmks0sp5g2yobdfxplw0i/org.openhab.core.persistence-4.3.0-SNAPSHOT.jar?rlkey=lmg3a0s3vy6kqqr2w8px0jtua&st=056uj3mx&dl=0).