### PR TITLE
Persistence exclude items and groups

### DIFF
--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -56,7 +56,8 @@ NotIncludeFilter:
 
 
 PersistenceConfiguration:
-	items+=(AllConfig | ItemConfig | GroupConfig) (',' items+=(AllConfig | ItemConfig | GroupConfig))* ('->' alias=STRING)? 
+	items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig)
+	   (',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* ('->' alias=STRING)? 
 	((':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)? 
 		 ('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
 		| ';')
@@ -73,6 +74,14 @@ ItemConfig:
 
 GroupConfig:
 	group=ID '*'
+;
+
+ItemExcludeConfig:
+    '!' itemExclude=ID
+;
+
+GroupExcludeConfig:
+    '!' groupExclude=ID '*'
 ;
 
 DECIMAL returns ecore::EBigDecimal :

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
@@ -29,8 +29,10 @@ import org.openhab.core.model.persistence.persistence.CronStrategy;
 import org.openhab.core.model.persistence.persistence.EqualsFilter;
 import org.openhab.core.model.persistence.persistence.Filter;
 import org.openhab.core.model.persistence.persistence.GroupConfig;
+import org.openhab.core.model.persistence.persistence.GroupExcludeConfig;
 import org.openhab.core.model.persistence.persistence.IncludeFilter;
 import org.openhab.core.model.persistence.persistence.ItemConfig;
+import org.openhab.core.model.persistence.persistence.ItemExcludeConfig;
 import org.openhab.core.model.persistence.persistence.NotEqualsFilter;
 import org.openhab.core.model.persistence.persistence.NotIncludeFilter;
 import org.openhab.core.model.persistence.persistence.PersistenceConfiguration;
@@ -43,7 +45,9 @@ import org.openhab.core.persistence.PersistenceService;
 import org.openhab.core.persistence.config.PersistenceAllConfig;
 import org.openhab.core.persistence.config.PersistenceConfig;
 import org.openhab.core.persistence.config.PersistenceGroupConfig;
+import org.openhab.core.persistence.config.PersistenceGroupExcludeConfig;
 import org.openhab.core.persistence.config.PersistenceItemConfig;
+import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.filter.PersistenceEqualsFilter;
 import org.openhab.core.persistence.filter.PersistenceFilter;
 import org.openhab.core.persistence.filter.PersistenceIncludeFilter;
@@ -98,7 +102,11 @@ public class PersistenceModelManager extends AbstractProvider<PersistenceService
             String serviceName = serviceName(modelName);
             if (type == EventType.REMOVED) {
                 PersistenceServiceConfiguration removed = configurations.remove(serviceName);
-                notifyListenersAboutRemovedElement(removed);
+                if (removed == null) {
+                    logger.warn("Service for {} was already removed from registry, ignoring.", modelName);
+                } else {
+                    notifyListenersAboutRemovedElement(removed);
+                }
             } else {
                 final PersistenceModel model = (PersistenceModel) modelRepository.getModel(modelName);
 
@@ -153,6 +161,10 @@ public class PersistenceModelManager extends AbstractProvider<PersistenceService
                 items.add(new PersistenceGroupConfig(groupConfig.getGroup()));
             } else if (item instanceof ItemConfig itemConfig) {
                 items.add(new PersistenceItemConfig(itemConfig.getItem()));
+            } else if (item instanceof GroupExcludeConfig groupExcludeConfig) {
+                items.add(new PersistenceGroupExcludeConfig(groupExcludeConfig.getGroupExclude()));
+            } else if (item instanceof ItemExcludeConfig itemExcludeConfig) {
+                items.add(new PersistenceItemExcludeConfig(itemExcludeConfig.getItemExclude()));
             }
         }
         return new PersistenceItemConfiguration(items, config.getAlias(), mapStrategies(config.getStrategies()),

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupExcludeConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupExcludeConfig.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.persistence.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This class represents the configuration that is used for excluding group items.
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+@NonNullByDefault
+public class PersistenceGroupExcludeConfig extends PersistenceConfig {
+
+    private final String group;
+
+    public PersistenceGroupExcludeConfig(final String group) {
+        this.group = group;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s [group=%s]", getClass().getSimpleName(), group);
+    }
+}

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemExcludeConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemExcludeConfig.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.persistence.config;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This class represents the configuration that identify item(s) by name for exclusion.
+ *
+ * @author Mark Herwege - Initial contribution
+ */
+@NonNullByDefault
+public class PersistenceItemExcludeConfig extends PersistenceConfig {
+    final String item;
+
+    public PersistenceItemExcludeConfig(final String item) {
+        this.item = item;
+    }
+
+    public String getItem() {
+        return item;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s [item=%s]", getClass().getSimpleName(), item);
+    }
+}

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -27,7 +27,9 @@ import org.openhab.core.persistence.PersistenceItemConfiguration;
 import org.openhab.core.persistence.config.PersistenceAllConfig;
 import org.openhab.core.persistence.config.PersistenceConfig;
 import org.openhab.core.persistence.config.PersistenceGroupConfig;
+import org.openhab.core.persistence.config.PersistenceGroupExcludeConfig;
 import org.openhab.core.persistence.config.PersistenceItemConfig;
+import org.openhab.core.persistence.config.PersistenceItemExcludeConfig;
 import org.openhab.core.persistence.dto.PersistenceCronStrategyDTO;
 import org.openhab.core.persistence.dto.PersistenceFilterDTO;
 import org.openhab.core.persistence.dto.PersistenceItemConfigurationDTO;
@@ -113,8 +115,14 @@ public class PersistenceServiceConfigurationDTOMapper {
         if ("*".equals(string)) {
             return new PersistenceAllConfig();
         } else if (string.endsWith("*")) {
+            if (string.startsWith("!")) {
+                return new PersistenceGroupExcludeConfig(string.substring(1, string.length() - 1));
+            }
             return new PersistenceGroupConfig(string.substring(0, string.length() - 1));
         } else {
+            if (string.startsWith("!")) {
+                return new PersistenceItemExcludeConfig(string.substring(1, string.length() - 1));
+            }
             return new PersistenceItemConfig(string);
         }
     }
@@ -149,6 +157,10 @@ public class PersistenceServiceConfigurationDTOMapper {
             return persistenceGroupConfig.getGroup() + "*";
         } else if (config instanceof PersistenceItemConfig persistenceItemConfig) {
             return persistenceItemConfig.getItem();
+        } else if (config instanceof PersistenceGroupExcludeConfig persistenceGroupExcludeConfig) {
+            return "!" + persistenceGroupExcludeConfig.getGroup() + "*";
+        } else if (config instanceof PersistenceItemExcludeConfig persistenceItemExcludeConfig) {
+            return "!" + persistenceItemExcludeConfig.getItem();
         }
         throw new IllegalArgumentException("Unknown persistence config class " + config.getClass());
     }


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/3665

This has been an often requested enhancement in the forum.

Allow syntax like in a persistence file:

```
Items {
    *, !Item1, !Item2 : strategy = everyChange // every Item but Item1 and Item2
    PersistGroup*, !DoNotPersistGroup* : strategy = everyMinute // items member of PersistGroup but not member of DoNotPersistGroup
}
```

The issue also proposes an alternative approach (`Vetoed`). I have not implemented this. It would also not be strategy/filter specific, so left that out for now and could be a future enhancement.