### PR TITLE
Upgrade Jollyday to 0.35.1

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -365,7 +365,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.32.0</version>
+      <version>0.35.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -950,7 +950,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.32.0</version>
+      <version>0.35.1</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -174,12 +174,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.32.0</capability>
+		<capability>openhab.tp;feature=jollyday;version=0.35.1</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/0.32.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/0.32.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/0.35.1</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/0.35.1</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -79,7 +79,7 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -79,7 +79,7 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -76,7 +76,7 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -79,7 +79,7 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -79,7 +79,7 @@ Fragment-Host: org.openhab.core.automation
 	org.openhab.core.thing;version='[4.3.0,4.3.1)',\
 	org.openhab.core.transform;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -74,7 +74,7 @@ feature.openhab-config: \
 	org.openhab.core.ephemeris.tests;version='[4.3.0,4.3.1)',\
 	org.openhab.core.test;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -125,7 +125,7 @@ Fragment-Host: org.openhab.core.model.item
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
 	com.google.guava;version='[33.3.0,33.3.1)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -128,8 +128,8 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
 	com.google.guava;version='[33.3.0,33.3.1)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.openhab.core.model.item.runtime;version='[4.3.0,4.3.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -132,7 +132,7 @@ Fragment-Host: org.openhab.core.model.script
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
 	com.google.guava;version='[33.3.0,33.3.1)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.openhab.core.model.item.runtime;version='[4.3.0,4.3.1)'
+	org.openhab.core.model.item.runtime;version='[4.3.0,4.3.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -134,7 +134,7 @@ Fragment-Host: org.openhab.core.model.thing
 	org.openhab.core.voice;version='[4.3.0,4.3.1)',\
 	stax2-api;version='[4.2.2,4.2.3)',\
 	com.google.guava;version='[33.3.0,33.3.1)',\
-	de.focus_shift.jollyday-core;version='[0.32.0,0.32.1)',\
-	de.focus_shift.jollyday-jackson;version='[0.32.0,0.32.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	org.osgi.service.cm;version='[1.6.0,1.6.1)'
+	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
+	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
+	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'


### PR DESCRIPTION
Upgrades Jollyday from 0.32.0 to 0.35.1.

For release notes, see:

* https://github.com/focus-shift/jollyday/releases/tag/v0.33.0
* https://github.com/focus-shift/jollyday/releases/tag/v0.34.0
* https://github.com/focus-shift/jollyday/releases/tag/v0.35.0
* https://github.com/focus-shift/jollyday/releases/tag/v0.35.1