### PR TITLE
Fixed a few non deterministic tests in the repository

### DIFF
--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.config.core.internal.validation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -268,7 +269,7 @@ public class ConfigDescriptionValidatorTest {
         params.put(DECIMAL_REQUIRED_PARAM_NAME, null);
         ConfigValidationException exception = Assertions.assertThrows(ConfigValidationException.class,
                 () -> configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI));
-        assertThat(getConfigValidationMessages(exception), is(expected));
+        assertThat(getConfigValidationMessages(exception), containsInAnyOrder(expected.toArray()));
     }
 
     void assertMissingRequired(String parameterName) {
@@ -352,7 +353,7 @@ public class ConfigDescriptionValidatorTest {
         params.put(DECIMAL_MAX_PARAM_NAME, DECIMAL_MAX_VIOLATED);
         ConfigValidationException exception = Assertions.assertThrows(ConfigValidationException.class,
                 () -> configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI));
-        assertThat(getConfigValidationMessages(exception), is(expected));
+        assertThat(getConfigValidationMessages(exception), containsInAnyOrder(expected.toArray()));
     }
 
     void assertMinMax(String parameterName, Object value, MessageKey msgKey, String minMax) {
@@ -405,7 +406,7 @@ public class ConfigDescriptionValidatorTest {
         params.put(DECIMAL_PARAM_NAME, INVALID);
         ConfigValidationException exception = Assertions.assertThrows(ConfigValidationException.class,
                 () -> configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI));
-        assertThat(getConfigValidationMessages(exception), is(expected));
+        assertThat(getConfigValidationMessages(exception), containsInAnyOrder(expected.toArray()));
     }
 
     void assertType(String parameterName, Type type) {
@@ -513,7 +514,7 @@ public class ConfigDescriptionValidatorTest {
         params.put(DECIMAL_MAX_PARAM_NAME, DECIMAL_MAX_VIOLATED);
         ConfigValidationException exception = Assertions.assertThrows(ConfigValidationException.class,
                 () -> configDescriptionValidator.validate(params, CONFIG_DESCRIPTION_URI));
-        assertThat(getConfigValidationMessages(exception), is(expected));
+        assertThat(getConfigValidationMessages(exception), containsInAnyOrder(expected.toArray()));
     }
 
     @Test

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
@@ -25,6 +25,7 @@ import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 
 /**
  * {@link InboxEventFactoryTest} tests the {@link InboxEventFactory}.
@@ -71,7 +72,7 @@ public class InboxEventFactoryTest {
 
         assertThat(event.getType(), is(INBOX_ADDED_EVENT_TYPE));
         assertThat(event.getTopic(), is(INBOX_ADDED_EVENT_TOPIC));
-        assertThat(event.getPayload(), is(INBOX_ADDED_EVENT_PAYLOAD));
+        assertThat(JsonParser.parseString(event.getPayload()), is(JsonParser.parseString(INBOX_ADDED_EVENT_PAYLOAD)));
         assertThat(event.getDiscoveryResult(), not(nullValue()));
         assertThat(event.getDiscoveryResult().thingUID, is(THING_UID.getAsString()));
     }

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
@@ -27,6 +27,7 @@ import org.openhab.core.library.types.DateTimeType;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
 
 /**
  * Tests {@link Stream2JSONInputStream}.
@@ -52,7 +53,8 @@ public class Stream2JSONInputStreamTest {
         List<DummyObject> dummyList = List.of(dummyObject);
         Stream2JSONInputStream collection2InputStream = new Stream2JSONInputStream(Stream.of(dummyObject));
 
-        assertThat(inputStreamToString(collection2InputStream), is(GSON.toJson(dummyList)));
+        assertThat(JsonParser.parseString(inputStreamToString(collection2InputStream)),
+                is(JsonParser.parseString(GSON.toJson(dummyList))));
     }
 
     @Test
@@ -62,7 +64,8 @@ public class Stream2JSONInputStreamTest {
         List<DummyObject> dummyCollection = List.of(dummyObject1, dummyObject2);
         Stream2JSONInputStream collection2InputStream = new Stream2JSONInputStream(dummyCollection.stream());
 
-        assertThat(inputStreamToString(collection2InputStream), is(GSON.toJson(dummyCollection)));
+        assertThat(JsonParser.parseString(inputStreamToString(collection2InputStream)),
+                is(JsonParser.parseString(GSON.toJson(dummyCollection))));
     }
 
     private String inputStreamToString(InputStream in) throws IOException {

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
@@ -14,6 +14,7 @@ package org.openhab.core.model.yaml.internal;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -41,6 +42,7 @@ import org.openhab.core.model.yaml.YamlModelListener;
 import org.openhab.core.model.yaml.test.FirstTypeDTO;
 import org.openhab.core.model.yaml.test.SecondTypeDTO;
 import org.openhab.core.service.WatchService;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * The {@link YamlModelRepositoryImplTest} contains tests for the {@link YamlModelRepositoryImpl} class.
@@ -204,8 +206,9 @@ public class YamlModelRepositoryImplTest {
 
         String actualFileContent = Files.readString(fullModelPath);
         String expectedFileContent = Files.readString(SOURCE_PATH.resolve("addToModelExpectedContent.yaml"));
+        Yaml yaml = new Yaml();
 
-        assertThat(actualFileContent, is(expectedFileContent.replaceAll("\r\n", "\n")));
+        assertThat(yaml.load(actualFileContent), equalTo(yaml.load(expectedFileContent.replaceAll("\r\n", "\n"))));
     }
 
     @Test
@@ -220,8 +223,9 @@ public class YamlModelRepositoryImplTest {
 
         String actualFileContent = Files.readString(fullModelPath);
         String expectedFileContent = Files.readString(SOURCE_PATH.resolve("updateInModelExpectedContent.yaml"));
+        Yaml yaml = new Yaml();
 
-        assertThat(actualFileContent, is(expectedFileContent.replaceAll("\r\n", "\n")));
+        assertThat(yaml.load(actualFileContent), equalTo(yaml.load(expectedFileContent.replaceAll("\r\n", "\n"))));
     }
 
     @Test

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
@@ -24,6 +24,7 @@ import org.openhab.core.thing.link.ItemChannelLink;
 import org.openhab.core.thing.link.dto.ItemChannelLinkDTO;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 
 /**
  * {@link LinkEventFactoryTest} tests the {@link LinkEventFactory}.
@@ -52,7 +53,7 @@ public class LinkEventFactoryTest {
 
         assertEquals(ItemChannelLinkAddedEvent.TYPE, event.getType());
         assertEquals(LINK_ADDED_EVENT_TOPIC, event.getTopic());
-        assertEquals(LINK_EVENT_PAYLOAD, event.getPayload());
+        assertEquals(JsonParser.parseString(LINK_EVENT_PAYLOAD), JsonParser.parseString(event.getPayload()));
     }
 
     @Test
@@ -73,7 +74,7 @@ public class LinkEventFactoryTest {
 
         assertEquals(ItemChannelLinkRemovedEvent.TYPE, event.getType());
         assertEquals(LINK_REMOVED_EVENT_TOPIC, event.getTopic());
-        assertEquals(LINK_EVENT_PAYLOAD, event.getPayload());
+        assertEquals(JsonParser.parseString(LINK_EVENT_PAYLOAD), JsonParser.parseString(event.getPayload()));
     }
 
     @Test

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheMapTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheMapTest.java
@@ -149,7 +149,7 @@ public class ExpiringCacheMapTest {
             expectedValues.add(value1);
 
             final Collection<@Nullable String> values = subject.values();
-            assertEquals(expectedValues, values);
+            assertEquals(new LinkedHashSet<>(expectedValues), new LinkedHashSet<>(values));
         }
 
         // use another different key

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/events/ItemEventFactoryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/events/ItemEventFactoryTest.java
@@ -31,6 +31,7 @@ import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 
 /**
  * {@link ItemEventFactoryTest} tests the {@link ItemEventFactory}.
@@ -96,7 +97,7 @@ public class ItemEventFactoryTest {
 
         assertEquals(ITEM_COMMAND_EVENT_TYPE, event.getType());
         assertEquals(ITEM_COMMAND_EVENT_TOPIC, event.getTopic());
-        assertEquals(ITEM_COMMAND_EVENT_PAYLOAD, event.getPayload());
+        assertEquals(JsonParser.parseString(ITEM_COMMAND_EVENT_PAYLOAD), JsonParser.parseString(event.getPayload()));
         assertEquals(ITEM_NAME, event.getItemName());
         assertEquals(SOURCE, event.getSource());
         assertEquals(OnOffType.class, event.getItemCommand().getClass());
@@ -189,7 +190,7 @@ public class ItemEventFactoryTest {
 
         assertThat(event.getType(), is(ITEM_STATE_EVENT_TYPE));
         assertThat(event.getTopic(), is(ITEM_STATE_EVENT_TOPIC));
-        assertThat(event.getPayload(), is(ITEM_STATE_EVENT_PAYLOAD));
+        assertThat(JsonParser.parseString(event.getPayload()), is(JsonParser.parseString(ITEM_STATE_EVENT_PAYLOAD)));
         assertThat(event.getItemName(), is(ITEM_NAME));
         assertThat(event.getSource(), is(SOURCE));
         assertEquals(OnOffType.class, event.getItemState().getClass());


### PR DESCRIPTION
# Fix a few non deterministic tests in the repository

This pull request resolves several non-deterministic tests in the repository, addressing some of the tests mentioned in the issue [openhab-core issue #4474](https://github.com/openhab/openhab-core/issues/4474).

There were a number of flaky tests in the repository which were detected using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. More details about the steps to reproduce it and the details for the tools are mentioned in [openhab-core issue #4474](https://github.com/openhab/openhab-core/issues/4474).

## Description
This PR fixes the following tests mentioned below and the steps to reproduce the issue is already mentioned in [openhab-core issue #4474](https://github.com/openhab/openhab-core/issues/4474):

### For the tests:
- org.openhab.core.thing.link.events.LinkEventFactoryTest.testCreateItemChannelLinkRemovedEvent
- org.openhab.core.thing.link.events.LinkEventFactoryTest.testCreateItemChannelLinkAddedEvent
- org.openhab.core.io.rest.Stream2JSONInputStreamTest.shouldStreamCollectionStreamToJSON
- org.openhab.core.io.rest.Stream2JSONInputStreamTest.shouldStreamSingleObjectToJSON
- org.openhab.core.config.discovery.inbox.events.InboxEventFactoryTest.inboxEventFactoryCreatesInboxAddedEventCorrectly
- org.openhab.core.items.events.ItemEventFactoryTest.testCreateCommandEventOnOffType
- org.openhab.core.items.events.ItemEventFactoryTest.testCreateStateEventOnOffType

The reason for flakiness is that since JSON-like structure is being compared using assertEquals, order dependency could cause the test to fail. JSON properties may not always maintain the same order, depending on the implementation of the object creation or serialization.

A JSON parser was utilized to process the objects before comparison. This ensures the content is evaluated irrespective of property order, resolving the order dependency issue.

### For the test:
- org.openhab.core.cache.ExpiringCacheMapTest.testValues

The test org.openhab.core.cache.ExpiringCacheMapTest.testValues failed due to non-deterministic ordering in the subject.values() function, causing assertEquals to fail.

The values were converted to a LinkedHashSet before comparison. This guarantees a consistent, deterministic order.

### For the tests:
- org.openhab.core.config.core.internal.validation.ConfigDescriptionValidatorTest.assertValidationThrowsExceptionContainingMessagesForAllMinMaxConfigParameters
- org.openhab.core.config.core.internal.validation.ConfigDescriptionValidatorTest.assertValidationThrowsExceptionContainingMessagesForMultipleInvalidTypedConfigParameters
- org.openhab.core.config.core.internal.validation.ConfigDescriptionValidatorTest.assertValidationThrowsExceptionContainingMultipleVariousViolations
- org.openhab.core.config.core.internal.validation.ConfigDescriptionValidatorTest.assertValidationThrowsExceptionContainingMessagesForAllRequiredConfigParameters

The flakiness in the tests are caused by non-deterministic ordering of the ConfigValidationMessage objects in the exception. The params map's entries are iterated in a non-deterministic order when processed by the configDescriptionValidator.validate method. This can result in the order of ConfigValidationMessage objects in the exception being inconsistent across different test runs.

To fix the test, I made use of the containsInAnyOrder matcher which ensures the comparison focuses on the content of the messages without depending on their order.

### For the tests:
- org.openhab.core.model.yaml.internal.YamlModelRepositoryImplTest.testUpdateElementInModel
- org.openhab.core.model.yaml.internal.YamlModelRepositoryImplTest.testAddElementToModel

The reason for flakiness is that YAML is a human-readable data serialization format, but it does not guarantee a deterministic order for keys in mappings. If the YamlModelRepositoryImpl modifies the content or serializes the added element in a different key order than expected, the string comparison (is(expectedFileContent)) will fail, even if the data structures are logically equivalent.

The fix involves making use of YAML parser to load the file contents as structured objects ensuring order independence.