### PR TITLE
IP addon finder: add support for sending local mac address

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
@@ -143,6 +143,11 @@ import org.slf4j.LoggerFactory;
  * <td>timeout to wait for a answers</td>
  * <td></td>
  * </tr>
+ * <tr>
+ * <td>{@code fmtMac}</td>
+ * <td>format specifier string for mac address</td>
+ * <td>e.g. '%02X', '%02X:', '%02x-'</td>
+ * </tr>
  * </table>
  * <p>
  * <table border="1">
@@ -163,9 +168,6 @@ import org.slf4j.LoggerFactory;
  * <td>source mac address</td>
  * </tr>
  * <tr>
- * <td>{@code $fmtMac}</td>
- * <td>format specifier string for mac address</td>
- * </tr>
  * <td>{@code $uuid}</td>
  * <td>String returned by {@code java.util.UUID.randomUUID()}</td>
  * </tr>


### PR DESCRIPTION
Adds support for a `srcMac` substitution token which allows the scan packets to include the source mac address.
The mac address is formatted by the given `fmtMac` format specifier.

See https://github.com/openhab/openhab-addons/issues/17847

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>