### PR TITLE
[ephemeris] Add option for disabling the cache

### DIFF
--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -224,8 +225,8 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     private URL getUrl(String filename) throws FileNotFoundException {
         if (Files.exists(Paths.get(filename))) {
             try {
-                return URI.create("file:" + filename).toURL();
-            } catch (MalformedURLException e) {
+                return (new URI("file:" + filename)).toURL();
+            } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
                 throw new FileNotFoundException(e.getMessage());
             }
         }

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -89,11 +89,11 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     private static final String PROPERTY_COUNTRY_DESCRIPTION_PREFIX = "country.description.";
     private static final String PROPERTY_COUNTRY_DESCRIPTION_DELIMITER = "\\.";
 
-    private final List<ParameterOption> countries = new ArrayList<>();
-    private final Map<String, List<ParameterOption>> regions = new HashMap<>();
-    private final Map<String, List<ParameterOption>> cities = new HashMap<>();
+    protected final List<ParameterOption> countries = new ArrayList<>();
+    protected final Map<String, List<ParameterOption>> regions = new HashMap<>();
+    protected final Map<String, List<ParameterOption>> cities = new HashMap<>();
 
-    private final Map<String, Set<DayOfWeek>> daysets = new HashMap<>();
+    protected final Map<String, Set<DayOfWeek>> daysets = new HashMap<>();
     private final Map<Object, HolidayManager> holidayManagers = new HashMap<>();
     private final List<String> countryParameters = new ArrayList<>();
 
@@ -224,7 +224,7 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     private URL getUrl(String filename) throws FileNotFoundException {
         if (Files.exists(Paths.get(filename))) {
             try {
-                return new URL("file:" + filename);
+                return URI.create("file:" + filename).toURL();
             } catch (MalformedURLException e) {
                 throw new FileNotFoundException(e.getMessage());
             }

--- a/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/config/ephemeris.xml
+++ b/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/config/ephemeris.xml
@@ -23,6 +23,12 @@
 			<description>Get the holidays for a specific city (e.g. New York City = "nyc").</description>
 			<advanced>true</advanced>
 		</parameter>
+        <parameter name="cache" type="boolean">
+            <label>Cache Files</label>
+            <description>User defined configuration files are cached once loaded. When set to false, files will be read for each access.</description>
+            <advanced>true</advanced>
+            <default>true</default>
+        </parameter>
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/config/ephemeris.xml
+++ b/bundles/org.openhab.core.ephemeris/src/main/resources/OH-INF/config/ephemeris.xml
@@ -23,12 +23,13 @@
 			<description>Get the holidays for a specific city (e.g. New York City = "nyc").</description>
 			<advanced>true</advanced>
 		</parameter>
-        <parameter name="cache" type="boolean">
-            <label>Cache Files</label>
-            <description>User defined configuration files are cached once loaded. When set to false, files will be read for each access.</description>
-            <advanced>true</advanced>
-            <default>true</default>
-        </parameter>
+		<parameter name="cache" type="boolean">
+			<label>Cache Files</label>
+			<description>User defined configuration files are cached once loaded. When set to false, files will be read for each
+				access.</description>
+			<advanced>true</advanced>
+			<default>true</default>
+		</parameter>
 	</config-description>
 
 </config-description:config-descriptions>


### PR DESCRIPTION
Adds possibility to disable user defined holiday description files caching.
This in interesting especially when defining/debugging these files.
A new option can be set  in the ephemeris.cfg file, `cache=true/false`.
Default value is true, so no breaking change if the option is absent.
