### PR TITLE
Thing action REST API: allow extended scope like bindingid-xxx

### DIFF
--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -219,7 +219,7 @@ public class ThingActionsResource implements RESTResource {
     @RolesAllowed({ Role.USER, Role.ADMIN })
     // accept actionUid in the form of "scope.actionTypeUid" or "scope.actionTypeUid#signatureHash"
     // # is URL encoded as %23
-    @Path("/{thingUID}/{actionUid: [a-zA-Z0-9]+\\.[a-zA-Z0-9]+(%23[A-Fa-f0-9]+)?}")
+    @Path("/{thingUID}/{actionUid: [a-zA-Z0-9]+(\\-[a-zA-Z0-9]+)?\\.[a-zA-Z0-9]+(%23[A-Fa-f0-9]+)?}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "executeThingAction", summary = "Executes a thing action.", responses = {


### PR DESCRIPTION
It is required for actions from the max binding.
