### PR TITLE
Fix UI persistence item exclude config

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -121,7 +121,7 @@ public class PersistenceServiceConfigurationDTOMapper {
             return new PersistenceGroupConfig(string.substring(0, string.length() - 1));
         } else {
             if (string.startsWith("!")) {
-                return new PersistenceItemExcludeConfig(string.substring(1, string.length() - 1));
+                return new PersistenceItemExcludeConfig(string.substring(1));
             }
             return new PersistenceItemConfig(string);
         }


### PR DESCRIPTION
A persistence item exclusion configuration done in the UI was not properly set in the REST call.

This PR fixes this.

See discussion: https://community.openhab.org/t/openhab-4-3-release-discussion/160888/59

If merged, this should probably be picked for the first 4.3 patch release.