### PR TITLE
Enhance `DateTimeType` to parse `ZonedDateTime` with time-zone ID

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -302,8 +302,12 @@ public class DateTimeType implements PrimitiveType, State, Command, Comparable<D
                 try {
                     date = ZonedDateTime.parse(value, PARSER_TZ);
                 } catch (DateTimeParseException tzException) {
-                    LocalDateTime localDateTime = LocalDateTime.parse(value, PARSER);
-                    date = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+                    try {
+                        date = ZonedDateTime.parse(value);
+                    } catch (DateTimeParseException e) {
+                        LocalDateTime localDateTime = LocalDateTime.parse(value, PARSER);
+                        date = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+                    }
                 }
             }
         }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -264,58 +264,22 @@ public class DateTimeTypeTest {
         assertTrue(dt1.compareTo(dt1) == 0);
     }
 
-    // This can only test explicit time zones, as we cannot mock the system default time zone
     @ParameterizedTest
     @ValueSource(strings = { //
             "2024-09-05T15:30:00Z", //
             "2024-09-05 15:30Z", //
+            "2024-09-05 15:30+0000", //
             "2024-09-05 16:30+0100", //
             "2024-09-05T17:30:00.000+0200", //
-            "2024-09-05T17:30:00.000+02:00" //
+            "2024-09-05T17:30:00.000+02:00", //
+            "2024-09-05T17:30+02:00", //
+            "2024-09-05T17:30+02:00[Europe/Berlin]" //
     })
     public void parserTest(String input) {
-        ZonedDateTime zdtReference = ZonedDateTime.parse("2024-09-05T15:30:00Z");
+        Instant instantReference = Instant.parse("2024-09-05T15:30:00Z");
 
-        ZonedDateTime zdt = new DateTimeType(input).getZonedDateTime().withZoneSameInstant(zdtReference.getZone());
-        assertThat(zdt, is(zdtReference));
-    }
-
-    @Test
-    public void zonedParsingTest() {
-        DateTimeType dt1 = new DateTimeType("2019-06-12T17:30:00Z");
-        DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00+0000");
-        DateTimeType dt3 = new DateTimeType("2019-06-12T19:30:00+0200");
-        DateTimeType dt4 = new DateTimeType("2019-06-12T19:30:00+0200");
-        assertThat(dt1, is(dt2));
-
-        ZonedDateTime zdt1 = dt1.getZonedDateTime();
-        ZonedDateTime zdt2 = dt2.getZonedDateTime();
-        ZonedDateTime zdt3 = dt3.getZonedDateTime();
-        ZonedDateTime zdt4 = dt4.getZonedDateTime(ZoneId.of("UTC"));
-        assertThat(zdt1.getZone(), is(zdt2.getZone()));
-        assertThat(zdt1, is(zdt2));
-        assertThat(zdt1, is(zdt3.withZoneSameInstant(zdt1.getZone())));
-        assertThat(zdt2, is(zdt3.withZoneSameInstant(zdt2.getZone())));
-        assertThat(zdt1, is(zdt4));
-    }
-
-    @Test
-    public void instantParsingTest() {
-        DateTimeType dt1 = new DateTimeType(Instant.parse("2019-06-12T17:30:00Z"));
-        DateTimeType dt2 = new DateTimeType("2019-06-12T17:30:00Z");
-        DateTimeType dt3 = new DateTimeType("2019-06-12T17:30:00+0000");
-        DateTimeType dt4 = new DateTimeType("2019-06-12T19:30:00+0200");
-        assertThat(dt1, is(dt2));
-        assertThat(dt2, is(dt3));
-        assertThat(dt3, is(dt4));
-
-        Instant i1 = dt1.getInstant();
-        Instant i2 = dt2.getInstant();
-        Instant i3 = dt3.getInstant();
-        Instant i4 = dt4.getInstant();
-        assertThat(i1, is(i2));
-        assertThat(i2, is(i3));
-        assertThat(i3, is(i4));
+        Instant instant = new DateTimeType(input).getInstant();
+        assertThat(instant, is(instantReference));
     }
 
     @Test


### PR DESCRIPTION
This DSL rule:
```java
rule "Test"
when
    Item Test changed to ON
then
    var zoned = ZonedDateTime.parse("2024-12-22T16:29+01:00")
    logInfo("zoned to item", zoned.toString)
    TestDateTime.postUpdate(zoned.toString)

    zoned = (TestDateTime.state as DateTimeType).getZonedDateTime()
    logInfo("zoned from item", zoned.toString)

    TestDateTime.postUpdate(zoned.toString)
end
```

generates the following output in 4.3:
```
2024-12-23 00:27:00.168 [INFO ] [nhab.core.model.script.zoned to item] - 2024-12-22T16:29+01:00
2024-12-23 00:27:00.169 [INFO ] [ab.core.model.script.zoned from item] - 2024-12-22T16:29+01:00[Europe/Copenhagen]
2024-12-23 00:27:00.170 [WARN ] [b.core.model.script.actions.BusEvent] - Cannot convert '2024-12-22T16:29+01:00[Europe/Copenhagen]' to a state type which item 'TestDateTime' accepts: [DateTimeType, UnDefType].
```

Until 4.2 this rule worked, because `getZonedDateTime()` returned the same `ZonedDateTime` as provided when creating the `DateTimeType`. Since it didn't necessarily contain time-zone ID but only offset (e.g. "2024-12-22T16:29+01:00"), `DateTimeType.parse` would then be able to parse it in some scenarios. Now, it contains the time-zone ID (e.g. "2024-12-22T16:29+01:00[Europe/Copenhagen]") always, which `DateTimeType.parse` is not able to parse (and never was).

To make this rule compatible I would propose to add support for parsing a full `ZonedDateTime` string that includes time-zone ID. If this is accepted, I think it should also be cherry-picked into 4.3.x for immediate value. i.e. to fix rules that might have been broken by 4.3. By the time we reach 5.0, users would otherwise have been forced to refactor their rules already.

See https://community.openhab.org/t/datetime-conversion-after-update-to-4-3-0/161053/1

Regression of #3583