### PR TITLE
Clean up arguments after executing Script Transformation

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -17,6 +17,7 @@ import static org.openhab.core.automation.module.script.profile.ScriptProfileFac
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -185,8 +186,10 @@ public class ScriptTransformationService implements TransformationService, Confi
                         : scriptEngineContainer.getScriptEngine();
                 ScriptContext executionContext = engine.getContext();
                 executionContext.setAttribute("input", source, ScriptContext.ENGINE_SCOPE);
+                ArrayList<String> injectedParams = null;
 
                 if (params != null) {
+                    injectedParams = new ArrayList<>();
                     for (String param : params.split("&")) {
                         String[] splitString = param.split("=");
                         if (splitString.length != 2) {
@@ -197,6 +200,7 @@ public class ScriptTransformationService implements TransformationService, Confi
                             param = URLDecoder.decode(splitString[0], StandardCharsets.UTF_8);
                             String value = URLDecoder.decode(splitString[1], StandardCharsets.UTF_8);
                             executionContext.setAttribute(param, value, ScriptContext.ENGINE_SCOPE);
+                            injectedParams.add(param);
                         }
                     }
                 }
@@ -210,8 +214,16 @@ public class ScriptTransformationService implements TransformationService, Confi
                     scriptRecord.compiledScript = compiledScript;
                 }
 
-                Object result = compiledScript != null ? compiledScript.eval() : engine.eval(scriptRecord.script);
-                return result == null ? null : result.toString();
+                try {
+                    Object result = compiledScript != null ? compiledScript.eval() : engine.eval(scriptRecord.script);
+                    return result == null ? null : result.toString();
+                } finally {
+                    if (injectedParams != null) {
+                        for (String param : injectedParams) {
+                            executionContext.removeAttribute(param, ScriptContext.ENGINE_SCOPE);
+                        }
+                    }
+                }
             } catch (ScriptException e) {
                 throw new TransformationException("Failed to execute script.", e);
             } catch (IllegalStateException e) {

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -219,9 +219,8 @@ public class ScriptTransformationService implements TransformationService, Confi
                     return result == null ? null : result.toString();
                 } finally {
                     if (injectedParams != null) {
-                        for (String param : injectedParams) {
-                            executionContext.removeAttribute(param, ScriptContext.ENGINE_SCOPE);
-                        }
+                        injectedParams
+                                .forEach(param -> executionContext.removeAttribute(param, ScriptContext.ENGINE_SCOPE));
                     }
                 }
             } catch (ScriptException e) {


### PR DESCRIPTION
Fix #4414

Note that the problem didn't occur with JRuby scripting, but it does occur with JS Scripting.

Perhaps this should be backported to 4.3.x?

