### PR TITLE
Fix config normalization in addon configuration

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -416,7 +416,7 @@ public class AddonResource implements RESTResource, EventSubscriber {
             }
             Configuration oldConfiguration = configurationService.get(addonInfo.getServiceId());
             configurationService.update(addonInfo.getServiceId(),
-                    new Configuration(normalizeConfiguration(configuration, addonId)));
+                    new Configuration(normalizeConfiguration(configuration, infoUid)));
             return oldConfiguration != null ? Response.ok(oldConfiguration.getProperties()).build()
                     : Response.noContent().build();
         } catch (IOException ex) {


### PR DESCRIPTION
Reported on the forum. When installing add-ons from the marketplace the config-description could not be found because a wrong uid was used when retrieving it. As a result the configuration was not normalized and all numeric values were converted to a `Double`instead of the correct type.
