### PR TITLE
New Upnp Device Finder Service

### DIFF
--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
@@ -1,0 +1,158 @@
+package org.openhab.core.io.transport.upnp;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.jupnp.UpnpService;
+import org.jupnp.model.message.header.RootDeviceHeader;
+import org.jupnp.model.message.header.UDNHeader;
+import org.jupnp.model.meta.LocalDevice;
+import org.jupnp.model.meta.RemoteDevice;
+import org.jupnp.model.types.UDN;
+import org.jupnp.registry.Registry;
+import org.jupnp.registry.RegistryListener;
+import org.openhab.core.common.ThreadPoolManager;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Component service that can be used to keep mis-behaving UPnP devices stored in the registry
+ * by sending a targeted M-SEARCH message for their UDN before their maxAge expires.
+ *
+ * @author Andrew Fiddian-Green - Initial Contribution
+ */
+@Component
+public class UpnpDeviceFinder implements RegistryListener {
+
+    private static final String DEVICE_FINDER_THREADPOOL = "upnpDeviceFinder";
+    private static final int SEARCH_SCHEDULE_SECONDS = 60;
+
+    private final Logger logger = LoggerFactory.getLogger(UpnpDeviceFinder.class);
+    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(DEVICE_FINDER_THREADPOOL);
+    private final Map<UDN, Future<?>> subscriptions = new ConcurrentHashMap<>();
+
+    private final UpnpService upnpService;
+
+    @Activate
+    public UpnpDeviceFinder(final @Reference UpnpService upnpService) {
+        this.upnpService = upnpService;
+    }
+
+    @Activate
+    public void activate() {
+        upnpService.getRegistry().addListener(this);
+        upnpService.getControlPoint().search();
+        upnpService.getControlPoint().search(new RootDeviceHeader());
+    }
+
+    @Deactivate
+    public void deactivate() {
+        upnpService.getRegistry().removeListener(this);
+        subscriptions.values().forEach(task -> task.cancel(false));
+        subscriptions.clear();
+    }
+
+    /**
+     * Cancel scheduled search (if any) for the given UDN.
+     */
+    private void cancelSearch(UDN udn) {
+        Future<?> task = subscriptions.get(udn);
+        if (task != null) {
+            task.cancel(false);
+        }
+    }
+
+    /**
+     * Schedule a search for the given device at a future time based on its maxAge.
+     */
+    private void scheduleSearch(RemoteDevice device) {
+        UDN udn = device.getIdentity().getUdn();
+        int delaySeconds = Math.max(SEARCH_SCHEDULE_SECONDS,
+                device.getIdentity().getMaxAgeSeconds() - SEARCH_SCHEDULE_SECONDS);
+        logger.debug("Scheduling search for {} in {} seconds", udn, delaySeconds);
+        cancelSearch(udn);
+        subscriptions.put(udn, scheduler.schedule(() -> {
+            logger.debug("Executing search for {}", udn);
+            upnpService.getControlPoint().search(new UDNHeader(udn));
+        }, delaySeconds, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Add the given UPnP device UDN to the subscriptions list and execute an initial immediate search.
+     */
+    public void addUDN(UDN udn) {
+        if (!subscriptions.containsKey(udn)) {
+            logger.debug("Added subscription for {}", udn);
+            subscriptions.put(udn, scheduler.submit(() -> upnpService.getControlPoint().search(new UDNHeader(udn))));
+        }
+    }
+
+    /**
+     * Remove the given UPnP device UDN from the subscriptions list and cancel any pending search.
+     */
+    public void removeUDN(UDN udn) {
+        subscriptions.remove(udn);
+        cancelSearch(udn);
+        logger.debug("Removed subscription for {}", udn);
+    }
+
+    @Override
+    public void afterShutdown() {
+    }
+
+    @Override
+    public void beforeShutdown(Registry registry) {
+        subscriptions.values().forEach(task -> task.cancel(false));
+        subscriptions.clear();
+    }
+
+    @Override
+    public void localDeviceAdded(Registry registry, LocalDevice device) {
+    }
+
+    @Override
+    public void localDeviceRemoved(Registry registry, LocalDevice device) {
+    }
+
+    @Override
+    public void remoteDeviceAdded(Registry registry, RemoteDevice device) {
+        if (subscriptions.containsKey(device.getIdentity().getUdn())) {
+            scheduleSearch(device);
+        }
+    }
+
+    @Override
+    public void remoteDeviceDiscoveryFailed(Registry registry, RemoteDevice device, Exception e) {
+        if (subscriptions.containsKey(device.getIdentity().getUdn())) {
+            logger.warn("Discovery of {} failed with exception {}", device.getIdentity().getUdn(), e.getMessage());
+        }
+    }
+
+    @Override
+    public void remoteDeviceDiscoveryStarted(Registry registry, RemoteDevice device) {
+    }
+
+    @Override
+    public void remoteDeviceRemoved(Registry registry, RemoteDevice device) {
+        if (subscriptions.containsKey(device.getIdentity().getUdn())) {
+            UDN udn = device.getIdentity().getUdn();
+            logger.warn("Device {} removed unexpectedly from registry; Executing search", udn);
+            cancelSearch(udn);
+            subscriptions.put(udn, scheduler.submit(() -> upnpService.getControlPoint().search(new UDNHeader(udn))));
+        }
+    }
+
+    @Override
+    public void remoteDeviceUpdated(Registry registry, RemoteDevice device) {
+        if (subscriptions.containsKey(device.getIdentity().getUdn())) {
+            scheduleSearch(device);
+        }
+    }
+}

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
@@ -140,8 +140,8 @@ public class UpnpDeviceFinder implements RegistryListener {
      * Remove the given UPnP device UDN from the subscriptions list and cancel any pending search.
      */
     public void removeUDN(UDN udn) {
-        subscriptions.remove(udn);
         cancelSearch(udn);
+        subscriptions.remove(udn);
         logger.debug("Removed subscription for {}", udn);
     }
 

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrew Fiddian-Green - Initial Contribution
  */
-@Component
+@Component(immediate = true)
 public class UpnpDeviceFinder implements RegistryListener {
 
     private static final String DEVICE_FINDER_THREADPOOL = "upnpDeviceFinder";

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpDeviceFinder.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.core.io.transport.upnp;
 
 import java.util.Map;


### PR DESCRIPTION
Relates to #4527 
Relates to https://github.com/openhab/openhab-addons/pull/17976

This PR adds a new component service that can be used to keep mis-behaving UPnP devices 'alive' in the UPnP registry by sending a targeted M-SEARCH message for their UDN before their maxAge expires.

I am not sure if we should add the to OH Core or if we should actually solve this issue in the respective OH addon [for example](https://github.com/openhab/openhab-addons/pull/17976) so I am posting this code (work-in-progress) for review and comments.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
