### PR TITLE
[websocket] Change EventWebSocketAdapter adapter id to `events`

### DIFF
--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
@@ -37,7 +37,7 @@ import com.google.gson.Gson;
 @NonNullByDefault
 @Component(immediate = true, service = { EventSubscriber.class, WebSocketAdapter.class })
 public class EventWebSocketAdapter implements EventSubscriber, WebSocketAdapter {
-    public static final String ADAPTER_ID = "event-subscriber";
+    public static final String ADAPTER_ID = "events";
     private final Gson gson = new Gson();
     private final EventPublisher eventPublisher;
 


### PR DESCRIPTION
This is aligns the event WS name with the SSE events endpoint.
This is a breaking change for clients that have explicitly used `/ws/event-subscriber` instead of the default `/ws`.