### PR TITLE
Remove thing status description for HANDLER_MISSING_ERROR

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -933,8 +933,8 @@ public class ThingManagerImpl implements ReadyTracker, ThingManager, ThingTracke
                             thing.getThingTypeUID());
                 }
             } else {
-                setThingStatus(thing, buildStatusInfo(ThingStatus.UNINITIALIZED,
-                        ThingStatusDetail.HANDLER_MISSING_ERROR, "Handler factory not found"));
+                setThingStatus(thing,
+                        buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_MISSING_ERROR));
                 logger.debug("Not registering a handler at this point. No handler factory for thing '{}' found.",
                         thing.getUID());
             }


### PR DESCRIPTION
Let webui handle the description.
See: https://github.com/openhab/openhab-webui/pull/2986