### PR TITLE
Start license headers with `/*` instead of `/**`

### DIFF
--- a/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
+++ b/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/BundleVersion.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/BundleVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceBundleInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceConstants.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceHandlerException.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceHandlerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/automation/MarketplaceRuleTemplateProvider.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/automation/MarketplaceRuleTemplateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/SerializedNameAnnotationIntrospector.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/SerializedNameAnnotationIntrospector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseCategoryResponseDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseCategoryResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/model/DiscourseTopicResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/model/AddonEntryDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/BundleVersionTest.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/BundleVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/test/java/org/openhab/core/addon/marketplace/test/TestAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/Addon.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonDiscoveryMethod.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonDiscoveryMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonEvent.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonEventFactory.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoList.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonMatchProperty.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonMatchProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonParameter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonType.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/AddonI18nUtil.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/AddonI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/JarFileAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonDiscoveryMethodConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonDiscoveryMethodConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListReader.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoListReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoReader.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoXmlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoXmlResult.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonMatchPropertyConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonMatchPropertyConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonParameterConverter.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonParameterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonXmlConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/XmlAddonInfoProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/XmlAddonInfoProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoListReaderTest.java
+++ b/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoListReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoRegistryMergeTest.java
+++ b/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoRegistryMergeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioException.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioHTTPServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSinkSync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ByteArrayAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ByteArrayAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/ClonableAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FileAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FixedLengthAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/FixedLengthAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/PipedAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/PipedAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/SizeableAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/SizeableAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/StreamServed.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/StreamServed.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/UnsupportedAudioFormatException.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/UnsupportedAudioFormatException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/UnsupportedAudioStreamException.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/UnsupportedAudioStreamException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/AudioPlayer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundAudioSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/javasound/JavaSoundInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/PlayURLEvent.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/PlayURLEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioAudioSink.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioAudioSink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioEventFactory.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/webaudio/WebAudioEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioSinkUtilsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioStreamUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/AudioWaveUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/ToneSynthesizer.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/utils/ToneSynthesizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AbstractAudioServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioFormatTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioFormatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/fake/AudioSinkFake.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/fake/AudioSinkFake.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/utils/BundledSoundFileHandler.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/utils/BundledSoundFileHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/JaasAuthenticationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginConfiguration.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginModule.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/Keyword.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/Keyword.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthFactoryImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandler.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/StorageRecordType.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/StorageRecordType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/cipher/SymmetricKeyCipher.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/cipher/SymmetricKeyCipher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaActionTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/MediaScriptScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SynthesizeActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SynthesizeActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/AbstractScriptedModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/AbstractScriptedModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedCustomModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedPrivateModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/ScriptedPrivateModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleConditionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleConditionHandlerDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerCallbackDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerCallbackDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleTriggerHandlerDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/BidiSetBag.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/BidiSetBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DefaultScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DefaultScriptFileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcher.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/loader/ScriptFileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedHandler.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedRuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ValueCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedActionHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedActionHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedConditionHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedConditionHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedTriggerHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/factories/ScriptedTriggerHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRuleActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRuleActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRuleActionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleRuleActionHandlerDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandler.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandlerCallback.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/simple/SimpleTriggerHandlerCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptDependencyTrackerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/AbstractScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/AbstractScriptEngineFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LifecycleScriptExtensionProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/LifecycleScriptExtensionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptDependencyListener.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptDependencyListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptDependencyTracker.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptDependencyTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineContainer.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineManager.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionAccessor.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionManagerWrapper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionManagerWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptExtensionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationServiceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/ScriptExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/Timer.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/action/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/defaultscope/ScriptBusEvent.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/defaultscope/ScriptBusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/defaultscope/ScriptThingActions.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/defaultscope/ScriptThingActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryBundleTracker.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryBundleTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineFactoryHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManager.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapperImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/ScriptExtensionManagerWrapperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptActionScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptActionScriptScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/ScriptExecutionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ItemRegistryDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEventImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptBusEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptThingActionsImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptThingActionsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/provider/ScriptModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfileFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/TimerImplTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/TimerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImplTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/internal/ScriptEngineManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/profile/ScriptProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/RuleResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/dto/EnrichedRuleDTO.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/dto/EnrichedRuleDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/dto/EnrichedRuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/dto/EnrichedRuleDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Action.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/AnnotatedActions.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/AnnotatedActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Condition.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ManagedRuleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ManagedRuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Module.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Module.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/ModuleHandlerCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Rule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleExecution.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RulePredicates.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RulePredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatus.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusDetail.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusInfo.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/RuleStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Trigger.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Trigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Visibility.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/Visibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionInput.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionInputs.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionInputs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutputs.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionOutputs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionScope.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/ActionScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/RuleAction.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/annotation/RuleAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionTypeDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ActionTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeActionTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeActionTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeConditionTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeConditionTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeTriggerTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/CompositeTriggerTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionTypeDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ConditionTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleTypeDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/ModuleTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleTemplateDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleTemplateDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleTemplateDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/RuleTemplateDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerTypeDTO.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerTypeDTOMapper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/dto/TriggerTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AbstractRuleRegistryEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AbstractRuleRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AutomationEventFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/AutomationEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/ExecutionEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/ExecutionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleAddedEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleRemovedEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleStatusInfoEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleStatusInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleUpdatedEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/RuleUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/TimerEvent.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/events/TimerEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseActionModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseActionModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseConditionModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseConditionModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseTriggerModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/BaseTriggerModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TimeBasedTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandlerCallback.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/TriggerHandlerCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ActionImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ActionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConditionImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConditionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/Connection.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConnectionValidator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ConnectionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ModuleImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ModuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleExecutionSimulator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleExecutionSimulator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerHandlerCallbackImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/TriggerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AbstractCommandProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AbstractCommandProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommand.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandEnableRule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandEnableRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandExport.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandExport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommands.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommands.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandsPluggable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineRuleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineRuleImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/CommandlineTemplateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Printer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Printer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Utils.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/AbstractCompositeModuleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/config/EphemerisConditionConfig.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/config/EphemerisConditionConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/exception/UncomparableException.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/exception/UncomparableException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/CompareConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DayOfWeekConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/DayOfWeekConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/EphemerisConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/EphemerisConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayConditionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimeOfDayTriggerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimerModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/TimerModuleHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/provider/AnnotatedActionModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/AbstractGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/AbstractGSONParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ActionInstanceCreator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ActionInstanceCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ConditionInstanceCreator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ConditionInstanceCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ModuleTypeGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ModuleTypeGSONParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ModuleTypeParsingContainer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/ModuleTypeParsingContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/RuleGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/RuleGSONParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TemplateGSONParser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TemplateGSONParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TriggerInstanceCreator.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/parser/gson/TriggerInstanceCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AbstractResourceBundleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesEventQueue.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesEventQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesTracker.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/ModuleTypeResourceBundleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/RuleResourceBundleImporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/TemplateResourceBundleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/Vendor.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/Vendor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AbstractFileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AutomationWatchService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/AutomationWatchService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProviderWatcher.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/ModuleTypeFileProviderWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProviderWatcher.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/TemplateFileProviderWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/WatchServiceUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/file/WatchServiceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/RuleTemplateI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedAction.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedCondition.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedModule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedRule.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedTrigger.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/ruleengine/WrappedTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/template/RuleTemplateRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/template/RuleTemplateRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/type/ModuleTypeRegistryImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/type/ModuleTypeRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ActionModuleKind.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ActionModuleKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/AnnotationActionModuleTypeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ModuleInformation.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ModuleInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/i18n/ModuleTypeI18nService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/Parser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/ParsingException.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/ParsingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/ParsingNestedException.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/parser/ParsingNestedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/RuleTemplateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/Template.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/Template.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/template/TemplateRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ActionType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ActionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeActionType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeActionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeConditionType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeConditionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeTriggerType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/CompositeTriggerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ConditionType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ConditionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Input.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Input.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/ModuleTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Output.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Output.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/TriggerType.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/TriggerType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConditionBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConditionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ModuleBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ModuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/RuleBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/RuleBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/TriggerBuilder.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/TriggerBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/ConnectionValidatorTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/ConnectionValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/RulePrefixTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/RulePrefixTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactoryTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ChannelEventTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GenericEventTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GroupCommandTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/GroupStateTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/SystemTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/provider/AnnotationActionModuleTypeProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/thingsupport/AnnotatedThingActionModuleTypeProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ActionInputHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescription.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionAliasProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionAliasProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigOptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableServiceUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurableServiceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationDeserializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/CurrencyServiceConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/CurrencyServiceConfigOptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/OrderingMapSerializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/OrderingMapSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/OrderingSetSerializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/OrderingSetSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ParameterOption.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ParameterOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOMapper.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterGroupDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterGroupDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/FilterCriteriaDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/FilterCriteriaDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ParameterOptionDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ParameterOptionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/i18n/ConfigI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionGroupI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/ConfigDescriptionI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/AbstractNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/AbstractNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/BooleanNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/BooleanNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/DecimalNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/DecimalNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/IntNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/IntNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/ListNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/ListNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/Normalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/Normalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/NormalizerFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/NormalizerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/TextNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/TextNormalizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionParameterValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionParameterValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionParameterValidatorFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionParameterValidatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MessageKey.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MessageKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/OptionsValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/PatternValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/PatternValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/RequiredValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/RequiredValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/metadata/MetadataConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/metadata/MetadataConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusCallback.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusInfo.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusService.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusSource.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusEventFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusInfoEvent.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/events/ConfigStatusInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigDescriptionValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigDescriptionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationException.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationMessage.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlBasedProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlBasedProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/AbstractXmlConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionParameterConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionParameterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionParameterGroupConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionParameterGroupConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/ConfigXmlConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/FilterCriteriaConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/FilterCriteriaConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/internal/ConfigDescriptionReader.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/internal/ConfigDescriptionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/internal/ConfigDescriptionXmlProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/internal/ConfigDescriptionXmlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentBundleTracker.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentBundleTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentProviderFactory.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/osgi/XmlDocumentProviderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/ConverterAttributeMapValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/ConverterAttributeMapValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/ConverterValueMap.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/ConverterValueMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/GenericUnmarshaller.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/GenericUnmarshaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeAttributes.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeAttributes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeAttributesConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeAttributesConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeIterator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeList.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeListConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeListConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeName.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeValue.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeValueConverter.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/NodeValueConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/XmlDocumentReader.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/xml/util/XmlDocumentReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/com/acme/Product.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/com/acme/Product.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterGroupBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionRegistryTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurableServiceUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/dto/ConfigDescriptionDTOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/i18n/I18nConfigOptionsProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/normalization/NormalizerTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/normalization/NormalizerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigValidationExceptionTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigValidationExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/xml/util/XmlDocumentReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.mdns/src/main/java/org/openhab/core/config/discovery/addon/mdns/MDNSAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.mdns/src/main/java/org/openhab/core/config/discovery/addon/mdns/MDNSAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.mdns/src/test/java/org/openhab/core/config/discovery/addon/mdns/tests/MDNSAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.mdns/src/test/java/org/openhab/core/config/discovery/addon/mdns/tests/MDNSAddonFinderTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.process/src/main/java/org/openhab/core/config/discovery/addon/process/ProcessAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.process/src/main/java/org/openhab/core/config/discovery/addon/process/ProcessAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.sddp/src/main/java/org/openhab/core/config/discovery/addon/sddp/SddpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.sddp/src/main/java/org/openhab/core/config/discovery/addon/sddp/SddpAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.sddp/src/test/java/org/openhab/core/config/discovery/addon/sddp/test/SddpAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.sddp/src/test/java/org/openhab/core/config/discovery/addon/sddp/test/SddpAddonFinderTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/main/java/org/openhab/core/config/discovery/addon/upnp/UpnpAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/test/java/org/openhab/core/config/discovery/addon/upnp/tests/UpnpAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/test/java/org/openhab/core/config/discovery/addon/upnp/tests/UpnpAddonFinderTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.usb/src/main/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.usb/src/main/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon.usb/src/test/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.usb/src/test/java/org/openhab/core/config/discovery/addon/usb/UsbAddonFinderTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderConstants.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonFinderService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/AddonSuggestionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/BaseAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/main/java/org/openhab/core/config/discovery/addon/BaseAddonFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.addon/src/test/java/org/openhab/core/config/discovery/addon/tests/AddonSuggestionServiceTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/test/java/org/openhab/core/config/discovery/addon/tests/AddonSuggestionServiceTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/MDNSDiscoveryParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.mdns/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDevice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDeviceParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDeviceParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/test/java/org/openhab/core/config/discovery/sddp/test/SddpDiscoveryServiceTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/UpnpDiscoveryParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/UsbSerialScanner.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.linuxsysfs/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/UsbSerialScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/main/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/main/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscovery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowsUsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowsUsbSerialDiscovery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDeviceInformation.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDeviceInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscovery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryParticipant.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/UsbSerialDiscoveryParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultFlag.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResultFlag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistry.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/ScanListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/ScanListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTO.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTOMapper.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/dto/DiscoveryResultDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/Inbox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxAutoApprovePredicate.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxAutoApprovePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxPredicates.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/InboxPredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/AbstractInboxEvent.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/AbstractInboxEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxAddedEvent.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactory.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxRemovedEvent.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxUpdatedEvent.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/inbox/events/InboxUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/DiscoveryConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/DiscoveryConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/DiscoveryResultBuilderTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/DiscoveryResultBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/InboxPredicatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/inbox/events/InboxEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/DiscoveryResultImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.dispatch/src/test/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcherTest.java
+++ b/bundles/org.openhab.core.config.dispatch/src/test/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherFileWatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.serial/src/main/java/org/openhab/core/config/serial/internal/SerialConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.serial/src/main/java/org/openhab/core/config/serial/internal/SerialConfigOptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.config.serial/src/test/java/org/openhab/core/config/serial/internal/SerialConfigOptionProviderTest.java
+++ b/bundles/org.openhab.core.config.serial/src/test/java/org/openhab/core/config/serial/internal/SerialConfigOptionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/EphemerisManager.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/EphemerisManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/InstanceUUID.java
+++ b/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/InstanceUUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
+++ b/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.id/src/test/java/org/openhab/core/id/InstanceUUIDTest.java
+++ b/bundles/org.openhab.core.id/src/test/java/org/openhab/core/id/InstanceUUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/Bin2Json.java
+++ b/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/Bin2Json.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/ConversionException.java
+++ b/bundles/org.openhab.core.io.bin2json/src/main/java/org/openhab/core/io/bin2json/ConversionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.bin2json/src/test/java/org/openhab/core/io/bin2json/Bin2JsonTest.java
+++ b/bundles/org.openhab.core.io.bin2json/src/test/java/org/openhab/core/io/bin2json/Bin2JsonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/ConsoleSupportEclipse.java
+++ b/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/ConsoleSupportEclipse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/OSGiConsole.java
+++ b/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/OSGiConsole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CompleterWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CompleterWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/InstallServiceCommand.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/InstallServiceCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/OSGiConsole.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/OSGiConsole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.karaf/src/test/java/org/openhab/core/io/console/karaf/internal/CompleterWrapperTest.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/test/java/org/openhab/core/io/console/karaf/internal/CompleterWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/CommandWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleCommandsContainer.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleCommandsContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleSupportRfc147.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/ConsoleSupportRfc147.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/OSGiConsole.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/OSGiConsole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/extension/HelpConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console.rfc147/src/main/java/org/openhab/core/io/console/rfc147/internal/extension/HelpConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/Console.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/Console.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleCommandCompleter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleCommandCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/ConsoleInterpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/StringsCompleter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/StringsCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/AbstractConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/AbstractConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/ConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/extensions/ConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/AddonConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/AddonConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleter.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/MetadataConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/MetadataConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/SendConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/SendConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/StatusConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/StatusConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UpdateConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UpdateConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/internal/extension/UserConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/StringsCompleterTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/StringsCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleterTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtensionTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/CredentialsExtractor.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/CredentialsExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AbstractAuthPageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AbstractAuthPageServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthenticationHandler.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthenticationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthorizePageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/AuthorizePageServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/ChangePasswordPageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/ChangePasswordPageServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/CreateAPITokenPageServlet.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/CreateAPITokenPageServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/RedirectHandler.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/RedirectHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/Handler.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/Handler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerPriorities.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerPriorities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HttpContextFactoryService.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HttpContextFactoryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/WrappingHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/WrappingHttpContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/BundleHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/BundleHttpContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/CatchHandler.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/CatchHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DefaultHandlerContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DefaultHandlerContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DelegatingHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DelegatingHttpContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImpl.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/OpenHABHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/OpenHABHttpContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.http/src/test/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImplTest.java
+++ b/bundles/org.openhab.core.io.http/src/test/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
+++ b/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/MeterRegistryProvider.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/MeterRegistryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/DefaultMetricsRegistration.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/DefaultMetricsRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/EventLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/BundleStateMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/BundleStateMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/EventCountMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/EventCountMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/JVMMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/JVMMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/OpenhabCoreMeterBinder.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/OpenhabCoreMeterBinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/RuleMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/RuleMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThreadPoolMetric.java
+++ b/bundles/org.openhab.core.io.monitor/src/main/java/org/openhab/core/io/monitor/internal/metrics/ThreadPoolMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.monitor/src/test/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetricTest.java
+++ b/bundles/org.openhab.core.io.monitor/src/test/java/org/openhab/core/io/monitor/internal/metrics/ThingStateMetricTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/exec/ExecUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/ExtensibleTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/ExtensibleTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpClientFactory.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpClientFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpClientInitializationException.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpClientInitializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpRequestBuilder.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpRequestBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsCertificateProvider.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsCertificateProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsProvider.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsTrustManagerProvider.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TlsTrustManagerProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TrustAllTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/TrustAllTrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/WebSocketFactory.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/WebSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/TlsCertificateTrustManagerAdapter.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/TlsCertificateTrustManagerAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/TrustManagerUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/TrustManagerUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/internal/WebClientFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/exec/ExecUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpRequestBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/ExtensibleTrustManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/internal/WebClientFactoryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioMapper.java
+++ b/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioResource.java
+++ b/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioSinkDTO.java
+++ b/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioSinkDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioSourceDTO.java
+++ b/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioSourceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AnonymousUserSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AnonymousUserSecurityContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AuthFilter.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/AuthFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/JwtHelper.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/JwtHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/JwtSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/JwtSecurityContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/RolesAllowedDynamicFeatureImpl.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/RolesAllowedDynamicFeatureImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenEndpointException.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenEndpointException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResponseDTO.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResponseDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResponseErrorDTO.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResponseErrorDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserApiTokenDTO.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserApiTokenDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserDTO.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSecurityContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSessionDTO.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/UserSessionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/AuthFilterTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/AuthFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCacheTest.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/test/java/org/openhab/core/io/rest/auth/internal/ExpiringUserSecurityContextCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionParameterDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/discovery/DiscoveryInfoDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/discovery/DiscoveryInfoDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyReader.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/MediaTypeExtension.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/MediaTypeExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyReader.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyWriter.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonServiceDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonServiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/EnrichedSemanticTagDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/EnrichedSemanticTagDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedGroupItemDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/BrokenItemChannelLinkDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/BrokenItemChannelLinkDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/link/EnrichedItemChannelLinkDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/persistence/ItemHistoryListDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/persistence/ItemHistoryListDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/service/ConfigurableServiceDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/service/ConfigurableServiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedChannelDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedChannelDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionDTOMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcherTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/item/MetadataSelectorMatcherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapperTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogConstants.java
+++ b/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
+++ b/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
+++ b/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/SitemapSubscriptionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/JerseyResponseBuilderUtils.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/JerseyResponseBuilderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/MappingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/PageDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/ServerAliveEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/ServerAliveEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapChangedEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SseSinkInfo.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SseSinkInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/WidgetsChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/SseResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SsePublisher.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SsePublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseSinkItemInfo.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseSinkItemInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseSinkTopicInfo.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/SseSinkTopicInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/EventDTO.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/EventDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/dto/StateDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/listeners/SseEventSubscriber.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/listeners/SseEventSubscriber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/main/java/org/openhab/core/io/rest/sse/internal/util/SseUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/util/SseUtilTest.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/util/SseUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/OpenApiResource.java
+++ b/bundles/org.openhab.core.io.rest.swagger/src/main/java/org/openhab/core/io/rest/swagger/impl/OpenApiResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/TransformationDTO.java
+++ b/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/TransformationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
+++ b/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/TileDTO.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/TileDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/HLIMapper.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/HLIMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/HumanLanguageInterpreterDTO.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/HumanLanguageInterpreterDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceDTO.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceMapper.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/DTOMapper.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/DTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONInputStream.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleService.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleServiceImpl.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/LocaleServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/RESTResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/SseBroadcaster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/Stream2JSONInputStream.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/Stream2JSONInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/Constants.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/DTOMapperImpl.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/DTOMapperImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/RESTApplicationImpl.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/RESTApplicationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/ProxyFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/RootBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/SystemInfoBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/SystemInfoBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/UoMInfoBean.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/beans/UoMInfoBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/JSONResponseTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/JSONResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/Stream2JSONInputStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/CorsFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/CorsFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSActivator.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusFailure.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusFailure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusReadResult.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusReadResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusWriteResult.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/AsyncModbusWriteResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/BitArray.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/BitArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusBitUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusBitUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusCommunicationInterface.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusCommunicationInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusConstants.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusFailureCallback.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusFailureCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadCallback.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadFunctionCode.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadFunctionCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusReadRequestBlueprint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusRegisterArray.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusRegisterArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResponse.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResultCallback.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusResultCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCallback.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCoilRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteCoilRequestBlueprint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteFunctionCode.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteFunctionCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRegisterRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRegisterRequestBlueprint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprintVisitor.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ModbusWriteRequestBlueprintVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/PollTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/PollTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/TaskWithEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/TaskWithEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ValueBuffer.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/ValueBuffer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/WriteTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/WriteTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/EndpointPoolConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusIPSlaveEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSerialSlaveEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpointVisitor.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusSlaveEndpointVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusTCPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusTCPSlaveEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusUDPSlaveEndpoint.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/endpoint/ModbusUDPSlaveEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusConnectionException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusConnectionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveErrorResponseException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveErrorResponseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveIOException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusSlaveIOException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusTransportException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusTransportException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedResponseFunctionCodeException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedResponseFunctionCodeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedResponseSizeException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedResponseSizeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedTransactionIdException.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/exception/ModbusUnexpectedTransactionIdException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/AggregateStopWatch.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/AggregateStopWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicPollTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicWriteTask.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/BasicWriteTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusConnectionPool.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusConnectionPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusLibraryWrapper.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusLibraryWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusPoolConfig.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusPoolConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusResponseImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusResponseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveErrorResponseExceptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveIOExceptionImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusSlaveIOExceptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/SimpleStopWatch.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/SimpleStopWatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionEvictionPolicy.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionEvictionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionFactory.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionFactoryImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/json/WriteRequestJsonUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/AbstractRequestComparer.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/AbstractRequestComparer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BasicBitArrayTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BasicBitArrayTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesCommandToRegistersTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesCommandToRegistersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractBitTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractBitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractFloat32Test.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractFloat32Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractIndividualMethodsTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractIndividualMethodsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractInt8Test.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractInt8Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractStateFromRegistersTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractStateFromRegistersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractStringTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesExtractStringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesTranslateCommand2BooleanTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/BitUtilitiesTranslateCommand2BooleanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/CoilMatcher.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/CoilMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/IntegrationTestSupport.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/IntegrationTestSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ModbusSlaveEndpointTestCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ModbusSlaveErrorResponseExceptionImplTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ModbusSlaveErrorResponseExceptionImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/RegisterMatcher.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/RegisterMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ResultCaptor.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ResultCaptor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/SmokeTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/SmokeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ValueBufferTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/ValueBufferTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/WriteRequestJsonUtilitiesTest.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/test/java/org/openhab/core/io/transport/modbus/test/WriteRequestJsonUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttActionCallback.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttActionCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionObserver.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionState.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttConnectionState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttException.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttMessageSubscriber.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttMessageSubscriber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttWillAndTestament.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttWillAndTestament.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/Subscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/reconnect/AbstractReconnectStrategy.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/reconnect/AbstractReconnectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/ssl/CustomTrustManagerFactory.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/ssl/CustomTrustManagerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/JavaCommPortProvider.java
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/JavaCommPortProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortEventImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.javacomm/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/src/main/java/org/openhab/core/io/transport/serial/rxtx/rfc2217/internal/RFC2217PortProvider.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/src/main/java/org/openhab/core/io/transport/serial/rxtx/rfc2217/internal/RFC2217PortProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/src/main/java/org/openhab/core/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx.rfc2217/src/main/java/org/openhab/core/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/RxTxPortProvider.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/RxTxPortProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortEventImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortEventImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortUtil.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/rxtx/RxTxSerialPort.java
+++ b/bundles/org.openhab.core.io.transport.serial.rxtx/src/main/java/org/openhab/core/io/transport/serial/rxtx/RxTxSerialPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/PortInUseException.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/PortInUseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/ProtocolType.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/ProtocolType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPort.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPort.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEventListener.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortIdentifier.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortManager.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortProvider.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/SerialPortProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/UnsupportedCommOperationException.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/UnsupportedCommOperationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortRegistry.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/SerialPortRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/console/SerialCommandExtension.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/console/SerialCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.transport.upnp/src/test/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceTest.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/test/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/CommonWebSocketServlet.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/CommonWebSocketServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/WebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/WebSocketAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventDTO.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventProcessingException.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventProcessingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocket.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/EventWebSocketAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/ItemEventUtility.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/event/ItemEventUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogDTO.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocketAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/CommonWebSocketServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/EventWebSocketTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/EventWebSocketTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/ItemEventUtilityTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/ItemEventUtilityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/FeatureInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonFinderService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonFinderService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerBean.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerBean.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/EventType.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/EventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelCoreConstants.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelCoreConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelParser.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepository.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepositoryChangeListener.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelRepositoryChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/SafeEMF.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/SafeEMF.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelCoreActivator.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelCoreActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/SafeEMFImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/SafeEMFImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/util/MathUtils.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/util/MathUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/valueconverter/ValueTypeToStringConverter.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/valueconverter/ValueTypeToStringConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.core/src/test/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
+++ b/bundles/org.openhab.core.model.core/src/test/java/org/openhab/core/model/core/internal/folder/FolderObserverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item.ide/src/org/openhab/core/model/ide/ItemsIdeModule.xtend
+++ b/bundles/org.openhab.core.model.item.ide/src/org/openhab/core/model/ide/ItemsIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item.ide/src/org/openhab/core/model/ide/ItemsIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.item.ide/src/org/openhab/core/model/ide/ItemsIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item.runtime/src/org/openhab/core/model/item/runtime/internal/ItemRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.item.runtime/src/org/openhab/core/model/item/runtime/internal/ItemRuntimeActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/GenerateItems.mwe2
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/GenerateItems.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/ItemsRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/ItemsRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/ItemsStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/ItemsStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/formatting/ItemsFormatter.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/formatting/ItemsFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/generator/ItemsGenerator.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/generator/ItemsGenerator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/internal/valueconverter/ItemValueConverters.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/internal/valueconverter/ItemValueConverters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/BindingConfigParseException.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/BindingConfigParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/BindingConfigReader.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/BindingConfigReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericMetadataProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/scoping/ItemsScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/scoping/ItemsScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/serializer/ItemsSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/serializer/ItemsSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/serializer/ItemsSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/serializer/ItemsSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/validation/ItemsValidator.xtend
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/validation/ItemsValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/MappingUriExtensions.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/MappingUriExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/ModelServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/RegistryProvider.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/RegistryProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/RuntimeServerModule.java
+++ b/bundles/org.openhab.core.model.lsp/src/main/java/org/openhab/core/model/lsp/internal/RuntimeServerModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.lsp/src/test/java/org/openhab/core/model/lsp/internal/MappingUriExtensionsTest.java
+++ b/bundles/org.openhab.core.model.lsp/src/test/java/org/openhab/core/model/lsp/internal/MappingUriExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence.ide/src/org/openhab/core/model/persistence/ide/PersistenceIdeModule.xtend
+++ b/bundles/org.openhab.core.model.persistence.ide/src/org/openhab/core/model/persistence/ide/PersistenceIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence.ide/src/org/openhab/core/model/persistence/ide/PersistenceIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.persistence.ide/src/org/openhab/core/model/persistence/ide/PersistenceIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence.runtime/src/org/openhab/core/model/persistence/runtime/internal/PersistenceRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.persistence.runtime/src/org/openhab/core/model/persistence/runtime/internal/PersistenceRuntimeActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/GeneratePersistence.mwe2
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/GeneratePersistence.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/PersistenceRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/PersistenceRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/PersistenceStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/PersistenceStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/formatting/PersistenceFormatter.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/formatting/PersistenceFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/generator/PersistenceGenerator.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/generator/PersistenceGenerator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/GlobalStrategies.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/GlobalStrategies.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/PersistenceGlobalScopeProvider.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/PersistenceGlobalScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/PersistenceScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/scoping/PersistenceScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/serializer/PersistenceSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/serializer/PersistenceSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/serializer/PersistenceSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/serializer/PersistenceSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/validation/PersistenceValidator.xtend
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/validation/PersistenceValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.ide/src/org/openhab/core/model/rule/ide/RulesIdeModule.xtend
+++ b/bundles/org.openhab.core.model.rule.ide/src/org/openhab/core/model/rule/ide/RulesIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.ide/src/org/openhab/core/model/rule/ide/RulesIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.rule.ide/src/org/openhab/core/model/rule/ide/RulesIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/DSLRuleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleContextHelper.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleContextHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleEvaluationContext.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleEvaluationContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleRuntimeActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/GenerateRules.mwe2
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/GenerateRules.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/formatting/RulesFormatter.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/formatting/RulesFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesRefresher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassCache.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassFinder.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesClassFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesImplicitlyImportedTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesJavaReflectAccess.java
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesJavaReflectAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/scoping/RulesScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/serializer/RulesSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/serializer/RulesSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/serializer/RulesSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/serializer/RulesSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/validation/RulesValidator.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/validation/RulesValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.ide/src/org/openhab/core/model/script/ide/ScriptIdeModule.xtend
+++ b/bundles/org.openhab.core.model.script.ide/src/org/openhab/core/model/script/ide/ScriptIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.ide/src/org/openhab/core/model/script/ide/ScriptIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.script.ide/src/org/openhab/core/model/script/ide/ScriptIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/DSLScriptContextProvider.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/DSLScriptContextProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/ScriptRuntime.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/ScriptRuntime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngineFactory.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/DSLScriptEngineFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/ScriptEngineImpl.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/ScriptEngineImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/ScriptImpl.java
+++ b/bundles/org.openhab.core.model.script.runtime/src/org/openhab/core/model/script/runtime/internal/engine/ScriptImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/actions/SemanticsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
+++ b/bundles/org.openhab.core.model.script/src.moved/test/java/org/openhab/core/model/script/lib/NumberExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/GenerateScript.mwe2
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/GenerateScript.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/OptimizingFeatureScopeTrackerProvider2.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/OptimizingFeatureScopeTrackerProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptServiceUtil.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptServiceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ServiceModule.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ServiceModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/BusEvent.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/BusEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/CoreUtil.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/CoreUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ephemeris.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ephemeris.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Exec.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Exec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Log.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Log.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ping.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Ping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/ScriptExecution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Semantics.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Semantics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Things.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Things.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Timer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Transformation.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Transformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/TransformationException.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/TransformationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Voice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/IActionServiceProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/IActionServiceProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/IThingActionsProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/IThingActionsProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/Script.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptEngine.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptEngine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptError.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptException.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptExecutionException.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptExecutionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptParsingException.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/ScriptParsingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ActionDoc.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ActionDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ParamDoc.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/engine/action/ParamDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/extension/ScriptEngineConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/extension/ScriptEngineConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/formatting/ScriptFormatter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/formatting/ScriptFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/RuleHumanLanguageInterpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/ScriptEncodingProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/ScriptEncodingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/ServiceTrackerActionServiceProvider.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/ServiceTrackerActionServiceProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/ServiceTrackerThingActionsProvider.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/ServiceTrackerThingActionsProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/AudioActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/AudioActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/EphemerisActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/EphemerisActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/PersistenceActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/PersistenceActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ScriptExecutionActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/SemanticsActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/SemanticsActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ThingActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/ThingActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/VoiceActionService.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/internal/engine/action/VoiceActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptItemRefresher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptTypeComputer.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptTypeComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/lib/NumberExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ActionClassLoader.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ActionClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/serializer/ScriptSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/serializer/ScriptSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/serializer/ScriptSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/serializer/ScriptSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/validation/ScriptValidator.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/validation/ScriptValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap.ide/src/org/openhab/core/model/sitemap/ide/SitemapIdeModule.xtend
+++ b/bundles/org.openhab.core.model.sitemap.ide/src/org/openhab/core/model/sitemap/ide/SitemapIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap.ide/src/org/openhab/core/model/sitemap/ide/SitemapIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.sitemap.ide/src/org/openhab/core/model/sitemap/ide/SitemapIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap.runtime/src/org/openhab/core/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.sitemap.runtime/src/org/openhab/core/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/GenerateSitemap.mwe2
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/GenerateSitemap.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapProvider.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/SitemapStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/formatting/SitemapFormatter.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/formatting/SitemapFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/generator/SitemapGenerator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/generator/SitemapGenerator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/SitemapProviderImpl.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/internal/SitemapProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/scoping/SitemapScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/scoping/SitemapScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/serializer/SitemapSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/serializer/SitemapSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/serializer/SitemapSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/serializer/SitemapSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/valueconverter/SitemapConverters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing.ide/src/org/openhab/core/model/thing/ide/ThingIdeModule.xtend
+++ b/bundles/org.openhab.core.model.thing.ide/src/org/openhab/core/model/thing/ide/ThingIdeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing.ide/src/org/openhab/core/model/thing/ide/ThingIdeSetup.xtend
+++ b/bundles/org.openhab.core.model.thing.ide/src/org/openhab/core/model/thing/ide/ThingIdeSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing.runtime/src/org/openhab/core/model/thing/runtime/internal/ThingRuntimeActivator.java
+++ b/bundles/org.openhab.core.model.thing.runtime/src/org/openhab/core/model/thing/runtime/internal/ThingRuntimeActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
+++ b/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/GenerateThing.mwe2
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/GenerateThing.mwe2
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/ThingRuntimeModule.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/ThingRuntimeModule.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/ThingStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/ThingStandaloneSetup.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/formatting/ThingFormatter.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/formatting/ThingFormatter.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/generator/ThingGenerator.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/generator/ThingGenerator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/AbstractProviderLazyNullness.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/AbstractProviderLazyNullness.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/scoping/ThingScopeProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/scoping/ThingScopeProvider.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSemanticSequencer.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSemanticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencer.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencer.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencerExtension.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/serializer/ThingSyntacticSequencerExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/validation/ThingValidator.xtend
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/valueconverter/ThingValueConverters.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/valueconverter/ThingValueConverters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/valueconverter/UIDtoStringConverter.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/valueconverter/UIDtoStringConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlElement.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlElementName.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlElementName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelListener.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelRepository.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelWrapper.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/semantics/YamlSemanticTagDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/semantics/YamlSemanticTagDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/semantics/YamlSemanticTagProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/semantics/YamlSemanticTagProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/test/FirstTypeDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/test/FirstTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/test/SecondTypeDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/test/SecondTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/HistoricItem.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/HistoricItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/ModifiablePersistenceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemConfiguration.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemInfo.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceItemInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceManager.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceServiceRegistry.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceServiceRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/QueryablePersistenceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceAllConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceAllConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupExcludeConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceGroupExcludeConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemExcludeConfig.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/config/PersistenceItemExcludeConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/ItemHistoryDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceCronStrategyDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceCronStrategyDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceFilterDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceFilterDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceItemConfigurationDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceItemConfigurationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceStrategyDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceStrategyDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceEqualsFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceEqualsFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceIncludeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceThresholdFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceTimeFilter.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/filter/PersistenceTimeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceBundleTracker.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceBundleTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceConfigurationRegistryImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceConfigurationRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceServiceRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/ManagedPersistenceServiceConfigurationProvider.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/ManagedPersistenceServiceConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationProvider.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationRegistry.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationRegistryChangeListener.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationRegistryChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/strategy/PersistenceCronStrategy.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/strategy/PersistenceCronStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/strategy/PersistenceStrategy.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/strategy/PersistenceStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceEqualsFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceEqualsFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceIncludeFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceIncludeFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceThresholdFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceThresholdFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceTimeFilterTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/filter/PersistenceTimeFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
+++ b/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Equipment.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Equipment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Location.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Location.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ManagedSemanticTagProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ManagedSemanticTagProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Point.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Property.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTag.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagRegistry.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsPredicates.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsPredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Tag.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/Tag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/dto/SemanticTagDTO.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/dto/SemanticTagDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/dto/SemanticTagDTOMapper.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/dto/SemanticTagDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticTagRegistryImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticTagRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsServiceImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/model/DefaultSemanticTagProvider.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/model/DefaultSemanticTagProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticTagRegistryImplTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticTagRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsMetadataProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsServiceImplTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/internal/SemanticsServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/InstantTypeAdapter.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/InstantTypeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntry.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntryMapDeserializer.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/StorageEntryMapDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/BridgeImplTypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/BridgeImplTypeMigrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/PersistedTransformationTypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/PersistedTransformationTypeMigrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/RenamingTypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/RenamingTypeMigrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/ThingImplTypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/ThingImplTypeMigrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrationException.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrator.java
+++ b/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/migration/TypeMigrator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/MigrationTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/MigrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/PersistedTransformationMigratorTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/PersistedTransformationMigratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/ThingStorageEntityMigratorTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/ThingStorageEntityMigratorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicBindingConstants.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicBindingConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/MagicService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicActionModuleThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicActionModuleThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgeHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgedThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicBridgedThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicButtonHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicButtonHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicChattyThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicChattyThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicColorLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicColorLightHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicConfigurableThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicConfigurableThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicContactHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicContactHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDelayedOnlineHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDelayedOnlineHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicDynamicStateDescriptionThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicExtensibleThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicExtensibleThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicFirmwareUpdateThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicFirmwareUpdateThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicImageHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicImageHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicLocationThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicLocationThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnlineOfflineHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicOnlineOfflineHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicPlayerHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicPlayerHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicRollershutterHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicRollershutterHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicThermostatThingHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicThermostatThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicTimeSeriesHandler.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/handler/MagicTimeSeriesHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDiscoveryService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDiscoveryService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicCommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicDynamicStateDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiActionMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicMultiServiceMultiActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicSingleActionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicThingActionsService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/automation/modules/MagicThingActionsService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/firmware/MagicFirmwareProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/firmware/MagicFirmwareProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataProvider.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataProvider2.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataProvider2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataUsingService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/internal/metadata/MagicMetadataUsingService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/service/MagicMultiInstanceServiceMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicColorLightHandlerTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicColorLightHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandlerTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicDimmableLightHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandlerTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/handler/MagicOnOffLightHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicServiceImplTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/AsyncResultWrapper.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/AsyncResultWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/BundleCloseable.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/BundleCloseable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/TestPortUtil.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/TestPortUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/TestServer.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/TestServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/internal/java/MissingServiceAnalyzer.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/internal/java/MissingServiceAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaTest.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/java/JavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/storage/VolatileStorage.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/storage/VolatileStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/storage/VolatileStorageService.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/storage/VolatileStorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.test/src/test/java/org/openhab/core/test/java/JavaTestTest.java
+++ b/bundles/org.openhab.core.test/src/test/java/org/openhab/core/test/java/JavaTestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Bridge.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Bridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Channel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelGroupUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelGroupUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/CommonTriggerEvents.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/CommonTriggerEvents.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/DefaultSystemChannelTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ManagedThingProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ManagedThingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/Thing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingRegistryChangeListener.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingRegistryChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatus.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatusDetail.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatusDetail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatusInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingTypeMigrationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingTypeMigrationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingTypeUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ThingUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/UID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractDynamicDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseBridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseBridgeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BridgeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusBridgeHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusBridgeHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ConfigStatusThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingActions.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingActionsScope.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingActionsScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingConfigStatusSource.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingConfigStatusSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingHandlerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/ThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/BridgeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/BridgeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ChannelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingStatusInfoBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/builder/ThingStatusInfoBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/Firmware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareRestriction.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareRestriction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareUpdateBackgroundTransferHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareUpdateBackgroundTransferHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareUpdateHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareUpdateHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressStep.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/firmware/ProgressStep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandlerContent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelHandlerContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelMode.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelValueConverterConfig.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelValueConverterConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/ColorChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/ColorChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/DimmerChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/DimmerChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/FixedValueMappingChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/FixedValueMappingChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/GenericChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/GenericChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/ImageChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/ImageChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/NumberChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/NumberChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/PlayerChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/PlayerChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/RollershutterChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/converter/RollershutterChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/AbstractThingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDefinitionDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelDefinitionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelGroupDefinitionDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelGroupDefinitionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ChannelTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/StrippedThingTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/AbstractThingRegistryEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/AbstractThingRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelDescriptionChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelTriggeredEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ChannelTriggeredEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingAddedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingRemovedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoChangedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingStatusInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingUpdatedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/events/ThingUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatus.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatusInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatusInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatusInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareStatusInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfoEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfoEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/dto/FirmwareDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/dto/FirmwareDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/dto/FirmwareStatusDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/dto/FirmwareStatusDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelGroupTypeI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/AutoUpdateManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/BridgeImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/BridgeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifier.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/CommunicationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ProfileContextImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingConfigDescriptionAliasProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingConfigDescriptionAliasProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingHandlerCallbackImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingTracker.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingChannelHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/FirmwareUpdateConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/FirmwareUpdateConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/LinkConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/LinkConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/console/ThingConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ParameterChecks.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ParameterChecks.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ChannelGroupI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ChannelGroupI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ChannelI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ChannelI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ThingTypeI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/i18n/ThingTypeI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileTypeRegistryImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ProfileTypeRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawButtonOnOffSwitchProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawButtonOnOffSwitchProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerDimmerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerDimmerProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerNextPreviousProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerNextPreviousProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerOnOffProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerOnOffProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerPlayPauseProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerPlayPauseProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerRewindFastforwardProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerRewindFastforwardProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerStopMoveProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerStopMoveProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerUpDownProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/RawRockerUpDownProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/StateProfileTypeImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/StateProfileTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemFollowProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemFollowProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampChangeProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampChangeProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampUpdateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TimestampUpdateProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ToggleProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/ToggleProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerProfileTypeImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/TriggerProfileTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/i18n/ProfileI18nUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/profiles/i18n/ProfileI18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/AbstractChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/AbstractChannelTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/StateChannelTypeBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/type/TriggerChannelTypeBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/RemoveChannelInstructionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstruction.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstruction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReaderImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateInstructionReaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/update/UpdateChannelInstructionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLink.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/AbstractLinkRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLink.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLink.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ItemChannelLinkRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ManagedItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/ManagedItemChannelLinkProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/AbstractLinkDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/AbstractLinkDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/ItemChannelLinkDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/dto/ItemChannelLinkDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/AbstractItemChannelLinkRegistryEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/AbstractItemChannelLinkRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/ItemChannelLinkAddedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/ItemChannelLinkAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/ItemChannelLinkRemovedEvent.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/ItemChannelLinkRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/link/events/LinkEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/Profile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/Profile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileAdvisor.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileAdvisor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/ProfileTypeUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfileType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/SystemProfiles.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TimeSeriesProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TimeSeriesProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TriggerProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TriggerProfile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TriggerProfileType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/TriggerProfileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/dto/ProfileTypeDTO.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/dto/ProfileTypeDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/dto/ProfileTypeDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/dto/ProfileTypeDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/i18n/ProfileTypeI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/i18n/ProfileTypeI18nLocalizationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AbstractDescriptionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AutoUpdatePolicy.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/AutoUpdatePolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/BridgeType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/BridgeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinition.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinitionBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelDefinitionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupDefinition.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelGroupTypeUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelKind.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ChannelTypeUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicCommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/DynamicStateDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/StateChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/StateChannelTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingTypeRegistry.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/ThingTypeRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/TriggerChannelTypeBuilder.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/type/TriggerChannelTypeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHandlerHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHandlerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingWebClientUtil.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/util/ThingWebClientUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/BridgeTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/BridgeTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/BridgeTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/BridgeTypeXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelTypeXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelXmlResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ChannelXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/CommandDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/CommandDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/EventDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/EventDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/StateDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionList.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionReader.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingDescriptionReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeConverter.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeXmlProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeXmlProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeXmlResult.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingTypeXmlResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/ThingXmlConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelGroupTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlChannelTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelGroupUIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelGroupUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelUIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ChannelUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ManagedThingProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ManagedThingProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ThingUIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/ThingUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/UIDTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/UIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicCommandDescriptionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProviderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/BaseDynamicStateDescriptionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ChannelBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ChannelBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingStatusInfoBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/builder/ThingStatusInfoBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/ChannelTransformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/converter/ConverterTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/binding/generic/converter/ConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ChannelDTOTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ChannelDTOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ThingDTOTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/dto/ThingDTOTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/firmware/FirmwareEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/firmware/FirmwareEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingItemConverterTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/binding/generic/converter/AbstractTransformingItemConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/firmware/ProgressCallbackTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/firmware/ProgressCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/RawButtonOnOffSwitchProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/RawButtonOnOffSwitchProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemFollowProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemFollowProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemOffsetProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampOffsetProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TimestampTriggerProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/ToggleProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/ToggleProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/TriggerEventStringProfileTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/link/events/LinkEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelGroupTypeBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelGroupTypeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelTypeBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ChannelTypeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ThingTypeBuilderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/type/ThingTypeBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingHandlerHelperTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingHandlerHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingHelperTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingWebClientUtilTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/util/ThingWebClientUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/xml/internal/ThingDescriptionReaderTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/xml/internal/ThingDescriptionReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/xml/internal/XmlHelperTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/xml/internal/XmlHelperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/AbstractFileTransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/AbstractFileTransformationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/FileTransformationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationProvider.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/ManagedTransformationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/Transformation.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/Transformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationException.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationProvider.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationRegistry.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/TransformationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/actions/Transformation.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/actions/Transformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/TransformationActivator.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/TransformationActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/TransformationRegistryImpl.java
+++ b/bundles/org.openhab.core.transform/src/main/java/org/openhab/core/transform/internal/TransformationRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/FileTransformationProviderTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/FileTransformationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/ManagedTransformationProviderTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/ManagedTransformationProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/actions/TransformationTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/actions/TransformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/internal/TransformationRegistryImplTest.java
+++ b/bundles/org.openhab.core.transform/src/test/java/org/openhab/core/transform/internal/TransformationRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/AbstractResourceIconProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/IconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/IconProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/IconSet.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/IconSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/CustomIconProvider.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/CustomIconProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/AbstractResourceIconProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/RootUIComponent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/RootUIComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentRegistryFactory.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponentRegistryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/UIActivator.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/UIActivator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartTheme.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartTheme.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBlackTransparent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBlackTransparent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBright.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBright.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBrightTransparent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeBrightTransparent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDarkTransparent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeDarkTransparent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeWhiteTransparent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/ChartThemeWhiteTransparent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedUIComponentProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/ManagedUIComponentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryFactoryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/AsyncProxyServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/AsyncProxyServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/BlockingProxyServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/BlockingProxyServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/tiles/TileService.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/tiles/TileService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/items/ItemUIRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/ExternalServiceTile.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/ExternalServiceTile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/Tile.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/Tile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/TileProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/tiles/TileProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/chart/ChartServletPeriodParamTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/chart/ChartServletPeriodParamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/items/ItemUIRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AbstractCachedTTSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AudioStartEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AudioStartEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AudioStopEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/AudioStopEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/DialogRegistration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSEdgeService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSEdgeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSErrorEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSErrorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSException.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSListener.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSServiceHandle.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSServiceHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSpottedEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/KSpottedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/RecognitionStartEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/RecognitionStartEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/RecognitionStopEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/RecognitionStopEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTException.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTListener.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTServiceHandle.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/STTServiceHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/SpeechRecognitionErrorEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/SpeechRecognitionErrorEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/SpeechRecognitionEvent.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/SpeechRecognitionEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSCache.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSException.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/TTSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/Voice.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/Voice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/VoiceManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/DialogProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/VoiceManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioFormatInfo.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioFormatInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioStreamFromCache.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/AudioStreamFromCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/CachedTTSService.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/CachedTTSService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/internal/text/StandardInterpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Expression.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionAlternatives.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionAlternatives.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionCardinality.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionCardinality.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionIdentifier.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionIdentifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionLet.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionLet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionMatch.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionMatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionSequence.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionSequence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/HumanLanguageInterpreter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/InterpretationException.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/InterpretationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/InterpretationResult.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/InterpretationResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/TokenList.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/TokenList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/STTExceptionTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/STTExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/SpeechRecognitionErrorEventTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/SpeechRecognitionErrorEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/SpeechRecognitionEventTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/SpeechRecognitionEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/TTSExceptionTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/TTSExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImplTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/cache/TTSLRUCacheImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
+++ b/bundles/org.openhab.core.voice/src/test/java/org/openhab/core/voice/internal/text/StandardInterpreterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/Activator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/OpenHAB.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/OpenHAB.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Authentication.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Authentication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/AuthenticationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Credentials.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Credentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/GenericUser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/GenericUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ManagedUser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/ManagedUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PendingToken.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PendingToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Role.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/Role.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SecurityException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/SecurityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UnsupportedCredentialsException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UnsupportedCredentialsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/User.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserApiToken.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserApiToken.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserApiTokenCredentials.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserApiTokenCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserSession.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UserSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UsernamePasswordCredentials.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/UsernamePasswordCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenRefreshListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenRefreshListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthClientService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthResponseException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/OAuthResponseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/StorageCipher.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/StorageCipher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ByteArrayFileCache.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ByteArrayFileCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCache.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheAsync.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheMap.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/ExpiringCacheMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/InputStreamCacheWrapper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/InputStreamCacheWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCache.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/cache/lru/LRUMediaCacheEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/AbstractUID.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/Disposable.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/Disposable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/NamedThreadFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/NamedThreadFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/PoolBasedSequentialScheduledExecutorService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/PoolBasedSequentialScheduledExecutorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/QueueingThreadPoolExecutor.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/QueueingThreadPoolExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/SafeCaller.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/SafeCaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/SafeCallerBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/SafeCallerBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadFactoryBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadFactoryBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/osgi/ResourceBundleClassLoader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/osgi/ResourceBundleClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractManagedProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/DefaultAbstractManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/DefaultAbstractManagedProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Identifiable.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Identifiable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/ManagedProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/ManagedProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Provider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Provider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/ProviderChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/ProviderChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Registry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/Registry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/RegistryChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/RegistryChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/RegistryChangedRunnableListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/RegistryChangedRunnableListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractTypedEventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/AbstractTypedEventSubscriber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/Event.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/Event.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventPublisher.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/EventSubscriber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicEventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicGlobEventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicGlobEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicPrefixEventFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/TopicPrefixEventFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/StartlevelEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/events/system/SystemEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/AbstractI18nException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/AbstractI18nException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/CommunicationException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/CommunicationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/ConfigurationException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/ConfigurationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/ConnectionException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/ConnectionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/I18nUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/I18nUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocaleProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocaleProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocalizedKey.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocalizedKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocationProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/LocationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/TimeZoneProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/TimeZoneProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/TranslationProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/TranslationProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/UnitProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/i18n/UnitProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/AuthenticationManagerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/AuthenticationManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/ManagedUserProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/ManagedUserProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/UserRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/auth/UserRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/AbstractInvocationHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/AbstractInvocationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/CombinedClassLoader.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/CombinedClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/DuplicateExecutionException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/DuplicateExecutionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/Invocation.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/Invocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/InvocationHandlerAsync.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/InvocationHandlerAsync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/InvocationHandlerSync.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/InvocationHandlerSync.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallManagerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerBuilderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/SafeCallerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/EventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventPublisher.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/OSGiEventPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/events/ThreadedEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/LanguageResourceBundleManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/LanguageResourceBundleManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/ResourceBundleTracker.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/ResourceBundleTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/DefaultStateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/DefaultStateDescriptionFragmentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/GroupFunctionHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemBuilderFactoryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemBuilderFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemBuilderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemStateConverterImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemStateConverterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemUpdater.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ItemUpdater.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ManagedMetadataProviderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataCommandDescriptionProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataCommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataRegistryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyConverter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/CurrencyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/FixedCurrencyProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/FixedCurrencyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/LocaleBasedCurrencyProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/LocaleBasedCurrencyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/UnitInitializer.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/library/unit/UnitInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/CronSchedulerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/DelegatedSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/DelegatedSchedulerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/PeriodicAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/PeriodicAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/SchedulerImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/scheduler/SchedulerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/BundleResolverImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/BundleResolverImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/CommandDescriptionServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/CommandDescriptionServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/ReadyServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/ReadyServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/StateDescriptionServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/StateDescriptionServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceFactoryImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceFactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/WatchServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/CommandDescriptionImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/CommandDescriptionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/types/StateDescriptionFragmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ActiveItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemBuilderFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemBuilderFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemLookupException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemLookupException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemNotFoundException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemNotUniqueException.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemNotUniqueException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemPredicates.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemPredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistryChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemRegistryChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemStateConverter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemStateConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ItemUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedItemProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedMetadataProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/ManagedMetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/Metadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataAwareItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataAwareItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataKey.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataPredicates.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataPredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/MetadataRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/RegistryHook.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/RegistryHook.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/StateChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/StateChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/TimeSeriesListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/TimeSeriesListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/GroupFunctionDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/GroupFunctionDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/GroupItemDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/GroupItemDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTOMapper.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/ItemDTOMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/MetadataDTO.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/dto/MetadataDTO.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/AbstractItemEventSubscriber.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/AbstractItemEventSubscriber.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/AbstractItemRegistryEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/AbstractItemRegistryEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupStateUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupStateUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemAddedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemAddedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemRemovedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemRemovedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStatePredictedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemUpdatedEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/CoreItemFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/ArealDensity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/ArealDensity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Currency.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Currency.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/DataAmount.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/DataAmount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/DataTransferRate.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/DataTransferRate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Density.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Density.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/ElectricConductivity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/ElectricConductivity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EmissionIntensity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EmissionIntensity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EnergyPrice.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/EnergyPrice.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Intensity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/Intensity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/RadiantExposure.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/RadiantExposure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/RadiationSpecificActivity.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/RadiationSpecificActivity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/VolumetricFlowRate.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/VolumetricFlowRate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/CallItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/CallItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ContactItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ImageItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/ArithmeticGroupFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeGroupFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DateTimeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/DecimalType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/HSBType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/HSBType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/IncreaseDecreaseType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/NextPreviousType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/NextPreviousType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OnOffType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OnOffType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OpenClosedType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/OpenClosedType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PercentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PlayPauseType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PlayPauseType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PointType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/PointType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/RawType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/RawType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/RewindFastforwardType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/RewindFastforwardType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StopMoveType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StopMoveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StringListType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StringListType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StringType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/StringType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/UpDownType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/UpDownType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/BinaryPrefix.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/BinaryPrefix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnit.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CustomUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CustomUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/ImperialUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/MetricPrefix.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/MetricPrefix.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/SIUnits.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/Units.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/CidrAddress.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/CidrAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/HttpServiceUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/HttpServiceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressChangeListener.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetworkAddressService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronJob.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronJob.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronScheduler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/CronScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/PeriodicScheduler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/PeriodicScheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/ScheduledCompletableFuture.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/ScheduledCompletableFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/Scheduler.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/Scheduler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/SchedulerRunnable.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/SchedulerRunnable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/SchedulerTemporalAdjuster.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/scheduler/SchedulerTemporalAdjuster.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractServiceBundleTracker.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/AbstractServiceBundleTracker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/CommandDescriptionService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/CommandDescriptionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarker.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarkerFilter.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarkerFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarkerUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyMarkerUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/ReadyService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StartLevelService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StateDescriptionService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/StateDescriptionService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchServiceFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/service/WatchServiceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/DeletableStorage.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/DeletableStorage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/DeletableStorageService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/DeletableStorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/Storage.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/Storage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/StorageService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/storage/StorageService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/Command.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescriptionBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescriptionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescriptionProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/CommandOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/ComplexType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/ComplexType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/EventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/PrimitiveType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/PrimitiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/RefreshType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/RefreshType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/State.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/State.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentProvider.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateDescriptionFragmentProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/StateOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TimeSeries.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TimeSeries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/Type.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/TypeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/UnDefType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/UnDefType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/types/util/UnitUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/BundleResolver.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/BundleResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/ColorUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/HexUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/HexUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/Statistics.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/Statistics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/UIDUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/UIDUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/JavaTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/JavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/auth/client/oauth2/AccessTokenResponseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ByteArrayFileCacheTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ByteArrayFileCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheAsyncTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheAsyncTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheMapTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheMapTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/ExpiringCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/InputStreamCacheWrapperTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/InputStreamCacheWrapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheEntryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheEntryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/cache/lru/LRUMediaCacheTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/AbstractUIDTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/AbstractUIDTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/QueueingThreadPoolExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadFactoryBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadFactoryBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadPoolManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/ThreadPoolManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/events/AbstractEventFactoryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/events/AbstractEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/events/TopicGlobEventFilterTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/events/TopicGlobEventFilterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/common/SafeCallerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nExceptionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nProviderImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/I18nProviderImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/i18n/TestUnitProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemStateConverterImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemStateConverterImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemTagTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemTagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterMiscTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterMiscTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronSchedulerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/DelegatedSchedulerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/DelegatedSchedulerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/PeriodicSchedulerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/SchedulerImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/SchedulerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/ReadyServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/ReadyServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/WatchServiceImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/types/StateDescriptionFragmentImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/types/StateDescriptionFragmentImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GroupItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GroupItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/MetadataKeyTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/MetadataKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/TestItem.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/TestItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/dto/ItemDTOMapperTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/dto/ItemDTOMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/events/ItemEventFactoryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/events/ItemEventFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/CoreItemFactoryTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/CoreItemFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/DataAmountTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/VolumetricFlowRateTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/dimension/VolumetricFlowRateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/CallItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/CallItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ColorItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ColorItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ContactItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ContactItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/DateTimeItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/DateTimeItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/DimmerItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/DimmerItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ImageItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/ImageItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/LocationItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/LocationItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/NumberItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/PlayerItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/PlayerItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/RollershutterItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/RollershutterItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StateUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StringItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/StringItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/SwitchItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/items/SwitchItemTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/ArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/ArithmeticGroupFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeGroupFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DateTimeTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/DecimalTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/HSBTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/HSBTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OnOffTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OpenClosedTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/OpenClosedTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PercentTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PointTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/PointTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringListTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringListTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/StringTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/UpDownTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/UpDownTypeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/CurrencyUnitTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/CurrencyUnitTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/HttpServiceUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/HttpServiceUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/NetUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/CommandDescriptionBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/CommandDescriptionBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/StateDescriptionFragmentBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TimeSeriesTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TimeSeriesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TypeParserTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/TypeParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/types/util/UnitUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/types/util/UnitUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/ColorUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/ColorUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/HexUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/HexUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StatisticsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StatisticsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/StringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/UIDUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/UIDUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInfoI18nTest.java
+++ b/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInfoI18nTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInfoTest.java
+++ b/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInstaller.java
+++ b/itests/org.openhab.core.addon.tests/src/main/java/org/openhab/core/addon/xml/test/AddonInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AbstractTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AbstractTestAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AuthorizationCodeTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AuthorizationCodeTestAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/ResourceOwnerTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/ResourceOwnerTestAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/TestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/TestAgent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/cipher/CipherTest.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/cipher/CipherTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/HostFragmentSupportTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/HostFragmentSupportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptRuleOSGiTest.java
+++ b/itests/org.openhab.core.automation.module.script.tests/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/ScriptRuleOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayConditionHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayTriggerHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/TimeOfDayTriggerHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleEngineTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleEngineTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleRegistryTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/RuleRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/internal/TestModuleTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/ConfigOptionRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/ConfigOptionRegistryOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/BindingInstaller.java
+++ b/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/BindingInstaller.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionI18nTest.java
+++ b/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionI18nTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.config.core.tests/src/main/java/org/openhab/core/config/core/xml/ConfigDescriptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.mdns.tests/src/main/java/org/openhab/core/config/discovery/mdns/internal/MDNSDiscoveryServiceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMock.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMockOfBridge.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceMockOfBridge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/test/DummyThingTypeProvider.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/test/DummyThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScannerTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/DeltaUsbSerialScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScannerTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysFsUsbSerialScannerTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/internal/SysFsUsbSerialScannerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/testutil/UsbSerialDeviceInformationGenerator.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/src/main/java/org/openhab/core/config/discovery/usbserial/linuxsysfs/testutil/UsbSerialDeviceInformationGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/testutil/UsbSerialDeviceInformationGenerator.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/testutil/UsbSerialDeviceInformationGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherOSGiTest.java
+++ b/itests/org.openhab.core.config.dispatch.tests/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcherOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
+++ b/itests/org.openhab.core.ephemeris.tests/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImplOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/ClientFactoryTest.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/ClientFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestHttpServlet.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestHttpServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestServer.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestStreamAdapter.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestStreamAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocket.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocketAdapter.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocketAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocketServlet.java
+++ b/itests/org.openhab.core.io.net.tests/src/main/java/org/openhab/core/io/net/tests/internal/TestWebSocketServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResourceOSGITest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResourceOSGITest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResourceTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
+++ b/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericMetadataProviderTest.java
+++ b/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericMetadataProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
+++ b/itests/org.openhab.core.model.script.tests/src/main/java/org/openhab/core/model/script/engine/ScriptEngineOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericItemChannelLinkProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest2.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/DumbThingHandlerFactory.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/DumbThingHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/DumbThingTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/DumbThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueChannelTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueChannelTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueConfigDescriptionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingHandlerFactory.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingHandlerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingHandlerFactoryX.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingHandlerFactoryX.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingTypeProvider.java
+++ b/itests/org.openhab.core.model.thing.testsupport/src/main/java/org/openhab/core/model/thing/testsupport/hue/TestHueThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/JsonStorageServiceOSGiTest.java
+++ b/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/JsonStorageServiceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/ThingMigrationOSGiTest.java
+++ b/itests/org.openhab.core.storage.json.tests/src/main/java/org/openhab/core/storage/json/internal/ThingMigrationOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/events/OSGiEventManagerOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/events/OSGiEventManagerOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/i18n/TranslationProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/i18n/TranslationProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/items/ItemUpdaterOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/internal/items/ItemUpdaterOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/GroupItemOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ItemRegistryImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/ManagedItemProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/TestItem.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/TestItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/events/AbstractItemEventSubscriberOSGiTest.java
+++ b/itests/org.openhab.core.tests/src/main/java/org/openhab/core/items/events/AbstractItemEventSubscriberOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/SystemWideChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/SystemWideChannelTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingChannelsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingPropertiesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/ThingPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/AbstractStorageBasedTypeProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/BindingBaseClassesOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/events/ThingEventOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/factory/ManagedThingProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/factory/ManagedThingProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/ModelRestrictedFirmwareUpdateServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/ModelRestrictedFirmwareUpdateServiceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/AutoUpdateManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelCommandDescriptionProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifierOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifierOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/SimpleThingTypeProvider.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/SimpleThingTypeProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingManagerOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ThingRegistryOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareRegistryOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/profiles/SystemProfileFactoryOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/LinkEventOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/LinkEventOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/profiles/i18n/SystemProfileI18nOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/profiles/i18n/SystemProfileI18nOSGiTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/testutil/i18n/DefaultLocaleSetter.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/testutil/i18n/DefaultLocaleSetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesI18nTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ChannelTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ConfigDescriptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/LoadedTestBundle.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/LoadedTestBundle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/SystemChannelsInChannelGroupsTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/SystemChannelsInChannelGroupsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/SystemWideChannelTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/SystemWideChannelTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypeI18nTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypeI18nTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/xml/test/ThingTypesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/AudioSourceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/AudioSourceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/ConsoleStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/ConsoleStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/HumanLanguageInterpreterStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/HumanLanguageInterpreterStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/KSServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/KSServiceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/STTServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/STTServiceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/SinkStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/SinkStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/TTSServiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/TTSServiceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceManagerImplTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceStub.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/internal/VoiceStub.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/InterpretCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/SayCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoiceConsoleCommandExtensionTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoiceConsoleCommandExtensionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
+++ b/itests/org.openhab.core.voice.tests/src/main/java/org/openhab/core/voice/voiceconsolecommandextension/VoicesCommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/pom.xml
+++ b/pom.xml
@@ -449,10 +449,8 @@ Import-Package: \\
             <strictCheck>true</strictCheck>
             <aggregate>true</aggregate>
             <mapping>
-              <groovy>JAVADOC_STYLE</groovy>
-              <java>JAVADOC_STYLE</java>
-              <mwe2>JAVADOC_STYLE</mwe2>
-              <xtend>JAVADOC_STYLE</xtend>
+              <mwe2>SLASHSTAR_STYLE</mwe2>
+              <xtend>SLASHSTAR_STYLE</xtend>
               <xml>xml-header-style</xml>
             </mapping>
             <useDefaultExcludes>true</useDefaultExcludes>

--- a/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/tools/archetype/binding/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/AbstractI18nMojo.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/AbstractI18nMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfo.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/BundleInfoReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/DefaultTranslationsGenerationMode.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/DefaultTranslationsGenerationMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojo.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/JsonToTranslationsConverter.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/JsonToTranslationsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/PropertiesToTranslationsConverter.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/PropertiesToTranslationsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/Translations.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/Translations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/TranslationsMerger.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/TranslationsMerger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverter.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/BundleInfoReaderTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/BundleInfoReaderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/JsonToTranslationsConverterTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/JsonToTranslationsConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/PropertiesToTranslationsConverterTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/PropertiesToTranslationsConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/TranslationsMergerTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/TranslationsMergerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverterTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,7 +1,7 @@
 checkstyle.beforeExecutionExclusionFileFilter.fileNamePattern=.+org.openhab.core.internal.i18n.I18nProviderImpl\.java$|.+org.openhab.core.i18n.TranslationProvider\.java$
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,org.junit.Assert,org.junit.Test
-checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
+checkstyle.headerCheck.content=^/\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
 checkstyle.headerCheck.values=2010,2025
 checkstyle.pomXmlCheck.currentVersionRegex=^4\.2\.0
 checkstyle.requiredFilesCheck.files=pom.xml

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/UpgradeTool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/Upgrader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
Prevents JavaDoc tooling issues because these tools check comments starting with `/**`.

Depends on #4543