### PR TITLE
HttpUtil: fix invalid URI

### DIFF
--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -152,6 +152,10 @@ public class HttpUtil {
     public static String executeUrl(String httpMethod, String url, Properties httpHeaders, InputStream content,
             String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
             String proxyPassword, String nonProxyHosts) throws IOException {
+        if (url == null) {
+            LOGGER.debug("Execute url failed: no url provided");
+            return null;
+        }
         ContentResponse response = executeUrlAndGetReponse(httpMethod, url, httpHeaders, content, contentType, timeout,
                 proxyHost, proxyPort, proxyUser, proxyPassword, nonProxyHosts);
         String encoding = response.getEncoding() != null ? response.getEncoding().replace("\"", "").trim()
@@ -438,6 +442,11 @@ public class HttpUtil {
      */
     public static RawType downloadData(String url, String contentTypeRegex, boolean scanTypeInContent,
             long maxContentLength, int timeout) {
+        if (url == null) {
+            LOGGER.debug("Media download failed: no url provided");
+            return null;
+        }
+
         final ProxyParams proxyParams = prepareProxyParams();
 
         RawType rawData = null;

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -314,9 +314,9 @@ public class HttpUtil {
             String givenHost = urlString;
 
             try {
-                URL url = new URL(urlString);
+                URL url = (new URI(urlString)).toURL();
                 givenHost = url.getHost();
-            } catch (MalformedURLException e) {
+            } catch (MalformedURLException | URISyntaxException e) {
                 LOGGER.error("the given url {} is malformed", urlString);
             }
 

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -55,7 +56,7 @@ public abstract class BaseHttpUtilTest {
         httpClientFactory.set(null, clientFactoryMock);
 
         when(clientFactoryMock.getCommonHttpClient()).thenReturn(httpClientMock);
-        when(httpClientMock.newRequest(URL)).thenReturn(requestMock);
+        when(httpClientMock.newRequest(URI.create(URL))).thenReturn(requestMock);
         when(requestMock.method(any(HttpMethod.class))).thenReturn(requestMock);
         when(requestMock.timeout(anyLong(), any(TimeUnit.class))).thenReturn(requestMock);
         when(requestMock.send()).thenReturn(contentResponseMock);

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpRequestBuilderTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpRequestBuilderTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.net.http;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
+import java.net.URI;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -45,7 +46,7 @@ public class HttpRequestBuilderTest extends BaseHttpUtilTest {
 
         assertEquals("Some content", result);
 
-        verify(httpClientMock).newRequest(URL);
+        verify(httpClientMock).newRequest(URI.create(URL));
         verify(requestMock).method(HttpMethod.GET);
         verify(requestMock).send();
     }

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.net.http;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -40,7 +41,7 @@ public class HttpUtilTest extends BaseHttpUtilTest {
 
         assertEquals("Some content", result);
 
-        verify(httpClientMock).newRequest(URL);
+        verify(httpClientMock).newRequest(URI.create(URL));
         verify(requestMock).method(HttpMethod.GET);
         verify(requestMock).timeout(500, TimeUnit.MILLISECONDS);
         verify(requestMock).send();
@@ -48,7 +49,7 @@ public class HttpUtilTest extends BaseHttpUtilTest {
 
     @Test
     public void testAuthentication() throws Exception {
-        when(httpClientMock.newRequest("http://john:doe@example.org/")).thenReturn(requestMock);
+        when(httpClientMock.newRequest(URI.create("http://john:doe@example.org/"))).thenReturn(requestMock);
         mockResponse(HttpStatus.OK_200);
 
         String result = HttpUtil.executeUrl("GET", "http://john:doe@example.org/", 500);


### PR DESCRIPTION
Providing an invalid URI input was throwing an IllegalArgumentException from the underlying jetty library. This change properly catches it and throws an IOException instead, aligned with the error treatment in the rest of the method.

See also https://github.com/openhab/openhab-addons/pull/18066