### PR TITLE
Remove calls to deprecated URL constructor

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace.karaf/src/main/java/org/openhab/core/addon/marketplace/karaf/internal/community/CommunityKarafAddonHandler.java
@@ -12,13 +12,13 @@
  */
 package org.openhab.core.addon.marketplace.karaf.internal.community;
 
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.KAR_CONTENT_TYPE;
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.KAR_DOWNLOAD_URL_PROPERTY;
+import static org.openhab.core.addon.marketplace.MarketplaceConstants.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -108,13 +108,14 @@ public class CommunityKarafAddonHandler implements MarketplaceAddonHandler {
 
     @Override
     public void install(Addon addon) throws MarketplaceHandlerException {
+        URL sourceUrl;
         try {
-            URL sourceUrl = new URL((String) addon.getProperties().get(KAR_DOWNLOAD_URL_PROPERTY));
-            addKarToCache(addon.getUid(), sourceUrl);
-            installFromCache(addon.getUid());
-        } catch (MalformedURLException e) {
+            sourceUrl = (new URI((String) addon.getProperties().get(KAR_DOWNLOAD_URL_PROPERTY))).toURL();
+        } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }
+        addKarToCache(addon.getUid(), sourceUrl);
+        installFromCache(addon.getUid());
     }
 
     @Override

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.core.addon.marketplace.internal.community;
 
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.BLOCKLIBRARIES_CONTENT_TYPE;
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.YAML_DOWNLOAD_URL_PROPERTY;
+import static org.openhab.core.addon.marketplace.MarketplaceConstants.*;
 import static org.openhab.core.addon.marketplace.internal.community.CommunityMarketplaceAddonService.YAML_CONTENT_PROPERTY;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -102,7 +104,12 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
     }
 
     private String getWidgetFromURL(String urlString) throws IOException {
-        URL u = new URL(urlString);
+        URL u;
+        try {
+            u = (new URI(urlString)).toURL();
+        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+            throw new IOException(e);
+        }
         try (InputStream in = u.openStream()) {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -107,7 +106,7 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
         URL u;
         try {
             u = (new URI(urlString)).toURL();
-        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+        } catch (IllegalArgumentException | URISyntaxException e) {
             throw new IOException(e);
         }
         try (InputStream in = u.openStream()) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -12,10 +12,11 @@
  */
 package org.openhab.core.addon.marketplace.internal.community;
 
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.JAR_CONTENT_TYPE;
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.JAR_DOWNLOAD_URL_PROPERTY;
+import static org.openhab.core.addon.marketplace.MarketplaceConstants.*;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -73,13 +74,14 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
 
     @Override
     public void install(Addon addon) throws MarketplaceHandlerException {
+        URL sourceUrl;
         try {
-            URL sourceUrl = new URL((String) addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY));
-            addBundleToCache(addon.getUid(), sourceUrl);
-            installFromCache(bundleContext, addon.getUid());
-        } catch (MalformedURLException e) {
+            sourceUrl = (new URI((String) addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY))).toURL();
+        } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }
+        addBundleToCache(addon.getUid(), sourceUrl);
+        installFromCache(bundleContext, addon.getUid());
     }
 
     @Override

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -163,7 +163,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
         try {
             List<DiscourseCategoryResponseDTO> pages = new ArrayList<>();
 
-            URL url = new URL(COMMUNITY_MARKETPLACE_URL);
+            URL url = URI.create(COMMUNITY_MARKETPLACE_URL).toURL();
             int pageNb = 1;
             while (url != null) {
                 URLConnection connection = url.openConnection();
@@ -180,7 +180,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
                     if (parsed.topicList.moreTopicsUrl != null) {
                         // Discourse URL for next page is wrong
-                        url = new URL(COMMUNITY_MARKETPLACE_URL + "?page=" + pageNb++);
+                        url = URI.create(COMMUNITY_MARKETPLACE_URL + "?page=" + pageNb++).toURL();
                     } else {
                         url = null;
                     }
@@ -215,7 +215,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
         // retrieve from remote
         try {
-            URL url = new URL(String.format("%s%s", COMMUNITY_TOPIC_URL, uid.replace(ADDON_ID_PREFIX, "")));
+            URL url = URI.create(String.format("%s%s", COMMUNITY_TOPIC_URL, uid.replace(ADDON_ID_PREFIX, ""))).toURL();
             URLConnection connection = url.openConnection();
             connection.addRequestProperty("Accept", "application/json");
             if (this.apiKey != null) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -215,7 +215,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
         // retrieve from remote
         try {
-            URL url = URI.create("%s%s".formatted(COMMUNITY_TOPIC_URL, uid.replace(ADDON_ID_PREFIX, ""))).toURL();
+            URL url = URI.create(COMMUNITY_TOPIC_URL + uid.replace(ADDON_ID_PREFIX, "")).toURL();
             URLConnection connection = url.openConnection();
             connection.addRequestProperty("Accept", "application/json");
             if (this.apiKey != null) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -215,7 +215,7 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
 
         // retrieve from remote
         try {
-            URL url = URI.create(String.format("%s%s", COMMUNITY_TOPIC_URL, uid.replace(ADDON_ID_PREFIX, ""))).toURL();
+            URL url = URI.create("%s%s".formatted(COMMUNITY_TOPIC_URL, uid.replace(ADDON_ID_PREFIX, ""))).toURL();
             URLConnection connection = url.openConnection();
             connection.addRequestProperty("Accept", "application/json");
             if (this.apiKey != null) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -105,7 +104,7 @@ public class CommunityRuleTemplateAddonHandler implements MarketplaceAddonHandle
         URL u;
         try {
             u = (new URI(urlString)).toURL();
-        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+        } catch (IllegalArgumentException | URISyntaxException e) {
             throw new IOException(e);
         }
         try (InputStream in = u.openStream()) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
@@ -17,6 +17,9 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -99,7 +102,12 @@ public class CommunityRuleTemplateAddonHandler implements MarketplaceAddonHandle
     }
 
     private String getTemplateFromURL(String urlString) throws IOException {
-        URL u = new URL(urlString);
+        URL u;
+        try {
+            u = (new URI(urlString)).toURL();
+        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+            throw new IOException(e);
+        }
         try (InputStream in = u.openStream()) {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -137,7 +136,7 @@ public class CommunityTransformationAddonHandler implements MarketplaceAddonHand
         URL u;
         try {
             u = (new URI(urlString)).toURL();
-        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+        } catch (IllegalArgumentException | URISyntaxException e) {
             throw new IOException(e);
         }
         try (InputStream in = u.openStream()) {

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
@@ -17,6 +17,9 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -131,7 +134,12 @@ public class CommunityTransformationAddonHandler implements MarketplaceAddonHand
     }
 
     private String downloadTransformation(String urlString) throws IOException {
-        URL u = new URL(urlString);
+        URL u;
+        try {
+            u = (new URI(urlString)).toURL();
+        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+            throw new IOException(e);
+        }
         try (InputStream in = u.openStream()) {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -12,12 +12,14 @@
  */
 package org.openhab.core.addon.marketplace.internal.community;
 
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.UIWIDGETS_CONTENT_TYPE;
-import static org.openhab.core.addon.marketplace.MarketplaceConstants.YAML_DOWNLOAD_URL_PROPERTY;
+import static org.openhab.core.addon.marketplace.MarketplaceConstants.*;
 import static org.openhab.core.addon.marketplace.internal.community.CommunityMarketplaceAddonService.YAML_CONTENT_PROPERTY;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -106,7 +108,12 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
     }
 
     private String getWidgetFromURL(String urlString) throws IOException {
-        URL u = new URL(urlString);
+        URL u;
+        try {
+            u = (new URI(urlString)).toURL();
+        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+            throw new IOException(e);
+        }
         try (InputStream in = u.openStream()) {
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -17,7 +17,6 @@ import static org.openhab.core.addon.marketplace.internal.community.CommunityMar
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -111,7 +110,7 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
         URL u;
         try {
             u = (new URI(urlString)).toURL();
-        } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {
+        } catch (IllegalArgumentException | URISyntaxException e) {
             throw new IOException(e);
         }
         try (InputStream in = u.openStream()) {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -16,6 +16,8 @@ import static org.openhab.core.auth.oauth2client.internal.Keyword.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.time.Instant;
@@ -168,7 +170,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
     public String extractAuthCodeFromAuthResponse(String redirectURLwithParams) throws OAuthException {
         // parse the redirectURL
         try {
-            URL redirectURLObject = new URL(redirectURLwithParams);
+            URL redirectURLObject = (new URI(redirectURLwithParams)).toURL();
             UrlEncoded urlEncoded = new UrlEncoded(redirectURLObject.getQuery());
 
             String stateFromRedirectURL = urlEncoded.getValue(STATE, 0); // may contain multiple...
@@ -186,7 +188,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
                 throw new OAuthException(String.format("state from redirectURL is incorrect.  Expected: %s Found: %s",
                         persistedParams.state, stateFromRedirectURL));
             }
-        } catch (MalformedURLException e) {
+        } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
             throw new OAuthException("Redirect URL is malformed", e);
         }
     }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandImport.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.internal.commands;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -101,13 +103,13 @@ public class AutomationCommandImport extends AutomationCommand {
      */
     private @Nullable URL initURL(String parameterValue) {
         try {
-            return new URL(parameterValue);
-        } catch (MalformedURLException mue) {
+            return (new URI(parameterValue)).toURL();
+        } catch (MalformedURLException | URISyntaxException mue) {
             File f = new File(parameterValue);
             if (f.isFile()) {
                 try {
                     return f.toURI().toURL();
-                } catch (MalformedURLException e) {
+                } catch (IllegalArgumentException | MalformedURLException e) {
                 }
             }
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandRemove.java
@@ -14,6 +14,8 @@ package org.openhab.core.automation.internal.commands;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -96,13 +98,13 @@ public class AutomationCommandRemove extends AutomationCommand {
      */
     private @Nullable URL initURL(String parameterValue) {
         try {
-            return new URL(parameterValue);
-        } catch (MalformedURLException mue) {
+            return (new URI(parameterValue)).toURL();
+        } catch (MalformedURLException | URISyntaxException mue) {
             File f = new File(parameterValue);
             if (f.isFile()) {
                 try {
                     return f.toURI().toURL();
-                } catch (MalformedURLException e) {
+                } catch (IllegalArgumentException | MalformedURLException e) {
                 }
             }
         }

--- a/bundles/org.openhab.core.config.discovery.addon.upnp/src/test/java/org/openhab/core/config/discovery/addon/upnp/tests/UpnpAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.upnp/src/test/java/org/openhab/core/config/discovery/addon/upnp/tests/UpnpAddonFinderTests.java
@@ -12,16 +12,12 @@
  */
 package org.openhab.core.config.discovery.addon.upnp.tests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -85,7 +81,7 @@ public class UpnpAddonFinderTests {
         upnpService = mock(UpnpService.class, Mockito.RETURNS_DEEP_STUBS);
         URL url = null;
         try {
-            url = new URL("http://www.openhab.org/");
+            url = URI.create("http://www.openhab.org/").toURL();
         } catch (MalformedURLException e) {
             fail("MalformedURLException");
         }

--- a/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
+++ b/bundles/org.openhab.core.ephemeris/src/main/java/org/openhab/core/ephemeris/internal/EphemerisManagerImpl.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -224,8 +225,8 @@ public class EphemerisManagerImpl implements EphemerisManager, ConfigOptionProvi
     private URL getUrl(String filename) throws FileNotFoundException {
         if (Files.exists(Paths.get(filename))) {
             try {
-                return new URL("file:" + filename);
-            } catch (MalformedURLException e) {
+                return (new URI("file:" + filename)).toURL();
+            } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
                 throw new FileNotFoundException(e.getMessage());
             }
         } else {

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/PEMTrustManager.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -113,7 +115,11 @@ public final class PEMTrustManager extends X509ExtendedTrustManager {
      * @throws CertificateInstantiationException
      */
     public static PEMTrustManager getInstanceFromServer(String url) throws MalformedURLException, CertificateException {
-        return getInstanceFromServer(new URL(url));
+        try {
+            return getInstanceFromServer((new URI(url)).toURL());
+        } catch (IllegalArgumentException | URISyntaxException e) {
+            throw new MalformedURLException(e.getMessage());
+        }
     }
 
     /**

--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.Instant;
@@ -306,8 +308,8 @@ public class JsonStorageTest extends JavaTest {
 
     private static URL newURL(String url) {
         try {
-            return new URL(url);
-        } catch (MalformedURLException e) {
+            return (new URI(url)).toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/ProxyServletService.java
@@ -17,7 +17,6 @@ import java.io.Serial;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Base64;
 import java.util.Hashtable;
 import java.util.List;
@@ -295,9 +294,15 @@ public class ProxyServletService extends HttpServlet {
     }
 
     private URI createURIFromString(String url) throws MalformedURLException, URISyntaxException {
-        // URI in this context should be valid URL. Therefore before creating URI, create URL,
+        URI uri = new URI(url);
+        // URI in this context should be valid URL. Therefore before returning URI, create URL,
         // which validates the string.
-        return new URL(url).toURI();
+        try {
+            uri.toURL();
+        } catch (IllegalArgumentException e) {
+            throw new MalformedURLException(e.getMessage());
+        }
+        return uri;
     }
 
     /**

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/firmware/FirmwareTest.java
@@ -20,6 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
@@ -91,7 +92,7 @@ public class FirmwareTest extends JavaOSGiTest {
         String description = "description";
         String model = "model";
         boolean modelRestricted = true;
-        URL onlineChangelog = new URL("http://online.changelog");
+        URL onlineChangelog = URI.create("http://online.changelog").toURL();
         String prerequisiteVersion = "0.0.9";
         String md5hash = "123abc";
         String vendor = "vendor";
@@ -304,7 +305,7 @@ public class FirmwareTest extends JavaOSGiTest {
         String description = "description";
         String model = "model";
         boolean modelRestricted = true;
-        URL onlineChangelog = new URL("https://secure.com/changelog");
+        URL onlineChangelog = URI.create("https://secure.com/changelog").toURL();
         String prerequisiteVersion = "0.1";
         String vendor = "vendor";
         Map<String, String> properties = Map.of("prop1", "val1", "prop2", "val2");
@@ -330,7 +331,7 @@ public class FirmwareTest extends JavaOSGiTest {
         String description = "description";
         String model = "model";
         boolean modelRestricted = true;
-        URL onlineChangelog = new URL("https://secure.com/changelog");
+        URL onlineChangelog = URI.create("https://secure.com/changelog").toURL();
         String prerequisiteVersion = "0.1";
         String vendor = "vendor";
         Map<String, String> properties = Map.of("prop1", "val1", "prop2", "val2");

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
@@ -133,7 +133,7 @@ public class Constants {
 
     private static URL newURL(String url) {
         try {
-            return new URL(url);
+            return URI.create(url).toURL();
         } catch (MalformedURLException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
As part of https://github.com/openhab/openhab-core/pull/4546, it was pointed out the `URL` constructor has been deprecated in Java 21.

This PR removes all uses of the URL constructor in core.

It starts from https://github.com/openhab/openhab-core/pull/4546, which only looks at one class in `HttpUtil` (and also solves a different problem), so that should be reviewed first (and this one rebased afterwards).

@holgerfriedrich Let me know what you think.