### PR TITLE
Ensure sitemap subscriptions are updated on Group Items

### DIFF
--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -74,6 +74,7 @@ import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService.SitemapSubscr
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
+import org.openhab.core.items.events.GroupItemStateChangedEvent;
 import org.openhab.core.items.events.ItemEvent;
 import org.openhab.core.items.events.ItemStateChangedEvent;
 import org.openhab.core.library.CoreItemFactory;
@@ -918,7 +919,7 @@ public class SitemapResource
 
     @Override
     public Set<String> getSubscribedEventTypes() {
-        return Set.of(ItemStateChangedEvent.TYPE);
+        return Set.of(ItemStateChangedEvent.TYPE, GroupItemStateChangedEvent.TYPE);
     }
 
     @Override


### PR DESCRIPTION
Fixes an issue where sitemaps containing group items that change,  only update when a subscription times out (30 seconds)

I noticed while troubleshooting our IOS client that the sitemap i use for the apple watch would not update in realtime, only every 30 seconds.  Turns out this sitemap only has group items, and our SitemapResource was not subscribing to those events.  This is a pretty small change, i would recommend to back port as well.  


