### PR TITLE
Improve cron exception handling

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/GenericCronTriggerHandler.java
@@ -68,9 +68,13 @@ public class GenericCronTriggerHandler extends BaseTriggerModuleHandler
     }
 
     private void scheduleJob() {
-        schedule = scheduler.schedule(this, expression);
-        logger.debug("Scheduled cron job '{}' for trigger '{}'.", module.getConfiguration().get(CFG_CRON_EXPRESSION),
-                module.getId());
+        try {
+            schedule = scheduler.schedule(this, expression);
+            logger.debug("Scheduled cron job '{}' for trigger '{}'.",
+                    module.getConfiguration().get(CFG_CRON_EXPRESSION), module.getId());
+        } catch (IllegalArgumentException e) { // Catch exception from CronAdjuster
+            logger.warn("Failed to schedule job for trigger '{}'. {}", module.getId(), e.getMessage());
+        }
     }
 
     @Override

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/CronAdjusterTest.java
@@ -203,9 +203,6 @@ public class CronAdjusterTest {
     @ParameterizedTest
     @ValueSource(strings = { "0 0 0 31 2 *", "* * *", "80 * * * * *" })
     public void testInvalidCronExpression(String cron) {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final CronAdjuster cronAdjuster = new CronAdjuster(cron);
-            cronAdjuster.adjustInto(java.time.ZonedDateTime.now());
-        });
+        assertThrows(IllegalArgumentException.class, () -> new CronAdjuster(cron));
     }
 }


### PR DESCRIPTION
Improve #4548

Log a warning instead of a big stack trace.

Also changed IAE to DateTimeException in `adjustInto` to comply with Java specs.

Sample log:

```
12:34:21.021 [WARN ] [ule.handler.GenericCronTriggerHandler] - Failed to schedule job for trigger '0'. Invalid cron expression '0 0  5 31 2 ?': Conditions not satisfied.
```