### PR TITLE
Avoid stack overflow - don't log a message within the log handler

### DIFF
--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
@@ -128,7 +128,7 @@ public class LogWebSocket implements LogListener {
             LogDTO logDTO = map(logEntry);
             sendMessage(gson.toJson(logDTO));
         } catch (IOException e) {
-            logger.debug("Failed to send log {} to {}: {}", logEntry, remoteIdentifier, e.getMessage());
+            // Fail silently!
         }
     }
 

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
@@ -113,7 +113,6 @@ public class LogWebSocket implements LogListener {
     private synchronized void sendMessage(String message) throws IOException {
         RemoteEndpoint remoteEndpoint = this.remoteEndpoint;
         if (remoteEndpoint == null) {
-            logger.warn("Could not determine remote endpoint, failed to send '{}'.", message);
             return;
         }
         remoteEndpoint.sendString(message);


### PR DESCRIPTION
Logging a log message within the log handler causes a stack overflow.