### PR TITLE
Extends updateThing method warning message.

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java
@@ -479,8 +479,8 @@ public abstract class BaseThingHandler implements ThingHandler {
                     channel.getConfiguration().getProperties()));
         } catch (ConfigValidationException e) {
             logger.warn(
-                    "Attempt to update thing '{}' with a thing containing invalid configuration '{}', blocked. This is most likely a bug.",
-                    thing.getUID(), thing.getConfiguration());
+                    "Attempt to update thing '{}' with a thing containing invalid configuration '{}' blocked. This is most likely a bug: {}",
+                    thing.getUID(), thing.getConfiguration(), e.getValidationMessages());
             return;
         }
         synchronized (this) {


### PR DESCRIPTION
This pull request fixes #4557. If the update of thing is not valid, the warning message now contains detailed information about the validation result.
