### PR TITLE
Set addons.xml as master addon info

### DIFF
--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
@@ -95,7 +95,7 @@ public class AddonInfoAddonsXmlProvider implements AddonInfoProvider {
             String xml = Files.readString(file.toPath());
             if (xml != null && !xml.isBlank()) {
                 addonInfos.addAll(reader.readFromXML(xml).getAddons().stream()
-                        .map(a -> AddonInfo.builder(a).isMasterAddonInfo(false).build()).collect(Collectors.toSet()));
+                        .map(a -> AddonInfo.builder(a).isMasterAddonInfo(true).build()).collect(Collectors.toSet()));
             } else {
                 logger.warn("File '{}' contents are null or empty", file.getName());
             }


### PR DESCRIPTION
This would prioritize the name and descriptions from addons.xml
which seem to be more complete.

Without this, many add-on data returned by the REST service /addons are missing their description.

The description will be used in add-on search and to show a short description for the binding in the UI

See
https://github.com/openhab/openhab-webui/issues/2870
https://github.com/openhab/openhab-webui/pull/3028