### PR TITLE
Upgrade JUPnP to 3.0.3

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -203,7 +203,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -475,7 +475,7 @@
     <dependency>
       <groupId>org.jupnp</groupId>
       <artifactId>org.jupnp</artifactId>
-      <version>3.0.1</version>
+      <version>3.0.3</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -200,11 +200,11 @@
 	</feature>
 
 	<feature name="openhab.tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">
-		<capability>openhab.tp;feature=jupnp;version=3.0.1</capability>
+		<capability>openhab.tp;feature=jupnp;version=3.0.3</capability>
 		<feature dependency="true">http</feature>
 		<feature dependency="true">scr</feature>
 		<feature dependency="true">openhab.tp-httpclient</feature>
-		<bundle>mvn:org.jupnp/org.jupnp/3.0.1</bundle>
+		<bundle>mvn:org.jupnp/org.jupnp/3.0.3</bundle>
 	</feature>
 
 	<feature name="openhab.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">


### PR DESCRIPTION
Upgrades JUPnP from 3.0.1 to 3.0.3.

For release notes, see:

* https://github.com/jupnp/jupnp/releases/tag/3.0.2
* https://github.com/jupnp/jupnp/releases/tag/3.0.3