### PR TITLE
Upgrade Jollyday to 1.4.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -365,7 +365,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.35.1</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -950,7 +950,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>0.35.1</version>
+      <version>1.4.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -180,12 +180,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=0.35.1</capability>
+		<capability>openhab.tp;feature=jollyday;version=1.4.0</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/0.35.1</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/0.35.1</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/1.4.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/1.4.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -77,5 +77,5 @@ Fragment-Host: org.openhab.core.automation.module.script
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -80,5 +80,5 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -75,5 +75,5 @@ feature.openhab-config: \
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -126,6 +126,6 @@ Fragment-Host: org.openhab.core.model.item
 	com.google.guava;version='[33.3.0,33.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)',\
-	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)'
+	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -129,5 +129,5 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.google.guava;version='[33.3.0,33.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)'
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -132,6 +132,6 @@ Fragment-Host: org.openhab.core.model.script
 	stax2-api;version='[4.2.2,4.2.3)',\
 	com.google.guava;version='[33.3.0,33.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)',\
-	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)'
+	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -135,6 +135,6 @@ Fragment-Host: org.openhab.core.model.thing
 	com.google.guava;version='[33.3.0,33.3.1)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[0.35.1,0.35.2)',\
-	de.focus_shift.jollyday-jackson;version='[0.35.1,0.35.2)',\
-	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)'
+	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)'


### PR DESCRIPTION
Upgrades Jollyday from 0.35.1 to 1.4.0.

For release notes, see:

https://github.com/focus-shift/jollyday/releases