### PR TITLE
Fix comparing QuantityType with inverted dimensions

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -240,10 +240,15 @@ public class QuantityType<T extends Quantity<T>> extends Number
         if (!(obj instanceof QuantityType<?> other)) {
             return false;
         }
-        if (!quantity.getUnit().isCompatible(other.quantity.getUnit())
-                && !quantity.getUnit().inverse().isCompatible(other.quantity.getUnit())) {
-            return false;
-        } else if (internalCompareTo(other) != 0) {
+        if (quantity.getUnit().isCompatible(other.quantity.getUnit())) {
+            if (internalCompareTo(other) != 0) {
+                return false;
+            }
+        } else if (quantity.getUnit().isCompatible(other.quantity.getUnit().inverse())) {
+            if (internalCompareTo(other.inverse()) != 0) {
+                return false;
+            }
+        } else {
             return false;
         }
 
@@ -260,7 +265,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             QuantityType<T> v1 = this.toUnit(getUnit().getSystemUnit());
             QuantityType<?> v2 = o.toUnit(o.getUnit().getSystemUnit());
             if (v1 != null && v2 != null) {
-                return v1.toBigDecimal().compareTo(v2.toBigDecimal());
+                return Double.compare(v1.doubleValue(), v2.doubleValue());
             } else {
                 throw new IllegalArgumentException("Unable to convert to system unit during compare.");
             }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -70,7 +70,7 @@ import tech.uom.lib.common.function.QuantityFunctions;
                                                                     // javax.measure.quantity.* interfaces are not
                                                                     // annotated.
 public class QuantityType<T extends Quantity<T>> extends Number
-        implements PrimitiveType, State, Command, Comparable<QuantityType<T>> {
+        implements PrimitiveType, State, Command, Comparable<QuantityType<?>> {
 
     @Serial
     private static final long serialVersionUID = 8828949721938234629L;
@@ -241,11 +241,11 @@ public class QuantityType<T extends Quantity<T>> extends Number
             return false;
         }
         if (quantity.getUnit().isCompatible(other.quantity.getUnit())) {
-            if (internalCompareTo(other) != 0) {
+            if (compareTo(other) != 0) {
                 return false;
             }
         } else if (quantity.getUnit().isCompatible(other.quantity.getUnit().inverse())) {
-            if (internalCompareTo(other.inverse()) != 0) {
+            if (compareTo(other.inverse()) != 0) {
                 return false;
             }
         } else {
@@ -256,11 +256,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
     }
 
     @Override
-    public int compareTo(QuantityType<T> o) {
-        return internalCompareTo(o);
-    }
-
-    private int internalCompareTo(QuantityType<?> o) {
+    public int compareTo(QuantityType<?> o) {
         if (quantity.getUnit().isCompatible(o.quantity.getUnit())) {
             QuantityType<T> v1 = this.toUnit(getUnit().getSystemUnit());
             QuantityType<?> v2 = o.toUnit(o.getUnit().getSystemUnit());

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -268,7 +268,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             QuantityType<T> v1 = this.toUnit(getUnit().getSystemUnit());
             QuantityType<?> v2 = o.toUnit(o.getUnit().getSystemUnit());
             if (v1 != null && v2 != null) {
-                return Double.compare(v1.doubleValue(), v2.doubleValue());
+                return v1.toBigDecimal().compareTo(v2.toBigDecimal());
             } else {
                 throw new IllegalArgumentException("Unable to convert to system unit during compare.");
             }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -250,6 +250,14 @@ public class QuantityType<T extends Quantity<T>> extends Number
         return true;
     }
 
+    /**
+     * This method overrides {@link Comparable.compareTo}
+     *
+     * Warning: This method will also compare {@link QuantityType<?>} where the arguments are of the inverted dimension.
+     * Contrary to what is stated as a requirements for overriding {@link Comparable.compareTo}, this implementation is
+     * not transitive when the arguments are of an inverted dimension. When the dimensions are inverted, a > b and b > a
+     * may also be true at the same time.
+     */
     @Override
     public int compareTo(QuantityType<T> o) {
         return internalCompareTo(o);
@@ -265,7 +273,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
                 throw new IllegalArgumentException("Unable to convert to system unit during compare.");
             }
         } else if (quantity.getUnit().inverse().isCompatible(o.quantity.getUnit())) {
-            return inverse().internalCompareTo(o);
+            return internalCompareTo(o.inverse());
         } else {
             throw new IllegalArgumentException("Can not compare incompatible units.");
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -70,7 +70,7 @@ import tech.uom.lib.common.function.QuantityFunctions;
                                                                     // javax.measure.quantity.* interfaces are not
                                                                     // annotated.
 public class QuantityType<T extends Quantity<T>> extends Number
-        implements PrimitiveType, State, Command, Comparable<QuantityType<?>> {
+        implements PrimitiveType, State, Command, Comparable<QuantityType<T>> {
 
     @Serial
     private static final long serialVersionUID = 8828949721938234629L;
@@ -241,11 +241,11 @@ public class QuantityType<T extends Quantity<T>> extends Number
             return false;
         }
         if (quantity.getUnit().isCompatible(other.quantity.getUnit())) {
-            if (compareTo(other) != 0) {
+            if (internalCompareTo(other) != 0) {
                 return false;
             }
         } else if (quantity.getUnit().isCompatible(other.quantity.getUnit().inverse())) {
-            if (compareTo(other.inverse()) != 0) {
+            if (internalCompareTo(other.inverse()) != 0) {
                 return false;
             }
         } else {
@@ -256,7 +256,11 @@ public class QuantityType<T extends Quantity<T>> extends Number
     }
 
     @Override
-    public int compareTo(QuantityType<?> o) {
+    public int compareTo(QuantityType<T> o) {
+        return internalCompareTo(o);
+    }
+
+    private int internalCompareTo(QuantityType<?> o) {
         if (quantity.getUnit().isCompatible(o.quantity.getUnit())) {
             QuantityType<T> v1 = this.toUnit(getUnit().getSystemUnit());
             QuantityType<?> v2 = o.toUnit(o.getUnit().getSystemUnit());

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/types/QuantityType.java
@@ -250,14 +250,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
         return true;
     }
 
-    /**
-     * This method overrides {@link Comparable.compareTo}
-     *
-     * Warning: This method will also compare {@link QuantityType<?>} where the arguments are of the inverted dimension.
-     * Contrary to what is stated as a requirements for overriding {@link Comparable.compareTo}, this implementation is
-     * not transitive when the arguments are of an inverted dimension. When the dimensions are inverted, a > b and b > a
-     * may also be true at the same time.
-     */
     @Override
     public int compareTo(QuantityType<T> o) {
         return internalCompareTo(o);
@@ -272,8 +264,6 @@ public class QuantityType<T extends Quantity<T>> extends Number
             } else {
                 throw new IllegalArgumentException("Unable to convert to system unit during compare.");
             }
-        } else if (quantity.getUnit().inverse().isCompatible(o.quantity.getUnit())) {
-            return internalCompareTo(o.inverse());
         } else {
             throw new IllegalArgumentException("Can not compare incompatible units.");
         }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -166,8 +166,7 @@ public class QuantityTypeArithmeticGroupFunctionTest {
         GroupFunction function = new QuantityTypeArithmeticGroupFunction.Avg(Temperature.class);
         State state = function.calculate(items);
 
-        QuantityType<?> qt = state.as(QuantityType.class).toUnit("°C");
-        assertEquals(55.33333334, qt.doubleValue(), 0.00001);
+        assertEquals(new QuantityType<>("55.33333333333333333333333333333334 °C"), state);
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeArithmeticGroupFunctionTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.library.types;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -166,7 +166,8 @@ public class QuantityTypeArithmeticGroupFunctionTest {
         GroupFunction function = new QuantityTypeArithmeticGroupFunction.Avg(Temperature.class);
         State state = function.calculate(items);
 
-        assertEquals(new QuantityType<>("55.33333333333333333333333333333334 °C"), state);
+        QuantityType<?> qt = state.as(QuantityType.class).toUnit("°C");
+        assertEquals(55.33333334, qt.doubleValue(), 0.00001);
     }
 
     @ParameterizedTest

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -664,4 +664,37 @@ public class QuantityTypeTest {
         QuantityType<Temperature> f = c.toUnitRelative(ImperialUnits.FAHRENHEIT);
         assertEquals(1.8, f.doubleValue());
     }
+
+    @Test
+    public void testCompareTo() {
+        QuantityType<Temperature> temp1 = new QuantityType<>("293.15 K");
+        QuantityType<Temperature> temp2 = new QuantityType<>("20 °C");
+        assertEquals(0, temp1.compareTo(temp2), 0.001);
+        temp2 = new QuantityType<>("-5 °C");
+        assertEquals(1, temp1.compareTo(temp2));
+        temp2 = new QuantityType<>("50 °C");
+        assertEquals(-1, temp1.compareTo(temp2));
+
+        temp1 = new QuantityType<>("100000 K");
+        temp2 = new QuantityType<>("10 mirek");
+        assertEquals(0, temp1.compareTo(temp2), 0.001);
+        assertEquals(0, temp2.compareTo(temp1), 0.001);
+        temp2 = new QuantityType<>("20 mirek");
+        assertEquals(1, temp1.compareTo(temp2)); // temp1 (100000 K) > temp2 (20 mirek = 50000 K) in Kelvin
+        assertEquals(1, temp2.compareTo(temp1)); // temp2 (20 mirek) > temp1 (100000 K = 10 mirek) in mirek
+        temp2 = new QuantityType<>("1 mirek");
+        assertEquals(-1, temp1.compareTo(temp2));
+        assertEquals(-1, temp2.compareTo(temp1));
+
+        temp1 = new QuantityType<>("0.1 MK");
+        temp2 = new QuantityType<>("10 mirek");
+        assertEquals(0, temp1.compareTo(temp2), 0.001);
+        assertEquals(0, temp2.compareTo(temp1), 0.001);
+        temp2 = new QuantityType<>("20 mirek");
+        assertEquals(1, temp1.compareTo(temp2));
+        assertEquals(1, temp2.compareTo(temp1));
+        temp2 = new QuantityType<>("1 mirek");
+        assertEquals(-1, temp1.compareTo(temp2));
+        assertEquals(-1, temp2.compareTo(temp1));
+    }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -666,6 +666,30 @@ public class QuantityTypeTest {
     }
 
     @Test
+    public void testEquals() {
+        QuantityType<Temperature> temp1 = new QuantityType<>("293.15 K");
+        QuantityType<Temperature> temp2 = new QuantityType<>("20 °C");
+        assertTrue(temp1.equals(temp2));
+        assertTrue(temp2.equals(temp1));
+        temp2 = new QuantityType<>("-5 °C");
+        assertFalse(temp1.equals(temp2));
+
+        temp1 = new QuantityType<>("100000 K");
+        temp2 = new QuantityType<>("10 mirek");
+        assertTrue(temp1.equals(temp2));
+        assertTrue(temp2.equals(temp1));
+        temp2 = new QuantityType<>("20 mirek");
+        assertFalse(temp1.equals(temp2));
+
+        temp1 = new QuantityType<>("0.1 MK");
+        temp2 = new QuantityType<>("10 mirek");
+        assertTrue(temp1.equals(temp2));
+        assertTrue(temp2.equals(temp1));
+        temp2 = new QuantityType<>("20 mirek");
+        assertFalse(temp1.equals(temp2));
+    }
+
+    @Test
     public void testCompareTo() {
         QuantityType<Temperature> temp1 = new QuantityType<>("293.15 K");
         QuantityType<Temperature> temp2 = new QuantityType<>("20 °C");
@@ -674,5 +698,11 @@ public class QuantityTypeTest {
         assertEquals(1, temp1.compareTo(temp2));
         temp2 = new QuantityType<>("50 °C");
         assertEquals(-1, temp1.compareTo(temp2));
+
+        QuantityType<Temperature> temp3 = new QuantityType<>("100000 K");
+        QuantityType<Temperature> temp4 = new QuantityType<>("10 mirek");
+        assertThrows(IllegalArgumentException.class, () -> {
+            temp3.compareTo(temp4);
+        });
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -674,27 +674,5 @@ public class QuantityTypeTest {
         assertEquals(1, temp1.compareTo(temp2));
         temp2 = new QuantityType<>("50 °C");
         assertEquals(-1, temp1.compareTo(temp2));
-
-        temp1 = new QuantityType<>("100000 K");
-        temp2 = new QuantityType<>("10 mirek");
-        assertEquals(0, temp1.compareTo(temp2));
-        assertEquals(0, temp2.compareTo(temp1));
-        temp2 = new QuantityType<>("20 mirek");
-        assertEquals(1, temp1.compareTo(temp2)); // temp1 (100000 K) > temp2 (20 mirek = 50000 K) in Kelvin
-        assertEquals(1, temp2.compareTo(temp1)); // temp2 (20 mirek) > temp1 (100000 K = 10 mirek) in mirek
-        temp2 = new QuantityType<>("1 mirek");
-        assertEquals(-1, temp1.compareTo(temp2));
-        assertEquals(-1, temp2.compareTo(temp1));
-
-        temp1 = new QuantityType<>("0.1 MK");
-        temp2 = new QuantityType<>("10 mirek");
-        assertEquals(0, temp1.compareTo(temp2));
-        assertEquals(0, temp2.compareTo(temp1));
-        temp2 = new QuantityType<>("20 mirek");
-        assertEquals(1, temp1.compareTo(temp2));
-        assertEquals(1, temp2.compareTo(temp1));
-        temp2 = new QuantityType<>("1 mirek");
-        assertEquals(-1, temp1.compareTo(temp2));
-        assertEquals(-1, temp2.compareTo(temp1));
     }
 }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/types/QuantityTypeTest.java
@@ -669,7 +669,7 @@ public class QuantityTypeTest {
     public void testCompareTo() {
         QuantityType<Temperature> temp1 = new QuantityType<>("293.15 K");
         QuantityType<Temperature> temp2 = new QuantityType<>("20 °C");
-        assertEquals(0, temp1.compareTo(temp2), 0.001);
+        assertEquals(0, temp1.compareTo(temp2));
         temp2 = new QuantityType<>("-5 °C");
         assertEquals(1, temp1.compareTo(temp2));
         temp2 = new QuantityType<>("50 °C");
@@ -677,8 +677,8 @@ public class QuantityTypeTest {
 
         temp1 = new QuantityType<>("100000 K");
         temp2 = new QuantityType<>("10 mirek");
-        assertEquals(0, temp1.compareTo(temp2), 0.001);
-        assertEquals(0, temp2.compareTo(temp1), 0.001);
+        assertEquals(0, temp1.compareTo(temp2));
+        assertEquals(0, temp2.compareTo(temp1));
         temp2 = new QuantityType<>("20 mirek");
         assertEquals(1, temp1.compareTo(temp2)); // temp1 (100000 K) > temp2 (20 mirek = 50000 K) in Kelvin
         assertEquals(1, temp2.compareTo(temp1)); // temp2 (20 mirek) > temp1 (100000 K = 10 mirek) in mirek
@@ -688,8 +688,8 @@ public class QuantityTypeTest {
 
         temp1 = new QuantityType<>("0.1 MK");
         temp2 = new QuantityType<>("10 mirek");
-        assertEquals(0, temp1.compareTo(temp2), 0.001);
-        assertEquals(0, temp2.compareTo(temp1), 0.001);
+        assertEquals(0, temp1.compareTo(temp2));
+        assertEquals(0, temp2.compareTo(temp1));
         temp2 = new QuantityType<>("20 mirek");
         assertEquals(1, temp1.compareTo(temp2));
         assertEquals(1, temp2.compareTo(temp1));


### PR DESCRIPTION
Comparing QuantityType with inverted units was opposite of what it should be.

Also included tests to verify.

See https://github.com/openhab/openhab-addons/issues/18122#issuecomment-2602466530

@andrewfg @jimtng