### PR TITLE
Always use name and description from addonInfo when available

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -134,12 +134,8 @@ public class KarafAddonService implements AddonService {
         AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid, locale);
 
         if (addonInfo != null) {
-            if (addonInfo.isMasterAddonInfo()) {
-                addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription());
-            } else {
-                addon = addon.withLabel(feature.getDescription());
-            }
-            addon = addon.withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
+                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                     .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {


### PR DESCRIPTION
Superseded by #4573 

This PR will use the name and description fields from addons.xml and return that to MainUI via REST. This data will be used for:

- This PR extends the search for addons within the description field too: https://github.com/openhab/openhab-webui/pull/3028
- Future improvements to addons store listing that can include addon description along with the title.

The addons.xml will be cleaned up so that all name/description fields of all addons contain the actual readable text, not i18n reference tags in this PR: https://github.com/openhab/openhab-addons/pull/18139

@mherwege