### PR TITLE
Revert "Fix addon name localisation before installation (#3908)"

### DIFF
--- a/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
+++ b/bundles/org.openhab.core.addon.eclipse/src/main/java/org/openhab/core/addon/eclipse/internal/EclipseAddonService.java
@@ -142,12 +142,9 @@ public class EclipseAddonService implements AddonService {
         AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid, locale);
 
         if (addonInfo != null) {
-            if (addonInfo.isMasterAddonInfo()) {
-                addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription());
-            } else {
-                addon = addon.withLabel(name);
-            }
-            addon = addon.withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+            // only enrich if this add-on is installed, otherwise wrong data might be added
+            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
+                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                     .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -33,8 +33,6 @@ import org.openhab.core.common.registry.Identifiable;
 @NonNullByDefault
 public class AddonInfo implements Identifiable<String> {
 
-    public static final String NA = "n/a";
-
     private static final Set<String> SUPPORTED_ADDON_TYPES = Set.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
 

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfo.java
@@ -33,6 +33,8 @@ import org.openhab.core.common.registry.Identifiable;
 @NonNullByDefault
 public class AddonInfo implements Identifiable<String> {
 
+    public static final String NA = "n/a";
+
     private static final Set<String> SUPPORTED_ADDON_TYPES = Set.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
 
@@ -48,13 +50,10 @@ public class AddonInfo implements Identifiable<String> {
     private @Nullable String sourceBundle;
     private @Nullable List<AddonDiscoveryMethod> discoveryMethods;
 
-    private boolean masterAddonInfo = true;
-
     private AddonInfo(String id, String type, @Nullable String uid, String name, String description,
             @Nullable String connection, List<String> countries, @Nullable String configDescriptionURI,
             @Nullable String serviceId, @Nullable String sourceBundle,
-            @Nullable List<AddonDiscoveryMethod> discoveryMethods, boolean isMasterAddonInfo)
-            throws IllegalArgumentException {
+            @Nullable List<AddonDiscoveryMethod> discoveryMethods) throws IllegalArgumentException {
         // mandatory fields
         if (id.isBlank()) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
@@ -82,8 +81,6 @@ public class AddonInfo implements Identifiable<String> {
         this.serviceId = Objects.requireNonNullElse(serviceId, type + "." + id);
         this.sourceBundle = sourceBundle;
         this.discoveryMethods = discoveryMethods;
-
-        this.masterAddonInfo = isMasterAddonInfo;
     }
 
     /**
@@ -158,10 +155,6 @@ public class AddonInfo implements Identifiable<String> {
         return discoveryMethods != null ? discoveryMethods : List.of();
     }
 
-    public boolean isMasterAddonInfo() {
-        return masterAddonInfo;
-    }
-
     public static Builder builder(String id, String type) {
         return new Builder(id, type);
     }
@@ -184,8 +177,6 @@ public class AddonInfo implements Identifiable<String> {
         private @Nullable String sourceBundle;
         private @Nullable List<AddonDiscoveryMethod> discoveryMethods;
 
-        private boolean masterAddonInfo = true;
-
         private Builder(String id, String type) {
             this.id = id;
             this.type = type;
@@ -203,7 +194,6 @@ public class AddonInfo implements Identifiable<String> {
             this.serviceId = addonInfo.serviceId;
             this.sourceBundle = addonInfo.sourceBundle;
             this.discoveryMethods = addonInfo.discoveryMethods;
-            this.masterAddonInfo = addonInfo.masterAddonInfo;
         }
 
         public Builder withUID(@Nullable String uid) {
@@ -256,11 +246,6 @@ public class AddonInfo implements Identifiable<String> {
             return this;
         }
 
-        public Builder isMasterAddonInfo(boolean masterAddonInfo) {
-            this.masterAddonInfo = masterAddonInfo;
-            return this;
-        }
-
         /**
          * Build an {@link AddonInfo} from this builder
          *
@@ -269,7 +254,7 @@ public class AddonInfo implements Identifiable<String> {
          */
         public AddonInfo build() throws IllegalArgumentException {
             return new AddonInfo(id, type, uid, name, description, connection, countries, configDescriptionURI,
-                    serviceId, sourceBundle, discoveryMethods, masterAddonInfo);
+                    serviceId, sourceBundle, discoveryMethods);
         }
     }
 }

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -95,15 +95,15 @@ public class AddonInfoRegistry {
             return a;
         }
         AddonInfo.Builder builder = AddonInfo.builder(a);
-        if (a.isMasterAddonInfo()) {
-            builder.withName(a.getName());
-            builder.withDescription(a.getDescription());
-        } else {
+        if (AddonInfo.NA.equals(a.getName())) {
             builder.withName(b.getName());
-            builder.withDescription(b.getDescription());
+        } else if (AddonInfo.NA.equals(b.getName())) {
+            builder.withName(a.getName());
         }
-        if (!a.isMasterAddonInfo() && b.isMasterAddonInfo()) {
-            builder.isMasterAddonInfo(true);
+        if (AddonInfo.NA.equals(a.getDescription())) {
+            builder.withDescription(b.getDescription());
+        } else if (AddonInfo.NA.equals(b.getDescription())) {
+            builder.withDescription(a.getDescription());
         }
         if (a.getConnection() == null && b.getConnection() != null) {
             builder.withConnection(b.getConnection());

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/AddonInfoRegistry.java
@@ -95,15 +95,8 @@ public class AddonInfoRegistry {
             return a;
         }
         AddonInfo.Builder builder = AddonInfo.builder(a);
-        if (AddonInfo.NA.equals(a.getName())) {
-            builder.withName(b.getName());
-        } else if (AddonInfo.NA.equals(b.getName())) {
-            builder.withName(a.getName());
-        }
-        if (AddonInfo.NA.equals(a.getDescription())) {
+        if (a.getDescription().isBlank()) {
             builder.withDescription(b.getDescription());
-        } else if (AddonInfo.NA.equals(b.getDescription())) {
-            builder.withDescription(a.getDescription());
         }
         if (a.getConnection() == null && b.getConnection() != null) {
             builder.withConnection(b.getConnection());

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/internal/xml/AddonInfoAddonsXmlProvider.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -94,8 +93,7 @@ public class AddonInfoAddonsXmlProvider implements AddonInfoProvider {
         try {
             String xml = Files.readString(file.toPath());
             if (xml != null && !xml.isBlank()) {
-                addonInfos.addAll(reader.readFromXML(xml).getAddons().stream()
-                        .map(a -> AddonInfo.builder(a).isMasterAddonInfo(false).build()).collect(Collectors.toSet()));
+                addonInfos.addAll(reader.readFromXML(xml).getAddons());
             } else {
                 logger.warn("File '{}' contents are null or empty", file.getName());
             }

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/KarafAddonService.java
@@ -134,12 +134,8 @@ public class KarafAddonService implements AddonService {
         AddonInfo addonInfo = addonInfoRegistry.getAddonInfo(uid, locale);
 
         if (addonInfo != null) {
-            if (addonInfo.isMasterAddonInfo()) {
-                addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription());
-            } else {
-                addon = addon.withLabel(feature.getDescription());
-            }
-            addon = addon.withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
+            addon = addon.withLabel(addonInfo.getName()).withDescription(addonInfo.getDescription())
+                    .withConnection(addonInfo.getConnection()).withCountries(addonInfo.getCountries())
                     .withLink(getDefaultDocumentationLink(type, name))
                     .withConfigDescriptionURI(addonInfo.getConfigDescriptionURI());
         } else {


### PR DESCRIPTION
This reverts commit 708a954081499754e3d36adc28cf16b7ffec7ad7
but with some modifications

This PR will use the name and description fields from addons.xml and return that to MainUI via REST. This is a change from before #3908 where the name and description fields from addons.xml were overwritten with "n/a". 


This data will be used for:

- This PR extends the search for addons within the description field too: https://github.com/openhab/openhab-webui/pull/3028
- Future improvements to addons store listing that can include addon description along with the title.

The addons.xml will be cleaned up so that all name/description fields of all addons contain the actual readable text, not i18n reference tags in this PR: https://github.com/openhab/openhab-addons/pull/18139

