### PR TITLE
Fix managed transformations retrieval

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
@@ -68,7 +68,8 @@ public class CommunityTransformationAddonHandler implements MarketplaceAddonHand
 
     @Activate
     public CommunityTransformationAddonHandler(final @Reference StorageService storageService) {
-        this.storage = storageService.getStorage("org.openhab.marketplace.transformation");
+        this.storage = storageService.getStorage("org.openhab.marketplace.transformation",
+                this.getClass().getClassLoader());
 
         this.yamlMapper = new ObjectMapper(new YAMLFactory());
         yamlMapper.findAndRegisterModules();


### PR DESCRIPTION
As discussed [here](https://community.openhab.org/t/marketplace-versioning-with-embedded-resource/161421/97), after installing transformations from the marketplace, retrieval of managed transformations from storage during OH startup fails with:
```
Couldn't deserialize value 'org.openhab.core.storage.json.internal.StorageEntry@168c2c9b'. Root cause is: org.openhab.core.transform.ManagedTransformationProvider$PersistedTransformation cannot be found by org.openhab.core.storage.json_5.0.0.202501210532
```

This PR fixes it according to my testing, the problem is that the correct classloader isn't available to `JsonStorage`.

I can't comply with the DCO as I don't submit real name and e-mail in public, but this should be small enough for the exception to apply. It was a one-liner until Spotless interfered.