### PR TITLE
Persistence extensions, calculate QuantityType sums in absolute values

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1799,7 +1799,8 @@ public class PersistenceExtensions {
             Iterator<HistoricItem> it = result.iterator();
 
             Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-            Unit<?> unit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
+            Unit<?> baseUnit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
+            Unit<?> unit = baseUnit != null ? baseUnit.getSystemUnit() : null;
 
             BigDecimal sum = BigDecimal.ZERO;
             while (it.hasNext()) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1243,9 +1243,8 @@ public class PersistenceExtensions {
 
         if (averageState != null) {
             Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-            Unit<?> baseUnit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
-            Unit<?> unit = baseUnit != null ? baseUnit.getSystemUnit() : null;
-
+            Unit<?> unit = (baseItem instanceof NumberItem numberItem)
+                    && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit() : null;
             DecimalType dt;
             if (unit != null && averageState instanceof QuantityType<?> averageQuantity) {
                 averageQuantity = averageQuantity.toUnit(unit);
@@ -1408,14 +1407,14 @@ public class PersistenceExtensions {
             if (dt != null && DecimalType.ZERO.compareTo(dt) <= 0) {
                 BigDecimal deviation = dt.toBigDecimal().sqrt(MathContext.DECIMAL64);
                 Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-                if (baseItem instanceof NumberItem numberItem) {
-                    Unit<?> baseUnit = numberItem.getUnit();
-                    Unit<?> unit = baseUnit != null ? baseUnit.getSystemUnit() : null;
-                    if (unit != null) {
-                        return new QuantityType<>(deviation, unit);
-                    }
+                Unit<?> unit = (baseItem instanceof NumberItem numberItem)
+                        && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit()
+                                : null;
+                if (unit != null) {
+                    return new QuantityType<>(deviation, unit);
+                } else {
+                    return new DecimalType(deviation);
                 }
-                return new DecimalType(deviation);
             }
         }
         return null;
@@ -1807,9 +1806,8 @@ public class PersistenceExtensions {
             Iterator<HistoricItem> it = result.iterator();
 
             Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-            Unit<?> baseUnit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
-            Unit<?> unit = baseUnit != null ? baseUnit.getSystemUnit() : null;
-
+            Unit<?> unit = (baseItem instanceof NumberItem numberItem)
+                    && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit() : null;
             BigDecimal sum = BigDecimal.ZERO;
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -75,6 +75,8 @@ public class PersistenceExtensionsTest {
     public static final String TEST_GROUP_QUANTITY_NUMBER = "testGroupQuantityNumber";
     public static final String TEST_SWITCH = "testSwitch";
 
+    public static final double KELVIN_OFFSET = 273.15;
+
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
     private @Mock @NonNullByDefault({}) UnitProvider unitProviderMock;
     private @Mock @NonNullByDefault({}) TimeZoneProvider timeZoneProviderMock;
@@ -2214,16 +2216,18 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum()
+                + (HISTORIC_END - HISTORIC_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         sum = PersistenceExtensions.sumSince(quantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum()
+                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(quantityItem,
@@ -2238,8 +2242,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum()
+                + (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(quantityItem,
@@ -2255,9 +2260,11 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
+        assertEquals(
+                IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum()
+                        + (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
@@ -2265,7 +2272,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
+        assertEquals(
+                IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum()
+                        + (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1) * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
@@ -2274,9 +2283,12 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
-                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
+        assertEquals(IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .sum()
+                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 2)
+                        * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
 
         // default persistence service
@@ -2294,16 +2306,18 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum()
+                + (HISTORIC_END - HISTORIC_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum()
+                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
@@ -2318,8 +2332,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum()
+                + (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
@@ -2335,9 +2350,11 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
+        assertEquals(
+                IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum()
+                        + (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
@@ -2345,7 +2362,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
+        assertEquals(
+                IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum()
+                        + (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1) * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
@@ -2354,9 +2373,12 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
-                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
+        assertEquals(IntStream
+                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
+                .sum()
+                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 2)
+                        * KELVIN_OFFSET,
                 qt.doubleValue(), 0.001);
 
         // default persistence service

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -994,7 +994,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceSince(quantityItem, startStored);
@@ -1018,7 +1018,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceUntil(quantityItem, endStored);
@@ -1042,7 +1042,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1057,7 +1057,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1074,7 +1074,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored);
@@ -1097,7 +1097,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceSince(groupQuantityItem, startStored);
@@ -1121,7 +1121,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceUntil(groupQuantityItem, endStored);
@@ -1145,7 +1145,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1160,7 +1160,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1177,7 +1177,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
+        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceBetween(groupQuantityItem, startStored, endStored);
@@ -1297,7 +1297,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(quantityItem, startStored);
@@ -1321,7 +1321,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationUntil(quantityItem, endStored);
@@ -1344,7 +1344,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1359,7 +1359,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1376,7 +1376,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored);
@@ -1399,7 +1399,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(groupQuantityItem, startStored);
@@ -1423,7 +1423,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationUntil(groupQuantityItem, endStored);
@@ -1446,7 +1446,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1461,7 +1461,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1478,7 +1478,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(SIUnits.CELSIUS, qt.getUnit());
+        assertEquals(Units.KELVIN, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(groupQuantityItem, startStored, endStored);


### PR DESCRIPTION
Sum calculations in persistence extensions for QuantityType items where done, summing the values in the configured unit.

This creates a challenge for temperatures, where the result would be different depending on the configured unit. To keep the results consistent, the sums should be done in the system unit for the dimension, wich has an absolute zero.

This PR changes that.

The only impact would be for summing temperatures, whereby it is highly unlikely someone would be summing temperatures over a time series.

This relates to https://github.com/openhab/openhab-core/pull/4563 and would make the logic consistent between summing for groups and summing over persisted values.

This PR would also change the returned units for QuantityType variance and deviation calculations to the  logically meaningful unit.