### PR TITLE
Fix Xtend warnings

### DIFF
--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/RulesStandaloneSetup.xtend
@@ -29,8 +29,8 @@ import org.openhab.core.model.script.engine.ScriptEngine
 class RulesStandaloneSetup extends RulesStandaloneSetupGenerated {
     static Injector injector
     
-    private ScriptServiceUtil scriptServiceUtil;
-    private ScriptEngine scriptEngine;
+    ScriptServiceUtil scriptServiceUtil;
+    ScriptEngine scriptEngine;
     
     override Injector createInjectorAndDoEMFRegistration() {
         ScriptStandaloneSetup.doSetup(scriptServiceUtil, scriptEngine);

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -17,7 +17,6 @@ import java.util.Set
 import org.openhab.core.items.Item
 import org.openhab.core.items.ItemRegistry
 import org.openhab.core.thing.ThingRegistry
-import org.openhab.core.thing.events.ChannelTriggeredEvent
 import org.openhab.core.types.Command
 import org.openhab.core.types.State
 import org.openhab.core.model.rule.rules.ChangedEventTrigger
@@ -33,14 +32,12 @@ import org.openhab.core.model.rule.rules.ThingStateChangedEventTrigger
 import org.openhab.core.model.rule.rules.UpdateEventTrigger
 import org.openhab.core.model.script.jvmmodel.ScriptJvmModelInferrer
 import org.openhab.core.model.script.scoping.StateAndCommandProvider
-import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypesBuilder
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.emf.common.util.EList
-import org.openhab.core.events.Event
 import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
 
 /**
@@ -54,13 +51,12 @@ import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
  */
 class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
 
-    private final Logger logger = LoggerFactory.getLogger(RulesJvmModelInferrer)
+    final Logger logger = LoggerFactory.getLogger(RulesJvmModelInferrer)
 
     /**
-     * conveninence API to build and initialize JvmTypes and their members.
+     * convenience API to build and initialize JvmTypes and their members.
      */
     @Inject extension JvmTypesBuilder
-    @Inject extension IQualifiedNameProvider
 
     @Inject
     ItemRegistry itemRegistry

--- a/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.rule/src/org/openhab/core/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -78,7 +78,7 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
      */
     def dispatch void infer(RuleModel ruleModel, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
         val className = ruleModel.eResource.URI.lastSegment.split("\\.").head.toFirstUpper + "Rules"
-        acceptor.accept(ruleModel.toClass(className)).initializeLater [
+        acceptor.accept(ruleModel.toClass(className), [
             members += ruleModel.variables.map [
                 toField(name, type?.cloneWithProxies) => [ field |
                     field.static = true
@@ -171,7 +171,7 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
                     body = rule.script
                 ]
             ]
-        ]
+        ])
     }
 
     def private boolean containsParam(EList<JvmFormalParameter> params, String param) {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptStandaloneSetup.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/ScriptStandaloneSetup.xtend
@@ -27,8 +27,8 @@ class ScriptStandaloneSetup extends ScriptStandaloneSetupGenerated {
     
     static Injector injector
 
-    private ScriptServiceUtil scriptServiceUtil;
-    private ScriptEngine scriptEngine;
+    ScriptServiceUtil scriptServiceUtil;
+    ScriptEngine scriptEngine;
     
     def ScriptStandaloneSetup setScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
         this.scriptServiceUtil = scriptServiceUtil;

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/interpreter/ScriptInterpreter.xtend
@@ -46,7 +46,7 @@ import org.eclipse.xtext.xbase.typesystem.IBatchTypeResolver
  * 
  */
 @SuppressWarnings("restriction")
-public class ScriptInterpreter extends XbaseInterpreter {
+class ScriptInterpreter extends XbaseInterpreter {
 
     @Inject
     ItemRegistry itemRegistry
@@ -55,7 +55,7 @@ public class ScriptInterpreter extends XbaseInterpreter {
     StateAndCommandProvider stateAndCommandProvider
     
     @Inject
-    private IBatchTypeResolver typeResolver;
+    IBatchTypeResolver typeResolver;
 
     @Inject
     extension IJvmModelAssociations
@@ -130,7 +130,7 @@ public class ScriptInterpreter extends XbaseInterpreter {
 
         // Check if the JvmField is inferred
         val sourceElement = jvmField.sourceElements.head
-        if (sourceElement != null) {
+        if (sourceElement !== null) {
             context.assignValue(QualifiedName.create(jvmField.simpleName), value)
             value
         } else {
@@ -142,7 +142,7 @@ public class ScriptInterpreter extends XbaseInterpreter {
         if (expression === null) {
             return null
         } else if (expression instanceof QuantityLiteral) {
-            return doEvaluate(expression as QuantityLiteral, context, indicator)
+            return doEvaluate(expression, context, indicator)
         } else {
             return super.doEvaluate(expression, context, indicator)
         }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory
 import org.openhab.core.items.Item
 import org.openhab.core.types.Command
 import org.openhab.core.types.State
-import org.openhab.core.events.Event
 import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
 
 /**
@@ -39,7 +38,7 @@ import org.openhab.core.automation.module.script.rulesupport.shared.ValueCache
  */
 class ScriptJvmModelInferrer extends AbstractModelInferrer {
 
-    static private final Logger logger = LoggerFactory.getLogger(ScriptJvmModelInferrer)
+    static final Logger logger = LoggerFactory.getLogger(ScriptJvmModelInferrer)
 
     /** Variable name for the input string in a "script transformation" or "script profile" */
     public static final String VAR_INPUT = "input";
@@ -85,7 +84,7 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
     public static final String VAR_SHARED_CACHE = "sharedCache";
 
     /**
-     * conveninence API to build and initialize JvmTypes and their members.
+     * convenience API to build and initialize JvmTypes and their members.
      */
     @Inject extension JvmTypesBuilder
 

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/jvmmodel/ScriptJvmModelInferrer.xtend
@@ -105,7 +105,7 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
      */
     def dispatch void infer(Script script, IJvmDeclaredTypeAcceptor acceptor, boolean isPreIndexingPhase) {
         val className = script.eResource.URI.lastSegment.split("\\.").head.toFirstUpper + "Script"
-        acceptor.accept(script.toClass(className)).initializeLater [
+        acceptor.accept(script.toClass(className), [
 
             val Set<String> fieldNames = newHashSet()
 
@@ -166,6 +166,6 @@ class ScriptJvmModelInferrer extends AbstractModelInferrer {
                 parameters += script.toParameter(VAR_SHARED_CACHE, sharedCacheTypeRef)
                 body = script
             ]
-        ]
+        ])
     }
 }

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/GenericThingProvider.xtend
@@ -25,10 +25,8 @@ import org.openhab.core.config.core.ConfigDescriptionRegistry
 import org.openhab.core.config.core.ConfigUtil
 import org.openhab.core.config.core.Configuration
 import org.openhab.core.common.AbstractUID
-import org.openhab.core.common.registry.AbstractProvider
 import org.openhab.core.i18n.LocaleProvider
 import org.openhab.core.service.ReadyMarker
-import org.openhab.core.service.ReadyMarkerFilter
 import org.openhab.core.service.ReadyService
 import org.openhab.core.service.StartLevelService
 import org.openhab.core.thing.Channel
@@ -77,31 +75,31 @@ import org.slf4j.LoggerFactory
 @Component(immediate=true, service=ThingProvider)
 class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implements ThingProvider, ModelRepositoryChangeListener, ReadyService.ReadyTracker {
 
-    private static final String XML_THING_TYPE = "openhab.xmlThingTypes";
+    static final String XML_THING_TYPE = "openhab.xmlThingTypes";
 
-    private LocaleProvider localeProvider
+    LocaleProvider localeProvider
 
-    private ModelRepository modelRepository
+    ModelRepository modelRepository
 
-    private ThingTypeRegistry thingTypeRegistry
-    private ChannelTypeRegistry channelTypeRegistry
+    ThingTypeRegistry thingTypeRegistry
+    ChannelTypeRegistry channelTypeRegistry
 
-    private BundleResolver bundleResolver;
+    BundleResolver bundleResolver;
 
-    private Map<String, Collection<Thing>> thingsMap = new ConcurrentHashMap
+    Map<String, Collection<Thing>> thingsMap = new ConcurrentHashMap
 
-    private List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<ThingHandlerFactory>()
+    List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<ThingHandlerFactory>()
 
-    private ConfigDescriptionRegistry configDescriptionRegistry
+    ConfigDescriptionRegistry configDescriptionRegistry
 
-    private val List<QueueContent> queue = new CopyOnWriteArrayList
-    private var Thread lazyRetryThread = null
+    val List<QueueContent> queue = new CopyOnWriteArrayList
+    var Thread lazyRetryThread = null
 
-    private static final Logger logger = LoggerFactory.getLogger(GenericThingProvider)
+    static final Logger logger = LoggerFactory.getLogger(GenericThingProvider)
 
-    private val Set<String> loadedXmlThingTypes = new CopyOnWriteArraySet
+    val Set<String> loadedXmlThingTypes = new CopyOnWriteArraySet
 
-    private var modelLoaded = false
+    var modelLoaded = false
 
     def void activate() {
         modelRepository.getAllModelNamesOfType("things").forEach [
@@ -138,7 +136,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
                 val factory = thingHandlerFactories.findFirst [
                     supportsThingType(thingTypeUID)
                 ]
-                if (factory == null && modelLoaded) {
+                if (factory === null && modelLoaded) {
                     logger.info("No ThingHandlerFactory found for thing {} (thing-type is {}). Deferring initialization.",
                         thingUID, thingTypeUID)
                 }
@@ -602,7 +600,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
     }
 
     def private createThingsFromModelForThingHandlerFactory(String modelName, ThingHandlerFactory factory) {
-        if (!loadedXmlThingTypes.contains(factory.bundleName) || modelRepository == null) {
+        if (!loadedXmlThingTypes.contains(factory.bundleName) || modelRepository === null) {
             return
         }
         val things = thingsMap.get(modelName)
@@ -633,7 +631,7 @@ class GenericThingProvider extends AbstractProviderLazyNullness<Thing> implement
         ]
     }
 
-    private val lazyRetryRunnable = new Runnable() {
+    val lazyRetryRunnable = new Runnable() {
         override run() {
             logger.debug("Starting lazy retry thread")
             while (!queue.empty) {


### PR DESCRIPTION
1. Remove unused imports and unnecessary private modifiers
2. Use `===` when comparing to null
3. Replace deprecated methods (`initializeLater`)

During the mvn phase ```generate-sources```, we have had around 70 warnings from the Xtend generator.
This PR fixes half of the warnings of the generate phase (still the compiler has some issues with the generated code, but this is out of scope for now).

These changes seem to be safe, the generated code does not have significant changes compared to the old output. 

FTR: those are the issues this PR is resolving:
```
[INFO] --- xtend:2.37.0:compile (default) @ org.openhab.core.model.rule ---
[WARNING] 
WARNING: 	RulesStandaloneSetup.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\RulesStandaloneSetup.xtend
32: The private modifier is unnecessary on field scriptServiceUtil
[WARNING] 
WARNING: 	RulesStandaloneSetup.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\RulesStandaloneSetup.xtend
33: The private modifier is unnecessary on field scriptEngine
[WARNING] 
WARNING: 	RulesJvmModelInferrer.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\jvmmodel\RulesJvmModelInferrer.xtend
43: The import 'org.openhab.core.events.Event' is never used.
[WARNING] 
WARNING: 	RulesJvmModelInferrer.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\jvmmodel\RulesJvmModelInferrer.xtend
20: The import 'org.openhab.core.thing.events.ChannelTriggeredEvent' is never used.
[WARNING] 
WARNING: 	RulesJvmModelInferrer.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\jvmmodel\RulesJvmModelInferrer.xtend
57: The private modifier is unnecessary on field logger
[WARNING] 
WARNING: 	RulesJvmModelInferrer.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\jvmmodel\RulesJvmModelInferrer.xtend
63: The extension org.eclipse.xtext.naming.IQualifiedNameProvider is not used in RulesJvmModelInferrer
[WARNING] 
WARNING: 	RulesJvmModelInferrer.xtend - org.openhab.core.model.rule\src\org\openhab\core\model\rule\jvmmodel\RulesJvmModelInferrer.xtend
85: The method initializeLater(Procedure1<? super T>) from the type IJvmDeclaredTypeAcceptor.IPostIndexingInitializing is deprecated


[INFO] --- xtend:2.37.0:compile (default) @ org.openhab.core.model.script ---
[WARNING] 
WARNING: 	ScriptJvmModelInferrer.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\jvmmodel\ScriptJvmModelInferrer.xtend
28: The import 'org.openhab.core.events.Event' is never used.
[WARNING] 
WARNING: 	ScriptJvmModelInferrer.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\jvmmodel\ScriptJvmModelInferrer.xtend
42: The private modifier is unnecessary on field logger
[WARNING] 
WARNING: 	ScriptJvmModelInferrer.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\jvmmodel\ScriptJvmModelInferrer.xtend
109: The method initializeLater(Procedure1<? super T>) from the type IJvmDeclaredTypeAcceptor.IPostIndexingInitializing is deprecated
[WARNING] 
WARNING: 	ScriptStandaloneSetup.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\ScriptStandaloneSetup.xtend
30: The private modifier is unnecessary on field scriptServiceUtil
[WARNING] 
WARNING: 	ScriptStandaloneSetup.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\ScriptStandaloneSetup.xtend
31: The private modifier is unnecessary on field scriptEngine
[WARNING] 
WARNING: 	ScriptInterpreter.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\interpreter\ScriptInterpreter.xtend
49: The public modifier is unnecessary on class ScriptInterpreter
[WARNING] 
WARNING: 	ScriptInterpreter.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\interpreter\ScriptInterpreter.xtend
58: The private modifier is unnecessary on field typeResolver
[WARNING] 
WARNING: 	ScriptInterpreter.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\interpreter\ScriptInterpreter.xtend
133: The operator '!=' should be replaced by '!==' when null is one of the arguments.
[WARNING] 
WARNING: 	ScriptInterpreter.xtend - org.openhab.core.model.script\src\org\openhab\core\model\script\interpreter\ScriptInterpreter.xtend
145: Unnecessary cast from QuantityLiteral to QuantityLiteral



[INFO] --- xtend:2.37.0:compile (default) @ org.openhab.core.model.thing ---
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
28: The import 'org.openhab.core.common.registry.AbstractProvider' is never used.
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
31: The import 'org.openhab.core.service.ReadyMarkerFilter' is never used.
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
80: The private modifier is unnecessary on field XML_THING_TYPE
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
82: The private modifier is unnecessary on field localeProvider
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
84: The private modifier is unnecessary on field modelRepository
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
86: The private modifier is unnecessary on field thingTypeRegistry
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
87: The private modifier is unnecessary on field channelTypeRegistry
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
89: The private modifier is unnecessary on field bundleResolver
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
91: The private modifier is unnecessary on field thingsMap
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
93: The private modifier is unnecessary on field thingHandlerFactories
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
95: The private modifier is unnecessary on field configDescriptionRegistry
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
97: The private modifier is unnecessary on field queue
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
98: The private modifier is unnecessary on field lazyRetryThread
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
100: The private modifier is unnecessary on field logger
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
102: The private modifier is unnecessary on field loadedXmlThingTypes
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
104: The private modifier is unnecessary on field modelLoaded
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
141: The operator '==' should be replaced by '===' when null is one of the arguments.
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
605: The operator '==' should be replaced by '===' when null is one of the arguments.
[WARNING] 
WARNING: 	GenericThingProvider.xtend - org.openhab.core.model.thing\src\org\openhab\core\model\thing\internal\GenericThingProvider.xtend
636: The private modifier is unnecessary on field lazyRetryRunnable
```
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- Introduce metadata for all add-ons
- Fix memory leak in ScriptedRuleProvider

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the Core README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis?
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

If your pull request contains a new contribution, it will likely take some time
before it is reviewed and processed by maintainers.
-->
