### PR TITLE
Call unregisterCommand instead of registerCommand

### DIFF
--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
@@ -100,7 +100,7 @@ public class ConsoleSupportKaraf {
      */
     private void unregisterCommands() {
         for (final ConsoleCommandExtension command : commands) {
-            registerCommand(command);
+            unregisterCommand(command);
         }
     }
 


### PR DESCRIPTION
I just came across this whilst reading the code. I'm not sure why it was calling registerCommand here, but it seems wrong.