### PR TITLE
JsonAddonService: Fix warning on startup if no URL configured

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/json/JsonAddonService.java
@@ -101,6 +101,9 @@ public class JsonAddonService extends AbstractRemoteAddonService {
     }
 
     private boolean isValidUrl(String urlString) {
+        if (urlString.isBlank()) {
+            return false;
+        }
         try {
             (new URI(urlString)).toURL();
         } catch (IllegalArgumentException | URISyntaxException | MalformedURLException e) {


### PR DESCRIPTION
When starting openHAB, I always get the following warning:

```
14:44:47.082 [WARN ] [tplace.internal.json.JsonAddonService] - JSON Addon Service invalid URL:
```

We should avoid this warning, I don't see a problem there, and we should not confuse users with unnecessary warnings.