### PR TITLE
Sitemap interpolation parameter for charts

### DIFF
--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/Sitemap.xtext
@@ -86,7 +86,8 @@ Chart:
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)*) ']')? &
     ('iconcolor=[' (IconColor+=ColorArray (',' IconColor+=ColorArray)*) ']')? &
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)*) ']')? &
-    ('yAxisDecimalPattern=' yAxisDecimalPattern=(STRING))?);
+    ('yAxisDecimalPattern=' yAxisDecimalPattern=(STRING))? &
+    ('interpolation=' interpolation=(STRING))?);
 
 Webview:
     'Webview' (('item=' item=ItemRef)? & ('label=' label=(ID | STRING))? &

--- a/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
+++ b/bundles/org.openhab.core.model.sitemap/src/org/openhab/core/model/sitemap/validation/SitemapValidator.xtend
@@ -28,6 +28,7 @@ import org.eclipse.xtext.validation.Check
 import java.math.BigDecimal
 import org.openhab.core.model.sitemap.sitemap.Input
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.openhab.core.model.sitemap.sitemap.Chart
 
 //import org.eclipse.xtext.validation.Check
 /**
@@ -38,6 +39,7 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 class SitemapValidator extends AbstractSitemapValidator {
 
     val ALLOWED_HINTS = #["text", "number", "date", "time", "datetime"]
+    val ALLOWED_INTERPOLATION = #["linear", "step"]
     
     @Check
     def void checkFramesInFrame(Frame frame) {
@@ -159,6 +161,16 @@ class SitemapValidator extends AbstractSitemapValidator {
             val line = node.getStartLine()
             error("Input on item '" + i.item + "' has invalid inputHint '" + i.inputHint + "' at line " + line,
                 SitemapPackage.Literals.INPUT.getEStructuralFeature(SitemapPackage.INPUT__INPUT_HINT))
+        }
+    }
+
+    @Check
+    def void checkInterpolationParameter(Chart i) {
+        if (i.interpolation !== null && !ALLOWED_INTERPOLATION.contains(i.interpolation)) {
+            val node = NodeModelUtils.getNode(i)
+            val line = node.getStartLine()
+            error("Input on item '" + i.item + "' has invalid interpolation '" + i.interpolation + "' at line " + line,
+                SitemapPackage.Literals.INPUT.getEStructuralFeature(SitemapPackage.CHART__INTERPOLATION))
         }
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
@@ -55,7 +55,8 @@ public interface ChartProvider {
      * @param groups The groups to display on the chart
      * @param dpi The DPI (dots per inch) value, can be <code>null</code>
      * @param interpolation The interpolation between two datapoint (<code>linear</code> or <code>step</code>),
-     *            <code>null</code> defaults to <code>linear</code>)
+     *            <code>null</code> defaults to <code>linear</code> for numeric values and to <code>step</code> for
+     *            binary values
      * @param legend Show the legend? If <code>null</code>, the ChartProvider should make his own decision.
      * @return BufferedImage object if the chart is rendered correctly,
      *         otherwise null.
@@ -86,7 +87,8 @@ public interface ChartProvider {
      * @param dpi The DPI (dots per inch) value, can be <code>null</code>
      * @param yAxisDecimalPattern The format pattern for the y-axis labels
      * @param interpolation The interpolation between two datapoint (<code>linear</code> or <code>step</code>),
-     *            <code>null</code> defaults to <code>linear</code>)
+     *            <code>null</code> defaults to <code>linear</code> for numeric values and to <code>step</code> for
+     *            binary values
      * @param legend Show the legend? If <code>null</code>, the ChartProvider should make his own decision.
      * @return BufferedImage object if the chart is rendered correctly,
      *         otherwise null.

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/chart/ChartProvider.java
@@ -54,6 +54,8 @@ public interface ChartProvider {
      * @param items The items to display on the chart
      * @param groups The groups to display on the chart
      * @param dpi The DPI (dots per inch) value, can be <code>null</code>
+     * @param interpolation The interpolation between two datapoint (<code>linear</code> or <code>step</code>),
+     *            <code>null</code> defaults to <code>linear</code>)
      * @param legend Show the legend? If <code>null</code>, the ChartProvider should make his own decision.
      * @return BufferedImage object if the chart is rendered correctly,
      *         otherwise null.
@@ -62,7 +64,8 @@ public interface ChartProvider {
      */
     BufferedImage createChart(@Nullable String service, @Nullable String theme, ZonedDateTime startTime,
             ZonedDateTime endTime, int height, int width, @Nullable String items, @Nullable String groups,
-            @Nullable Integer dpi, @Nullable Boolean legend) throws ItemNotFoundException;
+            @Nullable Integer dpi, @Nullable String interpolation, @Nullable Boolean legend)
+            throws ItemNotFoundException;
 
     /**
      * Creates a chart object. This sets the initial parameters for the chart
@@ -82,6 +85,8 @@ public interface ChartProvider {
      * @param groups The groups to display on the chart
      * @param dpi The DPI (dots per inch) value, can be <code>null</code>
      * @param yAxisDecimalPattern The format pattern for the y-axis labels
+     * @param interpolation The interpolation between two datapoint (<code>linear</code> or <code>step</code>),
+     *            <code>null</code> defaults to <code>linear</code>)
      * @param legend Show the legend? If <code>null</code>, the ChartProvider should make his own decision.
      * @return BufferedImage object if the chart is rendered correctly,
      *         otherwise null.
@@ -90,9 +95,10 @@ public interface ChartProvider {
      */
     default BufferedImage createChart(@Nullable String service, @Nullable String theme, ZonedDateTime startTime,
             ZonedDateTime endTime, int height, int width, @Nullable String items, @Nullable String groups,
-            @Nullable Integer dpi, @Nullable String yAxisDecimalPattern, @Nullable Boolean legend)
-            throws ItemNotFoundException {
-        return createChart(service, theme, startTime, endTime, height, width, items, groups, dpi, legend);
+            @Nullable Integer dpi, @Nullable String yAxisDecimalPattern, @Nullable String interpolation,
+            @Nullable Boolean legend) throws ItemNotFoundException {
+        return createChart(service, theme, startTime, endTime, height, width, items, groups, dpi, interpolation,
+                legend);
     }
 
     /**

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/ChartServlet.java
@@ -285,6 +285,7 @@ public class ChartServlet extends HttpServlet {
         }
 
         String yAxisDecimalPattern = req.getParameter("yAxisDecimalPattern");
+        String interpolation = req.getParameter("interpolation");
 
         // Read out parameter 'legend'
         String legendParam = req.getParameter("legend");
@@ -305,7 +306,7 @@ public class ChartServlet extends HttpServlet {
         try {
             BufferedImage chart = provider.createChart(serviceName, req.getParameter("theme"), beginEnd.begin(),
                     beginEnd.end(), height, width, req.getParameter("items"), req.getParameter("groups"), dpi,
-                    yAxisDecimalPattern, legend);
+                    yAxisDecimalPattern, interpolation, legend);
             // Set the content type to that provided by the chart provider
             res.setContentType("image/" + provider.getChartType());
             try (ImageOutputStream imageOutputStream = ImageIO.createImageOutputStream(res.getOutputStream())) {

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -192,8 +192,8 @@ public class DefaultChartProvider implements ChartProvider {
         // axis
         styler.setAxisTickLabelsFont(chartTheme.getAxisTickLabelsFont(dpi));
         styler.setAxisTickLabelsColor(chartTheme.getAxisTickLabelsColor());
-        styler.setXAxisMin(startTime.toInstant().toEpochMilli());
-        styler.setXAxisMax(endTime.toInstant().toEpochMilli());
+        styler.setXAxisMin((double) startTime.toInstant().toEpochMilli());
+        styler.setXAxisMax((double) endTime.toInstant().toEpochMilli());
         int yAxisSpacing = Math.max(height / 10, chartTheme.getAxisTickLabelsFont(dpi).getSize());
         if (yAxisDecimalPattern != null) {
             styler.setYAxisDecimalPattern(yAxisDecimalPattern);

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -106,6 +106,9 @@ public class DefaultChartProvider implements ChartProvider {
 
     private static final int DPI_DEFAULT = 96;
 
+    private static final String INTERPOLATION_LINEAR = "linear";
+    private static final String INTERPOLATION_STEP = "step";
+
     private final Logger logger = LoggerFactory.getLogger(DefaultChartProvider.class);
 
     private final ItemUIRegistry itemUIRegistry;
@@ -130,20 +133,21 @@ public class DefaultChartProvider implements ChartProvider {
     @Override
     public BufferedImage createChart(@Nullable String serviceId, @Nullable String theme, ZonedDateTime startTime,
             ZonedDateTime endTime, int height, int width, @Nullable String items, @Nullable String groups,
-            @Nullable Integer dpiValue, @Nullable Boolean legend)
+            @Nullable Integer dpiValue, @Nullable String interpolation, @Nullable Boolean legend)
             throws ItemNotFoundException, IllegalArgumentException {
-        return createChart(serviceId, theme, startTime, endTime, height, width, items, groups, dpiValue, null, legend);
+        return createChart(serviceId, theme, startTime, endTime, height, width, items, groups, dpiValue, null,
+                interpolation, legend);
     }
 
     @Override
     public BufferedImage createChart(@Nullable String serviceId, @Nullable String theme, ZonedDateTime startTime,
             ZonedDateTime endTime, int height, int width, @Nullable String items, @Nullable String groups,
-            @Nullable Integer dpiValue, @Nullable String yAxisDecimalPattern, @Nullable Boolean legend)
-            throws ItemNotFoundException, IllegalArgumentException {
+            @Nullable Integer dpiValue, @Nullable String yAxisDecimalPattern, @Nullable String interpolation,
+            @Nullable Boolean legend) throws ItemNotFoundException, IllegalArgumentException {
         logger.debug(
-                "Rendering chart: service: '{}', theme: '{}', startTime: '{}', endTime: '{}', width: '{}', height: '{}', items: '{}', groups: '{}', dpi: '{}', yAxisDecimalPattern: '{}', legend: '{}'",
+                "Rendering chart: service: '{}', theme: '{}', startTime: '{}', endTime: '{}', width: '{}', height: '{}', items: '{}', groups: '{}', dpi: '{}', yAxisDecimalPattern: '{}', interpolation: '{}', legend: '{}'",
                 serviceId, theme, startTime, endTime, width, height, items, groups, dpiValue, yAxisDecimalPattern,
-                legend);
+                interpolation, legend);
 
         // If a persistence service is specified, find the provider, or use the default provider
         PersistenceService service = (serviceId == null) ? persistenceServiceRegistry.getDefault()
@@ -188,8 +192,8 @@ public class DefaultChartProvider implements ChartProvider {
         // axis
         styler.setAxisTickLabelsFont(chartTheme.getAxisTickLabelsFont(dpi));
         styler.setAxisTickLabelsColor(chartTheme.getAxisTickLabelsColor());
-        styler.setXAxisMin((double) startTime.toInstant().toEpochMilli());
-        styler.setXAxisMax((double) endTime.toInstant().toEpochMilli());
+        styler.setXAxisMin(startTime.toInstant().toEpochMilli());
+        styler.setXAxisMax(endTime.toInstant().toEpochMilli());
         int yAxisSpacing = Math.max(height / 10, chartTheme.getAxisTickLabelsFont(dpi).getSize());
         if (yAxisDecimalPattern != null) {
             styler.setYAxisDecimalPattern(yAxisDecimalPattern);
@@ -219,7 +223,7 @@ public class DefaultChartProvider implements ChartProvider {
             for (String itemName : itemNames) {
                 Item item = itemUIRegistry.getItem(itemName);
                 if (addItem(chart, persistenceService, startTime, endTime, item, seriesCounter, chartTheme, dpi,
-                        legendPositionDecider)) {
+                        interpolation, legendPositionDecider)) {
                     seriesCounter++;
                 }
             }
@@ -233,7 +237,7 @@ public class DefaultChartProvider implements ChartProvider {
                 if (item instanceof GroupItem groupItem) {
                     for (Item member : groupItem.getMembers()) {
                         if (addItem(chart, persistenceService, startTime, endTime, member, seriesCounter, chartTheme,
-                                dpi, legendPositionDecider)) {
+                                dpi, interpolation, legendPositionDecider)) {
                             seriesCounter++;
                         }
                     }
@@ -307,7 +311,7 @@ public class DefaultChartProvider implements ChartProvider {
 
     private boolean addItem(XYChart chart, QueryablePersistenceService service, ZonedDateTime timeBegin,
             ZonedDateTime timeEnd, Item item, int seriesCounter, ChartTheme chartTheme, int dpi,
-            LegendPositionDecider legendPositionDecider) {
+            @Nullable String interpolation, LegendPositionDecider legendPositionDecider) {
         Color color = chartTheme.getLineColor(seriesCounter);
 
         // Get the item label
@@ -358,7 +362,9 @@ public class DefaultChartProvider implements ChartProvider {
         for (HistoricItem historicItem : result) {
             // For 'binary' states, we need to replicate the data
             // to avoid diagonal lines
-            if (state instanceof OnOffType || state instanceof OpenClosedType) {
+            if (state != null && INTERPOLATION_STEP.equals(interpolation)
+                    || ((state instanceof OnOffType || state instanceof OpenClosedType)
+                            && !INTERPOLATION_LINEAR.equals(interpolation))) {
                 xData.add(Date.from(historicItem.getInstant().minus(1, ChronoUnit.MILLIS)));
                 yData.add(convertData(state));
             }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/components/UIComponentSitemapProvider.java
@@ -220,6 +220,10 @@ public class UIComponentSitemapProvider implements SitemapProvider, RegistryChan
                 setWidgetPropertyFromComponentConfig(widget, component, "legend", SitemapPackage.CHART__LEGEND);
                 setWidgetPropertyFromComponentConfig(widget, component, "forceAsItem",
                         SitemapPackage.CHART__FORCE_AS_ITEM);
+                setWidgetPropertyFromComponentConfig(widget, component, "yAxisDecimalPattern",
+                        SitemapPackage.CHART__YAXIS_DECIMAL_PATTERN);
+                setWidgetPropertyFromComponentConfig(widget, component, "interpolation",
+                        SitemapPackage.CHART__INTERPOLATION);
                 break;
             case "Webview":
                 WebviewImpl webviewWidget = (WebviewImpl) SitemapFactory.eINSTANCE.createWebview();


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/3662

This introduces an extra parameter for sitemap charts, `interpolation`, that can take two possible values: `linear` or `step`. If not set, the current behaviour will be used (`step` for OnOff or OpenClosed and `linear` for all other values).

Also fixes an issue where the `yAxisDecimalPattern` was not considered for managed sitemaps.