### PR TITLE
Upgrade Jollyday to 1.5.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -358,7 +358,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -961,7 +961,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.0</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -175,12 +175,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=1.4.0</capability>
+		<capability>openhab.tp;feature=jollyday;version=1.5.0</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/1.4.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/1.4.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/1.5.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/1.5.0</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -79,8 +79,8 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -79,8 +79,8 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -76,8 +76,8 @@ Fragment-Host: org.openhab.core.automation.module.script
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -79,8 +79,8 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -79,8 +79,8 @@ Fragment-Host: org.openhab.core.automation
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -74,6 +74,6 @@ feature.openhab-config: \
 	stax2-api;version='[4.2.2,4.2.3)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
-	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)'
+	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -126,8 +126,8 @@ Fragment-Host: org.openhab.core.model.item
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -128,8 +128,8 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	com.google.guava;version='[33.3.1,33.3.2)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -132,8 +132,8 @@ Fragment-Host: org.openhab.core.model.script
 	com.google.guava;version='[33.3.1,33.3.2)',\
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -135,8 +135,8 @@ Fragment-Host: org.openhab.core.model.thing
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.openhab.core.model.rule.runtime;version='[5.0.0,5.0.1)',\
-	de.focus_shift.jollyday-core;version='[1.4.0,1.4.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.4.0,1.4.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
-	org.yaml.snakeyaml;version='[2.3.0,2.3.1)'
+	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'


### PR DESCRIPTION
Upgrades Jollyday from 1.4.0 to 1.5.0.

For release notes, see:

https://github.com/focus-shift/jollyday/releases