### PR TITLE
[DSL generator] Handle config parameter value of type Double

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemFileConverter.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemFileConverter.java
@@ -13,6 +13,7 @@
 package org.openhab.core.model.item.internal.fileconverter;
 
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -191,6 +192,11 @@ public class DslItemFileConverter extends AbstractItemFileGenerator {
             } else {
                 property = null;
             }
+        } else if (value instanceof Double doubleValue) {
+            // It was discovered that configuration parameter value of an item metadata can be of type Double
+            // when the metadata is added through Main UI.
+            // A conversion to a BigDecimal is then required to avoid an exception later when generating DSL
+            property.getValue().add(BigDecimal.valueOf(doubleValue));
         } else {
             property.getValue().add(value);
         }

--- a/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/fileconverter/DslThingFileConverter.java
+++ b/bundles/org.openhab.core.model.thing/src/org/openhab/core/model/thing/internal/fileconverter/DslThingFileConverter.java
@@ -15,6 +15,7 @@ package org.openhab.core.model.thing.internal.fileconverter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -184,6 +185,12 @@ public class DslThingFileConverter extends AbstractThingFileGenerator {
             } else {
                 property = null;
             }
+        } else if (value instanceof Double doubleValue) {
+            // DSL thing syntax does not like a configuration parameter value provided as Double type.
+            // By security, we apply a conversion to a BigDecimal in case this would happen.
+            logger.debug("Configuration parameter {} with value {} is provided unexpectedly as Double type", key,
+                    value);
+            property.getValue().add(BigDecimal.valueOf(doubleValue));
         } else {
             property.getValue().add(value);
         }


### PR DESCRIPTION
Fix a bug in link with item metadata when using DSL generator provided by PR #4569 