### PR TITLE
Provide Karaf Session object inside OSGiConsole

### DIFF
--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/OSGiConsole.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/OSGiConsole.java
@@ -10,11 +10,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.io.console.karaf.internal;
+package org.openhab.core.io.console.karaf;
 
+import java.io.IOException;
 import java.io.PrintStream;
 
+import org.apache.karaf.shell.api.console.Session;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.console.Console;
 
 /**
@@ -26,10 +29,12 @@ public class OSGiConsole implements Console {
 
     private final String scope;
     private final PrintStream out;
+    private final Session session;
 
-    public OSGiConsole(final String scope, PrintStream out) {
+    public OSGiConsole(final String scope, PrintStream out, Session session) {
         this.scope = scope;
         this.out = out;
+        this.session = session;
     }
 
     @Override
@@ -50,5 +55,13 @@ public class OSGiConsole implements Console {
     @Override
     public void printUsage(final String s) {
         out.println(String.format("Usage: %s:%s", scope, s));
+    }
+
+    public String readLine(String prompt, final @Nullable Character mask) throws IOException {
+        return session.readLine(prompt, mask);
+    }
+
+    public Session getSession() {
+        return session;
     }
 }

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -27,6 +27,7 @@ import org.apache.karaf.shell.api.console.Session;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.ConsoleInterpreter;
 import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
+import org.openhab.core.io.console.karaf.OSGiConsole;
 
 /**
  * This class wraps OH ConsoleCommandExtensions to commands for Apache Karaf
@@ -68,7 +69,7 @@ public class CommandWrapper implements Command, Action {
     public Object execute(Session session, List<Object> argList) throws Exception {
         String[] args = argList.stream().map(Object::toString).toArray(String[]::new);
         PrintStream out = Process.Utils.current().out();
-        final Console console = new OSGiConsole(getScope(), out);
+        final Console console = new OSGiConsole(getScope(), out, session);
 
         if (args.length == 1 && "--help".equals(args[0])) {
             for (final String usage : command.getUsages()) {

--- a/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/Console.java
+++ b/bundles/org.openhab.core.io.console/src/main/java/org/openhab/core/io/console/Console.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.core.io.console;
 
+import java.io.IOException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * This interface must be implemented by consoles which want to use the {@link ConsoleInterpreter}.
@@ -38,4 +41,16 @@ public interface Console {
      * @param s the main usage string (console independent)
      */
     void printUsage(String s);
+
+    /**
+     * Reads a line from the console. The prompt is displayed before the line is read.
+     *
+     * @param prompt the prompt to display
+     * @param mask the character to use for masking input (e.g. '*'), or null if no masking is required
+     * @return the line read from the console
+     * @throws IOException if an I/O error occurs
+     */
+    default String readLine(String prompt, final @Nullable Character mask) throws IOException {
+        throw new UnsupportedOperationException("readLine not supported");
+    }
 }


### PR DESCRIPTION
This PR provides Karaf's Session object through OSGiConsole object that's provided to `ConsoleCommandExtension`s.

The Karaf `Session` enables ConsoleCommandExtensions to prompt for user input. The simplest usage is provided through a convenience method `OSGiConsole.readLine()`.

A more advanced usage is also possible by constructing a custom org.jline.reader.LineReader object which requires the Terminal from console.getSession().getTerminal(). This is useful for more complex input scenarios, such as when you need to have sub-shell history, custom completion, etc.

This PR will enable the creation of a JRuby REPL inside the Karaf console. This REPL will run inside the same engine / environment as a normal JRuby rule, so it will have access to runtime Items, Things, events, etc, just like a normal openHAB script.

