### PR TITLE
Fix i18n:generate-default-translations on add-on config other than bindings

### DIFF
--- a/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojo.java
+++ b/tools/i18n-plugin/src/main/java/org/openhab/core/tools/i18n/plugin/GenerateDefaultTranslationsMojo.java
@@ -108,7 +108,7 @@ public class GenerateDefaultTranslationsMojo extends AbstractI18nMojo {
     }
 
     protected String generateDefaultTranslations(Path defaultTranslationsPath) {
-        XmlToTranslationsConverter xmlConverter = new XmlToTranslationsConverter();
+        XmlToTranslationsConverter xmlConverter = new XmlToTranslationsConverter(getLog());
         Translations generatedTranslations = xmlConverter.convert(bundleInfo);
 
         JsonToTranslationsConverter jsonConverter = new JsonToTranslationsConverter();

--- a/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverterTest.java
+++ b/tools/i18n-plugin/src/test/java/org/openhab/core/tools/i18n/plugin/XmlToTranslationsConverterTest.java
@@ -37,7 +37,7 @@ public class XmlToTranslationsConverterTest {
         BundleInfoReader reader = new BundleInfoReader(new SystemStreamLog());
         BundleInfo bundleInfo = reader.readBundleInfo(Path.of("src/test/resources/acmeweather.bundle/OH-INF"));
 
-        XmlToTranslationsConverter converter = new XmlToTranslationsConverter();
+        XmlToTranslationsConverter converter = new XmlToTranslationsConverter(new SystemStreamLog());
         Translations translations = converter.convert(bundleInfo);
 
         assertThat(translations.hasTranslations(), is(true));
@@ -65,7 +65,7 @@ public class XmlToTranslationsConverterTest {
         BundleInfoReader reader = new BundleInfoReader(new SystemStreamLog());
         BundleInfo bundleInfo = reader.readBundleInfo(Path.of("src/test/resources/acmetts.bundle/OH-INF"));
 
-        XmlToTranslationsConverter converter = new XmlToTranslationsConverter();
+        XmlToTranslationsConverter converter = new XmlToTranslationsConverter(new SystemStreamLog());
         Translations translations = converter.convert(bundleInfo);
 
         assertThat(translations.hasTranslations(), is(true));
@@ -86,7 +86,7 @@ public class XmlToTranslationsConverterTest {
         BundleInfoReader reader = new BundleInfoReader(new SystemStreamLog());
         BundleInfo bundleInfo = reader.readBundleInfo(Path.of("src/test/resources/infoless.bundle/OH-INF"));
 
-        XmlToTranslationsConverter converter = new XmlToTranslationsConverter();
+        XmlToTranslationsConverter converter = new XmlToTranslationsConverter(new SystemStreamLog());
         Translations translations = converter.convert(bundleInfo);
 
         assertThat(translations.hasTranslations(), is(false));


### PR DESCRIPTION
Fix the translations generation for non-binding addons, e.g. org.openhab.io.homekit, org.openhab.automation.jrubyscripting.

Previously it would only generate the main `addon.<id>.name` and description. It ignored config.xml for these types of add-ons.

This PR processes all the config descriptions into the translation file.

This should also resolve #4362 by translating all the found config descriptions (xml files) so it will work on profiles etc.
