### PR TITLE
Fix restoring nested group items from persistence

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -215,7 +215,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
             } else if (itemCfg instanceof PersistenceGroupConfig persistenceGroupConfig) {
                 try {
                     Item gItem = itemRegistry.getItem(persistenceGroupConfig.getGroup());
-                    if (gItem instanceof GroupItem gItem2 && gItem2.getAllMembers().contains(item)) {
+                    if (gItem instanceof GroupItem gItem2 && gItem2.getAllStateMembers().contains(item)) {
                         applies = true;
                     }
                 } catch (ItemNotFoundException e) {
@@ -259,7 +259,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                 try {
                     Item gItem = itemRegistry.getItem(groupName);
                     if (gItem instanceof GroupItem groupItem) {
-                        items.addAll(groupItem.getAllMembers());
+                        items.addAll(groupItem.getAllStateMembers());
                     }
                 } catch (ItemNotFoundException e) {
                     logger.debug("Item group '{}' does not exist.", groupName);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -242,14 +242,11 @@ public abstract class GenericItem implements ActiveItem {
     public void setState(State state, @Nullable State lastState, @Nullable ZonedDateTime lastStateUpdate,
             @Nullable ZonedDateTime lastStateChange) {
         State oldState = this.state;
-        ZonedDateTime oldStateUpdate = this.lastStateUpdate;
         this.state = state;
-        this.lastState = lastState;
-        this.lastStateUpdate = lastStateUpdate;
-        this.lastStateChange = lastStateChange;
-        if (oldStateUpdate != null && lastStateUpdate != null && !oldStateUpdate.equals(lastStateUpdate)) {
-            notifyListeners(oldState, state);
-        }
+        this.lastState = lastState != null ? lastState : this.lastState;
+        this.lastStateUpdate = lastStateUpdate != null ? lastStateUpdate : this.lastStateUpdate;
+        this.lastStateChange = lastStateChange != null ? lastStateChange : this.lastStateChange;
+        notifyListeners(oldState, state);
         sendStateUpdatedEvent(state);
         if (!oldState.equals(state)) {
             sendStateChangedEvent(state, oldState);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -122,14 +122,25 @@ public class GroupItem extends GenericItem implements StateChangeListener, Metad
     }
 
     /**
-     * Returns the direct members of this {@link GroupItem} and recursively all
-     * members of the potentially contained {@link GroupItem}s as well. The {@link GroupItem}s itself aren't contained.
+     * Returns the direct members of this {@link GroupItem} and recursively all members of the potentially contained
+     * {@link GroupItem}s as well. The {@link GroupItem}s itself aren't contained.
      * The returned items are unique.
      *
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
         return Collections.unmodifiableSet(new LinkedHashSet<>(getMembers((Item i) -> !(i instanceof GroupItem))));
+    }
+
+    /**
+     * Returns the direct members of this {@link GroupItem} and recursively all members of the potentially contained
+     * {@link GroupItem}s as well. The {@link GroupItem}s itself are contained if they can have a state.
+     * The returned items are unique.
+     *
+     * @return all members of this and all contained {@link GroupItem}s
+     */
+    public Set<Item> getAllStateMembers() {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(getStateMembers(getMembers())));
     }
 
     private void collectMembers(Collection<Item> allMembers, Collection<Item> members) {


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4649

https://github.com/openhab/openhab-core/pull/4463 introduced restoring `lastState`, `lastStateUpdate` and `lastStateChange` from persistence.
This broke restoring nested groups, as this relied on update events from the items to the groups. Update events would not allows group state updates to be restored with correct dates, or the `lastState` of the group to be restored.

This PR also saves the nested group itself when it has a state and uses this in restore.