### PR TITLE
Add support for concurrent multisink audio

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/AudioManager.java
@@ -19,6 +19,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.PercentType;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * This service provides functionality around audio services and is the central service to be used directly by others.
  *
@@ -27,6 +29,7 @@ import org.openhab.core.library.types.PercentType;
  * @author Christoph Weitkamp - Added parameter to adjust the volume
  * @author Wouter Born - Added methods for getting all sinks and sources
  * @author Miguel Álvarez - Add record method
+ * @author Karel Goderis - Add multisink support
  */
 @NonNullByDefault
 public interface AudioManager {
@@ -52,6 +55,14 @@ public interface AudioManager {
     void play(@Nullable AudioStream audioStream, @Nullable String sinkId);
 
     /**
+     * Plays the passed audio stream on the given set of sinks.
+     *
+     * @param audioStream The audio stream to play or null if streaming should be stopped
+     * @param sinkIds The set of the audio sink ids to use
+     */
+    void play(@Nullable AudioStream audioStream, @NonNull Set<String> sinkIds);
+
+    /**
      * Plays the passed audio stream on the given sink.
      *
      * @param audioStream The audio stream to play or null if streaming should be stopped
@@ -59,6 +70,15 @@ public interface AudioManager {
      * @param volume The volume to be used or null if the default notification volume should be used
      */
     void play(@Nullable AudioStream audioStream, @Nullable String sinkId, @Nullable PercentType volume);
+
+    /**
+     * Plays the passed audio stream on the given set of sinks.
+     *
+     * @param audioStream The audio stream to play or null if streaming should be stopped
+     * @param sinkIds The set of the audio sink ids to use
+     * @param volume The volume to be used or null if the default notification volume should be used
+     */
+    void play(@Nullable AudioStream audioStream, Set<String> sinkIds, @Nullable PercentType volume);
 
     /**
      * Plays an audio file from the "sounds" folder using the default audio sink.
@@ -87,6 +107,15 @@ public interface AudioManager {
     void playFile(String fileName, @Nullable String sinkId) throws AudioException;
 
     /**
+     * Plays an audio file from the "sounds" folder using the given audio sink.
+     *
+     * @param fileName The file from the "sounds" folder
+     * @param sinkIds The set of the audio sink ids to use
+     * @throws AudioException in case the file does not exist or cannot be opened
+     */
+    void playFile(String fileName, @NonNull Set<String> sinkIds) throws AudioException;
+
+    /**
      * Plays an audio file with the given volume from the "sounds" folder using the given audio sink.
      *
      * @param fileName The file from the "sounds" folder
@@ -95,6 +124,16 @@ public interface AudioManager {
      * @throws AudioException in case the file does not exist or cannot be opened
      */
     void playFile(String fileName, @Nullable String sinkId, @Nullable PercentType volume) throws AudioException;
+
+    /**
+     * Plays an audio file with the given volume from the "sounds" folder using the given audio sink.
+     *
+     * @param fileName The file from the "sounds" folder
+     * @param sinkIds The set of the audio sink ids to use
+     * @param volume The volume to be used or null if the default notification volume should be used
+     * @throws AudioException in case the file does not exist or cannot be opened
+     */
+    void playFile(String fileName, @NonNull Set<String> sinkIds, @Nullable PercentType volume) throws AudioException;
 
     /**
      * Stream audio from the passed url using the default audio sink.
@@ -112,6 +151,15 @@ public interface AudioManager {
      * @throws AudioException in case the url stream cannot be opened
      */
     void stream(@Nullable String url, @Nullable String sinkId) throws AudioException;
+
+    /**
+     * Stream audio from the passed url to the given set of sinks
+     *
+     * @param url The url to stream from or null if streaming should be stopped
+     * @param sinkIds The set of the audio sink ids to use
+     * @throws AudioException in case the url stream cannot be opened
+     */
+    void stream(@Nullable String url, @NonNull Set<String> sinkIds) throws AudioException;
 
     /**
      * Parse and synthesize a melody and play it into the default sink.
@@ -139,6 +187,19 @@ public interface AudioManager {
     void playMelody(String melody, @Nullable String sinkId);
 
     /**
+     * Parse and synthesize a melody and play it into the given sink.
+     *
+     * The melody should be a spaced separated list of note names or silences (character 0 or O).
+     * You can optionally add the character "'" to increase the note one octave.
+     * You can optionally add ":ms" where ms is an int value to customize the note/silence milliseconds duration
+     * (defaults to 200ms).
+     *
+     * @param melody The url to stream from or null if streaming should be stopped.
+     * @param sinkIds The set of the audio sink ids to use
+     */
+    void playMelody(String melody, @NonNull Set<String> sinkIds);
+
+    /**
      * Parse and synthesize a melody and play it into the given sink at the desired volume.
      *
      * The melody should be a spaced separated list of note names or silences (character 0 or O).
@@ -151,6 +212,20 @@ public interface AudioManager {
      * @param volume The volume to be used or null if the default notification volume should be used
      */
     void playMelody(String melody, @Nullable String sinkId, @Nullable PercentType volume);
+
+    /**
+     * Parse and synthesize a melody and play it into the given sink at the desired volume.
+     *
+     * The melody should be a spaced separated list of note names or silences (character 0 or O).
+     * You can optionally add the character "'" to increase the note one octave.
+     * You can optionally add ":ms" where ms is an int value to customize the note/silence milliseconds duration
+     * (defaults to 200ms).
+     *
+     * @param melody The url to stream from or null if streaming should be stopped.
+     * @param sinkIds The set of the audio sink ids to use
+     * @param volume The volume to be used or null if the default notification volume should be used
+     */
+    void playMelody(String melody, @NonNull Set<String> sinkIds, @Nullable PercentType volume);
 
     /**
      * Record audio as a WAV file of the specified length to the sounds folder.
@@ -256,9 +331,10 @@ public interface AudioManager {
     AudioSink getSink(@Nullable String sinkId);
 
     /**
-     * Get a list of sink ids that match a given pattern
+     * Get a list of sink ids that match a given set of patterns
      *
-     * @param pattern pattern to search, can include {@code *} and {@code ?} placeholders
+     * @param pattern patterns to search; patterns is a comma-separated list, whereby each can include {@code *} and
+     *            {@code ?} placeholders, or can be literal string to designate a single sink
      * @return ids of matching sinks
      */
     Set<String> getSinkIds(String pattern);

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/internal/AudioConsoleCommandExtension.java
@@ -35,6 +35,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import io.reactivex.annotations.NonNull;
+
 /**
  * Console command extension for all audio features.
  *
@@ -237,9 +239,7 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
     }
 
     private void playOnSinks(String pattern, String fileName, @Nullable PercentType volume, Console console) {
-        for (String sinkId : audioManager.getSinkIds(pattern)) {
-            playOnSink(sinkId, fileName, volume, console);
-        }
+        playOnSinks(audioManager.getSinkIds(pattern), fileName, volume, console);
     }
 
     private void playOnSink(@Nullable String sinkId, String fileName, @Nullable PercentType volume, Console console) {
@@ -248,6 +248,16 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
         } catch (AudioException e) {
             console.println(Objects.requireNonNullElse(e.getMessage(),
                     String.format("An error occurred while playing '%s' on sink '%s'", fileName, sinkId)));
+        }
+    }
+
+    private void playOnSinks(@NonNull Set<String> sinkIds, String fileName, @Nullable PercentType volume,
+            Console console) {
+        try {
+            audioManager.playFile(fileName, sinkIds, volume);
+        } catch (AudioException e) {
+            console.println(Objects.requireNonNullElse(e.getMessage(),
+                    String.format("An error occurred while playing '%s' on sinks '%s'", fileName, sinkIds)));
         }
     }
 

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/fake/AudioSinkFake.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/fake/AudioSinkFake.java
@@ -15,6 +15,7 @@ package org.openhab.core.audio.internal.fake;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -78,6 +79,18 @@ public class AudioSinkFake implements AudioSink {
             isStreamStopped = true;
         }
         isStreamProcessed = true;
+    }
+
+    @Override
+    public CompletableFuture<@Nullable Void> processAndComplete(@Nullable AudioStream audioStream) {
+        this.audioStream = audioStream;
+        if (audioStream != null) {
+            audioFormat = audioStream.getFormat();
+        } else {
+            isStreamStopped = true;
+        }
+        isStreamProcessed = true;
+        return CompletableFuture.completedFuture(null);
     }
 
     public @Nullable AudioFormat getAudioFormat() {

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/Audio.java
@@ -65,7 +65,7 @@ public class Audio {
     public static void playSound(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
             @ParamDoc(name = "filename", text = "the filename with extension") String filename) {
         try {
-            AudioActionService.audioManager.playFile(filename, sink);
+            AudioActionService.audioManager.playFile(filename, AudioActionService.audioManager.getSinkIds(sink));
         } catch (AudioException e) {
             logger.warn("Failed playing audio file: {}", e.getMessage());
         }
@@ -76,7 +76,8 @@ public class Audio {
             @ParamDoc(name = "filename", text = "the filename with extension") String filename,
             @ParamDoc(name = "volume", text = "the volume to be used") PercentType volume) {
         try {
-            AudioActionService.audioManager.playFile(filename, sink, volume);
+            AudioActionService.audioManager.playFile(filename, AudioActionService.audioManager.getSinkIds(sink),
+                    volume);
         } catch (AudioException e) {
             logger.warn("Failed playing audio file: {}", e.getMessage());
         }
@@ -103,7 +104,7 @@ public class Audio {
     public static synchronized void playStream(@ParamDoc(name = "sink", text = "the id of the sink") String sink,
             @ParamDoc(name = "url", text = "the url of the audio stream") String url) {
         try {
-            AudioActionService.audioManager.stream(url, sink);
+            AudioActionService.audioManager.stream(url, AudioActionService.audioManager.getSinkIds(sink));
         } catch (AudioException e) {
             logger.warn("Failed streaming audio url: {}", e.getMessage());
         }
@@ -167,7 +168,7 @@ public class Audio {
 
     /**
      * Converts a float volume to a {@link PercentType} volume and checks if float volume is in the [0;1] range.
-     * 
+     *
      * @param volume
      * @return
      */


### PR DESCRIPTION
# Add support for concurrent multisink audio

Allow playing audio concurrently on multiple sinks. In the context of the Sonos binding, this eliminates the need to group or ungroup Sonos players in order to play audio synchronously on all players (e.g. in Rules). Audio is also played concurrently on all sinks using a ThreadPool that is configurable in services.cfg ("threadpool:audio=10"), thereby eliminating the "sequential" output when playing audio on a large group of sinks (e.g. doorbell on Sonos)

Furthermore, it add support for comma-separated lists of sinks or patterns to the various commands, so that arbitrary groupings can be made by the end-user, e.g. "Sonos:CONNECT:*,enhancedjavasound" for usage with playSound() in Rules or the "openhab:audio play" command