### PR TITLE
fixes proposal for #4662, part1, createDTO changes:

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -559,7 +559,6 @@ public class PersistenceResource implements RESTResource {
 
         dto.datapoints = Long.toString(quantity);
         return dto;
-
     }
 
     /**


### PR DESCRIPTION
# fix proposal for #4662, part1, createDTO changes:

# Description

The pull request is intend to fix the handling of itemState=true/false parameters in "rest/persistence/items/xxxx" service calls.
The idea is to verify if current item state is already in the DTO before adding it if itemState = true.
By extension, we also want to remove it from DTO if itemState=false to be fully consistent.

The current / awaited behavior is describe in issue #4662.

- If currentState is already in Dto, and itemState=true, do nothing.
- If currentState is already in Dto, and itemState=false, remove it.
- If currentState is not in Dto, and itemState=false, do nothing.
- If currentState is not in Dto, and itemState=true, add it.

Search for currentState in dto by looping the dto data for value before the current timestamp. Ignore all other data that are future state in Dtos.
