### PR TITLE
Fix timeseries restore init late initialization of listeners on GenericItem

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -301,7 +301,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
     }
 
     public void addPersistenceListenners(Collection<String> oldItemNames) {
-        itemRegistry.getItems().forEach(this::addItemToPersistenceListenners);        
+        itemRegistry.getItems().forEach(this::addItemToPersistenceListenners);
     }
 
     public void addToPersistenceServiceContainer(Collection<String> oldItemNames) {
@@ -601,8 +601,8 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                 // try restoring the previous state if not yet set
                 if (item.getLastState() != null && item.getLastState() != UnDefType.NULL) {
                     // there is already a previous state, nothing to restore
-                return;
-            }
+                    return;
+                }
                 lastStateUpdate = item.getLastStateUpdate();
                 if (state.equals(persistedItem.getState())) {
                     lastState = persistedItem.getLastState();

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -296,12 +296,29 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
 
     @Override
     public void allItemsChanged(Collection<String> oldItemNames) {
-        itemRegistry.getItems().forEach(this::added);
+        addPersistenceListenners(oldItemNames);
+        addToPersistenceServiceContainer(oldItemNames);
+    }
+
+    public void addPersistenceListenners(Collection<String> oldItemNames) {
+        itemRegistry.getItems().forEach(this::addItemToPersistenceListenners);        
+    }
+
+    public void addToPersistenceServiceContainer(Collection<String> oldItemNames) {
+        itemRegistry.getItems().forEach(this::addItemToPersistenceServiceContainer);
     }
 
     @Override
     public void added(Item item) {
+        addItemToPersistenceListenners(item);
+        addItemToPersistenceServiceContainer(item);
+    }
+
+    public void addItemToPersistenceServiceContainer(Item item) {
         persistenceServiceContainers.values().forEach(container -> container.addItem(item));
+    }
+
+    public void addItemToPersistenceListenners(Item item) {
         if (item instanceof GenericItem genericItem) {
             genericItem.addStateChangeListener(this);
             genericItem.addTimeSeriesListener(this);
@@ -584,8 +601,8 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
                 // try restoring the previous state if not yet set
                 if (item.getLastState() != null && item.getLastState() != UnDefType.NULL) {
                     // there is already a previous state, nothing to restore
-                    return;
-                }
+                return;
+            }
                 lastStateUpdate = item.getLastStateUpdate();
                 if (state.equals(persistedItem.getState())) {
                     lastState = persistedItem.getLastState();

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -296,12 +296,12 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
 
     @Override
     public void allItemsChanged(Collection<String> oldItemNames) {
-        addPersistenceListenners(oldItemNames);
+        addPersistenceListeners(oldItemNames);
         addToPersistenceServiceContainer(oldItemNames);
     }
 
-    public void addPersistenceListenners(Collection<String> oldItemNames) {
-        itemRegistry.getItems().forEach(this::addItemToPersistenceListenners);
+    public void addPersistenceListeners(Collection<String> oldItemNames) {
+        itemRegistry.getItems().forEach(this::addItemToPersistenceListeners);
     }
 
     public void addToPersistenceServiceContainer(Collection<String> oldItemNames) {
@@ -310,7 +310,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
 
     @Override
     public void added(Item item) {
-        addItemToPersistenceListenners(item);
+        addItemToPersistenceListeners(item);
         addItemToPersistenceServiceContainer(item);
     }
 
@@ -318,7 +318,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         persistenceServiceContainers.values().forEach(container -> container.addItem(item));
     }
 
-    public void addItemToPersistenceListenners(Item item) {
+    public void addItemToPersistenceListeners(Item item) {
         if (item instanceof GenericItem genericItem) {
             genericItem.addStateChangeListener(this);
             genericItem.addTimeSeriesListener(this);


### PR DESCRIPTION
#Fix timeseries restore init late initialization of listenners on GenericItem, #4656,

# Description
This PR is to fix lost value in timeseries update observe on issue #4656 on openhab startup.

The GenericItem implements a timeSeriesListener that is initialized from PersistentManagerImpl.allItemsChanged().

The initialization of this timeSeriesListerner can occurs lately after initialization of openhab because the init is in the same loop as the perstistence value restore from persistence layer.

This persistence restore take long time because of multiple request to the persistence store and db, and so delayed the initialization.

The idea there is to break the loop into 2 parts:
One for the timeSeriesListener initialization which is very fast, and have to be done immedialty.
One for the value restore that can take more time.