### PR TITLE
Persistence filters allow unquoted units

### DIFF
--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -40,27 +40,27 @@ TimeFilter:
 ;
 
 EqualsFilter:
-   '=' values+=STRING (',' values+=STRING)*
+	'=' values+=STRING (',' values+=STRING)*
 ;
 
 NotEqualsFilter:
-   '!' values+=STRING (',' values+=STRING)*
+	'!' values+=STRING (',' values+=STRING)*
 ;
 
 IncludeFilter:
-  '[]' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
+	'[]' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
 ;
 
 NotIncludeFilter:
-  '][' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
+	'][' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
 ;
 
 
 PersistenceConfiguration:
 	items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig)
-	   (',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* 
+		(',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* 
 	((':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)? 
-		 ('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
+			('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
 		| ';')
 ;
 
@@ -78,21 +78,21 @@ GroupConfig:
 ;
 
 ItemExcludeConfig:
-    '!' itemExclude=ID
+	'!' itemExclude=ID
 ;
 
 GroupExcludeConfig:
-    '!' groupExclude=ID '*'
+	'!' groupExclude=ID '*'
 ;
 
 AliasConfiguration:
-    item=ID '->' alias=(ID|STRING)
+	item=ID '->' alias=(ID|STRING)
 ;
 
 DECIMAL returns ecore::EBigDecimal :
-    '-'? INT ('.' INT)?
+	'-'? INT ('.' INT)?
 ;
 
 UNIT:
-    (('^' INT)|'²'|'³'|'/'|'*'|'·'|'°'|'µ'|'%'|'‰'|'Ω'|'Å'|'('|')'|ID)+
+	(('^' INT)|'²'|'³'|'/'|'*'|'·'|'°'|'µ'|'%'|'‰'|'Ω'|'Å'|'('|')'|ID)+
 ;

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -32,7 +32,7 @@ FilterDetails:
 ;
 
 ThresholdFilter:
-	'>' (relative?='%')? value=DECIMAL unit=STRING?
+	'>' (relative?='%')? value=DECIMAL unit=(UNIT|STRING)?
 ;
 
 TimeFilter:
@@ -48,11 +48,11 @@ NotEqualsFilter:
 ;
 
 IncludeFilter:
-  '[]' lower=DECIMAL upper=DECIMAL unit=STRING?
+  '[]' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
 ;
 
 NotIncludeFilter:
-  '][' lower=DECIMAL upper=DECIMAL unit=STRING?
+  '][' lower=DECIMAL upper=DECIMAL unit=(UNIT|STRING)?
 ;
 
 
@@ -90,5 +90,9 @@ AliasConfiguration:
 ;
 
 DECIMAL returns ecore::EBigDecimal :
-	'-'? INT ('.' INT)?
+    '-'? INT ('.' INT)?
+;
+
+UNIT:
+    (('^' INT)|'²'|'³'|'/'|'*'|'·'|'°'|'µ'|'%'|'‰'|'Ω'|'Å'|'('|')'|ID)+
 ;


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4625#issuecomment-2692693848

Persistence definition filters with units required the unit to be a valid string. The parser would not recognize units containing special characters as Strings (e.g. °C, kΩ) unless the unit string would be surrounded by quotes. The documentation makes no mention of this constraint and only provided examples with no special characters and without quotes (https://www.openhab.org/docs/configuration/persistence.html#threshold-filter).

With this PR, the parser will also recognize special characters that can be part of a unit definition when parsing the unit, removing the need to have units with special characters to be enclosed in quotes.

This has been tested with the following filter definitions:

```
Filters {
    test0 : > 5 A
    test1 : [] -100 200 °C
    test2 : [] -100 200 /°C
    test3 : ][ 100 200 kΩ
    test4a : > 5
    test4b : > 5.5 Å
    test5 : [] -100 200 '°C'
    test6 : [] -100 200 "°C"
    test7 : > 10 %
    test8 : > % 10 %
}
```