### PR TITLE
Persistence no default strategies

### DIFF
--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -6,9 +6,7 @@ generate persistence "https://openhab.org/model/Persistence"
 
 PersistenceModel:
 	{PersistenceModel}
-	'Strategies' '{' strategies+=Strategy* 
-		('default' '=' defaults+=[Strategy|ID] (',' defaults+=[Strategy|ID])*)?
-	'}'
+	('Strategies' '{' strategies+=Strategy* '}')?
 	('Filters' '{' filters+=Filter* '}')?
 	('Items' '{' configs+=PersistenceConfiguration* '}')?
 	('Aliases' '{' aliases+=AliasConfiguration* '}')?
@@ -59,9 +57,8 @@ NotIncludeFilter:
 PersistenceConfiguration:
 	items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig)
 	   (',' items+=(AllConfig | ItemConfig | GroupConfig | ItemExcludeConfig | GroupExcludeConfig))* 
-	((':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)? 
+	(':' ('strategy' '=' strategies+=[Strategy|ID] (',' strategies+=[Strategy|ID])*)
 		 ('filter' '=' filters+=[Filter|ID] (',' filters+=[Filter|ID])*)?) 
-		| ';')
 ;
 
 AllConfig:

--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/internal/PersistenceModelManager.java
@@ -116,8 +116,7 @@ public class PersistenceModelManager extends AbstractProvider<PersistenceService
                 if (model != null) {
                     PersistenceServiceConfiguration newConfiguration = new PersistenceServiceConfiguration(serviceName,
                             mapConfigs(model.getConfigs()), mapAliases(model.getAliases()),
-                            mapStrategies(model.getDefaults()), mapStrategies(model.getStrategies()),
-                            mapFilters(model.getFilters()));
+                            mapStrategies(model.getStrategies()), mapFilters(model.getFilters()));
                     PersistenceServiceConfiguration oldConfiguration = configurations.put(serviceName,
                             newConfiguration);
                     if (oldConfiguration == null) {

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/PersistenceService.java
@@ -27,6 +27,7 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  * for sending data to an IoT (Internet of Things) service.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Mark Herwege - Make default strategy to be only a configuration suggestion
  */
 @NonNullByDefault
 public interface PersistenceService {
@@ -74,9 +75,10 @@ public interface PersistenceService {
     void store(Item item, @Nullable String alias);
 
     /**
-     * Provides default persistence strategies that are used for all items if no user defined configuration is found.
+     * Provides suggested persistence strategies that can be used in the UI as a suggestion for configuration. These
+     * persistence strategies are not applied automatically.
      *
-     * @return The default persistence strategies
+     * @return The suggested persistence strategies
      */
     List<PersistenceStrategy> getDefaultStrategies();
 }

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/dto/PersistenceServiceConfigurationDTO.java
@@ -22,13 +22,13 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  * The {@link PersistenceServiceConfigurationDTO} is used for transferring persistence service configurations
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Mark Herwege - Make default strategy to be only a configuration suggestion
  */
 @NonNullByDefault
 public class PersistenceServiceConfigurationDTO {
     public String serviceId = "";
     public Collection<PersistenceItemConfigurationDTO> configs = List.of();
     public Map<String, String> aliases = Map.of();
-    public Collection<String> defaults = List.of();
     public Collection<PersistenceCronStrategyDTO> cronStrategies = List.of();
     public Collection<PersistenceFilterDTO> thresholdFilters = List.of();
     public Collection<PersistenceFilterDTO> timeFilters = List.of();

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/internal/PersistenceManagerImpl.java
@@ -92,6 +92,7 @@ import org.slf4j.LoggerFactory;
  * @author Jan N. Klug - Refactored to use service configuration registry
  * @author Jan N. Klug - Added time series support
  * @author Mark Herwege - Added restoring lastState, lastStateChange and lastStateUpdate
+ * @author Mark Herwege - Make default strategy to be only a configuration suggestion
  */
 @Component(immediate = true, service = PersistenceManager.class)
 @NonNullByDefault
@@ -442,7 +443,7 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         public PersistenceServiceContainer(PersistenceService persistenceService,
                 @Nullable PersistenceServiceConfiguration configuration) {
             this.persistenceService = persistenceService;
-            this.configuration = Objects.requireNonNullElseGet(configuration, this::getDefaultConfig);
+            this.configuration = Objects.requireNonNullElseGet(configuration, this::getEmptyConfig);
         }
 
         public PersistenceService getPersistenceService() {
@@ -452,13 +453,13 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
         /**
          * Set a new configuration for this persistence service (also cancels all cron jobs)
          *
-         * @param configuration the new {@link PersistenceServiceConfiguration}, if {@code null} the default
-         *            configuration of the service is used
+         * @param configuration the new {@link PersistenceServiceConfiguration}, if {@code null} all configuration will
+         *            be removed
          */
         public void setConfiguration(@Nullable PersistenceServiceConfiguration configuration) {
             cancelPersistJobs();
             cancelForecastJobs();
-            this.configuration = Objects.requireNonNullElseGet(configuration, this::getDefaultConfig);
+            this.configuration = Objects.requireNonNullElseGet(configuration, this::getEmptyConfig);
             strategyCache.clear();
         }
 
@@ -470,25 +471,18 @@ public class PersistenceManagerImpl implements ItemRegistryChangeListener, State
          */
         public Stream<PersistenceItemConfiguration> getMatchingConfigurations(PersistenceStrategy strategy) {
             return Objects.requireNonNull(strategyCache.computeIfAbsent(strategy, s -> {
-                boolean matchesDefaultStrategies = configuration.getDefaults().contains(strategy);
                 return configuration.getConfigs().stream()
-                        .filter(itemConfig -> itemConfig.strategies().contains(strategy)
-                                || (itemConfig.strategies().isEmpty() && matchesDefaultStrategies))
-                        .toList();
-            }).stream());
+                        .filter(itemConfig -> itemConfig.strategies().contains(strategy)).toList();
+            })).stream();
         }
 
         public @Nullable String getAlias(Item item) {
             return configuration.getAliases().get(item.getName());
         }
 
-        private PersistenceServiceConfiguration getDefaultConfig() {
-            List<PersistenceStrategy> strategies = persistenceService.getDefaultStrategies();
-            List<PersistenceItemConfiguration> configs = List
-                    .of(new PersistenceItemConfiguration(List.of(new PersistenceAllConfig()), strategies, null));
-            Map<String, String> aliases = Map.of();
-            return new PersistenceServiceConfiguration(persistenceService.getId(), configs, aliases, strategies,
-                    strategies, List.of());
+        private PersistenceServiceConfiguration getEmptyConfig() {
+            return new PersistenceServiceConfiguration(persistenceService.getId(), List.of(), Map.of(), List.of(),
+                    List.of());
         }
 
         /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfiguration.java
@@ -27,23 +27,22 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  *
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Implement aliases
+ * @author Mark Herwege - Make default strategy to be only a configuration suggestion
  */
 @NonNullByDefault
 public class PersistenceServiceConfiguration implements Identifiable<String> {
     private final String serviceId;
     private final List<PersistenceItemConfiguration> configs;
     private final Map<String, String> aliases;
-    private final List<PersistenceStrategy> defaults;
     private final List<PersistenceStrategy> strategies;
     private final List<PersistenceFilter> filters;
 
     public PersistenceServiceConfiguration(String serviceId, Collection<PersistenceItemConfiguration> configs,
-            Map<String, String> aliases, Collection<PersistenceStrategy> defaults,
-            Collection<PersistenceStrategy> strategies, Collection<PersistenceFilter> filters) {
+            Map<String, String> aliases, Collection<PersistenceStrategy> strategies,
+            Collection<PersistenceFilter> filters) {
         this.serviceId = serviceId;
         this.configs = List.copyOf(configs);
         this.aliases = Map.copyOf(aliases);
-        this.defaults = List.copyOf(defaults);
         this.strategies = List.copyOf(strategies);
         this.filters = List.copyOf(filters);
     }
@@ -69,15 +68,6 @@ public class PersistenceServiceConfiguration implements Identifiable<String> {
      */
     public Map<String, String> getAliases() {
         return aliases;
-    }
-
-    /**
-     * Get the default strategies.
-     *
-     * @return an unmodifiable list of the default strategies
-     */
-    public List<PersistenceStrategy> getDefaults() {
-        return defaults;
     }
 
     /**

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/registry/PersistenceServiceConfigurationDTOMapper.java
@@ -47,6 +47,7 @@ import org.openhab.core.persistence.strategy.PersistenceStrategy;
  *
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Implement aliases
+ * @author Mark Herwege - Make default strategy to be only a configuration suggestion
  */
 @NonNullByDefault
 public class PersistenceServiceConfigurationDTOMapper {
@@ -62,8 +63,6 @@ public class PersistenceServiceConfigurationDTOMapper {
         dto.configs = persistenceServiceConfiguration.getConfigs().stream()
                 .map(PersistenceServiceConfigurationDTOMapper::mapPersistenceItemConfig).toList();
         dto.aliases = Map.copyOf(persistenceServiceConfiguration.getAliases());
-        dto.defaults = persistenceServiceConfiguration.getDefaults().stream().map(PersistenceStrategy::getName)
-                .toList();
         dto.cronStrategies = filterList(persistenceServiceConfiguration.getStrategies(), PersistenceCronStrategy.class,
                 PersistenceServiceConfigurationDTOMapper::mapPersistenceCronStrategy);
         dto.thresholdFilters = filterList(persistenceServiceConfiguration.getFilters(),
@@ -92,9 +91,6 @@ public class PersistenceServiceConfigurationDTOMapper {
                         .map(f -> new PersistenceIncludeFilter(f.name, f.lower, f.upper, f.unit, f.inverted)))
                 .flatMap(Function.identity()).collect(Collectors.toMap(PersistenceFilter::getName, e -> e));
 
-        List<PersistenceStrategy> defaults = dto.defaults.stream()
-                .map(str -> stringToPersistenceStrategy(str, strategyMap, dto.serviceId)).toList();
-
         List<PersistenceItemConfiguration> configs = dto.configs.stream().map(config -> {
             List<PersistenceConfig> items = config.items.stream()
                     .map(PersistenceServiceConfigurationDTOMapper::stringToPersistenceConfig).toList();
@@ -107,7 +103,7 @@ public class PersistenceServiceConfigurationDTOMapper {
 
         Map<String, String> aliases = Map.copyOf(dto.aliases);
 
-        return new PersistenceServiceConfiguration(dto.serviceId, configs, aliases, defaults, strategyMap.values(),
+        return new PersistenceServiceConfiguration(dto.serviceId, configs, aliases, strategyMap.values(),
                 filterMap.values());
     }
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -575,7 +575,7 @@ public class PersistenceManagerTest {
                 : List.of(strategy);
 
         PersistenceServiceConfiguration serviceConfiguration = new PersistenceServiceConfiguration(serviceId,
-                List.of(itemConfiguration), Map.of(), List.of(), strategies, filters);
+                List.of(itemConfiguration), Map.of(), strategies, filters);
         manager.added(serviceConfiguration);
 
         return serviceConfiguration;


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4470

This is a breaking change.

With this PR, the default persistence strategy is not applied automatically anymore when no other strategy is defined.

The `PersistenceService` interface still keeps the `getDefaultStrategies` method. Therefore no change is required in the persistence services implementations. But rather than applying this automatically, these  default strategies are now considered configuration suggestions.

An extra sub-endpoint to the `persistence` REST API endpoint is defined to retrieve these strategy suggestions (`GET persistence/strategysuggestions/{serviceId}`). This endpoint can be used by the UI to suggest strategies when configuring the service. Applying these suggestions will then become a clear user decision.

File based persistence configurations will have to be changed by the user if they use the default strategies.

To complete this functionality, the following is also needed:

- [ ] Breaking change notice (openhab-distro)
- [ ] Adapt the UI (openhab-web): remove default strategies and suggest when configuring, make setting a strategy required for the persistence configuration
- [ ] Upgrade logic for managed persistence configurations: if no strategies are defined, add the suggested ones to the configuration
- [ ] Change documentation

This PR should not be merged without the above also being available.