### PR TITLE
OAuth RFC-8628 various post-fixes

### DIFF
--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -297,18 +297,18 @@ public class OAuthClientServiceImpl implements OAuthClientService {
         if (isClosed()) {
             throw new OAuthException(EXCEPTION_MESSAGE_CLOSED);
         }
-        return refreshTokenInner(false);
+        return refreshTokenInner(true);
     }
 
     /**
-     * Inner private method for refreshToken. If 'allowUnexpired' is true then only fetch a new token if
-     * the prior token is not expired, otherwise return the prior token. If 'allowUnexpired' is false
+     * Inner private method for refreshToken. If 'forceRefresh' is false then only fetch a new token if
+     * the prior token is not expired, otherwise return the prior token. If 'forceRefresh' is true
      * then always fetch a new token.
      *
-     * @param allowUnexpired determines whether to check token expiry
+     * @param forceRefresh determines whether to force a refresh or check for token expiry
      * @return either the prior AccessTokenResponse or a new one
      */
-    private AccessTokenResponse refreshTokenInner(boolean allowUnexpired)
+    private AccessTokenResponse refreshTokenInner(boolean forceRefresh)
             throws OAuthException, IOException, OAuthResponseException {
         AccessTokenResponse accessTokenResponse = null;
 
@@ -331,7 +331,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
                 throw new OAuthException("tokenUrl is required but null");
             }
 
-            if (!allowUnexpired || lastAccessToken.isExpired(Instant.now(), tokenExpiresInSeconds)) {
+            if (forceRefresh || lastAccessToken.isExpired(Instant.now(), tokenExpiresInSeconds)) {
                 GsonBuilder gsonBuilder = this.gsonBuilder;
                 OAuthConnector connector = gsonBuilder == null ? new OAuthConnector(httpClientFactory, extraAuthFields)
                         : new OAuthConnector(httpClientFactory, extraAuthFields, gsonBuilder);
@@ -376,7 +376,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
 
         if (lastAccessToken.isExpired(Instant.now(), tokenExpiresInSeconds)
                 && lastAccessToken.getRefreshToken() != null) {
-            return refreshTokenInner(true);
+            return refreshTokenInner(false);
         }
         return lastAccessToken;
     }

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -23,6 +23,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Base64;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -61,6 +62,7 @@ import com.google.gson.JsonSyntaxException;
 public class OAuthConnector {
 
     private static final String HTTP_CLIENT_CONSUMER_NAME = "OAuthConnector";
+    private static final int TIMEOUT_SECONDS = 10;
 
     protected final HttpClientFactory httpClientFactory;
 
@@ -273,7 +275,8 @@ public class OAuthConnector {
     }
 
     private Request getMethod(HttpClient httpClient, String tokenUrl) {
-        Request request = httpClient.newRequest(tokenUrl).method(HttpMethod.POST);
+        Request request = httpClient.newRequest(tokenUrl).method(HttpMethod.POST).timeout(TIMEOUT_SECONDS,
+                TimeUnit.SECONDS);
         request.header(HttpHeader.ACCEPT, "application/json");
         request.header(HttpHeader.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
         return request;

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -48,6 +48,8 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 
 /**
@@ -89,6 +91,29 @@ public class OAuthConnector {
         this.extraFields = extraFields;
         gson = gsonBuilder.setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT)
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .registerTypeAdapter(OAuthResponseException.class,
+                        (JsonDeserializer<OAuthResponseException>) (json, typeOfT, context) -> {
+                            OAuthResponseException result = new OAuthResponseException();
+                            JsonObject jsonObject = json.getAsJsonObject();
+                            JsonElement jsonElement;
+                            jsonElement = jsonObject.get("error");
+                            if (jsonElement != null) {
+                                result.setError(jsonElement.getAsString());
+                            }
+                            jsonElement = jsonObject.get("error_description");
+                            if (jsonElement != null) {
+                                result.setErrorDescription(jsonElement.getAsString());
+                            }
+                            jsonElement = jsonObject.get("error_uri");
+                            if (jsonElement != null) {
+                                result.setErrorUri(jsonElement.getAsString());
+                            }
+                            jsonElement = jsonObject.get("state");
+                            if (jsonElement != null) {
+                                result.setState(jsonElement.getAsString());
+                            }
+                            return result;
+                        })
                 .registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (json, typeOfT, context) -> {
                     try {
                         return Instant.parse(json.getAsString());

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorRFC8628.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorRFC8628.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * The {@link OAuthConnectorRFC8628} extends {@link OAuthConnector} to implement
@@ -292,9 +293,10 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
         request.param(PARAM_SCOPE, scopeParameter);
         logger.trace("fetchDeviceCodeResponse() request: {}", request.getURI());
 
+        String content = null;
         try {
             ContentResponse response = request.send();
-            String content = response.getContentAsString();
+            content = response.getContentAsString();
             logger.trace("fetchDeviceCodeResponse() response: {}", content);
 
             if (response.getStatus() == HttpStatus.OK_200) {
@@ -310,6 +312,9 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
                 }
             }
             throw new OAuthException("fetchDeviceCodeResponse() error: " + response);
+        } catch (JsonSyntaxException e) {
+            logger.warn("fetchDeviceCodeResponse() error parsing content:{}", content);
+            throw new OAuthException("fetchDeviceCodeResponse() error", e);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             throw new OAuthException("fetchDeviceCodeResponse() error", e);
         }
@@ -341,9 +346,10 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
         request.param(PARAM_DEVICE_CODE, dcr.getDeviceCode());
         logger.trace("fetchAccessTokenResponse() request: {}", request.getURI());
 
+        String content = null;
         try {
             ContentResponse response = request.send();
-            String content = response.getContentAsString();
+            content = response.getContentAsString();
             logger.trace("fetchAccessTokenResponse() response: {}", content);
 
             switch (response.getStatus()) {
@@ -367,6 +373,9 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
              * completed the verification process
              */
             return null;
+        } catch (JsonSyntaxException e) {
+            logger.warn("fetchAccessTokenResponse() error parsing content:{}", content);
+            throw new OAuthException("fetchAccessTokenResponse() error", e);
         } catch (InterruptedException | TimeoutException | ExecutionException e) {
             throw new OAuthException("fetchAccessTokenResponse() error", e);
         }


### PR DESCRIPTION
Relates to #4698 

This PR contains the following post-fixes..
- Add a timeout to OAuth HTTP calls
- Eliminate thread-lock on notification call-backs
- Fix deserialization of OAuthResponseException JSON
- Catch JSON syntax errors

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>