### PR TITLE
Fix UPNP support to handle embededd devices

### DIFF
--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -149,6 +149,10 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     protected void startScan() {
         for (RemoteDevice device : upnpService.getRegistry().getRemoteDevices()) {
             remoteDeviceAdded(upnpService.getRegistry(), device);
+
+            for (RemoteDevice childDevice : device.getEmbeddedDevices()) {
+                remoteDeviceAdded(upnpService.getRegistry(), childDevice);
+            }
         }
         upnpService.getRegistry().addListener(this);
         upnpService.getControlPoint().search();

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -216,7 +216,7 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
     }
 
     private Device getDevice(UpnpIOParticipant participant) {
-        return upnpService.getRegistry().getDevice(new UDN(participant.getUDN()), true);
+        return upnpService.getRegistry().getDevice(new UDN(participant.getUDN()), false);
     }
 
     @Override
@@ -354,7 +354,7 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
 
     @Override
     public boolean isRegistered(UpnpIOParticipant participant) {
-        return upnpService.getRegistry().getDevice(new UDN(participant.getUDN()), true) != null;
+        return upnpService.getRegistry().getDevice(new UDN(participant.getUDN()), false) != null;
     }
 
     @Override
@@ -508,6 +508,10 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
     @Override
     public void remoteDeviceAdded(Registry registry, RemoteDevice device) {
         informParticipants(device, true);
+
+        for (RemoteDevice childDevice : device.getEmbeddedDevices()) {
+            informParticipants(childDevice, true);
+        }
     }
 
     @Override
@@ -517,6 +521,10 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
     @Override
     public void remoteDeviceRemoved(Registry registry, RemoteDevice device) {
         informParticipants(device, false);
+
+        for (RemoteDevice childDevice : device.getEmbeddedDevices()) {
+            informParticipants(childDevice, false);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Fix UPNP support to handle embedded devices

# Description

As describe in issue #4711, the UPNP embedded device are today ignore in openhab code.
We need three modification to handle them:

- In discovery service, loop on the EmbeddedDevice collection to also handle there as discovery result.
- In UpnpIOServiceImpl, change call to getDevice, passing false instead of true to rootOnly parameter.
- In UpnpIOServiceImpl, change logic in remoteDeviceAdded and remoteDeviceRemoved to also handle embeddedDevice.


