### PR TITLE
Allow ThingHandlers to dynamically register services

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandlerFactory.java
@@ -161,6 +161,23 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         }
     }
 
+    /**
+     * Registers a dynamic service for the given thing handler. The service must implement ThingHandlerService.
+     * 
+     * @param thingHandler The thing handler requesting a service to be registered.
+     * @param klass The service class to register.
+     */
+    public void registerService(ThingHandler thingHandler, Class<? extends ThingHandlerService> klass) {
+        ThingUID thingUID = thingHandler.getThing().getUID();
+        if (!ThingHandlerService.class.isAssignableFrom(klass)) {
+            logger.warn(
+                    "Should register service={} for thingUID={}, but it does not implement the interface ThingHandlerService.",
+                    klass.getCanonicalName(), thingUID);
+            return;
+        }
+        registerThingHandlerService(thingUID, thingHandler, klass);
+    }
+
     private <T extends ThingHandlerService> void registerThingHandlerService(ThingUID thingUID,
             ThingHandler thingHandler, Class<T> c) {
         RegisteredThingHandlerService<T> registeredService;

--- a/pom.xml
+++ b/pom.xml
@@ -496,30 +496,6 @@ Import-Package: \\
         </plugin>
 
         <plugin>
-          <groupId>org.openhab.tools.sat</groupId>
-          <artifactId>sat-plugin</artifactId>
-          <version>${sat.version}</version>
-          <configuration>
-            <pmdFilter>${basedirRoot}/tools/static-code-analysis/pmd/suppressions.properties</pmdFilter>
-            <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
-            <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
-            <spotbugsExclude>${basedirRoot}/tools/static-code-analysis/spotbugs/suppressions.xml</spotbugsExclude>
-          </configuration>
-          <executions>
-            <execution>
-              <id>sat-all</id>
-              <goals>
-                <goal>checkstyle</goal>
-                <goal>pmd</goal>
-                <goal>spotbugs</goal>
-                <goal>report</goal>
-              </goals>
-              <phase>verify</phase>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,30 @@ Import-Package: \\
         </plugin>
 
         <plugin>
+          <groupId>org.openhab.tools.sat</groupId>
+          <artifactId>sat-plugin</artifactId>
+          <version>${sat.version}</version>
+          <configuration>
+            <pmdFilter>${basedirRoot}/tools/static-code-analysis/pmd/suppressions.properties</pmdFilter>
+            <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
+            <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
+            <spotbugsExclude>${basedirRoot}/tools/static-code-analysis/spotbugs/suppressions.xml</spotbugsExclude>
+          </configuration>
+          <executions>
+            <execution>
+              <id>sat-all</id>
+              <goals>
+                <goal>checkstyle</goal>
+                <goal>pmd</goal>
+                <goal>spotbugs</goal>
+                <goal>report</goal>
+              </goals>
+              <phase>verify</phase>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless.version}</version>


### PR DESCRIPTION
This is needed for dynamic things like Home Assistant devices that may or may not have particular services available, and it's not known until the thing has be initialized if that is the case. See also https://github.com/openhab/openhab-addons/issues/17992