### PR TITLE
Make `expire` support days, ISO8601 Duration and fully configurable through metadata configuration map

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -14,6 +14,7 @@ package org.openhab.core.internal.items;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -294,6 +295,8 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
         static final String CONFIG_STATE = "state";
         static final String CONFIG_IGNORE_STATE_UPDATES = "ignoreStateUpdates";
         static final String CONFIG_IGNORE_COMMANDS = "ignoreCommands";
+        static final Set<String> CONFIG_KEYS = Set.of(CONFIG_DURATION, CONFIG_COMMAND, CONFIG_STATE,
+                CONFIG_IGNORE_STATE_UPDATES, CONFIG_IGNORE_COMMANDS);
 
         private static final StringType STRING_TYPE_NULL_HYPHEN = new StringType("'NULL'");
         private static final StringType STRING_TYPE_NULL = new StringType("NULL");
@@ -419,6 +422,13 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
                 // default is to post Undefined state
                 expireCommand = null;
                 expireState = UnDefType.UNDEF;
+            }
+
+            if (!CONFIG_KEYS.containsAll(configuration.keySet())) {
+                Set<String> unknownKeys = new HashSet<String>(configuration.keySet());
+                unknownKeys.removeAll(CONFIG_KEYS);
+                throw new IllegalArgumentException(
+                        "Expire configuration for item " + item.getName() + " contains unknown keys: " + unknownKeys);
             }
         }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -339,7 +339,8 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
          * @param item the item to which we are bound
          * @param configString the string that the user specified in the metadata
          * @param configuration the configuration map
-         * @throws IllegalArgumentException if it is ill-formatted
+         * @throws IllegalArgumentException if it is ill-formatted, or the configuration contains an unknown key,
+         *             or any setting is specified more than once
          */
         public ExpireConfig(Item item, String configString, Map<String, Object> configuration)
                 throws IllegalArgumentException {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -359,6 +359,10 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
 
             durationString = durationStr;
             duration = parseDuration(durationString);
+            if (duration.isNegative()) {
+                throw new IllegalArgumentException(
+                        "Expire duration for item " + item.getName() + " must be a positive value");
+            }
 
             String stateOrCommand = ((commaPos >= 0) && (configString.length() - 1) > commaPos)
                     ? configString.substring(commaPos + 1).trim()

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -390,40 +390,24 @@ class ExpireManagerTest {
     }
 
     @Test
-    void testValueVsConfigPrecedence() {
+    void testValueVsConfigMix() {
         Item testItem = new SwitchItem(ITEMNAME);
 
-        ExpireConfig cfg = new ExpireManager.ExpireConfig(testItem, "1h", Map.of("duration", "2h"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h,state=ON", Map.of("state", "OFF"));
-        assertEquals(OnOffType.ON, cfg.expireState);
-        assertNull(cfg.expireCommand);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h,state=ON", Map.of("command", "OFF"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-        assertEquals(OnOffType.ON, cfg.expireState);
-        assertNull(cfg.expireCommand);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h,command=ON", Map.of("command", "OFF"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-        assertEquals(OnOffType.ON, cfg.expireCommand);
-        assertNull(cfg.expireState);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h,command=ON", Map.of("state", "OFF"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-        assertEquals(OnOffType.ON, cfg.expireCommand);
-        assertNull(cfg.expireState);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h,command=ON", Map.of("command", "OFF", "state", "OFF"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-        assertEquals(OnOffType.ON, cfg.expireCommand);
-        assertNull(cfg.expireState);
-
-        cfg = new ExpireManager.ExpireConfig(testItem, "1h", Map.of("command", "ON", "state", "OFF"));
-        assertEquals(Duration.ofHours(1), cfg.duration);
-        assertEquals(OnOffType.ON, cfg.expireCommand);
-        assertNull(cfg.expireState);
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h", Map.of("duration", "1h")));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h,state=ON", Map.of("state", "ON")));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h,state=ON", Map.of("command", "ON")));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h,command=ON", Map.of("command", "ON")));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h,command=ON", Map.of("state", "ON")));
+        assertThrows(IllegalArgumentException.class, //
+                () -> new ExpireManager.ExpireConfig(testItem, "1h,command=ON",
+                        Map.of("command", "ON", "state", "ON")));
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h", Map.of("command", "ON", "state", "ON")));
     }
 
     private Metadata config(String metadata) {

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -445,6 +445,13 @@ class ExpireManagerTest {
                 () -> new ExpireManager.ExpireConfig(testItem, "1h", Map.of("unknownKey", "unknownValue")));
     }
 
+    @Test
+    void testNegativeDuration() {
+        Item testItem = new SwitchItem(ITEMNAME);
+        assertThrows(IllegalArgumentException.class, () -> new ExpireManager.ExpireConfig(testItem, "-1h", Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> new ExpireManager.ExpireConfig(testItem, "-PT1H", Map.of()));
+    }
+
     private Metadata config(String metadata) {
         return new Metadata(METADATA_KEY, metadata, null);
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -277,7 +277,35 @@ class ExpireManagerTest {
         assertFalse(cfg.ignoreStateUpdates);
         assertFalse(cfg.ignoreCommands);
 
+        cfg = new ExpireManager.ExpireConfig(testItem, "7d 5h 3m 2s", Map.of());
+        assertEquals(Duration.ofDays(7).plusHours(5).plusMinutes(3).plusSeconds(2), cfg.duration);
+        assertEquals(UnDefType.UNDEF, cfg.expireState);
+        assertNull(cfg.expireCommand);
+        assertFalse(cfg.ignoreStateUpdates);
+        assertFalse(cfg.ignoreCommands);
+
+        cfg = new ExpireManager.ExpireConfig(testItem, "PT5H3M2S", Map.of());
+        assertEquals(Duration.ofHours(5).plusMinutes(3).plusSeconds(2), cfg.duration);
+        assertEquals(UnDefType.UNDEF, cfg.expireState);
+        assertNull(cfg.expireCommand);
+        assertFalse(cfg.ignoreStateUpdates);
+        assertFalse(cfg.ignoreCommands);
+
+        cfg = new ExpireManager.ExpireConfig(testItem, "P7DT5H3M2S", Map.of());
+        assertEquals(Duration.ofDays(7).plusHours(5).plusMinutes(3).plusSeconds(2), cfg.duration);
+        assertEquals(UnDefType.UNDEF, cfg.expireState);
+        assertNull(cfg.expireCommand);
+        assertFalse(cfg.ignoreStateUpdates);
+        assertFalse(cfg.ignoreCommands);
+
         cfg = new ExpireManager.ExpireConfig(testItem, "", Map.of("duration", "5h 3m 2s"));
+        assertEquals(Duration.ofHours(5).plusMinutes(3).plusSeconds(2), cfg.duration);
+        assertEquals(UnDefType.UNDEF, cfg.expireState);
+        assertNull(cfg.expireCommand);
+        assertFalse(cfg.ignoreStateUpdates);
+        assertFalse(cfg.ignoreCommands);
+
+        cfg = new ExpireManager.ExpireConfig(testItem, "", Map.of("duration", "PT5H3M2S"));
         assertEquals(Duration.ofHours(5).plusMinutes(3).plusSeconds(2), cfg.duration);
         assertEquals(UnDefType.UNDEF, cfg.expireState);
         assertNull(cfg.expireCommand);

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -438,6 +438,13 @@ class ExpireManagerTest {
                 () -> new ExpireManager.ExpireConfig(testItem, "1h", Map.of("command", "ON", "state", "ON")));
     }
 
+    @Test
+    void testUnknownConfigKeys() {
+        Item testItem = new SwitchItem(ITEMNAME);
+        assertThrows(IllegalArgumentException.class,
+                () -> new ExpireManager.ExpireConfig(testItem, "1h", Map.of("unknownKey", "unknownValue")));
+    }
+
     private Metadata config(String metadata) {
         return new Metadata(METADATA_KEY, metadata, null);
     }


### PR DESCRIPTION
- Enrich duration format:

  - Duration format supports days e.g. `1d3h`
  - Supports ISO8601 Duration syntax e.g. `P1DT3H`

- Support configuring the expire manager through the metadata configuration map by adding:

  - `duration`: "1h 1m 1s"
  - `command`: ON
  - `state`: ON

- Fully backwards compatible. The old way of specifying expire value `1h5m,command=OFF` is still supported
- Specifying any setting (duration, command, state) in both value and metadata config will raise an error
- Specifying both command and state in the configuration will raise an error



