### PR TITLE
Shorten logging of timeseries updates

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
@@ -60,6 +60,6 @@ public class ItemTimeSeriesEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' shall process timeseries %s", itemName, timeSeries.getStates().toList());
+        return String.format("Item '%s' shall process timeseries with %d values.", itemName, timeSeries.size());
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
@@ -60,6 +60,6 @@ public class ItemTimeSeriesUpdatedEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' updated timeseries %s", itemName, timeSeries.getStates().toList());
+        return String.format("Item '%s' updated timeseries with %d values.", itemName, timeSeries.size());
     }
 }


### PR DESCRIPTION
When time series are updated, the event log files are flooded with values, which does not really help readibility - I would think that it is enough to state the number of elements, but not all the individual objects.
