### PR TITLE
Add stack trace to logger DTO

### DIFF
--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogDTO.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogDTO.java
@@ -30,15 +30,17 @@ public class LogDTO implements Comparable<LogDTO> {
     public Date timestamp;
     public long unixtime;
     public String message;
+    public String stackTrace;
     public long sequence;
 
-    public LogDTO(long sequence, String loggerName, LogLevel level, long unixtime, String message) {
+    public LogDTO(long sequence, String loggerName, LogLevel level, long unixtime, String message, String stackTrace) {
         this.sequence = sequence;
         this.loggerName = loggerName;
         this.level = level;
         this.timestamp = new Date(unixtime);
         this.unixtime = unixtime;
         this.message = message;
+        this.stackTrace = stackTrace;
     }
 
     @Override

--- a/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
+++ b/bundles/org.openhab.core.io.websocket/src/main/java/org/openhab/core/io/websocket/log/LogWebSocket.java
@@ -13,6 +13,8 @@
 package org.openhab.core.io.websocket.log;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -265,8 +267,18 @@ public class LogWebSocket implements LogListener {
     }
 
     private LogDTO map(LogEntry logEntry) {
+        String stackTrace;
+        if (logEntry.getException() != null) {
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            logEntry.getException().printStackTrace(pw);
+            stackTrace = sw.toString();
+        } else {
+            stackTrace = "";
+        }
+
         return new LogDTO(logEntry.getSequence(), logEntry.getLoggerName(), logEntry.getLogLevel(), logEntry.getTime(),
-                logEntry.getMessage());
+                logEntry.getMessage(), stackTrace);
     }
 
     private void stopDeferredScheduledFuture() {


### PR DESCRIPTION
This PR adds the stack trace to logger messages so it can be displayed in the UI. It separately adds the stack trace to the DTO since it was kept separate in the `LogEntry`.

https://github.com/openhab/openhab-webui/pull/3160
https://github.com/openhab/openhab-webui/issues/2961

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/78162b9d-8cf3-4fa0-880b-1a2c05811299" />

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
