### PR TITLE
Fix groupItem restore

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -141,7 +141,8 @@ public class GroupItem extends GenericItem implements StateChangeListener, Metad
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllStateMembers() {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(getStateMembers(getMembers())));
+        return Collections.unmodifiableSet(
+                new LinkedHashSet<>(getMembers((Item i) -> !(i instanceof GroupItem) || hasOwnState((GroupItem) i))));
     }
 
     private void collectMembers(Collection<Item> allMembers, Collection<Item> members) {


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4736
Closes https://github.com/openhab/openhab-addons/issues/18586

Regression of https://github.com/openhab/openhab-core/pull/4651

For group items with an aggregation function (state), nested items where not persisted and restored. These nested items where missed when building the list of items to persist/restore. It did work well when the group item did not have a state.