### PR TITLE
Enable semantic tag description translations

### DIFF
--- a/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
+++ b/bundles/org.openhab.core.semantics/model/generateTagClasses.groovy
@@ -96,6 +96,10 @@ def appendLabelsFile(FileWriter file, def line, String tagSet) {
         file.write("," + line.Synonyms.replaceAll(", ", ","))
     }
     file.write("\n")
+    if (line.Description) {
+        file.write(tagSet + "__description=" + line.Description)
+        file.write("\n")
+    }
 }
 
 def camelToUpperCasedSnake(def tag) {

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticTagImpl.java
@@ -112,6 +112,7 @@ public class SemanticTagImpl implements SemanticTag {
                 Control.getNoFallbackControl(Control.FORMAT_PROPERTIES));
         String label;
         List<String> synonyms;
+        String description;
         try {
             String entry = rb.getString(uid);
             int idx = entry.indexOf(",");
@@ -127,7 +128,12 @@ public class SemanticTagImpl implements SemanticTag {
             label = getLabel();
             synonyms = getSynonyms();
         }
+        try {
+            description = rb.getString(uid + "__description");
+        } catch (MissingResourceException e) {
+            description = getDescription();
+        }
 
-        return new SemanticTagImpl(uid, label, getDescription(), synonyms);
+        return new SemanticTagImpl(uid, label, description, synonyms);
     }
 }

--- a/bundles/org.openhab.core.semantics/src/main/resources/tags.properties
+++ b/bundles/org.openhab.core.semantics/src/main/resources/tags.properties
@@ -1,5 +1,6 @@
 # Generated content - do not edit!
 Location_Indoor=Indoor
+Location_Indoor__description=Anything that is inside a closed building
 Location_Indoor_Apartment=Apartment,Apartments
 Location_Indoor_Building=Building,Buildings
 Location_Indoor_Building_Garage=Garage,Garages
@@ -54,6 +55,7 @@ Property_AirQuality_VOC=VOC,Volatile Organic Compounds
 Property_Airconditioning=Airconditioning
 Property_Airflow=Airflow
 Property_App=App,Application
+Property_App__description=Software program
 Property_Brightness=Brightness
 Property_Channel=Channel
 Property_Color=Color


### PR DESCRIPTION
With all the work being done on adding better semantic tags, I was looking at making the semantic tag descriptions available in the UI, to help the user in deciding what tag to use.
It turned out very few had descriptions in the first place, and they cannot be localized.

This PR adds the ability to localize the semantic tag descriptions.

I would think an effort should be made to give the semantic tags relevant descriptions that help the user to understand what tag to use when. I think the best people to do that are also the ones that worked on changing and adding the semantic tags. @andrewfg @jimtng and others?

I intend to enhance the UI to make these descriptions visible when available. They are already in the the semantic tag maintenance UI proposed in https://github.com/openhab/openhab-webui/pull/3165.