### PR TITLE
Yaml Model Repository: Include `.yaml` in log messages

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -147,14 +147,11 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public synchronized void processWatchEvent(Kind kind, Path path) {
         Path fullPath = watchPath.resolve(path);
-        String pathString = path.toString();
-        if (path.startsWith("automation") || !pathString.endsWith(".yaml")) {
+        String modelName = path.toString();
+        if (path.startsWith("automation") || !modelName.endsWith(".yaml")) {
             logger.trace("Ignored {}", fullPath);
             return;
         }
-
-        // strip extension for model name
-        String modelName = pathString.substring(0, pathString.lastIndexOf("."));
 
         try {
             if (kind == WatchService.Kind.DELETE) {
@@ -586,7 +583,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         }
 
         try {
-            Path outFile = watchPath.resolve(modelName + ".yaml");
+            Path outFile = watchPath.resolve(modelName);
             String fileContent = objectMapper.writeValueAsString(rootNode);
             if (Files.exists(outFile) && !Files.isWritable(outFile)) {
                 logger.warn("Failed writing model {}: model exists but is read-only.", modelName);

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
@@ -56,10 +56,10 @@ import org.yaml.snakeyaml.Yaml;
 @NonNullByDefault
 public class YamlModelRepositoryImplTest {
     private static final Path SOURCE_PATH = Path.of("src/test/resources/model");
-    private static final String MODEL_NAME = "model";
-    private static final Path MODEL_PATH = Path.of(MODEL_NAME + ".yaml");
-    private static final String MODEL2_NAME = "model2";
-    private static final Path MODEL2_PATH = Path.of(MODEL2_NAME + ".yaml");
+    private static final String MODEL_NAME = "model.yaml";
+    private static final Path MODEL_PATH = Path.of(MODEL_NAME);
+    private static final String MODEL2_NAME = "model2.yaml";
+    private static final Path MODEL2_PATH = Path.of(MODEL2_NAME);
 
     private @Mock @NonNullByDefault({}) WatchService watchServiceMock;
     private @TempDir @NonNullByDefault({}) Path watchPath;


### PR DESCRIPTION
Make the log messages include the .yaml extension, e.g.

```
2025-04-25 17:19:03.757 [INFO ] [aml.internal.YamlModelRepositoryImpl] - Adding YAML model things/test.yaml
2025-04-25 17:19:03.770 [WARN ] [aml.internal.YamlModelRepositoryImpl] - Version is missing or not a number in model things/test.yaml. Ignoring it.
```

It is even more important to include the extension in other messages such as:
https://github.com/openhab/openhab-core/blob/685264295c62f5e8179d36ba06b60aa55cc9115f/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java#L200
https://github.com/openhab/openhab-core/blob/685264295c62f5e8179d36ba06b60aa55cc9115f/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java#L274-L276
https://github.com/openhab/openhab-core/blob/685264295c62f5e8179d36ba06b60aa55cc9115f/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java#L301
https://github.com/openhab/openhab-core/blob/685264295c62f5e8179d36ba06b60aa55cc9115f/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java#L326-L327

... and a few more

See https://github.com/openhab/openhab-core/issues/3666#issuecomment-2829347883

This makes it consistent with the other messages, e.g.

```
2025-04-25 17:36:20.580 [INFO ] [el.core.internal.ModelRepositoryImpl] - Loading model 'test.items'
2025-04-25 17:36:43.542 [INFO ] [el.core.internal.ModelRepositoryImpl] - Loading model 'test.rules'
2025-04-25 17:36:57.970 [INFO ] [el.core.internal.ModelRepositoryImpl] - Loading model 'test.things'
2025-04-25 17:37:35.365 [INFO ] [el.core.internal.ModelRepositoryImpl] - Loading model 'test.script'
2025-04-25 17:37:48.331 [INFO ] [el.core.internal.ModelRepositoryImpl] - Loading model 'test.sitemap'
```

