### PR TITLE
YAMLThing: fix typo and minor refactor

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
@@ -33,9 +33,9 @@ import org.openhab.core.model.yaml.internal.util.YamlElementUtils;
 @YamlElementName("things")
 public class YamlThingDTO implements YamlElement, Cloneable {
 
-    private static final Pattern THING_UID_SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z0-9_][a-zA-Z0-9_-]*$");
+    private static final Pattern THING_UID_SEGMENT_PATTERN = Pattern.compile("[a-zA-Z0-9_][a-zA-Z0-9_-]*");
     private static final Pattern CHANNEL_ID_PATTERN = Pattern
-            .compile("^[a-zA-Z0-9_][a-zA-Z0-9_-]*(#[a-zA-Z0-9_][a-zA-Z0-9_-]*)?$");
+            .compile("[a-zA-Z0-9_][a-zA-Z0-9_-]*(#[a-zA-Z0-9_][a-zA-Z0-9_-]*)?");
 
     public String uid;
     public Boolean isBridge;
@@ -90,11 +90,10 @@ public class YamlThingDTO implements YamlElement, Cloneable {
             ok = false;
         }
         for (String segment : segments) {
-            if (!THING_UID_SEGMENT_PATTERN.matcher(segment).find()) {
+            if (!THING_UID_SEGMENT_PATTERN.matcher(segment).matches()) {
                 if (errors != null) {
-                    errors.add(
-                            "thing %s: segement \"%s\" in uid is not matching the expected syntax [a-zA-Z0-9_][a-zA-Z0-9_-]*"
-                                    .formatted(uid, segment));
+                    errors.add("thing %s: segment \"%s\" in uid is not matching the expected syntax %s".formatted(uid,
+                            segment, THING_UID_SEGMENT_PATTERN.pattern()));
                 }
                 ok = false;
             }
@@ -109,11 +108,10 @@ public class YamlThingDTO implements YamlElement, Cloneable {
                 ok = false;
             }
             for (String segment : segments) {
-                if (!THING_UID_SEGMENT_PATTERN.matcher(segment).find()) {
+                if (!THING_UID_SEGMENT_PATTERN.matcher(segment).matches()) {
                     if (errors != null) {
-                        errors.add(
-                                "thing %s: segement \"%s\" in bridge is not matching the expected syntax [a-zA-Z0-9_][a-zA-Z0-9_-]*"
-                                        .formatted(uid, segment));
+                        errors.add("thing %s: segment \"%s\" in bridge is not matching the expected syntax %s"
+                                .formatted(uid, segment, THING_UID_SEGMENT_PATTERN.pattern()));
                     }
                     ok = false;
                 }
@@ -122,11 +120,10 @@ public class YamlThingDTO implements YamlElement, Cloneable {
         if (channels != null) {
             for (Map.Entry<@NonNull String, @NonNull YamlChannelDTO> entry : channels.entrySet()) {
                 String channelId = entry.getKey();
-                if (!CHANNEL_ID_PATTERN.matcher(channelId).find()) {
+                if (!CHANNEL_ID_PATTERN.matcher(channelId).matches()) {
                     if (errors != null) {
-                        errors.add(
-                                "thing %s: channel id \"%s\" is not matching the expected syntax [a-zA-Z0-9_][a-zA-Z0-9_-]*(#[a-zA-Z0-9_][a-zA-Z0-9_-]*)?"
-                                        .formatted(uid, channelId));
+                        errors.add("thing %s: channel id \"%s\" is not matching the expected syntax %s".formatted(uid,
+                                channelId, CHANNEL_ID_PATTERN.pattern()));
                     }
                     ok = false;
                 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingProvider.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -176,7 +175,7 @@ public class YamlThingProvider extends AbstractProvider<Thing>
 
     @Override
     public Collection<Thing> getAll() {
-        return thingsMap.values().stream().flatMap(list -> list.stream()).collect(Collectors.toList());
+        return thingsMap.values().stream().flatMap(list -> list.stream()).toList();
     }
 
     @Override


### PR DESCRIPTION
The typo was `segement`.

@lolodomo