### PR TITLE
YAML Model Repository: Fix premature unknown element warning

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -41,6 +41,8 @@ import org.openhab.core.model.yaml.YamlElement;
 import org.openhab.core.model.yaml.YamlElementName;
 import org.openhab.core.model.yaml.YamlModelListener;
 import org.openhab.core.model.yaml.YamlModelRepository;
+import org.openhab.core.model.yaml.internal.semantics.YamlSemanticTagDTO;
+import org.openhab.core.model.yaml.internal.things.YamlThingDTO;
 import org.openhab.core.service.WatchService;
 import org.openhab.core.service.WatchService.Kind;
 import org.osgi.service.component.annotations.Activate;
@@ -84,7 +86,10 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     private static final int DEFAULT_MODEL_VERSION = 2;
     private static final String VERSION = "version";
     private static final String READ_ONLY = "readOnly";
-    private static final Set<String> KNOWN_ELEMENTS = Set.of("tags", "things");
+    private static final Set<String> KNOWN_ELEMENTS = Set.of( //
+            getElementName(YamlSemanticTagDTO.class), // "tags"
+            getElementName(YamlThingDTO.class) // "things"
+    );
 
     private final Logger logger = LoggerFactory.getLogger(YamlModelRepositoryImpl.class);
 
@@ -395,7 +400,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         }
     }
 
-    private String getElementName(Class<? extends YamlElement> elementClass) {
+    private static String getElementName(Class<? extends YamlElement> elementClass) {
         YamlElementName annotation = elementClass.getAnnotation(YamlElementName.class);
         if (annotation == null) {
             throw new IllegalStateException("Class " + elementClass.getName()

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -137,7 +137,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                 @Override
                 public FileVisitResult visitFileFailed(@NonNullByDefault({}) Path file,
                         @NonNullByDefault({}) IOException exc) throws IOException {
-                    logger.warn("Failed to process {}: {}", file.toAbsolutePath(), exc.getClass().getSimpleName());
+                    logger.warn("Failed to process {}: {}", file.toAbsolutePath(), exc.getMessage());
                     return FileVisitResult.CONTINUE;
                 }
             });

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -230,8 +230,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                     List<JsonNode> oldNodeV1Elements = model.getNodesV1().getOrDefault(elementName, List.of());
                     JsonNode oldNodeElements = model.getNodes().get(elementName);
 
-                    List<YamlModelListener<?>> elementListeners = getElementListeners(elementName, modelVersion);
-                    for (YamlModelListener<?> elementListener : elementListeners) {
+                    for (YamlModelListener<?> elementListener : getElementListeners(elementName, modelVersion)) {
                         Class<? extends YamlElement> elementClass = elementListener.getElementClass();
 
                         List<String> errors = new ArrayList<>();


### PR DESCRIPTION
Fix a problem introduced in #4749

Wait until all known elements are loaded before issuing warnings about unknown elements.

