### PR TITLE
YAML parser: filter unexpected part from the parse exception message

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -694,8 +694,10 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
             return Optional.of(objectMapper.treeToValue(node, elementClass));
         } catch (JsonProcessingException e) {
             if (errors != null) {
+                String msg = e.getMessage();
                 errors.add("Could not parse element %s to %s: %s".formatted(node.toPrettyString(),
-                        elementClass.getSimpleName(), e.getMessage()));
+                        elementClass.getSimpleName(),
+                        msg == null ? "" : msg.replace("at [Source: UNKNOWN; byte offset: #UNKNOWN] ", "")));
             }
             return Optional.empty();
         }
@@ -729,8 +731,10 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                         elt.setId(id);
                     } catch (JsonProcessingException e) {
                         if (errors != null) {
+                            String msg = e.getMessage();
                             errors.add("could not parse element %s to %s: %s".formatted(node.toPrettyString(),
-                                    elementClass.getSimpleName(), e.getMessage()));
+                                    elementClass.getSimpleName(), msg == null ? ""
+                                            : msg.replace("at [Source: UNKNOWN; byte offset: #UNKNOWN] ", "")));
                         }
                     }
                 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -84,6 +84,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     private static final String VERSION = "version";
     private static final String READ_ONLY = "readOnly";
 
+    private static final String UNWANTED_EXCEPTION_TEXT = "at [Source: UNKNOWN; byte offset: #UNKNOWN] ";
+
     private final Logger logger = LoggerFactory.getLogger(YamlModelRepositoryImpl.class);
 
     private final WatchService watchService;
@@ -696,8 +698,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
             if (errors != null) {
                 String msg = e.getMessage();
                 errors.add("Could not parse element %s to %s: %s".formatted(node.toPrettyString(),
-                        elementClass.getSimpleName(),
-                        msg == null ? "" : msg.replace("at [Source: UNKNOWN; byte offset: #UNKNOWN] ", "")));
+                        elementClass.getSimpleName(), msg == null ? "" : msg.replace(UNWANTED_EXCEPTION_TEXT, "")));
             }
             return Optional.empty();
         }
@@ -733,8 +734,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                         if (errors != null) {
                             String msg = e.getMessage();
                             errors.add("could not parse element %s to %s: %s".formatted(node.toPrettyString(),
-                                    elementClass.getSimpleName(), msg == null ? ""
-                                            : msg.replace("at [Source: UNKNOWN; byte offset: #UNKNOWN] ", "")));
+                                    elementClass.getSimpleName(),
+                                    msg == null ? "" : msg.replace(UNWANTED_EXCEPTION_TEXT, "")));
                         }
                     }
                 }


### PR DESCRIPTION
The text "at [Source: UNKNOWN; byte offset: #UNKNOWN] " is removed from the exception message before being logged.
