### PR TITLE
[GHA] Adapt rebuild

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,12 +11,10 @@ on:
       - 'main'
     paths-ignore:
       - '.github/**/*.md'
-    types: [opened,synchronize,reopened,labeled]
   workflow_dispatch:
 
 jobs:
   build:
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'labeled') || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'rebuild' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,0 +1,92 @@
+# This workflow can be used to trigger a rebuild of checks for a certain PR.
+#
+# Automatic triggering is based on PR labeled event.
+# The workflow will check if the new label is "rebuild".
+# It triggers up to 3 check runs taken from the PR and triggers all their jobs again, independent
+# of the previous status. (3 is an arbitrary number, it was just necessary to have more than one in
+# case there are different relevant workflows, e.g. build and codeql. This could be limited to
+# checks marked as "required" or "failed", but it seems better to trigger all).
+# The label "rebuild" is removed after the rebuild is triggered.
+#
+# It can be triggered manually, referencing a PR number (this is mainly for testing purposes).
+name: Rebuild PR
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to rebuild'
+        required: false
+        default: '0'
+      label:
+        description: 'Label to trigger rebuild'
+        required: false
+        default: 'rebuild'
+
+# grant permission
+# - actions:write to allow rerun
+# - PR:write to allow removing the label
+# - checks:write to allow setting build status
+permissions:
+  actions: write
+  checks: write
+  pull-requests: write
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_NUMBER: ${{ github.event.number || inputs.pr }}
+  LABEL: ${{ github.event.label.name || inputs.label }}
+  BASE: ${{ github.event.pull_request.base.repo.full_name || github.event.repository.full_name }}
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Info
+      env:
+        GITHUB: ${{ toJson(github) }}
+      run: |
+        echo "$GITHUB"
+
+    - name: Checkout
+      if: ${{ github.head_ref == '' && env.LABEL == 'rebuild' }}
+      uses: actions/checkout@v4
+
+    - name: Checkout merge
+      if: ${{ github.head_ref != '' && env.LABEL == 'rebuild' }}
+      uses: actions/checkout@v4
+      with:
+        ref: refs/pull/${{github.event.pull_request.number}}/merge
+
+    - name: List Jobs
+      if: ${{ env.LABEL == 'rebuild' }}
+      run: |
+        echo "Label: ${{ env.LABEL }}"
+        echo "PR: ${{ env.PR_NUMBER }}"
+        NUMBER=$(gh pr checks ${{ env.PR_NUMBER }} -R ${{ env.BASE }}|grep -v "^rebuild"| sed -E 's#.*/([0-9]+)/job/([0-9]+)#\1#'|grep -ve '[[:alpha:]]'|sort -nu|head -n3|xargs|tr '\n' ' ')
+        echo "Number of last 3 check jobs: $NUMBER"
+        echo "NUMBER=$NUMBER">>$GITHUB_ENV
+
+    - name: Trigger Rebuild
+      if: ${{ env.LABEL == 'rebuild' }}
+      env:
+        PR: ${{ env.PR_NUMBER }}
+        NUMBER: ${{ env.NUMBER }}
+      run: |
+        if [ -z "$NUMBER" ]; then
+          echo "Error: Previous check run not found, cannot rebuild"
+          exit 1
+        fi
+        for i in $(echo $NUMBER|tr ' ' '\n'); do
+          echo   "Rebuilding PR #$i"
+          gh run rerun $i || true
+        done
+
+    - name: Remove Label
+      if: ${{ always() && env.LABEL == 'rebuild' }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ env.PR_NUMBER }}
+      run: |
+        gh pr edit $PR --remove-label rebuild


### PR DESCRIPTION
* Move triggering rebuild on label to separate workflow

```
# This workflow can be used to trigger a rebuild of checks for a certain PR.
#
# Automatic triggering is based on PR labeled event.
# The workflow will check if the new label is "rebuild".
# It triggers up to 3 check runs taken from the PR and triggers all their jobs again, independent
# of the previous status. (3 is an arbitrary number, it was just necessary to have more than one in
# case there are different relevant workflows, e.g. build and codeql. This could be limited to
# checks marked as "required" or "failed", but it seems better to trigger all).
# The label "rebuild" is removed after the rebuild is triggered.
#
# It can be triggered manually, referencing a PR number (this is mainly for testing purposes).
```

* Grant permissions for removing label

Due to our default settings on this repo, changing PR labels is not possible from Actions:
```
Run gh pr edit $PR --remove-label rebuild
GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)
Error: Process completed with exit code 1.
```
This PR adds the necessary permissions for `GITHUB_TOKEN` used by the `gh` tool to remove the label.




<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").

ATTENTION: Don't use "git merge" when working with your pull request branch!
This can clutter your Git history and make your PR unusable.
Use "git rebase" instead. See this forum post for further details:
https://community.openhab.org/t/rebase-your-code-or-how-to-fix-your-git-history-before-requesting-a-pull/129358

All PRs should be created using the "main" branch as base.
Important bugfixes are cherry-picked by maintainers to the patch release branch after a PR has been merged.

If your PR's code is not backward compatible with previous releases (which
should be avoided), add a message to the release notes by filing another PR:
https://github.com/openhab/openhab-distro/blob/main/distributions/openhab/src/main/resources/bin/update.lst

# Title

Provide a short summary in the *Title* above. It will show up in the release notes.
For example:
- Introduce metadata for all add-ons
- Fix memory leak in ScriptedRuleProvider

# Description

Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the Core README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/guidelines.html
- Did you check for any (relevant) issues from the static code analysis?
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing.html#sign-your-work

If your pull request contains a new contribution, it will likely take some time
before it is reviewed and processed by maintainers.
-->
