### PR TITLE
Refactor to avoid possible null pointer dereference in YamlModelRepositoryImpl

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -292,11 +292,13 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                         }
 
                         List<JsonNode> removedNodes = e.getValue();
-                        getElementListeners(elementName, modelVersion).forEach(listener -> {
-                            List removedElements = parseJsonNodesV1(removedNodes, listener.getElementClass(), null,
-                                    null);
-                            listener.removedModel(modelName, removedElements);
-                        });
+                        if (removedNodes != null) {
+                            getElementListeners(elementName, modelVersion).forEach(listener -> {
+                                List removedElements = parseJsonNodesV1(removedNodes, listener.getElementClass(), null,
+                                        null);
+                                listener.removedModel(modelName, removedElements);
+                            });
+                        }
                         return true;
                     });
                 } else {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -285,25 +285,35 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
 
                 // remove removed elements
                 if (modelVersion == 1) {
-                    model.getNodesV1().keySet().stream().filter(e -> !newElementNames.contains(e))
-                            .forEach(removedElement -> {
-                                List<JsonNode> removedNodes = model.getNodesV1().remove(removedElement);
-                                getElementListeners(removedElement, modelVersion).forEach(listener -> {
-                                    List removedElements = parseJsonNodesV1(removedNodes, listener.getElementClass(),
-                                            null, null);
-                                    listener.removedModel(modelName, removedElements);
-                                });
-                            });
+                    model.getNodesV1().entrySet().removeIf(e -> {
+                        String elementName = e.getKey();
+                        if (newElementNames.contains(elementName)) {
+                            return false;
+                        }
+
+                        List<JsonNode> removedNodes = e.getValue();
+                        getElementListeners(elementName, modelVersion).forEach(listener -> {
+                            List removedElements = parseJsonNodesV1(removedNodes, listener.getElementClass(), null,
+                                    null);
+                            listener.removedModel(modelName, removedElements);
+                        });
+                        return true;
+                    });
                 } else {
-                    model.getNodes().keySet().stream().filter(e -> !newElementNames.contains(e))
-                            .forEach(removedElement -> {
-                                JsonNode removedNode = model.getNodes().remove(removedElement);
-                                getElementListeners(removedElement, modelVersion).forEach(listener -> {
-                                    List removedElements = parseJsonMapNode(removedNode, listener.getElementClass(),
-                                            null, null);
-                                    listener.removedModel(modelName, removedElements);
-                                });
-                            });
+                    model.getNodes().entrySet().removeIf(e -> {
+                        String elementName = e.getKey();
+                        if (newElementNames.contains(elementName)) {
+                            return false;
+                        }
+
+                        JsonNode removedNode = e.getValue();
+                        getElementListeners(elementName, modelVersion).forEach(listener -> {
+                            List removedElements = parseJsonMapNode(removedNode, listener.getElementClass(), null,
+                                    null);
+                            listener.removedModel(modelName, removedElements);
+                        });
+                        return true;
+                    });
                 }
 
                 checkElementNames(modelName, model);
@@ -315,6 +325,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         }
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void removeModel(String modelName) {
         YamlModelWrapper removedModel = modelCache.remove(modelName);
         if (removedModel == null) {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -362,7 +362,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     public void addYamlModelListener(YamlModelListener<? extends YamlElement> listener) {
         Class<? extends YamlElement> elementClass = listener.getElementClass();
         String elementName = getElementName(elementClass);
-        elementListeners.computeIfAbsent(elementName, k -> new CopyOnWriteArrayList<>()).add(listener);
+        Objects.requireNonNull(elementListeners.computeIfAbsent(elementName, k -> new CopyOnWriteArrayList<>()))
+                .add(listener);
 
         // iterate over all models and notify the new listener of already existing models with this type
         modelCache.forEach((modelName, model) -> {
@@ -437,8 +438,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         List<JsonNode> addedNodes = new ArrayList<>();
         JsonNode mapAddedNode = null;
         if (model.getVersion() == 1) {
-            List<JsonNode> modelNodes = model.getNodesV1().computeIfAbsent(elementName,
-                    k -> new CopyOnWriteArrayList<>());
+            List<JsonNode> modelNodes = Objects
+                    .requireNonNull(model.getNodesV1().computeIfAbsent(elementName, k -> new CopyOnWriteArrayList<>()));
             JsonNode newNode = objectMapper.convertValue(element, JsonNode.class);
             modelNodes.add(newNode);
             addedNodes.add(newNode);


### PR DESCRIPTION
@Nadahar see https://github.com/openhab/openhab-core/commit/f5f8921e14814b3e3e6f43e32a28d2cb8d9cd23d#r156317816

The compiler issued warnings about null type mismatch. There may be a small possibility that it would return null in case `modelCache`/`model` is modified elsewhere perhaps. This refactor removes that possibility and as a result the compiler no longer has a warning about it.

