### PR TITLE
YAML config files: restrict processed folders

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -90,7 +90,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
             getElementName(YamlSemanticTagDTO.class), // "tags"
             getElementName(YamlThingDTO.class) // "things"
     );
-    private static final Set<String> RESTRICTED_SUB_FOLDERS = Set.of("tags", "items", "things", "yaml");
+    private static final Set<Path> WATCHED_FOLDERS = Set.of(Path.of("tags"), Path.of("items"), Path.of("things"),
+            Path.of("yaml"));
 
     private static final String UNWANTED_EXCEPTION_TEXT = "at [Source: UNKNOWN; byte offset: #UNKNOWN] ";
 
@@ -166,8 +167,10 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     public synchronized void processWatchEvent(Kind kind, Path path) {
         Path fullPath = watchPath.resolve(path);
         String modelName = path.toString();
-        if (!modelName.endsWith(".yaml") || (!folderRestrictionIgnored
-                && !RESTRICTED_SUB_FOLDERS.stream().anyMatch(sf -> path.startsWith(sf)))) {
+        if (!folderRestrictionIgnored && !WATCHED_FOLDERS.stream().anyMatch(f -> path.startsWith(f))) {
+            return;
+        }
+        if (!modelName.endsWith(".yaml")) {
             logger.trace("Ignored {}", fullPath);
             return;
         }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
@@ -99,6 +99,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelV2FileAddedOrRemoved.yaml"), fullModel2Path);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
         modelRepository.addYamlModelListener(secondTypeListener1);
         modelRepository.addYamlModelListener(secondTypeListener2);
@@ -157,6 +158,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelV2FileAddedOrRemoved.yaml"), fullModel2Path);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
 
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL2_PATH);
@@ -213,6 +215,7 @@ public class YamlModelRepositoryImplTest {
     @Test
     public void testFileUpdated() throws IOException {
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         // File in v1 format
@@ -278,6 +281,7 @@ public class YamlModelRepositoryImplTest {
     })
     public void testFileRemovedElements(String v1File, String v2File) throws IOException {
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         // File in v1 format
@@ -317,7 +321,7 @@ public class YamlModelRepositoryImplTest {
     @Test
     public void testFileRemoved() throws IOException {
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
-
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         // File in v1 format
@@ -365,6 +369,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modifyModelInitialContent.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
         modelRepository.addYamlModelListener(secondTypeListener1);
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
@@ -423,6 +428,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modifyModelInitialContent.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
 
@@ -464,6 +470,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modifyModelInitialContent.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
 
         FirstTypeDTO removed = new FirstTypeDTO("element1", "description1");
@@ -505,6 +512,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelFileAddedOrRemoved.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
 
         FirstTypeDTO added = new FirstTypeDTO("element3", "description3");
@@ -544,6 +552,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelFileAddedOrRemoved.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
@@ -568,6 +577,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelFileAddedOrRemoved.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
@@ -592,6 +602,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelFileAddedOrRemoved.yaml"), fullModelPath);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(firstTypeListener);
 
         modelRepository.processWatchEvent(WatchService.Kind.CREATE, MODEL_PATH);
@@ -616,6 +627,7 @@ public class YamlModelRepositoryImplTest {
         Files.copy(SOURCE_PATH.resolve("modelV2FileAddedOrRemoved.yaml"), fullModel2Path);
 
         YamlModelRepositoryImpl modelRepository = new YamlModelRepositoryImpl(watchServiceMock);
+        modelRepository.ignoreFolderRestriction();
         modelRepository.addYamlModelListener(secondTypeListener1);
         modelRepository.addYamlModelListener(secondTypeListener2);
 


### PR DESCRIPTION
YAML files will be processed by the OH YAML model repository only if the file is inside one of these folders:
- conf/tags/
- conf/items/
- conf/things/
- conf/yaml/

Files can be in a sub-foder of these folders, whatever the depth.

Related to #3666
