### PR TITLE
Yaml Model: restrict the watched folders to `things`, `items`, `tags`, and `yaml`; support both '.yaml' and '.yml' extensions

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -166,7 +166,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     public synchronized void processWatchEvent(Kind kind, Path fullPath) {
         Path relativePath = mainWatchPath.relativize(fullPath);
         String modelName = relativePath.toString();
-        if (!modelName.endsWith(".yaml")) {
+        if (!modelName.endsWith(".yaml") && !modelName.endsWith(".yml")) {
             logger.trace("Ignored {}", fullPath);
             return;
         }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -93,10 +94,12 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
 
     private static final String UNWANTED_EXCEPTION_TEXT = "at [Source: UNKNOWN; byte offset: #UNKNOWN] ";
 
+    private static final List<Path> WATCHED_PATHS = Stream.of("things", "items", "tags", "yaml").map(Path::of).toList();
+
     private final Logger logger = LoggerFactory.getLogger(YamlModelRepositoryImpl.class);
 
     private final WatchService watchService;
-    private final Path watchPath;
+    private final Path mainWatchPath;
     private final ObjectMapper objectMapper;
 
     private final Map<String, List<YamlModelListener<?>>> elementListeners = new ConcurrentHashMap<>();
@@ -120,31 +123,36 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         objectMapper.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
 
         this.watchService = watchService;
-        watchService.registerListener(this, Path.of(""));
-        watchPath = watchService.getWatchPath();
+        this.mainWatchPath = watchService.getWatchPath();
+
+        watchService.registerListener(this, WATCHED_PATHS);
 
         // read initial contents
-        try {
-            Files.walkFileTree(watchPath, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult visitFile(@NonNullByDefault({}) Path file,
-                        @NonNullByDefault({}) BasicFileAttributes attrs) throws IOException {
-                    if (attrs.isRegularFile()) {
-                        processWatchEvent(CREATE, file);
+        WATCHED_PATHS.forEach(watchPath -> {
+            Path fullPath = mainWatchPath.resolve(watchPath);
+            try {
+                Files.walkFileTree(fullPath, new SimpleFileVisitor<>() {
+                    @Override
+                    public FileVisitResult visitFile(@NonNullByDefault({}) Path file,
+                            @NonNullByDefault({}) BasicFileAttributes attrs) throws IOException {
+                        if (attrs.isRegularFile()) {
+                            processWatchEvent(CREATE, file);
+                        }
+                        return FileVisitResult.CONTINUE;
                     }
-                    return FileVisitResult.CONTINUE;
-                }
 
-                @Override
-                public FileVisitResult visitFileFailed(@NonNullByDefault({}) Path file,
-                        @NonNullByDefault({}) IOException exc) throws IOException {
-                    logger.warn("Failed to process {}: {}", file.toAbsolutePath(), exc.getMessage());
-                    return FileVisitResult.CONTINUE;
-                }
-            });
-        } catch (IOException e) {
-            logger.warn("Could not list YAML files in '{}', models might be missing: {}", watchPath, e.getMessage());
-        }
+                    @Override
+                    public FileVisitResult visitFileFailed(@NonNullByDefault({}) Path file,
+                            @NonNullByDefault({}) IOException exc) throws IOException {
+                        logger.warn("Failed to process {}: {}", file.toAbsolutePath(), exc.getMessage());
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            } catch (IOException e) {
+                logger.warn("Could not list YAML files in '{}', models might be missing: {}", watchPath,
+                        e.getMessage());
+            }
+        });
     }
 
     @Deactivate
@@ -156,9 +164,9 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public synchronized void processWatchEvent(Kind kind, Path fullPath) {
-        Path relativePath = watchPath.relativize(fullPath);
+        Path relativePath = mainWatchPath.relativize(fullPath);
         String modelName = relativePath.toString();
-        if (relativePath.startsWith("automation") || !modelName.endsWith(".yaml")) {
+        if (!modelName.endsWith(".yaml")) {
             logger.trace("Ignored {}", fullPath);
             return;
         }
@@ -528,7 +536,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         }
 
         try {
-            Path outFile = watchPath.resolve(modelName);
+            Path outFile = mainWatchPath.resolve(modelName);
             String fileContent = objectMapper.writeValueAsString(rootNode);
             if (Files.exists(outFile) && !Files.isWritable(outFile)) {
                 logger.warn("Failed writing model {}: model exists but is read-only.", modelName);


### PR DESCRIPTION
This takes advantage of #4796 to restrict the folders being watched.