### PR TITLE
YAML item proviuder: fix method isVersionSupported

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
@@ -89,7 +89,7 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
 
     @Override
     public boolean isVersionSupported(int version) {
-        return version >= 2;
+        return version >= 1;
     }
 
     @Override


### PR DESCRIPTION
Required after the merge of PR #4807 and PR #4776