### PR TITLE
Semantics health REST endpoint

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -947,7 +947,8 @@ public class ItemResource implements RESTResource {
                     @ApiResponse(responseCode = "404", description = "Item not found.") })
     public Response getSemanticsHealth(@Context HttpHeaders headers) {
         List<ItemSemanticsProblem> semanticsProblems = this.itemRegistry.stream().flatMap(item -> {
-            return semanticsService.getItemSemanticProblems(item).stream();
+            return semanticsService.getItemSemanticsProblems(item).stream()
+                    .map(p -> p.setEditable(isEditable(p.item())));
         }).toList();
         return JSONResponse.createResponse(Status.OK, semanticsProblems, null);
     }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -940,7 +940,7 @@ public class ItemResource implements RESTResource {
     @GET
     @RolesAllowed({ Role.ADMIN })
     @Produces({ MediaType.APPLICATION_JSON })
-    @Path("semanticshealth")
+    @Path("semantics/health")
     @Operation(operationId = "getSemanticsHealth", summary = "Gets configuration problems with item semantics.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ItemSemanticsProblem.class)))),

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ItemSemanticsProblem.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ItemSemanticsProblem.java
@@ -22,10 +22,15 @@ import org.eclipse.jdt.annotation.Nullable;
  * @param semanticType item semantic type
  * @param reason description for the item semantics configuration problem
  * @param explanation longer explanation of problem
+ * @param editable true if the item with the problem is a managed item, null if editable status is not checked
  *
  * @author Mark Herwege - Persistence health API endpoint
  */
 @NonNullByDefault
 public record ItemSemanticsProblem(String item, @Nullable String semanticType, String reason,
-        @Nullable String explanation) {
+        @Nullable String explanation, @Nullable Boolean editable) {
+
+    public ItemSemanticsProblem setEditable(boolean editable) {
+        return new ItemSemanticsProblem(this.item, this.semanticType, this.reason, this.explanation, editable);
+    }
 }

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ItemSemanticsProblem.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/ItemSemanticsProblem.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.semantics;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * This is a representation of an item semantics configuration problem.
+ *
+ * @param item item with problem
+ * @param semanticType item semantic type
+ * @param reason description for the item semantics configuration problem
+ * @param explanation longer explanation of problem
+ *
+ * @author Mark Herwege - Persistence health API endpoint
+ */
+@NonNullByDefault
+public record ItemSemanticsProblem(String item, @Nullable String semanticType, String reason,
+        @Nullable String explanation) {
+}

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
@@ -78,4 +78,14 @@ public interface SemanticsService {
      * @return the list containing the label and all synonyms of a semantic tag
      */
     List<String> getLabelAndSynonyms(Class<? extends Tag> tagClass, Locale locale);
+
+    /**
+     * Verifies the semantics of an item
+     *
+     * @param item
+     * @return list of semantics configuration problems
+     */
+    default List<ItemSemanticsProblem> getItemSemanticProblems(Item item) {
+        return List.of();
+    };
 }

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/SemanticsService.java
@@ -85,7 +85,7 @@ public interface SemanticsService {
      * @param item
      * @return list of semantics configuration problems
      */
-    default List<ItemSemanticsProblem> getItemSemanticProblems(Item item) {
+    default List<ItemSemanticsProblem> getItemSemanticsProblems(Item item) {
         return List.of();
     };
 }

--- a/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsServiceImpl.java
+++ b/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticsServiceImpl.java
@@ -248,7 +248,7 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
                         if (logWarnings) {
                             logger.warn("Item '{}' ({}): {} {}", item.getName(), semanticType, reason, explanation);
                         }
-                        return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation);
+                        return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation, null);
                     } else {
                         String reason = String.format("Invalid combination of semantic tags: %s (%s) and %s (%s).",
                                 firstTag.getSimpleName(), firstType, lastTag.getSimpleName(), lastType);
@@ -256,7 +256,7 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
                         if (logWarnings) {
                             logger.warn("Item '{}' ({}): {} {}", item.getName(), semanticType, reason, explanation);
                         }
-                        return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation);
+                        return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation, null);
                     }
                 } else {
                     String reason = String.format("Invalid combination of semantic tags: %s (%s) and %s (%s).",
@@ -266,7 +266,7 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
                     if (logWarnings) {
                         logger.warn("Item '{}' ({}): {} {}", item.getName(), semanticType, reason, explanation);
                     }
-                    return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation);
+                    return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation, null);
                 }
             default:
                 List<String> allTags = tags.stream().map(tag -> {
@@ -278,7 +278,7 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
                 if (logWarnings) {
                     logger.warn("Item '{}' ({}): {} {}", item.getName(), semanticType, reason, explanation);
                 }
-                return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation);
+                return new ItemSemanticsProblem(item.getName(), semanticType, reason, explanation, null);
         }
     }
 
@@ -289,15 +289,15 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
      * @return true if the semantics are valid, false otherwise
      */
     boolean checkSemantics(Item item) {
-        return getItemSemanticProblems(item, true).size() == 0 ? true : false;
+        return getItemSemanticsProblems(item, true).size() == 0 ? true : false;
     }
 
     @Override
-    public List<ItemSemanticsProblem> getItemSemanticProblems(Item item) {
-        return getItemSemanticProblems(item, false);
+    public List<ItemSemanticsProblem> getItemSemanticsProblems(Item item) {
+        return getItemSemanticsProblems(item, false);
     }
 
-    List<ItemSemanticsProblem> getItemSemanticProblems(Item item, boolean logWarnings) {
+    List<ItemSemanticsProblem> getItemSemanticsProblems(Item item, boolean logWarnings) {
         String itemName = item.getName();
         Class<? extends Tag> semanticTag = SemanticTags.getSemanticType(item);
         if (semanticTag == null) {
@@ -404,7 +404,8 @@ public class SemanticsServiceImpl implements SemanticsService, RegistryChangeLis
                 logger.warn("Item '{}' ({}): Invalid semantic structure:{}", itemName, semanticType, warnings.stream()
                         .map((w) -> w[0] + " " + w[1]).reduce("", (result, w) -> result + "\n        " + w));
             }
-            return warnings.stream().map((w) -> new ItemSemanticsProblem(itemName, semanticType, w[0], w[1])).toList();
+            return warnings.stream().map((w) -> new ItemSemanticsProblem(itemName, semanticType, w[0], w[1], false))
+                    .toList();
         }
         return List.of();
     }


### PR DESCRIPTION
This is building on the excellent work from @jimtng in https://github.com/openhab/openhab-core/pull/4613

This PR refactors the logging to also make the warning messages available through the REST API in a new `/items/semantics/health` endpoint.

The UI part is in https://github.com/openhab/openhab-webui/pull/3202