### PR TITLE
[Skeleton script] FIX scripts create a README.md with a missing new line that causes compile errors.

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/README.md
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/README.md
@@ -76,6 +76,7 @@ _*.sitemap examples are optional._
 ```java
 Example thing configuration goes here.
 ```
+
 #[[###]]# Item Configuration
 
 ```java


### PR DESCRIPTION
Add an extra line so new bindings do not create as many errors when you compile for the first time with a fresh created binding to help new devs get started quicker.

[ERROR] Code Analysis Tool has found:
 4 error(s)!
 1 warning(s)
 4 info(s)
[WARNING] .binding.mamotion\README.md:[78]
The line after code formatting section must be empty.