### PR TITLE
[Skeleton]Fix copyright message format error in skeleton

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__BindingConstants.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__BindingConstants.java
@@ -1,7 +1,7 @@
 #set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
 #set( $year = $dt.getYear() + 1900 )
 #set( $copyright = "Contributors to the ${vendorName} project" )
-/**
+/*
  * Copyright (c) ${startYear}-${year} ${copyright}
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
@@ -1,7 +1,7 @@
 #set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
 #set( $year = $dt.getYear() + 1900 )
 #set( $copyright = "Contributors to the ${vendorName} project" )
-/**
+/*
  * Copyright (c) ${startYear}-${year} ${copyright}
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
@@ -1,7 +1,7 @@
 #set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
 #set( $year = $dt.getYear() + 1900 )
 #set( $copyright = "Contributors to the ${vendorName} project" )
-/**
+/*
  * Copyright (c) ${startYear}-${year} ${copyright}
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -1,7 +1,7 @@
 #set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
 #set( $year = $dt.getYear() + 1900 )
 #set( $copyright = "Contributors to the ${vendorName} project" )
-/**
+/*
  * Copyright (c) ${startYear}-${year} ${copyright}
  *
  * See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
Fixes the following messages when a new binding created with the skeleton script is compiled for the first time:

/** does not match until you make the files start with /*

[INFO] --- sat:0.17.0:report (sat-all) @ org.openhab.binding.mamotion ---
[INFO] Individual report appended to summary report.
[ERROR] Code Analysis Tool has found:
 4 error(s)!
 1 warning(s)
 4 info(s)
[WARNING] .binding.mamotion\README.md:[78]
The line after code formatting section must be empty.
[ERROR] org.openhab.binding.mamotion.internal.MamotionBindingConstants.java:[1]
Header line doesn't match pattern ^/\*$
[ERROR] org.openhab.binding.mamotion.internal.MamotionConfiguration.java:[1]
Header line doesn't match pattern ^/\*$
[ERROR] org.openhab.binding.mamotion.internal.MamotionHandler.java:[1]
Header line doesn't match pattern ^/\*$
[ERROR] org.openhab.binding.mamotion.internal.MamotionHandlerFactory.java:[1]
Header line doesn't match pattern ^/\*$