### PR TITLE
Fix itests after #4513

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedItemProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ScriptedItemProvider.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-@Component(immediate = true, service = { ScriptedItemProvider.class, ItemProvider.class })
+@Component(immediate = true, service = { ItemProvider.class, ScriptedItemProvider.class })
 public class ScriptedItemProvider extends AbstractProvider<Item>
         implements ItemProvider, ManagedProvider<Item, String> {
     private final Logger logger = LoggerFactory.getLogger(ScriptedItemProvider.class);

--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/GenericItemProvider.java
@@ -69,7 +69,8 @@ import org.slf4j.LoggerFactory;
  * @author Thomas Eichstaedt-Engelen - Initial contribution
  */
 @NonNullByDefault
-@Component(service = { ItemProvider.class, StateDescriptionFragmentProvider.class }, immediate = true)
+@Component(service = { ItemProvider.class, GenericItemProvider.class,
+        StateDescriptionFragmentProvider.class }, immediate = true)
 public class GenericItemProvider extends AbstractProvider<Item>
         implements ModelRepositoryChangeListener, ItemProvider, StateDescriptionFragmentProvider {
 

--- a/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
+++ b/itests/org.openhab.core.model.item.tests/src/main/java/org/openhab/core/model/item/internal/GenericItemProviderTest.java
@@ -39,7 +39,6 @@ import org.openhab.core.items.GroupFunction;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
-import org.openhab.core.items.ItemProvider;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
@@ -491,7 +490,7 @@ public class GenericItemProviderTest extends JavaOSGiTest {
 
     @Test
     public void testGroupItemIsSame() {
-        GenericItemProvider gip = (GenericItemProvider) getService(ItemProvider.class);
+        GenericItemProvider gip = getService(GenericItemProvider.class);
         assertThat(gip, is(notNullValue()));
 
         GroupItem g1 = new GroupItem("testGroup", new SwitchItem("test"),
@@ -504,7 +503,7 @@ public class GenericItemProviderTest extends JavaOSGiTest {
 
     @Test
     public void testGroupItemChangesBaseItem() {
-        GenericItemProvider gip = (GenericItemProvider) getService(ItemProvider.class);
+        GenericItemProvider gip = getService(GenericItemProvider.class);
         assertThat(gip, is(notNullValue()));
 
         GroupItem g1 = new GroupItem("testGroup", new SwitchItem("test"),
@@ -517,7 +516,7 @@ public class GenericItemProviderTest extends JavaOSGiTest {
 
     @Test
     public void testGroupItemChangesFunctionParameters() {
-        GenericItemProvider gip = (GenericItemProvider) getService(ItemProvider.class);
+        GenericItemProvider gip = getService(GenericItemProvider.class);
         assertThat(gip, is(notNullValue()));
 
         GroupItem g1 = new GroupItem("testGroup", new SwitchItem("test"),
@@ -530,7 +529,7 @@ public class GenericItemProviderTest extends JavaOSGiTest {
 
     @Test
     public void testGroupItemChangesBaseItemAndFunction() {
-        GenericItemProvider gip = (GenericItemProvider) getService(ItemProvider.class);
+        GenericItemProvider gip = getService(GenericItemProvider.class);
         assertThat(gip, is(notNullValue()));
 
         GroupItem g1 = new GroupItem("testGroup", new SwitchItem("test"),


### PR DESCRIPTION
Fixes itest after #4513.

I do not understand why the new ScriptedItemProvider is returned when retrieving the ItemProvider service, as this did not happen with the ManagedItemProvider and the YamlItemProvider. Anyway, this change fixes the problem by explicitly retrieving the GenericItemProvider.