### PR TITLE
NonNullByDefault for all classes

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/AbstractRemoteAddonService.java
@@ -239,7 +239,9 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             return;
         }
         for (MarketplaceAddonHandler handler : addonHandlers) {
-            if (handler.supports(addon.getType(), addon.getContentType())) {
+            String type = addon.getType();
+            String contentType = addon.getContentType();
+            if (type != null && contentType != null && handler.supports(type, contentType)) {
                 if (!handler.isInstalled(addon.getUid())) {
                     try {
                         handler.install(addon);
@@ -268,7 +270,9 @@ public abstract class AbstractRemoteAddonService implements AddonService {
             return;
         }
         for (MarketplaceAddonHandler handler : addonHandlers) {
-            if (handler.supports(addon.getType(), addon.getContentType())) {
+            String type = addon.getType();
+            String contentType = addon.getContentType();
+            if (type != null && contentType != null && handler.supports(type, contentType)) {
                 if (handler.isInstalled(addon.getUid())) {
                     try {
                         handler.uninstall(addon);

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceConstants.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/MarketplaceConstants.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.core.addon.marketplace;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This class contains constants used in marketplace add-on services
  *
  * @author Jan N. Klug - Initial contribution
  */
+@NonNullByDefault
 public class MarketplaceConstants {
     public static final String JAR_CONTENT_TYPE = "application/vnd.openhab.bundle";
     public static final String KAR_CONTENT_TYPE = "application/vnd.openhab.feature;type=karfile";

--- a/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/Addon.java
+++ b/bundles/org.openhab.core.addon/src/main/java/org/openhab/core/addon/Addon.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -26,30 +27,31 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Kai Kreuzer - Initial contribution
  * @author Yannick Schaus - Add fields
  */
+@NonNullByDefault
 public class Addon {
     public static final Set<String> CODE_MATURITY_LEVELS = Set.of("alpha", "beta", "mature", "stable");
     public static final String ADDON_SEPARATOR = "-";
 
     private final String uid;
 
-    private final String id;
-    private final String label;
+    private final @Nullable String id;
+    private final @Nullable String label;
     private final String version;
     private final @Nullable String maturity;
     private final boolean compatible;
-    private final String contentType;
+    private final @Nullable String contentType;
     private final @Nullable String link;
     private final String author;
     private final boolean verifiedAuthor;
     private boolean installed;
-    private final String type;
+    private final @Nullable String type;
     private final @Nullable String description;
     private final @Nullable String detailedDescription;
     private final String configDescriptionURI;
     private final String keywords;
     private final List<String> countries;
     private final @Nullable String license;
-    private final String connection;
+    private final @Nullable String connection;
     private final @Nullable String backgroundColor;
     private final @Nullable String imageLink;
     private final Map<String, Object> properties;
@@ -84,12 +86,12 @@ public class Addon {
      * @param loggerPackages a {@link List} containing the package names belonging to this add-on
      * @throws IllegalArgumentException when a mandatory parameter is invalid
      */
-    private Addon(String uid, String type, String id, String label, String version, @Nullable String maturity,
-            boolean compatible, String contentType, @Nullable String link, String author, boolean verifiedAuthor,
-            boolean installed, @Nullable String description, @Nullable String detailedDescription,
-            String configDescriptionURI, String keywords, List<String> countries, @Nullable String license,
-            String connection, @Nullable String backgroundColor, @Nullable String imageLink,
-            @Nullable Map<String, Object> properties, List<String> loggerPackages) {
+    private Addon(String uid, @Nullable String type, @Nullable String id, @Nullable String label, String version,
+            @Nullable String maturity, boolean compatible, @Nullable String contentType, @Nullable String link,
+            String author, boolean verifiedAuthor, boolean installed, @Nullable String description,
+            @Nullable String detailedDescription, String configDescriptionURI, String keywords, List<String> countries,
+            @Nullable String license, @Nullable String connection, @Nullable String backgroundColor,
+            @Nullable String imageLink, @Nullable Map<String, Object> properties, List<String> loggerPackages) {
         if (uid.isBlank()) {
             throw new IllegalArgumentException("uid must not be empty");
         }
@@ -129,7 +131,7 @@ public class Addon {
     /**
      * The type of the addon (same as id of {@link AddonType})
      */
-    public String getType() {
+    public @Nullable String getType() {
         return type;
     }
 
@@ -143,14 +145,14 @@ public class Addon {
     /**
      * The id of the add-on (e.g. "influxdb")
      */
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 
     /**
      * The label of the add-on
      */
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
@@ -199,7 +201,7 @@ public class Addon {
     /**
      * The content type of the add-on
      */
-    public String getContentType() {
+    public @Nullable String getContentType() {
         return contentType;
     }
 
@@ -248,7 +250,7 @@ public class Addon {
     /**
      * A string describing the type of connection (local, cloud, cloudDiscovery) this add-on uses, if applicable.
      */
-    public String getConnection() {
+    public @Nullable String getConnection() {
         return connection;
     }
 
@@ -333,24 +335,24 @@ public class Addon {
 
     public static class Builder {
         private final String uid;
-        private String id;
-        private String label;
+        private @Nullable String id;
+        private @Nullable String label;
         private String version = "";
         private @Nullable String maturity;
         private boolean compatible = true;
-        private String contentType;
+        private @Nullable String contentType;
         private @Nullable String link;
         private String author = "";
         private boolean verifiedAuthor = false;
         private boolean installed = false;
-        private String type;
+        private @Nullable String type;
         private @Nullable String description;
         private @Nullable String detailedDescription;
         private String configDescriptionURI = "";
         private String keywords = "";
         private List<String> countries = List.of();
         private @Nullable String license;
-        private String connection = "";
+        private @Nullable String connection = "";
         private @Nullable String backgroundColor;
         private @Nullable String imageLink;
         private Map<String, Object> properties = new HashMap<>();
@@ -360,17 +362,17 @@ public class Addon {
             this.uid = uid;
         }
 
-        public Builder withType(String type) {
+        public Builder withType(@Nullable String type) {
             this.type = type;
             return this;
         }
 
-        public Builder withId(String id) {
+        public Builder withId(@Nullable String id) {
             this.id = id;
             return this;
         }
 
-        public Builder withLabel(String label) {
+        public Builder withLabel(@Nullable String label) {
             this.label = label;
             return this;
         }
@@ -395,7 +397,7 @@ public class Addon {
             return this;
         }
 
-        public Builder withLink(String link) {
+        public Builder withLink(@Nullable String link) {
             this.link = link;
             return this;
         }
@@ -416,12 +418,12 @@ public class Addon {
             return this;
         }
 
-        public Builder withDescription(String description) {
+        public Builder withDescription(@Nullable String description) {
             this.description = description;
             return this;
         }
 
-        public Builder withDetailedDescription(String detailedDescription) {
+        public Builder withDetailedDescription(@Nullable String detailedDescription) {
             this.detailedDescription = detailedDescription;
             return this;
         }
@@ -446,12 +448,12 @@ public class Addon {
             return this;
         }
 
-        public Builder withConnection(String connection) {
+        public Builder withConnection(@Nullable String connection) {
             this.connection = connection;
             return this;
         }
 
-        public Builder withBackgroundColor(String backgroundColor) {
+        public Builder withBackgroundColor(@Nullable String backgroundColor) {
             this.backgroundColor = backgroundColor;
             return this;
         }

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginConfiguration.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginConfiguration.java
@@ -18,15 +18,19 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 import javax.security.auth.login.Configuration;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Describes a JAAS configuration with the {@link ManagedUserLoginModule} as a sufficient login module.
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 public class ManagedUserLoginConfiguration extends Configuration {
 
     @Override
-    public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+    public AppConfigurationEntry @Nullable [] getAppConfigurationEntry(@Nullable String name) {
         return new AppConfigurationEntry[] { new AppConfigurationEntry(ManagedUserLoginModule.class.getCanonicalName(),
                 LoginModuleControlFlag.SUFFICIENT, new HashMap<>()) };
     }

--- a/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginModule.java
+++ b/bundles/org.openhab.core.auth.jaas/src/main/java/org/openhab/core/auth/jaas/internal/ManagedUserLoginModule.java
@@ -19,6 +19,8 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.AuthenticationException;
 import org.openhab.core.auth.Credentials;
 import org.openhab.core.auth.UserRegistry;
@@ -33,15 +35,17 @@ import org.slf4j.LoggerFactory;
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 public class ManagedUserLoginModule implements LoginModule {
 
     private final Logger logger = LoggerFactory.getLogger(ManagedUserLoginModule.class);
 
-    private UserRegistry userRegistry;
+    private @Nullable UserRegistry userRegistry;
 
-    private Subject subject;
+    private @Nullable Subject subject;
 
     @Override
+    @NonNullByDefault({})
     public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState,
             Map<String, ?> options) {
         this.subject = subject;

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/Keyword.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/Keyword.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.core.auth.oauth2client.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Just a place to store all the important, reused keywords.
  *
  * @author Gary Tse - Initial contribution
  */
+@NonNullByDefault
 public interface Keyword {
 
     String CLIENT_ID = "client_id";

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnector.java
@@ -214,8 +214,8 @@ public class OAuthConnector {
      * @throws OAuthResponseException Error codes given by authorization provider, as in RFC 6749 section 5.2 Error
      *             Response
      */
-    public AccessTokenResponse grantTypeRefreshToken(String tokenUrl, String refreshToken, @Nullable String clientId,
-            @Nullable String clientSecret, @Nullable String scope, boolean supportsBasicAuth)
+    public AccessTokenResponse grantTypeRefreshToken(String tokenUrl, @Nullable String refreshToken,
+            @Nullable String clientId, @Nullable String clientSecret, @Nullable String scope, boolean supportsBasicAuth)
             throws OAuthResponseException, OAuthException, IOException {
         HttpClient httpClient = null;
         try {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorRFC8628.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthConnectorRFC8628.java
@@ -82,10 +82,10 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
     private final ScheduledExecutorService scheduler;
     private final String handle;
 
-    private final String accessTokenRequestUrl;
-    private final String deviceCodeRequestUrl;
-    private final String clientIdParameter;
-    private final String scopeParameter;
+    private final @Nullable String accessTokenRequestUrl;
+    private final @Nullable String deviceCodeRequestUrl;
+    private final @Nullable String clientIdParameter;
+    private final @Nullable String scopeParameter;
 
     private @Nullable ScheduledFuture<?> atrPollTaskSchedule;
     private @Nullable DeviceCodeResponseDTO dcrCached;
@@ -110,8 +110,8 @@ public class OAuthConnectorRFC8628 extends OAuthConnector implements AutoCloseab
      */
     public OAuthConnectorRFC8628(OAuthClientService oAuthClientService, String handle,
             OAuthStoreHandler oAuthStoreHandler, HttpClientFactory httpClientFactory, @Nullable GsonBuilder gsonBuilder,
-            String accessTokenRequestUrl, String deviceCodeRequestUrl, String clientId, String scope)
-            throws OAuthException {
+            @Nullable String accessTokenRequestUrl, @Nullable String deviceCodeRequestUrl, @Nullable String clientId,
+            @Nullable String scope) throws OAuthException {
         super(httpClientFactory, null, gsonBuilder != null ? gsonBuilder : new GsonBuilder());
         this.oAuthClientService = oAuthClientService;
         this.oAuthStoreHandler = oAuthStoreHandler;

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
@@ -252,7 +252,7 @@ public class OAuthStoreHandlerImpl implements OAuthStoreHandler {
         return dcrDecrypted;
     }
 
-    private @Nullable String encrypt(String token) throws GeneralSecurityException {
+    private @Nullable String encrypt(@Nullable String token) throws GeneralSecurityException {
         if (storageCipher.isEmpty()) {
             return token; // do nothing if no cipher
         } else {

--- a/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/main/java/org/openhab/core/auth/oauth2client/internal/PersistedParams.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.auth.oauth2client.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -22,15 +23,25 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Hilbrand Bouwkamp - Moved class to it's own file and added hashCode and equals methods
  * @author Gaël L'hopital - Added deserializerClassName
  */
+@NonNullByDefault
 class PersistedParams {
+    @Nullable
     String handle;
+    @Nullable
     String tokenUrl;
+    @Nullable
     String authorizationUrl;
+    @Nullable
     String clientId;
+    @Nullable
     String clientSecret;
+    @Nullable
     String scope;
+    @Nullable
     Boolean supportsBasicAuth;
+    @Nullable
     String state;
+    @Nullable
     String redirectUri;
     int tokenExpiresInSeconds = 60;
 
@@ -58,9 +69,9 @@ class PersistedParams {
      *            official stated expiry time; thus prevents the caller obtaining a valid token at the time of invoke,
      *            only to find the token immediately expired.
      */
-    public PersistedParams(String handle, String tokenUrl, String authorizationUrl, String clientId,
-            String clientSecret, String scope, Boolean supportsBasicAuth, int tokenExpiresInSeconds,
-            @Nullable String deserializerClassName) {
+    public PersistedParams(@Nullable String handle, @Nullable String tokenUrl, @Nullable String authorizationUrl,
+            @Nullable String clientId, @Nullable String clientSecret, @Nullable String scope,
+            @Nullable Boolean supportsBasicAuth, int tokenExpiresInSeconds, @Nullable String deserializerClassName) {
         this.handle = handle;
         this.tokenUrl = tokenUrl;
         this.authorizationUrl = authorizationUrl;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistry.java
@@ -12,12 +12,15 @@
  */
 package org.openhab.core.automation.module.script.providersupport.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Interface to be implemented by all {@link org.openhab.core.common.registry.Registry} (delegates) that are used to
  * provide openHAB entities from scripts.
  *
  * @author Florian Hotze - Initial contribution
  */
+@NonNullByDefault
 public interface ProviderRegistry {
 
     /**

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/CacheScriptExtension.java
@@ -178,8 +178,8 @@ public class CacheScriptExtension implements ScriptExtensionProvider {
         }
 
         @Override
-        @Nullable
-        public Object compute(String key, BiFunction<String, @Nullable Object, @Nullable Object> remappingFunction) {
+        public @Nullable Object compute(String key,
+                BiFunction<String, @Nullable Object, @Nullable Object> remappingFunction) {
             return cache.compute(key, (k, v) -> remappingFunction.apply(k, v));
         }
 
@@ -252,8 +252,8 @@ public class CacheScriptExtension implements ScriptExtensionProvider {
         }
 
         @Override
-        @Nullable
-        public Object compute(String key, BiFunction<String, @Nullable Object, @Nullable Object> remappingFunction) {
+        public @Nullable Object compute(String key,
+                BiFunction<String, @Nullable Object, @Nullable Object> remappingFunction) {
             cacheLock.lock();
             try {
                 Object value = sharedCache.compute(key, (k, v) -> remappingFunction.apply(k, v));

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/DelegatingScheduledExecutorService.java
@@ -22,11 +22,15 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Implementation of {@link ScheduledExecutorService} which simply delegates to the instance supplied.
  *
  * @author Jonathan Gilbert - initial contribution
  */
+@NonNullByDefault
 public class DelegatingScheduledExecutorService implements ScheduledExecutorService {
     private ScheduledExecutorService delegate;
 
@@ -35,22 +39,25 @@ public class DelegatingScheduledExecutorService implements ScheduledExecutorServ
     }
 
     @Override
-    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    public ScheduledFuture<?> schedule(@Nullable Runnable command, long delay, @Nullable TimeUnit unit) {
         return delegate.schedule(command, delay, unit);
     }
 
     @Override
+    @NonNullByDefault({})
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
         return delegate.schedule(callable, delay, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+    public ScheduledFuture<?> scheduleAtFixedRate(@Nullable Runnable command, long initialDelay, long period,
+            @Nullable TimeUnit unit) {
         return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    public ScheduledFuture<?> scheduleWithFixedDelay(@Nullable Runnable command, long initialDelay, long delay,
+            @Nullable TimeUnit unit) {
         return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 
@@ -60,6 +67,7 @@ public class DelegatingScheduledExecutorService implements ScheduledExecutorServ
     }
 
     @Override
+    @NonNullByDefault({})
     public List<Runnable> shutdownNow() {
         return delegate.shutdownNow();
     }
@@ -75,42 +83,48 @@ public class DelegatingScheduledExecutorService implements ScheduledExecutorServ
     }
 
     @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    public boolean awaitTermination(long timeout, @Nullable TimeUnit unit) throws InterruptedException {
         return delegate.awaitTermination(timeout, unit);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> Future<T> submit(Callable<T> task) {
         return delegate.submit(task);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> Future<T> submit(Runnable task, T result) {
         return delegate.submit(task, result);
     }
 
     @Override
-    public Future<?> submit(Runnable task) {
+    public @Nullable Future<?> submit(@Nullable Runnable task) {
         return delegate.submit(task);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
         return delegate.invokeAll(tasks);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
         return delegate.invokeAll(tasks, timeout, unit);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
         return delegate.invokeAny(tasks);
     }
 
     @Override
+    @NonNullByDefault({})
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         return delegate.invokeAny(tasks, timeout, unit);

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ModuleTypeResource.java
@@ -99,7 +99,7 @@ public class ModuleTypeResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getModuleTypes", summary = "Get all available module types.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ModuleTypeDTO.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @QueryParam("tags") @Parameter(description = "tags for filtering") @Nullable String tagList,
             @QueryParam("type") @Parameter(description = "filtering by action, condition or trigger") @Nullable String type,
@@ -147,7 +147,7 @@ public class ModuleTypeResource implements RESTResource {
     @Operation(operationId = "getModuleTypeById", summary = "Gets a module type corresponding to the given UID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ModuleTypeDTO.class))),
             @ApiResponse(responseCode = "404", description = "Module Type corresponding to the given UID does not found.") })
-    public Response getByUID(
+    public @Nullable Response getByUID(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("moduleTypeUID") @Parameter(description = "moduleTypeUID") String moduleTypeUID) {
         Locale locale = localeService.getLocale(language);

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/TemplateResource.java
@@ -24,7 +24,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.dto.RuleTemplateDTO;
@@ -73,12 +72,12 @@ public class TemplateResource implements RESTResource {
     public static final String PATH_TEMPLATES = "templates";
 
     private final LocaleService localeService;
-    private final TemplateRegistry<@NonNull RuleTemplate> templateRegistry;
+    private final TemplateRegistry<RuleTemplate> templateRegistry;
 
     @Activate
     public TemplateResource( //
             final @Reference LocaleService localeService,
-            final @Reference TemplateRegistry<@NonNull RuleTemplate> templateRegistry) {
+            final @Reference TemplateRegistry<RuleTemplate> templateRegistry) {
         this.localeService = localeService;
         this.templateRegistry = templateRegistry;
     }
@@ -87,7 +86,7 @@ public class TemplateResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getTemplates", summary = "Get all available templates.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Template.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
         Collection<RuleTemplateDTO> result = templateRegistry.getAll(locale).stream()
@@ -101,7 +100,7 @@ public class TemplateResource implements RESTResource {
     @Operation(operationId = "getTemplateById", summary = "Gets a template corresponding to the given UID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Template.class))),
             @ApiResponse(responseCode = "404", description = "Template corresponding to the given UID does not found.") })
-    public Response getByUID(
+    public @Nullable Response getByUID(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("templateUID") @Parameter(description = "templateUID") String templateUID) {
         Locale locale = localeService.getLocale(language);

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -166,7 +166,7 @@ public class ThingActionsResource implements RESTResource {
     @Operation(operationId = "getAvailableActionsForThing", summary = "Get all available actions for provided thing UID", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ThingActionDTO.class), uniqueItems = true))),
             @ApiResponse(responseCode = "404", description = "No actions found.") })
-    public Response getActions(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
+    public @Nullable Response getActions(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
         ThingUID aThingUID = new ThingUID(thingUID);
@@ -226,7 +226,8 @@ public class ThingActionsResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Map.class))),
             @ApiResponse(responseCode = "404", description = "Action not found"),
             @ApiResponse(responseCode = "500", description = "Creation of action handler or execution failed") })
-    public Response executeThingAction(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
+    public @Nullable Response executeThingAction(
+            @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @PathParam("actionUid") @Parameter(description = "action type UID (including scope, separated by '.')") String actionTypeUid,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "action inputs as map (parameter name as key / argument as value)") Map<String, Object> actionInputs) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/AutomationCommandList.java
@@ -17,7 +17,10 @@ import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.RuleStatus;
 import org.openhab.core.automation.template.RuleTemplate;
@@ -34,20 +37,21 @@ import org.openhab.core.automation.type.ModuleType;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class AutomationCommandList extends AutomationCommand {
 
     /**
      * This field serves to keep the UID of a {@link Rule}, {@link Template} or {@link ModuleType}, or part of it, or
      * sequence number of a {@link Rule}, {@link Template}, or {@link ModuleType} in the list.
      */
-    private String id;
+    private String id = "";
 
     /**
      * This field is used to search for templates or types of modules, which have been translated to the language from
      * the locale. If the parameter <b>locale</b> is not passed to the command line then the default locale will be
      * used.
      */
-    private Locale locale;
+    private @Nullable Locale locale;
 
     /**
      * @see AutomationCommand#AutomationCommand(String, String[], int, AutomationCommandsPluggable)
@@ -293,7 +297,7 @@ public class AutomationCommandList extends AutomationCommand {
                 } else {
                     for (String ruleUID : list.values()) {
                         if (ruleUID.contains(id)) {
-                            rules.add(autoCommands.getRule(ruleUID));
+                            rules.add(Objects.requireNonNull(autoCommands.getRule(ruleUID)));
                         }
                     }
                 }
@@ -328,7 +332,7 @@ public class AutomationCommandList extends AutomationCommand {
             } else {
                 for (String templateUID : list.keySet()) {
                     if (templateUID.contains(id)) {
-                        templates.add(autoCommands.getTemplate(templateUID, locale));
+                        templates.add(Objects.requireNonNull(autoCommands.getTemplate(templateUID, locale)));
                     }
                 }
             }
@@ -363,7 +367,7 @@ public class AutomationCommandList extends AutomationCommand {
                 } else {
                     for (String typeUID : list.values()) {
                         if (typeUID.contains(id)) {
-                            moduleTypes.add(autoCommands.getModuleType(typeUID, locale));
+                            moduleTypes.add(Objects.requireNonNull(autoCommands.getModuleType(typeUID, locale)));
                         }
                     }
                 }
@@ -382,7 +386,7 @@ public class AutomationCommandList extends AutomationCommand {
      *            filled with the objects from <tt>collection</tt>.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private void addCollection(Collection collection, Map list) {
+    private void addCollection(@Nullable Collection collection, Map list) {
         if (collection != null && !collection.isEmpty()) {
             for (Object element : collection) {
                 if (element instanceof ModuleType type) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Printer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/commands/Printer.java
@@ -17,8 +17,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.Module;
@@ -45,6 +47,7 @@ import org.openhab.core.config.core.ParameterOption;
  * @author Ana Dimova - Initial contribution
  * @author Yordan Mihaylov - updates related to api changes
  */
+@NonNullByDefault
 public class Printer {
 
     private static final int TABLE_WIDTH = 100;
@@ -111,7 +114,7 @@ public class Printer {
                 columnValues.set(0, id);
                 columnValues.set(1, uid);
                 Rule rule = autoCommands.getRule(uid);
-                columnValues.set(2, rule.getName());
+                columnValues.set(2, Objects.requireNonNullElse(rule.getName(), "null"));
                 columnValues.set(3, autoCommands.getRuleStatus(uid).toString());
                 rulesRows.add(Utils.getRow(columnWidths, columnValues));
             }
@@ -174,12 +177,12 @@ public class Printer {
         ruleContent.add(Utils.getRow(columnWidths, ruleProperty));
         if (rule.getName() != null) {
             ruleProperty.set(0, NAME);
-            ruleProperty.set(1, rule.getName());
+            ruleProperty.set(1, Objects.requireNonNullElse(rule.getName(), "null"));
             ruleContent.add(Utils.getRow(columnWidths, ruleProperty));
         }
         if (rule.getDescription() != null) {
             ruleProperty.set(0, DESCRIPTION);
-            ruleProperty.set(1, rule.getDescription());
+            ruleProperty.set(1, Objects.requireNonNullElse(rule.getDescription(), "null"));
             ruleContent.add(Utils.getRow(columnWidths, ruleProperty));
         }
         ruleProperty.set(0, TAGS);
@@ -216,12 +219,12 @@ public class Printer {
         templateContent.add(Utils.getRow(columnWidths, templateProperty));
         if (template.getLabel() != null) {
             templateProperty.set(0, LABEL);
-            templateProperty.set(1, template.getLabel());
+            templateProperty.set(1, Objects.requireNonNullElse(template.getLabel(), "null"));
             templateContent.add(Utils.getRow(columnWidths, templateProperty));
         }
         if (template.getDescription() != null) {
             templateProperty.set(0, DESCRIPTION);
-            templateProperty.set(1, template.getDescription());
+            templateProperty.set(1, Objects.requireNonNullElse(template.getDescription(), "null"));
             templateContent.add(Utils.getRow(columnWidths, templateProperty));
         }
         templateProperty.set(0, VISIBILITY);
@@ -260,12 +263,12 @@ public class Printer {
         moduleTypeContent.add(Utils.getRow(columnWidths, moduleTypeProperty));
         if (moduleType.getLabel() != null) {
             moduleTypeProperty.set(0, LABEL);
-            moduleTypeProperty.set(1, moduleType.getLabel());
+            moduleTypeProperty.set(1, Objects.requireNonNullElse(moduleType.getLabel(), "null"));
             moduleTypeContent.add(Utils.getRow(columnWidths, moduleTypeProperty));
         }
         if (moduleType.getDescription() != null) {
             moduleTypeProperty.set(0, DESCRIPTION);
-            moduleTypeProperty.set(1, moduleType.getDescription());
+            moduleTypeProperty.set(1, Objects.requireNonNullElse(moduleType.getDescription(), "null"));
             moduleTypeContent.add(Utils.getRow(columnWidths, moduleTypeProperty));
         }
         moduleTypeProperty.set(0, VISIBILITY);
@@ -405,12 +408,12 @@ public class Printer {
 
         if (module.getLabel() != null) {
             columnValues.set(0, LABEL);
-            columnValues.set(1, module.getLabel());
+            columnValues.set(1, Objects.requireNonNullElse(module.getLabel(), "null"));
             moduleContent.add(Utils.getRow(columnWidths, columnValues));
         }
         if (module.getDescription() != null) {
             columnValues.set(0, DESCRIPTION);
-            columnValues.set(1, module.getDescription());
+            columnValues.set(1, Objects.requireNonNullElse(module.getDescription(), "null"));
             moduleContent.add(Utils.getRow(columnWidths, columnValues));
         }
 
@@ -474,27 +477,27 @@ public class Printer {
                 configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 if (parameter.getLabel() != null) {
                     configParamProperty.set(1, LABEL);
-                    configParamProperty.set(2, parameter.getLabel());
+                    configParamProperty.set(2, Objects.requireNonNullElse(parameter.getLabel(), "null"));
                     configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 }
                 if (parameter.getDescription() != null) {
                     configParamProperty.set(1, DESCRIPTION);
-                    configParamProperty.set(2, parameter.getDescription());
+                    configParamProperty.set(2, Objects.requireNonNullElse(parameter.getDescription(), "null"));
                     configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 }
                 if (parameter.getDefault() != null) {
                     configParamProperty.set(1, DEFAULT);
-                    configParamProperty.set(2, parameter.getDefault());
+                    configParamProperty.set(2, Objects.requireNonNullElse(parameter.getDefault(), "null"));
                     configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 }
                 if (parameter.getContext() != null) {
                     configParamProperty.set(1, CONTEXT);
-                    configParamProperty.set(2, parameter.getContext());
+                    configParamProperty.set(2, Objects.requireNonNullElse(parameter.getContext(), "null"));
                     configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 }
                 if (parameter.getPattern() != null) {
                     configParamProperty.set(1, PATTERN);
-                    configParamProperty.set(2, parameter.getPattern());
+                    configParamProperty.set(2, Objects.requireNonNullElse(parameter.getPattern(), "null"));
                     configParamContent.add(Utils.getRow(columnWidths, configParamProperty));
                 }
                 if (parameter.getStepSize() != null) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesTracker.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/AutomationResourceBundlesTracker.java
@@ -17,7 +17,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.ManagedRuleProvider;
 import org.openhab.core.automation.Rule;
 import org.openhab.core.automation.parser.Parser;
@@ -43,6 +46,7 @@ import org.osgi.util.tracker.BundleTrackerCustomizer;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 @SuppressWarnings("deprecation")
 @Component(immediate = true)
 public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer<Bundle> {
@@ -62,7 +66,7 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
     /**
      * This field is a bundle tracker for bundles providing automation resources.
      */
-    private BundleTracker<Bundle> bTracker;
+    private @Nullable BundleTracker<Bundle> bTracker;
 
     /**
      * This field serves for saving the BundleEvents for the bundles providing automation resources until their
@@ -174,7 +178,7 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      * This method returns the object to be tracked for the specified {@code Bundle}. The returned object is stored in
      * the {@code BundleTracker} and is available from the {@link BundleTracker#getObject(Bundle) getObject} method.
      *
-     * @param bundle The {@code Bundle} being added to the {@code BundleTracker} .
+     * @param bundle The {@code Bundle} (non-null) being added to the {@code BundleTracker} .
      * @param event The bundle event which caused this customizer method to be
      *            called or {@code null} if there is no bundle event associated with
      *            the call to this method.
@@ -183,7 +187,8 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      *         be tracked.
      */
     @Override
-    public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+    public Bundle addingBundle(@Nullable Bundle bundle, @Nullable BundleEvent event) {
+        Objects.requireNonNull(bundle);
         if (isAnAutomationProvider(bundle)) {
             if (HostFragmentMappingUtil.isFragmentBundle(bundle)) {
                 List<Bundle> hosts = HostFragmentMappingUtil.returnHostBundles(bundle);
@@ -213,14 +218,16 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      * <p>
      * This method is called when a bundle being tracked by the {@code BundleTracker} has had its state modified.
      *
-     * @param bundle The {@code Bundle} whose state has been modified.
-     * @param event The bundle event which caused this customizer method to be
+     * @param bundle The {@code Bundle} (non-null) whose state has been modified.
+     * @param event The bundle event (non-null) which caused this customizer method to be
      *            called or {@code null} if there is no bundle event associated with
      *            the call to this method.
      * @param object The tracked object for the specified bundle.
      */
     @Override
-    public void modifiedBundle(Bundle bundle, BundleEvent event, Bundle object) {
+    public void modifiedBundle(@Nullable Bundle bundle, @Nullable BundleEvent event, @Nullable Bundle object) {
+        Objects.requireNonNull(bundle);
+        Objects.requireNonNull(event);
         int type = event.getType();
         if (type == BundleEvent.UPDATED || type == BundleEvent.RESOLVED) {
             addEvent(bundle, event);
@@ -233,14 +240,15 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      * <p>
      * This method is called after a bundle is no longer being tracked by the {@code BundleTracker}.
      *
-     * @param bundle The {@code Bundle} that has been removed.
+     * @param bundle The {@code Bundle} (non-null) that has been removed.
      * @param event The bundle event which caused this customizer method to be
      *            called or {@code null} if there is no bundle event associated with
      *            the call to this method.
      * @param object The tracked object for the specified bundle.
      */
     @Override
-    public void removedBundle(Bundle bundle, BundleEvent event, Bundle object) {
+    public void removedBundle(@Nullable Bundle bundle, @Nullable BundleEvent event, @Nullable Bundle object) {
+        Objects.requireNonNull(bundle);
         if (HostFragmentMappingUtil.isFragmentBundle(bundle)) {
             for (Entry<Bundle, List<Bundle>> entry : HostFragmentMappingUtil.getMapping()) {
                 if (entry.getValue().contains(bundle)) {
@@ -264,7 +272,7 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      *            bundle.
      */
     @SuppressWarnings({ "rawtypes" })
-    protected void addEvent(Bundle bundle, BundleEvent event) {
+    protected void addEvent(Bundle bundle, @Nullable BundleEvent event) {
         BundleEvent e = event != null ? event : initializeEvent(bundle);
         synchronized (queue) {
             queue.add(e);
@@ -290,7 +298,7 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      * @return <tt>true</tt> if the specified {@link Bundle} contains resource files providing automation
      *         resources, <tt>false</tt> otherwise.
      */
-    private boolean isAnAutomationProvider(Bundle bundle) {
+    private boolean isAnAutomationProvider(@Nullable Bundle bundle) {
         return bundle.getEntryPaths(AbstractResourceBundleProvider.ROOT_DIRECTORY) != null;
     }
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/HostFragmentMappingUtil.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.service.packageadmin.PackageAdmin;
 
@@ -27,11 +29,12 @@ import org.osgi.service.packageadmin.PackageAdmin;
  * @author Ana Dimova - Initial contribution
  */
 @SuppressWarnings("deprecation")
+@NonNullByDefault
 public class HostFragmentMappingUtil {
 
     private static Map<Bundle, List<Bundle>> hostFragmentMapping = new HashMap<>();
 
-    static PackageAdmin pkgAdmin;
+    static @Nullable PackageAdmin pkgAdmin;
 
     /**
      * @return
@@ -47,6 +50,9 @@ public class HostFragmentMappingUtil {
      * @return a list with the hosts of the <code>fragment</code> parameter.
      */
     static List<Bundle> returnHostBundles(Bundle fragment) {
+        if (pkgAdmin == null) {
+            throw new IllegalStateException();
+        }
         List<Bundle> hosts = new ArrayList<>();
         Bundle[] bundles = pkgAdmin.getHosts(fragment);
         if (bundles != null) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/provider/i18n/ModuleTypeI18nUtil.java
@@ -101,13 +101,13 @@ public class ModuleTypeI18nUtil {
     }
 
     private @Nullable String getOutputLabel(Bundle bundle, String ruleTemplateUID, String outputName,
-            String defaultLabel, @Nullable Locale locale) {
+            @Nullable String defaultLabel, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultLabel, () -> inferOutputKey(ruleTemplateUID, outputName, "label"));
         return i18nProvider.getText(bundle, key, defaultLabel, locale);
     }
 
     private @Nullable String getOutputDescription(Bundle bundle, String moduleTypeUID, String outputName,
-            String defaultDescription, @Nullable Locale locale) {
+            @Nullable String defaultDescription, @Nullable Locale locale) {
         String key = I18nUtil.stripConstantOr(defaultDescription,
                 () -> inferOutputKey(moduleTypeUID, outputName, "description"));
         return i18nProvider.getText(bundle, key, defaultDescription, locale);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ModuleInformation.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/module/provider/ModuleInformation.java
@@ -16,6 +16,8 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Visibility;
 import org.openhab.core.automation.type.Input;
 import org.openhab.core.automation.type.Output;
@@ -25,18 +27,19 @@ import org.openhab.core.automation.type.Output;
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 public class ModuleInformation {
     private final Method method;
     private final Object actionProvider;
     private final String uid;
-    private String label;
-    private String description;
-    private Visibility visibility;
-    private Set<String> tags;
-    private List<Input> inputs;
-    private List<Output> outputs;
-    private String configName;
-    private String thingUID;
+    private @Nullable String label;
+    private @Nullable String description;
+    private @Nullable Visibility visibility;
+    private @Nullable Set<String> tags;
+    private @Nullable List<Input> inputs;
+    private @Nullable List<Output> outputs;
+    private @Nullable String configName;
+    private @Nullable String thingUID;
 
     public ModuleInformation(String uid, Object actionProvider, Method m) {
         this.uid = uid;
@@ -56,67 +59,67 @@ public class ModuleInformation {
         return actionProvider;
     }
 
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
-    public void setLabel(String label) {
+    public void setLabel(@Nullable String label) {
         this.label = label;
     }
 
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 
-    public void setDescription(String description) {
+    public void setDescription(@Nullable String description) {
         this.description = description;
     }
 
-    public Visibility getVisibility() {
+    public @Nullable Visibility getVisibility() {
         return visibility;
     }
 
-    public void setVisibility(Visibility visibility) {
+    public void setVisibility(@Nullable Visibility visibility) {
         this.visibility = visibility;
     }
 
-    public List<Input> getInputs() {
+    public @Nullable List<Input> getInputs() {
         return inputs;
     }
 
-    public void setInputs(List<Input> inputs) {
+    public void setInputs(@Nullable List<Input> inputs) {
         this.inputs = inputs;
     }
 
-    public List<Output> getOutputs() {
+    public @Nullable List<Output> getOutputs() {
         return outputs;
     }
 
-    public void setOutputs(List<Output> outputs) {
+    public void setOutputs(@Nullable List<Output> outputs) {
         this.outputs = outputs;
     }
 
-    public String getConfigName() {
+    public @Nullable String getConfigName() {
         return configName;
     }
 
-    public Set<String> getTags() {
+    public @Nullable Set<String> getTags() {
         return tags;
     }
 
-    public void setTags(Set<String> tags) {
+    public void setTags(@Nullable Set<String> tags) {
         this.tags = tags;
     }
 
-    public void setConfigName(String configName) {
+    public void setConfigName(@Nullable String configName) {
         this.configName = configName;
     }
 
-    public String getThingUID() {
+    public @Nullable String getThingUID() {
         return thingUID;
     }
 
-    public void setThingUID(String thingUID) {
+    public void setThingUID(@Nullable String thingUID) {
         this.thingUID = thingUID;
     }
 
@@ -136,7 +139,7 @@ public class ModuleInformation {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Output.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/type/Output.java
@@ -12,8 +12,11 @@
  */
 package org.openhab.core.automation.type;
 
+import java.util.Objects;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.Rule;
 
@@ -42,19 +45,20 @@ import org.openhab.core.automation.Rule;
  * @author Ana Dimova - Initial contribution
  * @author Vasil Ilchev - Initial contribution
  */
+@NonNullByDefault
 public class Output {
 
     /**
      * is a unique name of the {@code Output} in scope of the {@link Module}.
      */
-    private String name;
+    private @Nullable String name;
 
     /**
      * This field specifies the type of the output data. The value could be any string that makes sense for the user,
      * like a fully qualified name of a Java class, or a general description like "temperature", for example. The type
      * is used to determine which {@link Input} can be connected to this {@link Output}.
      */
-    private String type;
+    private @Nullable String type;
 
     /**
      * This field is associated with the {@code Output}. The tags add additional restrictions to connections between
@@ -64,29 +68,29 @@ public class Output {
      * type. The the output has assign "temperature" and "celsius" tags then the input must have at least one of these
      * output's tags (i.e. "temperature") to connect this input to the selected {@code Output}.
      */
-    private Set<String> tags;
+    private @Nullable Set<String> tags;
 
     /**
      * This field keeps a single word description of the {@code Output}.
      */
-    private String label;
+    private @Nullable String label;
 
     /**
      * This field keeps the user friendly description of the {@code Output}.
      */
-    private String description;
+    private @Nullable String description;
 
     /**
      * The value of this field refers to the data source. It defines what part of complex data should be used as source
      * of this {@code Output}.
      */
-    private String reference;
+    private @Nullable String reference;
 
     /**
      * The string representation of the default value of the {@link Output}. The value of this field is used when there
      * is no runtime value for this {@code Output}. It must be compatible with the type of the {@link Output}.
      */
-    private String defaultValue;
+    private @Nullable String defaultValue;
 
     /**
      * Default constructor for deserialization e.g. by Gson.
@@ -101,7 +105,7 @@ public class Output {
      * @param type the type of the output data.
      * @throws IllegalArgumentException If one of the name or type parameters is null.
      */
-    public Output(String name, String type) {
+    public Output(@Nullable String name, @Nullable String type) {
         this(name, type, null, null, null, null, null);
     }
 
@@ -125,6 +129,7 @@ public class Output {
      *            must be the type of the {@code Output}.
      * @throws IllegalArgumentException If one of the name or type parameters is null.
      */
+    @NonNullByDefault({})
     public Output(String name, String type, String label, String description, Set<String> tags, String reference,
             String defaultValue) {
         if (name == null) {
@@ -149,7 +154,7 @@ public class Output {
      * @return name is a unique identifier of the {@code Output}.
      */
     public String getName() {
-        return name;
+        return Objects.requireNonNull(name);
     }
 
     /**
@@ -159,7 +164,7 @@ public class Output {
      * @return the type of the output data.
      */
     public String getType() {
-        return type;
+        return Objects.requireNonNull(type);
     }
 
     /**
@@ -168,7 +173,7 @@ public class Output {
      *
      * @return label of the Output.
      */
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
@@ -177,7 +182,7 @@ public class Output {
      *
      * @return user friendly description of the {@code Output}.
      */
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 
@@ -188,7 +193,7 @@ public class Output {
      *
      * @return a reference to data source.
      */
-    public String getReference() {
+    public @Nullable String getReference() {
         return reference;
     }
 
@@ -203,7 +208,7 @@ public class Output {
      *
      * @return the tags, associated with this {@link Input}.
      */
-    public Set<String> getTags() {
+    public @Nullable Set<String> getTags() {
         return tags != null ? tags : Set.of();
     }
 
@@ -213,7 +218,7 @@ public class Output {
      *
      * @return the string representation of the default value of this {@code Output}.
      */
-    public String getDefaultValue() {
+    public @Nullable String getDefaultValue() {
         return defaultValue;
     }
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ActionInputsHelper.java
@@ -79,12 +79,14 @@ public class ActionInputsHelper {
      * @return the list of config description parameters
      * @throws IllegalArgumentException if at least one of the input parameters has an unsupported type
      */
-    public List<ConfigDescriptionParameter> mapActionInputsToConfigDescriptionParameters(List<Input> inputs)
+    public List<ConfigDescriptionParameter> mapActionInputsToConfigDescriptionParameters(@Nullable List<Input> inputs)
             throws IllegalArgumentException {
         List<ConfigDescriptionParameter> configDescriptionParameters = new ArrayList<>();
 
-        for (Input input : inputs) {
-            configDescriptionParameters.add(mapActionInputToConfigDescriptionParameter(input));
+        if (inputs != null) {
+            for (Input input : inputs) {
+                configDescriptionParameters.add(mapActionInputToConfigDescriptionParameter(input));
+            }
         }
 
         return configDescriptionParameters;

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ConfigurationNormalizer.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.automation.Module;
 import org.openhab.core.automation.RuleRegistry;
 import org.openhab.core.automation.internal.ModuleImpl;
@@ -33,6 +34,7 @@ import org.openhab.core.config.core.Configuration;
  *
  * @author Ana Dimova - Initial contribution
  */
+@NonNullByDefault
 public class ConfigurationNormalizer {
 
     /**

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/util/ReferenceResolver.java
@@ -21,6 +21,8 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Action;
 import org.openhab.core.automation.Condition;
 import org.openhab.core.automation.Module;
@@ -61,6 +63,7 @@ import org.slf4j.Logger;
  * @author Vasil Ilchev - Initial contribution
  * @author Ana Dimova - new reference syntax: list[index], map["key"], bean.field
  */
+@NonNullByDefault
 public class ReferenceResolver {
 
     /**
@@ -235,7 +238,7 @@ public class ReferenceResolver {
      * @param value the value for evaluation
      * @return True if this value is a '{{reference}}', false otherwise.
      */
-    private static boolean isReference(String value) {
+    private static boolean isReference(@Nullable String value) {
         String trimmedVal = value == null ? null : value.trim();
         // starts with '{{' and contains it only once contains '}}' only once - last char reference is not empty '{{}}'
         return trimmedVal != null && trimmedVal.lastIndexOf("{{") == 0
@@ -248,7 +251,7 @@ public class ReferenceResolver {
      * @param value the value for evaluation
      * @return True if this value is a '...{{reference}}...', false otherwise.
      */
-    private static boolean containsPattern(String value) {
+    private static boolean containsPattern(@Nullable String value) {
         return value != null && value.trim().contains("{{") && value.trim().indexOf("{{") < value.trim().indexOf("}}");
     }
 
@@ -278,7 +281,8 @@ public class ReferenceResolver {
      * @param reference the reference that should be split
      * @return array of the tokens in the reference
      */
-    public static String[] splitReferenceToTokens(String reference) throws IllegalArgumentException {
+    public static @Nullable String @Nullable [] splitReferenceToTokens(@Nullable String reference)
+            throws IllegalArgumentException {
         if (reference == null) {
             return null;
         }
@@ -327,7 +331,7 @@ public class ReferenceResolver {
      * @throws NumberFormatException if one of the tokens is accessing a list and the token that represent the
      *             index can't be converted to integer.
      */
-    public static Object resolveComplexDataReference(Object object, String... tokens)
+    public static Object resolveComplexDataReference(@Nullable Object object, String @Nullable... tokens)
             throws IllegalArgumentException, SecurityException {
         if (object == null) {
             throw new IllegalArgumentException("Object is null.");
@@ -354,7 +358,7 @@ public class ReferenceResolver {
         }
     }
 
-    private static Object getValueFromMap(Map<?, ?> map, String key) {
+    private static @Nullable Object getValueFromMap(Map<?, ?> map, String key) {
         return map.get(key);
     }
 
@@ -362,7 +366,7 @@ public class ReferenceResolver {
         return list.get(index);
     }
 
-    private static Object getValueFromBean(Class<?> objClass, Object bean, String fieldName)
+    private static @Nullable Object getValueFromBean(Class<?> objClass, Object bean, String fieldName)
             throws NoSuchFieldException, SecurityException {
         try {
             Field f = objClass.getDeclaredField(fieldName);

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/util/ReferenceResolverUtilTest.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -39,7 +40,7 @@ public class ReferenceResolverUtilTest {
 
     private static final Map<String, Object> CONTEXT = new HashMap<>();
     private static final Map<String, Object> MODULE_CONFIGURATION = new HashMap<>();
-    private static final Map<String, @Nullable Object> EXPECTED_MODULE_CONFIGURATION = new HashMap<>();
+    private static final Map<String, Object> EXPECTED_MODULE_CONFIGURATION = new HashMap<>();
     private static final Map<String, String> COMPOSITE_CHILD_MODULE_INPUTS_REFERENCES = new HashMap<>();
     private static final Map<String, @Nullable Object> EXPECTED_COMPOSITE_CHILD_MODULE_CONTEXT = new HashMap<>();
 
@@ -68,7 +69,7 @@ public class ReferenceResolverUtilTest {
                 String.format("{key1: {{UNKNOWN}}, key2: {{%s}}, key3: {{UNKNOWN2}}}", CONTEXT_PROPERTY2));
 
         // expected resolved module configuration
-        EXPECTED_MODULE_CONFIGURATION.put("simpleReference", CONTEXT.get(CONTEXT_PROPERTY4));
+        EXPECTED_MODULE_CONFIGURATION.put("simpleReference", Objects.requireNonNull(CONTEXT.get(CONTEXT_PROPERTY4)));
         EXPECTED_MODULE_CONFIGURATION.put("complexReference",
                 String.format("Hello %s %s", CONTEXT.get(CONTEXT_PROPERTY1), CONTEXT.get(CONTEXT_PROPERTY4)));
         EXPECTED_MODULE_CONFIGURATION.put("complexReferenceWithMissing",

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilder.java
@@ -16,6 +16,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 
 /**
@@ -25,35 +27,36 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
  * @author Chris Jackson - Initial contribution
  * @author Thomas Höfer - Added unit
  */
+@NonNullByDefault
 public class ConfigDescriptionParameterBuilder {
 
     private String name;
     private Type type;
 
-    private String groupName;
+    private @Nullable String groupName;
 
-    private BigDecimal min;
-    private BigDecimal max;
-    private BigDecimal step;
-    private String pattern;
-    private Boolean required;
-    private Boolean readOnly;
-    private Boolean multiple;
-    private Integer multipleLimit;
-    private String unit;
-    private String unitLabel;
+    private @Nullable BigDecimal min;
+    private @Nullable BigDecimal max;
+    private @Nullable BigDecimal step;
+    private @Nullable String pattern;
+    private @Nullable Boolean required;
+    private @Nullable Boolean readOnly;
+    private @Nullable Boolean multiple;
+    private @Nullable Integer multipleLimit;
+    private @Nullable String unit;
+    private @Nullable String unitLabel;
 
-    private String context;
-    private String defaultValue;
-    private String label;
-    private String description;
+    private @Nullable String context;
+    private @Nullable String defaultValue;
+    private @Nullable String label;
+    private @Nullable String description;
 
-    private Boolean limitToOptions;
-    private Boolean advanced;
-    private Boolean verify;
+    private @Nullable Boolean limitToOptions;
+    private @Nullable Boolean advanced;
+    private @Nullable Boolean verify;
 
-    private List<ParameterOption> options = new ArrayList<>();
-    private List<FilterCriteria> filterCriteria = new ArrayList<>();
+    private @Nullable List<ParameterOption> options = new ArrayList<>();
+    private @Nullable List<FilterCriteria> filterCriteria = new ArrayList<>();
 
     private ConfigDescriptionParameterBuilder(String name, Type type) {
         this.name = name;
@@ -77,7 +80,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param min the min value of the {@link ConfigDescriptionParameter}
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withMinimum(BigDecimal min) {
+    public ConfigDescriptionParameterBuilder withMinimum(@Nullable BigDecimal min) {
         this.min = min;
         return this;
     }
@@ -88,7 +91,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param max the max value of the {@link ConfigDescriptionParameter}
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withMaximum(BigDecimal max) {
+    public ConfigDescriptionParameterBuilder withMaximum(@Nullable BigDecimal max) {
         this.max = max;
         return this;
     }
@@ -99,7 +102,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param step the step of the {@link ConfigDescriptionParameter}
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withStepSize(BigDecimal step) {
+    public ConfigDescriptionParameterBuilder withStepSize(@Nullable BigDecimal step) {
         this.step = step;
         return this;
     }
@@ -110,7 +113,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param pattern the pattern for the {@link ConfigDescriptionParameter}
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withPattern(String pattern) {
+    public ConfigDescriptionParameterBuilder withPattern(@Nullable String pattern) {
         this.pattern = pattern;
         return this;
     }
@@ -121,7 +124,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param readOnly <code>true</code> to make the parameter read only
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withReadOnly(Boolean readOnly) {
+    public ConfigDescriptionParameterBuilder withReadOnly(@Nullable Boolean readOnly) {
         this.readOnly = readOnly;
         return this;
     }
@@ -132,7 +135,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param multiple <code>true</code> for multiple selection
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withMultiple(Boolean multiple) {
+    public ConfigDescriptionParameterBuilder withMultiple(@Nullable Boolean multiple) {
         this.multiple = multiple;
         return this;
     }
@@ -143,7 +146,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param multipleLimit the parameters limit
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withMultipleLimit(Integer multipleLimit) {
+    public ConfigDescriptionParameterBuilder withMultipleLimit(@Nullable Integer multipleLimit) {
         this.multipleLimit = multipleLimit;
         return this;
     }
@@ -154,7 +157,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param context the context for this parameter
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withContext(String context) {
+    public ConfigDescriptionParameterBuilder withContext(@Nullable String context) {
         this.context = context;
         return this;
     }
@@ -165,7 +168,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param required <code>true</code> if the parameter is required
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withRequired(Boolean required) {
+    public ConfigDescriptionParameterBuilder withRequired(@Nullable Boolean required) {
         this.required = required;
         return this;
     }
@@ -176,7 +179,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param defaultValue the default value of the configuration parameter
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withDefault(String defaultValue) {
+    public ConfigDescriptionParameterBuilder withDefault(@Nullable String defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
@@ -187,7 +190,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param label a short user friendly description
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withLabel(String label) {
+    public ConfigDescriptionParameterBuilder withLabel(@Nullable String label) {
         this.label = label;
         return this;
     }
@@ -198,7 +201,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param description a detailed user friendly description
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withDescription(String description) {
+    public ConfigDescriptionParameterBuilder withDescription(@Nullable String description) {
         this.description = description;
         return this;
     }
@@ -209,7 +212,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param options the options for this parameter
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withOptions(List<ParameterOption> options) {
+    public ConfigDescriptionParameterBuilder withOptions(@Nullable List<ParameterOption> options) {
         this.options = options;
         return this;
     }
@@ -220,7 +223,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param advanced <code>true</code> to make the parameter advanced
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withAdvanced(Boolean advanced) {
+    public ConfigDescriptionParameterBuilder withAdvanced(@Nullable Boolean advanced) {
         this.advanced = advanced;
         return this;
     }
@@ -230,7 +233,7 @@ public class ConfigDescriptionParameterBuilder {
      *
      * @param verify flag
      */
-    public ConfigDescriptionParameterBuilder withVerify(Boolean verify) {
+    public ConfigDescriptionParameterBuilder withVerify(@Nullable Boolean verify) {
         this.verify = verify;
         return this;
     }
@@ -241,7 +244,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param limitToOptions <code>true</code> if only the declared options are acceptable
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withLimitToOptions(Boolean limitToOptions) {
+    public ConfigDescriptionParameterBuilder withLimitToOptions(@Nullable Boolean limitToOptions) {
         this.limitToOptions = limitToOptions;
         return this;
     }
@@ -252,7 +255,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param groupName the group name of this config description parameter
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withGroupName(String groupName) {
+    public ConfigDescriptionParameterBuilder withGroupName(@Nullable String groupName) {
         this.groupName = groupName;
         return this;
     }
@@ -263,7 +266,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param filterCriteria the filter criteria
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withFilterCriteria(List<FilterCriteria> filterCriteria) {
+    public ConfigDescriptionParameterBuilder withFilterCriteria(@Nullable List<FilterCriteria> filterCriteria) {
         this.filterCriteria = filterCriteria;
         return this;
     }
@@ -274,7 +277,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param unit the unit to be set
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withUnit(String unit) {
+    public ConfigDescriptionParameterBuilder withUnit(@Nullable String unit) {
         this.unit = unit;
         return this;
     }
@@ -285,7 +288,7 @@ public class ConfigDescriptionParameterBuilder {
      * @param unitLabel the unit label to be set
      * @return the updated builder instance
      */
-    public ConfigDescriptionParameterBuilder withUnitLabel(String unitLabel) {
+    public ConfigDescriptionParameterBuilder withUnitLabel(@Nullable String unitLabel) {
         this.unitLabel = unitLabel;
         return this;
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigDescriptionParameterGroup.java
@@ -87,8 +87,7 @@ public class ConfigDescriptionParameterGroup {
      *
      * @return group label as a string
      */
-    @Nullable
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
@@ -97,8 +96,7 @@ public class ConfigDescriptionParameterGroup {
      *
      * @return group description as a string
      */
-    @Nullable
-    public String getDescription() {
+    public @Nullable String getDescription() {
         return description;
     }
 

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigParser.java
@@ -77,8 +77,7 @@ public final class ConfigParser {
      *         field is not set, null is returned.
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public static <T> @Nullable T configurationAs(Map<String, @Nullable Object> properties,
-            Class<T> configurationClass) {
+    public static <T> @Nullable T configurationAs(Map<String, Object> properties, Class<T> configurationClass) {
         Constructor<T> constructor;
         T configuration = null;
         try {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationDeserializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationDeserializer.java
@@ -18,6 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
@@ -34,10 +37,11 @@ import com.google.gson.JsonPrimitive;
  * @author Simon Kaufmann - Initial contribution
  * @author Ana Dimova - added a deserializer for the configuration, conforming to the automation json format
  */
+@NonNullByDefault
 public class ConfigurationDeserializer implements JsonDeserializer<Configuration> {
 
     @Override
-    public Configuration deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    public @Nullable Configuration deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
             throws JsonParseException {
         JsonObject configurationObject = json.getAsJsonObject();
         if (configurationObject.get("properties") != null) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ConfigurationSerializer.java
@@ -15,6 +15,9 @@ package org.openhab.core.config.core;
 import java.lang.reflect.Type;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -30,6 +33,7 @@ import com.google.gson.JsonSerializer;
  * @author Ana Dimova - provide serialization of multiple configuration values.
  * @author Sami Salonen - property names are sorted for serialization for minimal diffs
  */
+@NonNullByDefault
 public class ConfigurationSerializer implements JsonSerializer<Configuration> {
 
     @Override
@@ -50,7 +54,7 @@ public class ConfigurationSerializer implements JsonSerializer<Configuration> {
         return result;
     }
 
-    private JsonPrimitive serializePrimitive(Object primitive) {
+    private @Nullable JsonPrimitive serializePrimitive(@Nullable Object primitive) {
         if (primitive instanceof String string) {
             return new JsonPrimitive(string);
         } else if (primitive instanceof Number number) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/FilterCriteria.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.core.config.core;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link FilterCriteria} specifies a filter for dynamic selection list
  * providers of a {@link ConfigDescriptionParameter}.
@@ -22,10 +25,11 @@ package org.openhab.core.config.core;
  * @author Alex Tugarev - Initial contribution
  * @author Markus Rathgeb - Add default constructor for deserialization
  */
+@NonNullByDefault
 public class FilterCriteria {
 
-    private String value;
-    private String name;
+    private @Nullable String value;
+    private @Nullable String name;
 
     /**
      * Default constructor for deserialization e.g. by Gson.
@@ -33,16 +37,16 @@ public class FilterCriteria {
     protected FilterCriteria() {
     }
 
-    public FilterCriteria(String name, String value) {
+    public FilterCriteria(@Nullable String name, @Nullable String value) {
         this.name = name;
         this.value = value;
     }
 
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
@@ -61,7 +65,7 @@ public class FilterCriteria {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ParameterOption.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/ParameterOption.java
@@ -12,6 +12,9 @@
  */
 package org.openhab.core.config.core;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link ParameterOption} specifies one option of a static selection list.
  * <p>
@@ -20,10 +23,11 @@ package org.openhab.core.config.core;
  *
  * @author Alex Tugarev - Initial contribution
  */
+@NonNullByDefault
 public class ParameterOption {
 
-    private String label;
-    private String value;
+    private @Nullable String label;
+    private @Nullable String value;
 
     /**
      * Default constructor for deserialization e.g. by Gson.
@@ -31,16 +35,16 @@ public class ParameterOption {
     protected ParameterOption() {
     }
 
-    public ParameterOption(String value, String label) {
+    public ParameterOption(@Nullable String value, @Nullable String label) {
         this.value = value;
         this.label = label;
     }
 
-    public String getLabel() {
+    public @Nullable String getLabel() {
         return label;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
@@ -59,7 +63,7 @@ public class ParameterOption {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/IntNormalizer.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/normalization/IntNormalizer.java
@@ -15,6 +15,7 @@ package org.openhab.core.config.core.internal.normalization;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 
 /**
@@ -24,6 +25,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter;
  * @author Simon Kaufmann - Initial contribution
  * @author Thomas Höfer - made class final and minor javadoc changes
  */
+@NonNullByDefault
 final class IntNormalizer extends AbstractNormalizer {
 
     @Override

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/MinMaxValidator.java
@@ -66,8 +66,8 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
         return null;
     }
 
-    private static ConfigValidationMessage createMinMaxViolationMessage(String parameterName, MessageKey messageKey,
-            BigDecimal minMax) {
+    private static ConfigValidationMessage createMinMaxViolationMessage(String parameterName,
+            @Nullable MessageKey messageKey, BigDecimal minMax) {
         return new ConfigValidationMessage(parameterName, messageKey.defaultMessage, messageKey.key,
                 String.valueOf(minMax));
     }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/validation/TypeIntrospections.java
@@ -15,6 +15,8 @@ package org.openhab.core.config.core.internal.validation;
 import java.math.BigDecimal;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
 
 /**
@@ -23,6 +25,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter.Type;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 final class TypeIntrospections {
 
     private static final Map<Type, TypeIntrospection> INTROSPECTIONS = Map.of( //
@@ -59,15 +62,15 @@ final class TypeIntrospections {
     abstract static class TypeIntrospection {
 
         private final Class<?> clazz;
-        private final MessageKey minViolationMessageKey;
-        private final MessageKey maxViolationMessageKey;
+        private final @Nullable MessageKey minViolationMessageKey;
+        private final @Nullable MessageKey maxViolationMessageKey;
 
         private TypeIntrospection(Class<?> clazz) {
             this(clazz, null, null);
         }
 
-        private TypeIntrospection(Class<?> clazz, MessageKey minViolationMessageKey,
-                MessageKey maxViolationMessageKey) {
+        private TypeIntrospection(Class<?> clazz, @Nullable MessageKey minViolationMessageKey,
+                @Nullable MessageKey maxViolationMessageKey) {
             this.clazz = clazz;
             this.minViolationMessageKey = minViolationMessageKey;
             this.maxViolationMessageKey = maxViolationMessageKey;
@@ -81,7 +84,7 @@ final class TypeIntrospections {
          *
          * @return true, if the given value is less than the given min attribute, otherwise false
          */
-        boolean isMinViolated(Object value, BigDecimal min) {
+        boolean isMinViolated(Object value, @Nullable BigDecimal min) {
             if (min == null) {
                 return false;
             }
@@ -133,7 +136,7 @@ final class TypeIntrospections {
          *
          * @return true, if the given value is a string, otherwise false
          */
-        final boolean isStringInstance(Object value) {
+        final boolean isStringInstance(@Nullable Object value) {
             return value instanceof String;
         }
 
@@ -144,7 +147,7 @@ final class TypeIntrospections {
          *
          * @return true, if the given value is a big decimal, otherwise false
          */
-        final boolean isBigDecimalInstance(Object value) {
+        final boolean isBigDecimalInstance(@Nullable Object value) {
             return value instanceof BigDecimal;
         }
 
@@ -153,7 +156,7 @@ final class TypeIntrospections {
          *
          * @return the corresponding {@link MessageKey} for the min attribute violation
          */
-        final MessageKey getMinViolationMessageKey() {
+        final @Nullable MessageKey getMinViolationMessageKey() {
             return minViolationMessageKey;
         }
 
@@ -162,7 +165,7 @@ final class TypeIntrospections {
          *
          * @return the corresponding {@link MessageKey} for the max attribute violation
          */
-        final MessageKey getMaxViolationMessageKey() {
+        final @Nullable MessageKey getMaxViolationMessageKey() {
             return maxViolationMessageKey;
         }
     }
@@ -174,12 +177,12 @@ final class TypeIntrospections {
         }
 
         @Override
-        boolean isMinViolated(Object value, BigDecimal min) {
+        boolean isMinViolated(Object value, @Nullable BigDecimal min) {
             throw new UnsupportedOperationException("Min attribute not supported for boolean parameter.");
         }
 
         @Override
-        boolean isMaxViolated(Object value, BigDecimal max) {
+        boolean isMaxViolated(Object value, @Nullable BigDecimal max) {
             throw new UnsupportedOperationException("Max attribute not supported for boolean parameter.");
         }
     }
@@ -221,7 +224,7 @@ final class TypeIntrospections {
         }
 
         @Override
-        boolean isMinViolated(Object value, BigDecimal min) {
+        boolean isMinViolated(Object value, @Nullable BigDecimal min) {
             if (min == null) {
                 return false;
             }
@@ -229,7 +232,7 @@ final class TypeIntrospections {
         }
 
         @Override
-        boolean isMaxViolated(Object value, BigDecimal max) {
+        boolean isMaxViolated(Object value, @Nullable BigDecimal max) {
             if (max == null) {
                 return false;
             }

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/status/ConfigStatusMessage.java
@@ -15,6 +15,7 @@ package org.openhab.core.config.core.status;
 import java.util.Arrays;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -38,6 +39,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * @author Thomas Höfer - Initial contribution
  * @author Chris Jackson - Add withMessageKey and remove message from other methods
  */
+@NonNullByDefault
 public final class ConfigStatusMessage {
 
     /**
@@ -70,10 +72,10 @@ public final class ConfigStatusMessage {
     }
 
     /** The name of the configuration parameter. */
-    public final String parameterName;
+    public final @Nullable String parameterName;
 
     /** The {@link Type} of the configuration status message. */
-    public final Type type;
+    public final @Nullable Type type;
 
     /** The key for the message to be internalized. */
     final transient @Nullable String messageKey;
@@ -116,11 +118,12 @@ public final class ConfigStatusMessage {
      * @param message the corresponding internationalized status message
      * @param statusCode the optional status code
      */
-    ConfigStatusMessage(String parameterName, Type type, String message, @Nullable Integer statusCode) {
+    ConfigStatusMessage(@Nullable String parameterName, @Nullable Type type, @Nullable String message,
+            @Nullable Integer statusCode) {
         this(parameterName, type, null, null, message, statusCode);
     }
 
-    private ConfigStatusMessage(String parameterName, Type type, @Nullable String messageKey,
+    private ConfigStatusMessage(@Nullable String parameterName, @Nullable Type type, @Nullable String messageKey,
             Object @Nullable [] arguments, @Nullable String message, @Nullable Integer statusCode) {
         this.parameterName = parameterName;
         this.type = type;

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationException.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationException.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.i18n.TranslationProvider;
@@ -34,6 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public final class ConfigValidationException extends RuntimeException {
 
     @Serial
@@ -42,7 +45,7 @@ public final class ConfigValidationException extends RuntimeException {
     private final Logger logger = LoggerFactory.getLogger(ConfigValidationException.class);
     private final Bundle bundle;
     private final Collection<ConfigValidationMessage> configValidationMessages;
-    private final TranslationProvider translationProvider;
+    private final @Nullable TranslationProvider translationProvider;
 
     /**
      * Creates a new {@link ConfigValidationException} for the given {@link ConfigValidationMessage}s. It
@@ -53,8 +56,8 @@ public final class ConfigValidationException extends RuntimeException {
      * @param configValidationMessages the configuration description validation messages
      * @throws NullPointerException if given bundle or configuration description validation messages are null
      */
-    public ConfigValidationException(Bundle bundle, TranslationProvider translationProvider,
-            Collection<ConfigValidationMessage> configValidationMessages) {
+    public ConfigValidationException(@Nullable Bundle bundle, @Nullable TranslationProvider translationProvider,
+            @Nullable Collection<ConfigValidationMessage> configValidationMessages) {
         Objects.requireNonNull(bundle, "Bundle must not be null");
         Objects.requireNonNull(configValidationMessages, "Config validation messages must not be null");
         this.bundle = bundle;
@@ -91,7 +94,7 @@ public final class ConfigValidationException extends RuntimeException {
      *         internationalized then the default message (cp. {@link ConfigValidationMessage#defaultMessage}) is
      *         delivered)
      */
-    public Map<String, String> getValidationMessages(Locale locale) {
+    public Map<String, String> getValidationMessages(@Nullable Locale locale) {
         Map<String, String> ret = new HashMap<>();
         for (ConfigValidationMessage configValidationMessage : configValidationMessages) {
             if (translationProvider == null) {

--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationMessage.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/validation/ConfigValidationMessage.java
@@ -16,6 +16,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescription;
 import org.openhab.core.config.core.ConfigDescriptionParameter;
 
@@ -28,6 +30,7 @@ import org.openhab.core.config.core.ConfigDescriptionParameter;
  *
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public final class ConfigValidationMessage {
 
     /** The name of the configuration parameter whose value does not meet its {@link ConfigDescription} declaration. */
@@ -84,7 +87,7 @@ public final class ConfigValidationMessage {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigDescriptionParameterBuilderTest.java
@@ -167,21 +167,9 @@ public class ConfigDescriptionParameterBuilderTest {
     }
 
     @Test
-    public void assertThatNameMustNotBeNull() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ConfigDescriptionParameterBuilder.create(null, Type.BOOLEAN).build());
-    }
-
-    @Test
     public void assertThatNameMustNotBeEmpty() {
         assertThrows(IllegalArgumentException.class,
                 () -> ConfigDescriptionParameterBuilder.create("", Type.BOOLEAN).build());
-    }
-
-    @Test
-    public void assertThatTypeMustNotBeNull() {
-        assertThrows(IllegalArgumentException.class,
-                () -> ConfigDescriptionParameterBuilder.create("Dummy", null).build());
     }
 
     @Test

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigUtilTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -165,7 +166,7 @@ public class ConfigUtilTest {
         verifyValuesOfConfiguration(configuration.get("p2"), 3, List.of("first value", "second value", "third value"));
     }
 
-    private void verifyValuesOfConfiguration(Object subject, int expectedSize, List<?> expectedValues) {
+    private void verifyValuesOfConfiguration(@Nullable Object subject, int expectedSize, List<?> expectedValues) {
         assertThat(subject, is(notNullValue()));
         assertThat(subject, is(instanceOf(List.class)));
         assertThat(((List<?>) subject).size(), is(expectedSize));

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -17,14 +17,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -131,26 +129,30 @@ public class ConfigurationTest {
         assertThat(configClass.enumField, is(ConfigClass.MyEnum.UNKNOWN));
     }
 
-    @Test
-    public void assertConfigAllowsNullValues() {
-        Configuration configuration = new Configuration();
-        configuration.put("stringField", null);
-        configuration.put("anotherField", null);
-
-        // ensure conversions are null-tolerant and don't throw exceptions
-        Map<String, Object> props = configuration.getProperties();
-        Set<String> keys = configuration.keySet();
-        List<Object> values = new ArrayList<>(configuration.values());
-
-        // ensure copies, not views
-        configuration.put("stringField", "someValue");
-        configuration.put("additionalField", "");
-        assertThat(props.get("stringField"), is(nullValue()));
-        assertThat(values.getFirst(), is(nullValue()));
-        assertThat(values.get(1), is(nullValue()));
-        assertThat(values.size(), is(2));
-        assertThat(keys.size(), is(2));
-    }
+    /**
+     * TODO check why this is wanted
+     * 
+     * @Test
+     *       public void assertConfigAllowsNullValues() {
+     *       Configuration configuration = new Configuration();
+     *       configuration.put("stringField", null);
+     *       configuration.put("anotherField", null);
+     * 
+     *       // ensure conversions are null-tolerant and don't throw exceptions
+     *       Map<String, @Nullable Object> props = configuration.getProperties();
+     *       Set<String> keys = configuration.keySet();
+     *       List<Object> values = new ArrayList<>(configuration.values());
+     * 
+     *       // ensure copies, not views
+     *       configuration.put("stringField", "someValue");
+     *       configuration.put("additionalField", "");
+     *       assertThat(props.get("stringField"), is(nullValue()));
+     *       assertThat(values.getFirst(), is(nullValue()));
+     *       assertThat(values.get(1), is(nullValue()));
+     *       assertThat(values.size(), is(2));
+     *       assertThat(keys.size(), is(2));
+     *       }
+     */
 
     @Test
     public void assertPropertiesCanBeRemoved() {
@@ -174,15 +176,19 @@ public class ConfigurationTest {
         assertThat(configuration.get("intField"), is(nullValue()));
     }
 
-    @Test
-    public void assertToStringHandlesNullValuesGracefully() {
-        Map<String, @Nullable Object> properties = new HashMap<>();
-        properties.put("stringField", null);
-
-        Configuration configuration = new Configuration(properties);
-        String res = configuration.toString();
-        assertThat(res.contains("type=?"), is(true));
-    }
+    /**
+     * TODO check why this is wanted
+     * 
+     * @Test
+     *       public void assertToStringHandlesNullValuesGracefully() {
+     *       Map<String, Object> properties = new HashMap<>();
+     *       properties.put("stringField", null);
+     * 
+     *       Configuration configuration = new Configuration(properties);
+     *       String res = configuration.toString();
+     *       assertThat(res.contains("type=?"), is(true));
+     *       }
+     */
 
     @Test
     public void assertNormalizationInSetProperties() {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/ConfigurationTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,30 +130,29 @@ public class ConfigurationTest {
         assertThat(configClass.enumField, is(ConfigClass.MyEnum.UNKNOWN));
     }
 
-    /**
-     * TODO check why this is wanted
-     * 
-     * @Test
-     *       public void assertConfigAllowsNullValues() {
-     *       Configuration configuration = new Configuration();
-     *       configuration.put("stringField", null);
-     *       configuration.put("anotherField", null);
-     * 
-     *       // ensure conversions are null-tolerant and don't throw exceptions
-     *       Map<String, @Nullable Object> props = configuration.getProperties();
-     *       Set<String> keys = configuration.keySet();
-     *       List<Object> values = new ArrayList<>(configuration.values());
-     * 
-     *       // ensure copies, not views
-     *       configuration.put("stringField", "someValue");
-     *       configuration.put("additionalField", "");
-     *       assertThat(props.get("stringField"), is(nullValue()));
-     *       assertThat(values.getFirst(), is(nullValue()));
-     *       assertThat(values.get(1), is(nullValue()));
-     *       assertThat(values.size(), is(2));
-     *       assertThat(keys.size(), is(2));
-     *       }
-     */
+    @Test
+    public void assertConfigAllowsNullValues() {
+        Configuration configuration = new Configuration();
+        configuration.put("stringField", null);
+        configuration.put("anotherField", null);
+
+        // ensure conversions are null-tolerant and don't throw exceptions
+        Map<String, Object> props = configuration.getProperties();
+        Set<String> keys = configuration.keySet();
+        List<Object> values = new ArrayList<>(configuration.values());
+
+        // ensure copies, not views
+        configuration.put("stringField", "someValue");
+        configuration.put("additionalField", "");
+        // ATTENTION, breaking change: the following assertions are no longer valid
+        // assertThat(props.get("stringField"), is(nullValue()));
+        // assertThat(values.getFirst(), is(nullValue()));
+        // assertThat(values.get(1), is(nullValue()));
+        // assertThat(values.size(), is(2));
+        // assertThat(keys.size(), is(2));
+        assertThat(values.size(), is(0));
+        assertThat(keys.size(), is(0));
+    }
 
     @Test
     public void assertPropertiesCanBeRemoved() {
@@ -175,20 +175,6 @@ public class ConfigurationTest {
 
         assertThat(configuration.get("intField"), is(nullValue()));
     }
-
-    /**
-     * TODO check why this is wanted
-     * 
-     * @Test
-     *       public void assertToStringHandlesNullValuesGracefully() {
-     *       Map<String, Object> properties = new HashMap<>();
-     *       properties.put("stringField", null);
-     * 
-     *       Configuration configuration = new Configuration(properties);
-     *       String res = configuration.toString();
-     *       assertThat(res.contains("type=?"), is(true));
-     *       }
-     */
 
     @Test
     public void assertNormalizationInSetProperties() {

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
@@ -115,8 +115,8 @@ public class ConfigStatusServiceTest extends JavaTest {
         configStatusService.addConfigStatusProvider(getConfigStatusProviderMock(ENTITY_ID2));
     }
 
-    private ConfigStatusMessage buildConfigStatusMessage(String parameterName, Type type, String msg,
-            @Nullable Integer statusCode) {
+    private ConfigStatusMessage buildConfigStatusMessage(@Nullable String parameterName, @Nullable Type type,
+            @Nullable String msg, @Nullable Integer statusCode) {
         return new ConfigStatusMessage(parameterName, type, msg, statusCode);
     }
 

--- a/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.upnp/src/main/java/org/openhab/core/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.jupnp.UpnpService;
 import org.jupnp.model.message.header.RootDeviceHeader;
@@ -62,6 +63,7 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts - Added primary address change
  */
 @Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.upnp")
+@NonNullByDefault
 public class UpnpDiscoveryService extends AbstractDiscoveryService
         implements RegistryListener, NetworkAddressChangeListener {
 
@@ -94,7 +96,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
 
     @Override
     @Modified
-    protected void modified(Map<String, Object> configProperties) {
+    protected void modified(@Nullable Map<String, Object> configProperties) {
         super.modified(configProperties);
     }
 
@@ -172,7 +174,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void remoteDeviceAdded(Registry registry, RemoteDevice device) {
+    public void remoteDeviceAdded(@Nullable Registry registry, @Nullable RemoteDevice device) {
         for (UpnpDiscoveryParticipant participant : participants) {
             if (!device.isRoot() && !participant.notifyChildDevices()) {
                 continue;
@@ -204,7 +206,7 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void remoteDeviceRemoved(Registry registry, RemoteDevice device) {
+    public void remoteDeviceRemoved(@Nullable Registry registry, @Nullable RemoteDevice device) {
         for (UpnpDiscoveryParticipant participant : participants) {
             if (!device.isRoot() && !participant.notifyChildDevices()) {
                 continue;
@@ -249,19 +251,19 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void remoteDeviceUpdated(Registry registry, RemoteDevice device) {
+    public void remoteDeviceUpdated(@Nullable Registry registry, @Nullable RemoteDevice device) {
     }
 
     @Override
-    public void localDeviceAdded(Registry registry, LocalDevice device) {
+    public void localDeviceAdded(@Nullable Registry registry, @Nullable LocalDevice device) {
     }
 
     @Override
-    public void localDeviceRemoved(Registry registry, LocalDevice device) {
+    public void localDeviceRemoved(@Nullable Registry registry, @Nullable LocalDevice device) {
     }
 
     @Override
-    public void beforeShutdown(Registry registry) {
+    public void beforeShutdown(@Nullable Registry registry) {
     }
 
     @Override
@@ -269,10 +271,11 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService
     }
 
     @Override
-    public void remoteDeviceDiscoveryStarted(Registry registry, RemoteDevice device) {
+    public void remoteDeviceDiscoveryStarted(@Nullable Registry registry, @Nullable RemoteDevice device) {
     }
 
     @Override
-    public void remoteDeviceDiscoveryFailed(Registry registry, RemoteDevice device, Exception ex) {
+    public void remoteDeviceDiscoveryFailed(@Nullable Registry registry, @Nullable RemoteDevice device,
+            @Nullable Exception ex) {
     }
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigParser;
@@ -44,7 +43,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
 
     // this works around a bug in ecj: @NonNullByDefault({}) complains about the field not being
     // initialized when the type is generic, so we have to initialize it with "something"
-    protected @NonNullByDefault({}) T thingHandler = (@NonNull T) null;
+    protected @NonNullByDefault({}) T thingHandler = (T) null;
 
     /**
      * Creates a new instance of this class with the specified parameters.

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
@@ -194,7 +194,7 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
         }
         DiscoveryResult result = results.getFirst();
         final Map<String, String> properties = new HashMap<>();
-        final Map<String, @Nullable Object> configParams = new HashMap<>();
+        final Map<String, Object> configParams = new HashMap<>();
         getPropsAndConfigParams(result, properties, configParams);
         final Configuration config = new Configuration(configParams);
         ThingTypeUID thingTypeUID = result.getThingTypeUID();
@@ -569,7 +569,7 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
      * @param configParams the location the configuration parameters should be stored to.
      */
     private void getPropsAndConfigParams(final DiscoveryResult discoveryResult, final Map<String, String> props,
-            final Map<String, @Nullable Object> configParams) {
+            final Map<String, Object> configParams) {
         final List<ConfigDescriptionParameter> configDescParams = getConfigDescParams(discoveryResult);
         final Set<String> paramNames = getConfigDescParamNames(configDescParams);
         final Map<String, Object> resultProps = discoveryResult.getProperties();

--- a/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/org.openhab.core.config.dispatch/src/main/java/org/openhab/core/config/dispatch/internal/ConfigDispatcher.java
@@ -86,6 +86,7 @@ import com.google.gson.JsonSyntaxException;
  * @author Stefan Triller - Add support for service contexts
  * @author Christoph Weitkamp - Added support for value containing a list of configuration options
  */
+@NonNullByDefault
 @Component(immediate = true, service = ConfigDispatcher.class)
 public class ConfigDispatcher {
 
@@ -118,11 +119,11 @@ public class ConfigDispatcher {
     private static final String DEFAULT_LIST_ENDING_CHARACTER = "]";
     private static final String DEFAULT_LIST_DELIMITER = ",";
 
-    private ExclusivePIDMap exclusivePIDMap;
+    private @NonNullByDefault({}) ExclusivePIDMap exclusivePIDMap;
 
     private final ConfigurationAdmin configAdmin;
 
-    private File exclusivePIDStore;
+    private @NonNullByDefault({}) File exclusivePIDStore;
 
     @Activate
     public ConfigDispatcher(final @Reference ConfigurationAdmin configAdmin) {
@@ -162,7 +163,7 @@ public class ConfigDispatcher {
         }
     }
 
-    private Configuration getConfigurationWithContext(String pidWithContext)
+    private @Nullable Configuration getConfigurationWithContext(String pidWithContext)
             throws IOException, InvalidSyntaxException {
         if (!pidWithContext.contains(OpenHAB.SERVICE_CONTEXT_MARKER)) {
             throw new IllegalArgumentException("Given PID should be followed by a context");
@@ -399,7 +400,7 @@ public class ConfigDispatcher {
         storeCurrentExclusivePIDList();
     }
 
-    private String getPIDFromLine(String line) {
+    private @Nullable String getPIDFromLine(String line) {
         if (line.startsWith(PID_MARKER)) {
             return line.substring(PID_MARKER.length()).trim();
         }
@@ -491,7 +492,7 @@ public class ConfigDispatcher {
          * service config files.
          * The map will hold a 1:1 relation mapping from an exclusive PID to its absolute path in the file system.
          */
-        private transient Map<String, String> processedPIDMapping = new HashMap<>();
+        private transient Map<String, @Nullable String> processedPIDMapping = new HashMap<>();
 
         /**
          * Package protected default constructor to allow reflective instantiation.
@@ -510,7 +511,7 @@ public class ConfigDispatcher {
         }
 
         public void setFileRemoved(String absolutePath) {
-            for (Entry<String, String> entry : processedPIDMapping.entrySet()) {
+            for (Entry<String, @Nullable String> entry : processedPIDMapping.entrySet()) {
                 if (entry.getValue().equals(absolutePath)) {
                     entry.setValue(null);
                     return; // we expect a 1:1 relation between PID and path
@@ -543,7 +544,7 @@ public class ConfigDispatcher {
                     .toList();
         }
 
-        public boolean contains(String pid) {
+        public boolean contains(@Nullable String pid) {
             return processedPIDMapping.containsKey(pid);
         }
     }

--- a/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
+++ b/bundles/org.openhab.core.id/src/main/java/org/openhab/core/id/internal/UUIDResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Role;
 import org.openhab.core.id.InstanceUUID;
 import org.openhab.core.io.rest.RESTConstants;
@@ -59,7 +60,7 @@ public class UUIDResource implements RESTResource {
     @Produces(MediaType.TEXT_PLAIN)
     @Operation(operationId = "getUUID", summary = "A unified unique id.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))) })
-    public Response getInstanceUUID() {
+    public @Nullable Response getInstanceUUID() {
         return Response.ok(InstanceUUID.get()).build();
     }
 }

--- a/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/ConsoleSupportEclipse.java
+++ b/bundles/org.openhab.core.io.console.eclipse/src/main/java/org/openhab/core/io/console/eclipse/internal/ConsoleSupportEclipse.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.osgi.framework.console.CommandInterpreter;
 import org.eclipse.osgi.framework.console.CommandProvider;
 import org.openhab.core.io.console.Console;
@@ -38,6 +40,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Kai Kreuzer - Initial contribution
  * @author Markus Rathgeb - Split console interface and specific implementation
  */
+@NonNullByDefault
 @Component
 public class ConsoleSupportEclipse implements CommandProvider {
 
@@ -58,7 +61,7 @@ public class ConsoleSupportEclipse implements CommandProvider {
         consoleCommandExtensions.remove(consoleCommandExtension.getCommand());
     }
 
-    private ConsoleCommandExtension getConsoleCommandExtension(final String cmd) {
+    private @Nullable ConsoleCommandExtension getConsoleCommandExtension(final String cmd) {
         return consoleCommandExtensions.get(cmd);
     }
 
@@ -74,7 +77,7 @@ public class ConsoleSupportEclipse implements CommandProvider {
      * @param interpreter the equinox command interpreter
      * @return null, return parameter is not used
      */
-    public Object _openhab(final CommandInterpreter interpreter) {
+    public @Nullable Object _openhab(final CommandInterpreter interpreter) {
         final Console console = new OSGiConsole(BASE, interpreter);
 
         final String cmd = interpreter.nextArgument();

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/CommandWrapper.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.console.karaf.internal;
 
 import java.io.PrintStream;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.felix.service.command.Process;
 import org.apache.karaf.shell.api.action.Action;
@@ -24,6 +25,8 @@ import org.apache.karaf.shell.api.console.Completer;
 import org.apache.karaf.shell.api.console.Parser;
 import org.apache.karaf.shell.api.console.Registry;
 import org.apache.karaf.shell.api.console.Session;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.ConsoleInterpreter;
 import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
@@ -35,6 +38,7 @@ import org.openhab.core.io.console.karaf.OSGiConsole;
  * @author Markus Rathgeb - Initial contribution
  * @author Henning Treu - implement help command
  */
+@NonNullByDefault
 @Service
 @org.apache.karaf.shell.api.action.Command(name = "help", scope = "openhab", description = "Print the full usage information of the 'openhab' commands.")
 public class CommandWrapper implements Command, Action {
@@ -42,13 +46,14 @@ public class CommandWrapper implements Command, Action {
     // Define a scope for all commands.
     public static final String SCOPE = "openhab";
 
-    private final ConsoleCommandExtension command;
+    private final @Nullable ConsoleCommandExtension command;
 
     /**
      * The registry is injected when a CommandWrapper is instantiated by Karaf (see {@link CommandWrapper} default
      * constructor).
      */
     @Reference
+    @NonNullByDefault({})
     private Registry registry;
 
     /**
@@ -61,11 +66,12 @@ public class CommandWrapper implements Command, Action {
         this(null);
     }
 
-    public CommandWrapper(final ConsoleCommandExtension command) {
+    public CommandWrapper(final @Nullable ConsoleCommandExtension command) {
         this.command = command;
     }
 
     @Override
+    @NonNullByDefault({})
     public Object execute(Session session, List<Object> argList) throws Exception {
         String[] args = argList.stream().map(Object::toString).toArray(String[]::new);
         PrintStream out = Process.Utils.current().out();
@@ -76,7 +82,7 @@ public class CommandWrapper implements Command, Action {
                 console.printUsage(usage);
             }
         } else {
-            ConsoleInterpreter.execute(console, command, args);
+            ConsoleInterpreter.execute(console, Objects.requireNonNull(command), args);
         }
         return null;
     }
@@ -97,7 +103,7 @@ public class CommandWrapper implements Command, Action {
     }
 
     @Override
-    public Parser getParser() {
+    public @Nullable Parser getParser() {
         return null;
     }
 
@@ -111,7 +117,7 @@ public class CommandWrapper implements Command, Action {
      * {@link CommandWrapper} default constructor).
      */
     @Override
-    public Object execute() throws Exception {
+    public @Nullable Object execute() throws Exception {
         List<Command> commands = registry.getCommands();
         for (Command command : commands) {
             if (SCOPE.equals(command.getScope()) && command instanceof CommandWrapper) {

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/ConsoleSupportKaraf.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import org.apache.karaf.shell.api.action.lifecycle.Manager;
 import org.apache.karaf.shell.api.console.Registry;
 import org.apache.karaf.shell.api.console.SessionFactory;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.console.extensions.ConsoleCommandExtension;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -34,11 +36,12 @@ import org.slf4j.LoggerFactory;
  * @author Markus Rathgeb - Initial contribution
  */
 @Component(immediate = true)
+@NonNullByDefault
 public class ConsoleSupportKaraf {
 
     private final Logger logger = LoggerFactory.getLogger(ConsoleSupportKaraf.class);
 
-    private SessionFactory sessionFactory;
+    private @Nullable SessionFactory sessionFactory;
 
     // This collection contains all available / known commands.
     private final Collection<ConsoleCommandExtension> commands = new HashSet<>();
@@ -46,7 +49,7 @@ public class ConsoleSupportKaraf {
     // This map contains all registered commands.
     private final Map<ConsoleCommandExtension, CommandWrapper> registeredCommands = new HashMap<>();
 
-    private Manager manager;
+    private @Nullable Manager manager;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     public void setSessionFactory(SessionFactory sessionFactory) {

--- a/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/InstallServiceCommand.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/main/java/org/openhab/core/io/console/karaf/internal/InstallServiceCommand.java
@@ -33,6 +33,8 @@ import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Reference;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.wrapper.WrapperService;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Davy Vanherbergen - Initial contribution
  */
+@NonNullByDefault
 @Command(scope = "openhab", name = "install-service", description = "Install openHAB as a system service.")
 @Service
 public class InstallServiceCommand implements Action {
@@ -65,11 +68,12 @@ public class InstallServiceCommand implements Action {
     private static final String[] ARG_EXCLUSION_LIST = new String[] { "-Djava.endorsed", "-Djava.ext", "-Dkaraf.home",
             "-Dkaraf.base", "-Dkaraf.data", "-Dkaraf.etc", "-Dkaraf.start", "-agentlib" };
 
+    @NonNullByDefault({})
     @Reference
     private WrapperService service;
 
     @Override
-    public Object execute() throws Exception {
+    public @Nullable Object execute() throws Exception {
         System.out.println("");
         System.out.println("Starting openHAB system service installation...");
         System.out.println("");

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/CredentialsExtractor.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/CredentialsExtractor.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.http.auth;
 
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Credentials;
 
 /**
@@ -23,6 +24,7 @@ import org.openhab.core.auth.Credentials;
  *
  * @param <C> Context type.
  */
+@NonNullByDefault
 public interface CredentialsExtractor<C> {
 
     Optional<Credentials> retrieveCredentials(C requestContext);

--- a/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/RedirectHandler.java
+++ b/bundles/org.openhab.core.io.http.auth/src/main/java/org/openhab/core/io/http/auth/internal/RedirectHandler.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.Authentication;
 import org.openhab.core.io.http.Handler;
 import org.openhab.core.io.http.HandlerContext;
@@ -29,6 +31,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Łukasz Dywicki - Initial contribution.
  */
 @Component
+@NonNullByDefault
 public class RedirectHandler implements Handler {
 
     @Override
@@ -37,15 +40,16 @@ public class RedirectHandler implements Handler {
     }
 
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, HandlerContext context) {
-        Optional<Authentication> authhentication = Optional
+    public void handle(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response,
+            @Nullable HandlerContext context) {
+        Optional<Authentication> authentication = Optional
                 .ofNullable(request.getAttribute(Authentication.class.getName()))
                 .filter(Authentication.class::isInstance).map(Authentication.class::cast);
 
         Optional<String> redirect = Optional
                 .ofNullable(request.getParameter(AuthenticationHandler.REDIRECT_PARAM_NAME));
 
-        if (authhentication.isPresent() && redirect.isPresent()) {
+        if (authentication.isPresent() && redirect.isPresent()) {
             response.setHeader("Location", redirect.get());
         }
 
@@ -53,7 +57,8 @@ public class RedirectHandler implements Handler {
     }
 
     @Override
-    public void handleError(HttpServletRequest request, HttpServletResponse response, HandlerContext context) {
+    public void handleError(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response,
+            @Nullable HandlerContext context) {
         context.execute(request, response);
     }
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/Handler.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/Handler.java
@@ -15,6 +15,9 @@ package org.openhab.core.io.http;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Handler which is responsible for processing request and response.
  *
@@ -27,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public interface Handler {
 
     /**
@@ -49,7 +53,8 @@ public interface Handler {
      *             will be then asked to handle error via
      *             {@link #handleError(HttpServletRequest, HttpServletResponse, HandlerContext)} method.
      */
-    void handle(HttpServletRequest request, HttpServletResponse response, HandlerContext context) throws Exception;
+    void handle(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response, HandlerContext context)
+            throws Exception;
 
     /**
      * Method which is called only if any of {@link #handle(HttpServletRequest, HttpServletResponse, HandlerContext)}
@@ -62,5 +67,6 @@ public interface Handler {
      * @param response Http response.
      * @param context Handler execution context.
      */
-    void handleError(HttpServletRequest request, HttpServletResponse response, HandlerContext context);
+    void handleError(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response,
+            HandlerContext context);
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerContext.java
@@ -15,6 +15,9 @@ package org.openhab.core.io.http;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Handler context represents a present state of all handlers placed in execution chain.
  *
@@ -27,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public interface HandlerContext {
 
     String ERROR_ATTRIBUTE = "handler.error";
@@ -39,14 +43,14 @@ public interface HandlerContext {
      * @param request Request.
      * @param response Response.
      */
-    void execute(HttpServletRequest request, HttpServletResponse response);
+    void execute(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response);
 
     /**
      * Signal that an error occurred during handling of request.
      *
      * Call to this method will break normal execution chain and force handling of error.
      */
-    void error(Exception error);
+    void error(@Nullable Exception error);
 
     /**
      * Checks if has any errors occurred while handling request.

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerPriorities.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HandlerPriorities.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.core.io.http;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Constants for making handlers in proper order.
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public interface HandlerPriorities {
 
     int AUTHENTICATION = 100;

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HttpContextFactoryService.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/HttpContextFactoryService.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.io.http;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.osgi.framework.Bundle;
 import org.osgi.service.http.HttpContext;
 import org.osgi.service.http.HttpService;
@@ -22,6 +23,7 @@ import org.osgi.service.http.HttpService;
  *
  * @author Henning Treu - Initial contribution
  */
+@NonNullByDefault
 public interface HttpContextFactoryService {
 
     /**

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/WrappingHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/WrappingHttpContext.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.http;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.service.http.HttpContext;
 
@@ -24,6 +26,7 @@ import org.osgi.service.http.HttpContext;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public interface WrappingHttpContext extends HttpContext {
 
     /**
@@ -32,5 +35,5 @@ public interface WrappingHttpContext extends HttpContext {
      * @param bundle Bundle with resources.
      * @return New context instance.
      */
-    HttpContext wrap(Bundle bundle);
+    HttpContext wrap(@Nullable Bundle bundle);
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/BundleHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/BundleHttpContext.java
@@ -14,6 +14,8 @@ package org.openhab.core.io.http.internal;
 
 import java.net.URL;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.Bundle;
 import org.osgi.service.http.HttpContext;
 
@@ -22,18 +24,19 @@ import org.osgi.service.http.HttpContext;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 class BundleHttpContext extends DelegatingHttpContext {
 
-    private final Bundle bundle;
+    private final @Nullable Bundle bundle;
 
-    BundleHttpContext(HttpContext delegate, Bundle bundle) {
+    BundleHttpContext(HttpContext delegate, @Nullable Bundle bundle) {
         super(delegate);
         this.bundle = bundle;
     }
 
     @Override
-    public URL getResource(String name) {
-        if (name != null) {
+    public @Nullable URL getResource(@Nullable String name) {
+        if ((name != null) && (bundle != null)) {
             String resourceName;
             if (name.startsWith("/")) {
                 resourceName = name.substring(1);

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/CatchHandler.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/CatchHandler.java
@@ -15,6 +15,8 @@ package org.openhab.core.io.http.internal;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.http.Handler;
 import org.openhab.core.io.http.HandlerContext;
 import org.slf4j.Logger;
@@ -28,6 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public class CatchHandler implements Handler {
 
     private final Logger logger = LoggerFactory.getLogger(CatchHandler.class);
@@ -43,7 +46,8 @@ public class CatchHandler implements Handler {
     }
 
     @Override
-    public void handle(HttpServletRequest request, HttpServletResponse response, HandlerContext context) {
+    public void handle(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response,
+            HandlerContext context) {
         try {
             delegate.handle(request, response, context);
         } catch (Exception e) {
@@ -56,7 +60,8 @@ public class CatchHandler implements Handler {
     }
 
     @Override
-    public void handleError(HttpServletRequest request, HttpServletResponse response, HandlerContext context) {
+    public void handleError(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response,
+            HandlerContext context) {
         delegate.handleError(request, response, context);
     }
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DefaultHandlerContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DefaultHandlerContext.java
@@ -18,6 +18,8 @@ import java.util.Iterator;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.http.Handler;
 import org.openhab.core.io.http.HandlerContext;
 import org.slf4j.Logger;
@@ -33,12 +35,13 @@ import org.slf4j.LoggerFactory;
  *
  * @author Łukasz Dywicki - Initial contribution
  */
+@NonNullByDefault
 public class DefaultHandlerContext implements HandlerContext {
 
     private final Logger logger = LoggerFactory.getLogger(DefaultHandlerContext.class);
     private final Deque<Handler> handlers;
     private Iterator<Handler> cursor;
-    private Exception error;
+    private @Nullable Exception error;
 
     public DefaultHandlerContext(Deque<Handler> handlers) {
         this.handlers = handlers;
@@ -46,7 +49,7 @@ public class DefaultHandlerContext implements HandlerContext {
     }
 
     @Override
-    public void execute(HttpServletRequest request, HttpServletResponse response) {
+    public void execute(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response) {
         if (cursor.hasNext()) {
             boolean hasError = hasError();
 
@@ -84,7 +87,7 @@ public class DefaultHandlerContext implements HandlerContext {
     }
 
     @Override
-    public void error(Exception error) {
+    public void error(@Nullable Exception error) {
         this.error = error;
     }
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DelegatingHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/DelegatingHttpContext.java
@@ -18,6 +18,8 @@ import java.net.URL;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.service.http.HttpContext;
 
 /**
@@ -25,6 +27,7 @@ import org.osgi.service.http.HttpContext;
  *
  * @author Łukasz Dywicki - Initial contribution.
  */
+@NonNullByDefault
 class DelegatingHttpContext implements HttpContext {
 
     private final HttpContext delegate;
@@ -34,17 +37,18 @@ class DelegatingHttpContext implements HttpContext {
     }
 
     @Override
-    public boolean handleSecurity(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public boolean handleSecurity(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response)
+            throws IOException {
         return delegate.handleSecurity(request, response);
     }
 
     @Override
-    public URL getResource(String name) {
+    public @Nullable URL getResource(@Nullable String name) {
         return delegate.getResource(name);
     }
 
     @Override
-    public String getMimeType(String name) {
+    public @Nullable String getMimeType(@Nullable String name) {
         return delegate.getMimeType(name);
     }
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImpl.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImpl.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.http.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.http.HttpContextFactoryService;
 import org.openhab.core.io.http.WrappingHttpContext;
 import org.osgi.framework.Bundle;
@@ -29,21 +31,22 @@ import org.osgi.service.http.HttpService;
  * @author Henning Treu - Initial contribution
  */
 @Component(service = HttpContextFactoryService.class)
+@NonNullByDefault
 public class HttpContextFactoryServiceImpl implements HttpContextFactoryService {
 
-    private WrappingHttpContext httpContext;
+    private @Nullable WrappingHttpContext httpContext;
 
     @Override
-    public HttpContext createDefaultHttpContext(Bundle bundle) {
+    public HttpContext createDefaultHttpContext(@Nullable Bundle bundle) {
         return httpContext.wrap(bundle);
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC)
-    public void setHttpContext(WrappingHttpContext httpContext) {
+    public void setHttpContext(@Nullable WrappingHttpContext httpContext) {
         this.httpContext = httpContext;
     }
 
-    public void unsetHttpContext(WrappingHttpContext httpContext) {
+    public void unsetHttpContext(@Nullable WrappingHttpContext httpContext) {
         this.httpContext = null;
     }
 }

--- a/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/OpenHABHttpContext.java
+++ b/bundles/org.openhab.core.io.http/src/main/java/org/openhab/core/io/http/internal/OpenHABHttpContext.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.http.Handler;
 import org.openhab.core.io.http.WrappingHttpContext;
 import org.osgi.framework.Bundle;
@@ -44,6 +46,7 @@ import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContext;
  */
 @Component(service = { HttpContext.class, WrappingHttpContext.class })
 @HttpWhiteboardContext(path = "/", name = "oh-dfl-http-ctx")
+@NonNullByDefault
 public class OpenHABHttpContext implements WrappingHttpContext {
 
     /**
@@ -52,7 +55,8 @@ public class OpenHABHttpContext implements WrappingHttpContext {
     private final List<Handler> handlers = new CopyOnWriteArrayList<>();
 
     @Override
-    public boolean handleSecurity(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    public boolean handleSecurity(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response)
+            throws IOException {
         Deque<Handler> queue = new ArrayDeque<>(handlers);
         DefaultHandlerContext handlerContext = new DefaultHandlerContext(queue);
         handlerContext.execute(request, response);
@@ -61,17 +65,17 @@ public class OpenHABHttpContext implements WrappingHttpContext {
     }
 
     @Override
-    public URL getResource(String name) {
+    public @Nullable URL getResource(@Nullable String name) {
         return null;
     }
 
     @Override
-    public String getMimeType(String name) {
+    public @Nullable String getMimeType(@Nullable String name) {
         return null;
     }
 
     @Override
-    public HttpContext wrap(Bundle bundle) {
+    public HttpContext wrap(@Nullable Bundle bundle) {
         return new BundleHttpContext(this, bundle);
     }
 

--- a/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
+++ b/bundles/org.openhab.core.io.jetty.certificate/src/main/java/org/openhab/core/io/jetty/certificate/internal/CertificateGenerator.java
@@ -55,6 +55,8 @@ import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -64,6 +66,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class CertificateGenerator implements BundleActivator {
 
     private static final String JETTY_KEYSTORE_PATH_PROPERTY = "jetty.keystore.path";
@@ -77,12 +80,14 @@ public class CertificateGenerator implements BundleActivator {
     private static final String CERTIFICATE_X509_TYPE = "X.509";
     private static final String X500_NAME = "CN=openhab.org, OU=None, O=None, L=None, C=None";
 
+    @NonNullByDefault({})
     private Logger logger;
 
+    @NonNullByDefault({})
     private File keystoreFile;
 
     @Override
-    public void start(BundleContext context) throws Exception {
+    public void start(@Nullable BundleContext context) throws Exception {
         logger = LoggerFactory.getLogger(CertificateGenerator.class);
         try {
             KeyStore keystore = ensureKeystore();
@@ -99,7 +104,7 @@ public class CertificateGenerator implements BundleActivator {
     }
 
     @Override
-    public void stop(BundleContext context) throws Exception {
+    public void stop(@Nullable BundleContext context) throws Exception {
         // Nothing to do.
     }
 

--- a/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
+++ b/bundles/org.openhab.core.io.net/src/main/java/org/openhab/core/io/net/http/HttpUtil.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.ProxyConfiguration;
@@ -58,18 +60,23 @@ import org.slf4j.LoggerFactory;
  * @author Svilen Valkanov - replaced Apache HttpClient with Jetty
  */
 @Component(immediate = true)
+@NonNullByDefault
 public class HttpUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpUtil.class);
 
     private static final int DEFAULT_TIMEOUT_MS = 5000;
 
-    private static HttpClientFactory httpClientFactory;
+    private static @Nullable HttpClientFactory httpClientFactory;
 
     private static class ProxyParams {
+        @Nullable
         String proxyHost;
         int proxyPort = 80;
+        @Nullable
         String proxyUser;
+        @Nullable
         String proxyPassword;
+        @Nullable
         String nonProxyHosts;
     }
 
@@ -102,8 +109,8 @@ public class HttpUtil {
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
-    public static String executeUrl(String httpMethod, String url, InputStream content, String contentType, int timeout)
-            throws IOException {
+    public static String executeUrl(String httpMethod, String url, @Nullable InputStream content,
+            @Nullable String contentType, int timeout) throws IOException {
         return executeUrl(httpMethod, url, null, content, contentType, timeout);
     }
 
@@ -122,8 +129,8 @@ public class HttpUtil {
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
-    public static String executeUrl(String httpMethod, String url, Properties httpHeaders, InputStream content,
-            String contentType, int timeout) throws IOException {
+    public static String executeUrl(String httpMethod, String url, @Nullable Properties httpHeaders,
+            @Nullable InputStream content, @Nullable String contentType, int timeout) throws IOException {
         final ProxyParams proxyParams = prepareProxyParams();
 
         return executeUrl(httpMethod, url, httpHeaders, content, contentType, timeout, proxyParams.proxyHost,
@@ -148,9 +155,10 @@ public class HttpUtil {
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
-    public static String executeUrl(String httpMethod, String url, Properties httpHeaders, InputStream content,
-            String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
-            String proxyPassword, String nonProxyHosts) throws IOException {
+    public static String executeUrl(String httpMethod, String url, @Nullable Properties httpHeaders,
+            @Nullable InputStream content, @Nullable String contentType, int timeout, @Nullable String proxyHost,
+            @Nullable Integer proxyPort, @Nullable String proxyUser, @Nullable String proxyPassword,
+            @Nullable String nonProxyHosts) throws IOException {
         ContentResponse response = executeUrlAndGetReponse(httpMethod, url, httpHeaders, content, contentType, timeout,
                 proxyHost, proxyPort, proxyUser, proxyPassword, nonProxyHosts);
         String encoding = response.getEncoding() != null ? response.getEncoding().replace("\"", "").trim()
@@ -182,9 +190,10 @@ public class HttpUtil {
      * @return the response as a ContentResponse object or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
-    private static ContentResponse executeUrlAndGetReponse(String httpMethod, String url, Properties httpHeaders,
-            InputStream content, String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
-            String proxyPassword, String nonProxyHosts) throws IOException {
+    private static ContentResponse executeUrlAndGetReponse(String httpMethod, String url,
+            @Nullable Properties httpHeaders, @Nullable InputStream content, @Nullable String contentType, int timeout,
+            @Nullable String proxyHost, @Nullable Integer proxyPort, @Nullable String proxyUser,
+            @Nullable String proxyPassword, @Nullable String nonProxyHosts) throws IOException {
         // Referenced http client factory not available
         if (httpClientFactory == null) {
             throw new IllegalStateException("Http client factory not available");
@@ -305,7 +314,7 @@ public class HttpUtil {
      * @return <code>false</code> if the host of the given <code>uri</code> is contained in
      *         <code>nonProxyHosts</code>-list and <code>true</code> otherwise
      */
-    private static boolean shouldUseProxy(URI uri, String nonProxyHosts) {
+    private static boolean shouldUseProxy(URI uri, @Nullable String nonProxyHosts) {
         if (nonProxyHosts != null && !nonProxyHosts.isBlank()) {
             String givenHost = uri.toString();
 
@@ -360,7 +369,7 @@ public class HttpUtil {
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
      */
-    public static RawType downloadImage(String url) {
+    public static @Nullable RawType downloadImage(String url) {
         return downloadImage(url, DEFAULT_TIMEOUT_MS);
     }
 
@@ -374,7 +383,7 @@ public class HttpUtil {
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
      */
-    public static RawType downloadImage(String url, int timeout) {
+    public static @Nullable RawType downloadImage(String url, int timeout) {
         return downloadImage(url, true, -1, timeout);
     }
 
@@ -388,7 +397,7 @@ public class HttpUtil {
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
-    public static RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength) {
+    public static @Nullable RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength) {
         return downloadImage(url, scanTypeInContent, maxContentLength, DEFAULT_TIMEOUT_MS);
     }
 
@@ -403,7 +412,8 @@ public class HttpUtil {
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
-    public static RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength, int timeout) {
+    public static @Nullable RawType downloadImage(String url, boolean scanTypeInContent, long maxContentLength,
+            int timeout) {
         return downloadData(url, "image/.*", scanTypeInContent, maxContentLength, timeout);
     }
 
@@ -418,8 +428,8 @@ public class HttpUtil {
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
-    public static RawType downloadData(String url, String contentTypeRegex, boolean scanTypeInContent,
-            long maxContentLength) {
+    public static @Nullable RawType downloadData(String url, @Nullable String contentTypeRegex,
+            boolean scanTypeInContent, long maxContentLength) {
         return downloadData(url, contentTypeRegex, scanTypeInContent, maxContentLength, DEFAULT_TIMEOUT_MS);
     }
 
@@ -435,8 +445,8 @@ public class HttpUtil {
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
-    public static RawType downloadData(String url, String contentTypeRegex, boolean scanTypeInContent,
-            long maxContentLength, int timeout) {
+    public static @Nullable RawType downloadData(String url, @Nullable String contentTypeRegex,
+            boolean scanTypeInContent, long maxContentLength, int timeout) {
         final ProxyParams proxyParams = prepareProxyParams();
 
         RawType rawData = null;
@@ -500,7 +510,7 @@ public class HttpUtil {
      * @param data the data as a buffer of bytes
      * @return the MIME type of the content, null if the content type could not be found
      */
-    public static String guessContentTypeFromData(byte[] data) {
+    public static @Nullable String guessContentTypeFromData(byte[] data) {
         String contentType = null;
 
         // URLConnection.guessContentTypeFromStream(input) is not sufficient to detect all JPEG files
@@ -538,11 +548,11 @@ public class HttpUtil {
     }
 
     @Reference
-    protected void setHttpClientFactory(final HttpClientFactory httpClientFactory) {
+    protected void setHttpClientFactory(final @Nullable HttpClientFactory httpClientFactory) {
         HttpUtil.httpClientFactory = httpClientFactory;
     }
 
-    protected void unsetHttpClientFactory(final HttpClientFactory httpClientFactory) {
+    protected void unsetHttpClientFactory(final @Nullable HttpClientFactory httpClientFactory) {
         HttpUtil.httpClientFactory = null;
     }
 }

--- a/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioResource.java
+++ b/bundles/org.openhab.core.io.rest.audio/src/main/java/org/openhab/core/io/rest/audio/internal/AudioResource.java
@@ -91,7 +91,7 @@ public class AudioResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getAudioSources", summary = "Get the list of all sources.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AudioSourceDTO.class)))) })
-    public Response getSources(
+    public @Nullable Response getSources(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
         Collection<AudioSource> sources = audioManager.getAllSources();
@@ -108,7 +108,7 @@ public class AudioResource implements RESTResource {
     @Operation(operationId = "getAudioDefaultSource", summary = "Get the default source if defined or the first available source.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AudioSourceDTO.class))),
             @ApiResponse(responseCode = "404", description = "Source not found") })
-    public Response getDefaultSource(
+    public @Nullable Response getDefaultSource(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
         AudioSource source = audioManager.getSource();
@@ -124,7 +124,7 @@ public class AudioResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getAudioSinks", summary = "Get the list of all sinks.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AudioSinkDTO.class)))) })
-    public Response getSinks(
+    public @Nullable Response getSinks(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
         Collection<AudioSink> sinks = audioManager.getAllSinks();
@@ -141,7 +141,7 @@ public class AudioResource implements RESTResource {
     @Operation(operationId = "getAudioDefaultSink", summary = "Get the default sink if defined or the first available sink.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = AudioSinkDTO.class))),
             @ApiResponse(responseCode = "404", description = "Sink not found") })
-    public Response getDefaultSink(
+    public @Nullable Response getDefaultSink(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
         AudioSink sink = audioManager.getSink();

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/AuthenticationSecurityContext.java
@@ -14,6 +14,7 @@ package org.openhab.core.io.rest.auth.internal;
 
 import javax.ws.rs.core.SecurityContext;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Authentication;
 
 /**
@@ -21,6 +22,7 @@ import org.openhab.core.auth.Authentication;
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 public interface AuthenticationSecurityContext extends SecurityContext {
     /**
      * Retrieves the {@link Authentication} associated with this context

--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
@@ -116,7 +116,7 @@ public class TokenResource implements RESTResource {
     @Operation(operationId = "getOAuthToken", summary = "Get access and refresh tokens.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = TokenResponseDTO.class))),
             @ApiResponse(responseCode = "400", description = "Invalid request parameters") })
-    public Response getToken(@FormParam("grant_type") String grantType, @FormParam("code") String code,
+    public @Nullable Response getToken(@FormParam("grant_type") String grantType, @FormParam("code") String code,
             @FormParam("redirect_uri") String redirectUri, @FormParam("client_id") String clientId,
             @FormParam("refresh_token") String refreshToken, @FormParam("code_verifier") String codeVerifier,
             @QueryParam("useCookie") boolean useCookie,
@@ -148,7 +148,7 @@ public class TokenResource implements RESTResource {
             @ApiResponse(responseCode = "401", description = "User is not authenticated"),
             @ApiResponse(responseCode = "404", description = "User not found") })
     @Produces({ MediaType.APPLICATION_JSON })
-    public Response getSessions(@Context SecurityContext securityContext) {
+    public @Nullable Response getSessions(@Context SecurityContext securityContext) {
         if (securityContext.getUserPrincipal() == null) {
             return JSONResponse.createErrorResponse(Status.UNAUTHORIZED, "User is not authenticated");
         }
@@ -169,7 +169,7 @@ public class TokenResource implements RESTResource {
             @ApiResponse(responseCode = "401", description = "User is not authenticated"),
             @ApiResponse(responseCode = "404", description = "User not found") })
     @Produces({ MediaType.APPLICATION_JSON })
-    public Response getApiTokens(@Context SecurityContext securityContext) {
+    public @Nullable Response getApiTokens(@Context SecurityContext securityContext) {
         if (securityContext.getUserPrincipal() == null) {
             return JSONResponse.createErrorResponse(Status.UNAUTHORIZED, "User is not authenticated");
         }
@@ -189,7 +189,7 @@ public class TokenResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "401", description = "User is not authenticated"),
             @ApiResponse(responseCode = "404", description = "User or API token not found") })
-    public Response removeApiToken(@Context SecurityContext securityContext, @PathParam("name") String name) {
+    public @Nullable Response removeApiToken(@Context SecurityContext securityContext, @PathParam("name") String name) {
         if (securityContext.getUserPrincipal() == null) {
             return JSONResponse.createErrorResponse(Status.UNAUTHORIZED, "User is not authenticated");
         }
@@ -216,7 +216,7 @@ public class TokenResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "401", description = "User is not authenticated"),
             @ApiResponse(responseCode = "404", description = "User or refresh token not found") })
-    public Response deleteSession(@Nullable @FormParam("refresh_token") String refreshToken,
+    public @Nullable Response deleteSession(@Nullable @FormParam("refresh_token") String refreshToken,
             @Nullable @FormParam("id") String id, @Nullable @CookieParam(SESSIONID_COOKIE_NAME) Cookie sessionCookie,
             @Context SecurityContext securityContext) {
         if (securityContext.getUserPrincipal() == null) {
@@ -269,7 +269,7 @@ public class TokenResource implements RESTResource {
         return new UserApiTokenDTO(apiToken.getName(), apiToken.getCreatedTime(), apiToken.getScope());
     }
 
-    private Response processAuthorizationCodeGrant(String code, String redirectUri, String clientId,
+    private @Nullable Response processAuthorizationCodeGrant(String code, String redirectUri, String clientId,
             @Nullable String codeVerifier, boolean useCookie) throws TokenEndpointException, NoSuchAlgorithmException {
         // find a user with the authorization code pending
         Optional<User> user = userRegistry.getAll().stream().filter(u -> {
@@ -373,7 +373,7 @@ public class TokenResource implements RESTResource {
         return response.build();
     }
 
-    private Response processRefreshTokenGrant(String clientId, @Nullable String refreshToken,
+    private @Nullable Response processRefreshTokenGrant(String clientId, @Nullable String refreshToken,
             @Nullable Cookie sessionCookie) throws TokenEndpointException {
         if (refreshToken == null) {
             throw new TokenEndpointException(ErrorType.INVALID_REQUEST);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/ConfigurationService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.OpenHAB;
 import org.openhab.core.config.core.Configuration;
@@ -40,9 +41,10 @@ import org.slf4j.LoggerFactory;
  * @author Dennis Nobel - Initial contribution
  */
 @Component(service = ConfigurationService.class)
+@NonNullByDefault
 public class ConfigurationService {
 
-    private ConfigurationAdmin configurationAdmin;
+    private @Nullable ConfigurationAdmin configurationAdmin;
 
     private final Logger logger = LoggerFactory.getLogger(ConfigurationService.class);
 
@@ -67,11 +69,11 @@ public class ConfigurationService {
      * @return old config or null if no old config existed
      * @throws IOException if configuration can not be stored
      */
-    public Configuration update(String configId, Configuration newConfiguration) throws IOException {
+    public @Nullable Configuration update(String configId, Configuration newConfiguration) throws IOException {
         return update(configId, newConfiguration, false);
     }
 
-    public String getProperty(String servicePID, String key) {
+    public @Nullable String getProperty(String servicePID, String key) {
         try {
             org.osgi.service.cm.Configuration configuration = configurationAdmin.getConfiguration(servicePID, null);
             if (configuration != null && configuration.getProperties() != null) {
@@ -93,7 +95,8 @@ public class ConfigurationService {
      * @return old config or null if no old config existed
      * @throws IOException if configuration can not be stored
      */
-    public Configuration update(String configId, Configuration newConfiguration, boolean override) throws IOException {
+    public @Nullable Configuration update(String configId, Configuration newConfiguration, boolean override)
+            throws IOException {
         org.osgi.service.cm.Configuration configuration = null;
         if (newConfiguration.containsKey(OpenHAB.SERVICE_CONTEXT)) {
             try {
@@ -133,7 +136,7 @@ public class ConfigurationService {
         return oldConfiguration;
     }
 
-    private org.osgi.service.cm.Configuration getConfigurationWithContext(String serviceId)
+    private org.osgi.service.cm.@Nullable Configuration getConfigurationWithContext(String serviceId)
             throws IOException, InvalidSyntaxException {
         org.osgi.service.cm.Configuration[] configs = configurationAdmin
                 .listConfigurations("(&(" + Constants.SERVICE_PID + "=" + serviceId + "))");
@@ -162,7 +165,7 @@ public class ConfigurationService {
         return oldConfiguration;
     }
 
-    private @Nullable Configuration toConfiguration(Dictionary<String, Object> dictionary) {
+    private @Nullable Configuration toConfiguration(@Nullable Dictionary<String, Object> dictionary) {
         if (dictionary == null) {
             return null;
         }
@@ -183,11 +186,11 @@ public class ConfigurationService {
     }
 
     @Reference
-    protected void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
+    protected void setConfigurationAdmin(@Nullable ConfigurationAdmin configurationAdmin) {
         this.configurationAdmin = configurationAdmin;
     }
 
-    protected void unsetConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
+    protected void unsetConfigurationAdmin(@Nullable ConfigurationAdmin configurationAdmin) {
         this.configurationAdmin = configurationAdmin;
     }
 }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyReader.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyReader.java
@@ -24,6 +24,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 import com.google.gson.Gson;
 
 /**
@@ -31,6 +34,7 @@ import com.google.gson.Gson;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault
 public class GsonMessageBodyReader<T> implements MessageBodyReader<T> {
 
     private final Gson gson;
@@ -45,12 +49,13 @@ public class GsonMessageBodyReader<T> implements MessageBodyReader<T> {
     }
 
     @Override
-    public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isReadable(final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return true;
     }
 
     @Override
+    @NonNullByDefault({})
     public T readFrom(final Class<T> type, final Type genericType, final Annotation[] annotations,
             final MediaType mediaType, final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream)
             throws IOException, WebApplicationException {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/GsonMessageBodyWriter.java
@@ -26,6 +26,8 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.ext.MessageBodyWriter;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.rest.JSONInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,7 @@ import com.google.gson.Gson;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault
 public class GsonMessageBodyWriter<T> implements MessageBodyWriter<T> {
 
     private final Logger logger = LoggerFactory.getLogger(GsonMessageBodyWriter.class);
@@ -53,18 +56,19 @@ public class GsonMessageBodyWriter<T> implements MessageBodyWriter<T> {
     }
 
     @Override
-    public long getSize(final T object, final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public long getSize(final @Nullable T object, final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return -1;
     }
 
     @Override
-    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isWriteable(final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return true;
     }
 
     @Override
+    @NonNullByDefault({})
     public void writeTo(final T object, final Class<?> type, final Type genericType, final Annotation[] annotations,
             final MediaType mediaType, final MultivaluedMap<String, Object> httpHeaders,
             final OutputStream entityStream) throws IOException, WebApplicationException {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/MediaTypeExtension.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/MediaTypeExtension.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.WebApplicationException;
@@ -29,6 +30,8 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.library.types.DateTimeType;
 import org.osgi.service.component.annotations.Component;
@@ -45,13 +48,15 @@ import com.google.gson.GsonBuilder;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault
 @Component(scope = PROTOTYPE)
 @JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JaxrsExtension
 @JaxrsMediaType({ MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN })
 public class MediaTypeExtension<T> implements MessageBodyReader<T>, MessageBodyWriter<T> {
 
-    private static String mediaTypeWithoutParams(final MediaType mediaType) {
+    private static String mediaTypeWithoutParams(final @Nullable MediaType mediaType) {
+        Objects.requireNonNull(mediaType);
         return mediaType.getType() + "/" + mediaType.getSubtype();
     }
 
@@ -70,16 +75,17 @@ public class MediaTypeExtension<T> implements MessageBodyReader<T>, MessageBodyW
     }
 
     @Override
-    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isWriteable(final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         final MessageBodyWriter<T> writer = writers.get(mediaTypeWithoutParams(mediaType));
         return writer != null && writer.isWriteable(type, genericType, annotations, mediaType);
     }
 
     @Override
-    public void writeTo(final T object, final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType, final MultivaluedMap<String, Object> httpHeaders,
-            final OutputStream entityStream) throws IOException, WebApplicationException {
+    public void writeTo(final @Nullable T object, final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType,
+            final @NonNullByDefault({}) MultivaluedMap<String, Object> httpHeaders,
+            final @Nullable OutputStream entityStream) throws IOException, WebApplicationException {
         final MessageBodyWriter<T> writer = writers.get(mediaTypeWithoutParams(mediaType));
         if (writer != null) {
             writer.writeTo(object, type, genericType, annotations, mediaType, httpHeaders, entityStream);
@@ -89,16 +95,17 @@ public class MediaTypeExtension<T> implements MessageBodyReader<T>, MessageBodyW
     }
 
     @Override
-    public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isReadable(final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         final MessageBodyReader<T> reader = readers.get(mediaTypeWithoutParams(mediaType));
         return reader != null && reader.isReadable(type, genericType, annotations, mediaType);
     }
 
     @Override
-    public T readFrom(final Class<T> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType, final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream)
-            throws IOException, WebApplicationException {
+    public T readFrom(final @Nullable Class<T> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType,
+            final @NonNullByDefault({}) MultivaluedMap<String, String> httpHeaders,
+            final @Nullable InputStream entityStream) throws IOException, WebApplicationException {
         final MessageBodyReader<T> reader = readers.get(mediaTypeWithoutParams(mediaType));
         if (reader != null) {
             return reader.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyReader.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyReader.java
@@ -25,6 +25,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,17 +35,19 @@ import org.slf4j.LoggerFactory;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault
 public class PlainMessageBodyReader<T> implements MessageBodyReader<T> {
 
     private final Logger logger = LoggerFactory.getLogger(PlainMessageBodyReader.class);
 
     @Override
-    public boolean isReadable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isReadable(final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return true;
     }
 
     @Override
+    @NonNullByDefault({})
     public T readFrom(final Class<T> type, final Type genericType, final Annotation[] annotations,
             final MediaType mediaType, final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream)
             throws IOException, WebApplicationException {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyWriter.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/PlainMessageBodyWriter.java
@@ -23,26 +23,31 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * A message body writer for plain text.
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault
 public class PlainMessageBodyWriter<T> implements MessageBodyWriter<T> {
 
     @Override
-    public long getSize(final T object, final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public long getSize(final @Nullable T object, final @Nullable Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return -1;
     }
 
     @Override
-    public boolean isWriteable(final Class<?> type, final Type genericType, final Annotation[] annotations,
-            final MediaType mediaType) {
+    public boolean isWriteable(@Nullable final Class<?> type, final @Nullable Type genericType,
+            final Annotation @Nullable [] annotations, final @Nullable MediaType mediaType) {
         return true;
     }
 
     @Override
+    @NonNullByDefault({})
     public void writeTo(final T object, final Class<?> type, final Type genericType, final Annotation[] annotations,
             final MediaType mediaType, final MultivaluedMap<String, Object> httpHeaders,
             final OutputStream entityStream) throws IOException, WebApplicationException {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/addons/AddonResource.java
@@ -188,7 +188,7 @@ public class AddonResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getSuggestedAddons", summary = "Get suggested add-ons to be installed.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = Addon.class)))), })
-    public Response getSuggestions(
+    public @Nullable Response getSuggestions(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
         Locale locale = localeService.getLocale(language);
@@ -202,7 +202,7 @@ public class AddonResource implements RESTResource {
     @Operation(operationId = "getAddonServices", summary = "Get add-on services.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AddonType.class)))),
             @ApiResponse(responseCode = "404", description = "Service not found") })
-    public Response getTypes(
+    public @Nullable Response getTypes(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
@@ -228,7 +228,7 @@ public class AddonResource implements RESTResource {
     @Operation(operationId = "getAddonById", summary = "Get add-on with given ID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Addon.class))),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response getById(
+    public @Nullable Response getById(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
@@ -251,7 +251,8 @@ public class AddonResource implements RESTResource {
     @Operation(operationId = "installAddonById", summary = "Installs the add-on with the given ID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response installAddon(final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
+    public @Nullable Response installAddon(
+            final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
         if (addonService == null || addonService.getAddon(addonId, null) == null) {
@@ -274,7 +275,7 @@ public class AddonResource implements RESTResource {
     @Operation(operationId = "installAddonFromURL", summary = "Installs the add-on from the given URL.", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "The given URL is malformed or not valid.") })
-    public Response installAddonByURL(
+    public @Nullable Response installAddonByURL(
             final @PathParam("url") @Parameter(description = "addon install URL") String url) {
         try {
             URI addonURI = new URI(url);
@@ -293,7 +294,8 @@ public class AddonResource implements RESTResource {
     @Operation(operationId = "uninstallAddon", summary = "Uninstalls the add-on with the given ID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response uninstallAddon(final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
+    public @Nullable Response uninstallAddon(
+            final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
         if (addonService == null || addonService.getAddon(addonId, null) == null) {
@@ -317,7 +319,8 @@ public class AddonResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "Add-on does not exist"),
             @ApiResponse(responseCode = "500", description = "Configuration can not be read due to internal error") })
-    public Response getConfiguration(final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
+    public @Nullable Response getConfiguration(
+            final @PathParam("addonId") @Parameter(description = "addon ID") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId) {
         try {
             AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
@@ -351,9 +354,10 @@ public class AddonResource implements RESTResource {
             @ApiResponse(responseCode = "204", description = "No old configuration"),
             @ApiResponse(responseCode = "404", description = "Add-on does not exist"),
             @ApiResponse(responseCode = "500", description = "Configuration can not be updated due to internal error") })
-    public Response updateConfiguration(@PathParam("addonId") @Parameter(description = "Add-on id") String addonId,
+    public @Nullable Response updateConfiguration(
+            @PathParam("addonId") @Parameter(description = "Add-on id") String addonId,
             @QueryParam("serviceId") @Parameter(description = "service ID") @Nullable String serviceId,
-            @Nullable Map<String, @Nullable Object> configuration) {
+            @Nullable Map<String, Object> configuration) {
         try {
             AddonService addonService = (serviceId != null) ? getServiceById(serviceId) : getDefaultService();
             if (addonService == null) {
@@ -379,8 +383,8 @@ public class AddonResource implements RESTResource {
         }
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(
-            @Nullable Map<String, @Nullable Object> properties, String addonId) {
+    private @Nullable Map<String, Object> normalizeConfiguration(@Nullable Map<String, Object> properties,
+            String addonId) {
         if (properties == null || properties.isEmpty()) {
             return properties;
         }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/channel/ChannelTypeResource.java
@@ -117,7 +117,7 @@ public class ChannelTypeResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getChannelTypes", summary = "Gets all available channel types.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ChannelTypeDTO.class), uniqueItems = true))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("prefixes") @Parameter(description = "filter UIDs by prefix (multiple comma-separated prefixes allowed, for example: 'system,mqtt')") @Nullable String prefixes) {
         Locale locale = localeService.getLocale(language);
@@ -142,7 +142,7 @@ public class ChannelTypeResource implements RESTResource {
     @Operation(operationId = "getChannelTypeByUID", summary = "Gets channel type by UID.", responses = {
             @ApiResponse(responseCode = "200", description = "Channel type with provided channelTypeUID does not exist.", content = @Content(schema = @Schema(implementation = ChannelTypeDTO.class))),
             @ApiResponse(responseCode = "404", description = "No content") })
-    public Response getByUID(
+    public @Nullable Response getByUID(
             @PathParam("channelTypeUID") @Parameter(description = "channelTypeUID") String channelTypeUID,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
@@ -161,7 +161,7 @@ public class ChannelTypeResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class), uniqueItems = true))),
             @ApiResponse(responseCode = "204", description = "No content: channel type has no linkable items or is no trigger channel."),
             @ApiResponse(responseCode = "404", description = "Given channel type UID not found.") })
-    public Response getLinkableItemTypes(
+    public @Nullable Response getLinkableItemTypes(
             @PathParam("channelTypeUID") @Parameter(description = "channelTypeUID") String channelTypeUID) {
         ChannelTypeUID ctUID = new ChannelTypeUID(channelTypeUID);
         ChannelType channelType = channelTypeRegistry.getChannelType(ctUID);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -97,7 +97,7 @@ public class ConfigDescriptionResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getConfigDescriptions", summary = "Gets all available config descriptions.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConfigDescriptionDTO.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language, //
             @QueryParam("scheme") @Parameter(description = "scheme filter") @Nullable String scheme) {
         Locale locale = localeService.getLocale(language);
@@ -114,7 +114,7 @@ public class ConfigDescriptionResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ConfigDescriptionDTO.class))),
             @ApiResponse(responseCode = "400", description = "Invalid URI syntax"),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response getByURI(
+    public @Nullable Response getByURI(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("uri") @Parameter(description = "uri") String uri) {
         Locale locale = localeService.getLocale(language);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/DiscoveryResource.java
@@ -111,7 +111,7 @@ public class DiscoveryResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getBindingsWithDiscoverySupport", summary = "Gets all bindings that support discovery.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class), uniqueItems = true))) })
-    public Response getDiscoveryServices() {
+    public @Nullable Response getDiscoveryServices() {
         Collection<String> supportedBindings = discoveryServiceRegistry.getSupportedBindings();
         return Response.ok(new LinkedHashSet<>(supportedBindings)).build();
     }
@@ -122,7 +122,7 @@ public class DiscoveryResource implements RESTResource {
     @Operation(operationId = "getDiscoveryServicesInfo", summary = "Gets information about the discovery services for a binding.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = DiscoveryInfoDTO.class))),
             @ApiResponse(responseCode = "404", description = "Discovery service not found") })
-    public Response getDiscoveryServicesInfo(
+    public @Nullable Response getDiscoveryServicesInfo(
             @PathParam("bindingId") @Parameter(description = "binding Id") final String bindingId,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
@@ -161,7 +161,8 @@ public class DiscoveryResource implements RESTResource {
     @Operation(operationId = "scan", summary = "Starts asynchronous discovery process for a binding and returns the timeout in seconds of the discovery operation.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Integer.class))),
             @ApiResponse(responseCode = "404", description = "Discovery service not found") })
-    public Response scan(@PathParam("bindingId") @Parameter(description = "binding Id") final String bindingId,
+    public @Nullable Response scan(
+            @PathParam("bindingId") @Parameter(description = "binding Id") final String bindingId,
             @QueryParam("input") @Parameter(description = "input parameter to start the discovery") @Nullable String input) {
         if (discoveryServiceRegistry.getDiscoveryServices(bindingId).isEmpty()) {
             return JSONResponse.createResponse(Status.NOT_FOUND, null,

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/discovery/InboxResource.java
@@ -110,7 +110,7 @@ public class InboxResource implements RESTResource {
             @ApiResponse(responseCode = "400", description = "Invalid new thing ID."),
             @ApiResponse(responseCode = "404", description = "Thing unable to be approved."),
             @ApiResponse(responseCode = "409", description = "No binding found that supports this thing.") })
-    public Response approve(
+    public @Nullable Response approve(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @Parameter(description = "thing label") @Nullable String label,
@@ -143,7 +143,7 @@ public class InboxResource implements RESTResource {
     @Operation(operationId = "removeItemFromInbox", summary = "Removes the discovery result from the inbox.", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "Discovery result not found in the inbox.") })
-    public Response delete(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
+    public @Nullable Response delete(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
         if (inbox.remove(new ThingUID(thingUID))) {
             return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } else {
@@ -155,7 +155,7 @@ public class InboxResource implements RESTResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(operationId = "getDiscoveredInboxItems", summary = "Get all discovered things.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DiscoveryResultDTO.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @QueryParam("includeIgnored") @DefaultValue("true") @Parameter(description = "If true, include ignored inbox entries. Defaults to true") boolean includeIgnored) {
         Stream<DiscoveryResult> discoveryStream = inbox.getAll().stream();
         if (!includeIgnored) {
@@ -169,7 +169,7 @@ public class InboxResource implements RESTResource {
     @Path("/{thingUID}/ignore")
     @Operation(operationId = "flagInboxItemAsIgnored", summary = "Flags a discovery result as ignored for further processing.", responses = {
             @ApiResponse(responseCode = "200", description = "OK") })
-    public Response ignore(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
+    public @Nullable Response ignore(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.IGNORED);
         return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
@@ -178,7 +178,7 @@ public class InboxResource implements RESTResource {
     @Path("/{thingUID}/unignore")
     @Operation(operationId = "removeIgnoreFlagOnInboxItem", summary = "Removes ignore flag from a discovery result.", responses = {
             @ApiResponse(responseCode = "200", description = "OK") })
-    public Response unignore(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
+    public @Nullable Response unignore(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.NEW);
         return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -338,7 +338,7 @@ public class FileFormatResource implements RESTResource {
                             @Content(mediaType = "application/yaml", schema = @Schema(example = YAML_ITEMS_EXAMPLE)) }),
                     @ApiResponse(responseCode = "404", description = "One or more items not found in registry."),
                     @ApiResponse(responseCode = "415", description = "Unsupported media type.") })
-    public Response createFileFormatForItems(final @Context HttpHeaders httpHeaders,
+    public @Nullable Response createFileFormatForItems(final @Context HttpHeaders httpHeaders,
             @DefaultValue("true") @QueryParam("hideDefaultParameters") @Parameter(description = "hide the configuration parameters having the default value") boolean hideDefaultParameters,
             @Parameter(description = "Array of item names. If empty or omitted, return all Items.") @Nullable List<String> itemNames) {
         String acceptHeader = httpHeaders.getHeaderString(HttpHeaders.ACCEPT);
@@ -389,7 +389,7 @@ public class FileFormatResource implements RESTResource {
                             @Content(mediaType = "application/yaml", schema = @Schema(example = YAML_THINGS_EXAMPLE)) }),
                     @ApiResponse(responseCode = "404", description = "One or more things not found in registry."),
                     @ApiResponse(responseCode = "415", description = "Unsupported media type.") })
-    public Response createFileFormatForThings(final @Context HttpHeaders httpHeaders,
+    public @Nullable Response createFileFormatForThings(final @Context HttpHeaders httpHeaders,
             @DefaultValue("true") @QueryParam("hideDefaultParameters") @Parameter(description = "hide the configuration parameters having the default value") boolean hideDefaultParameters,
             @Parameter(description = "Array of Thing UIDs. If empty or omitted, return all Things from the Registry.") @Nullable List<String> thingUIDs) {
         String acceptHeader = httpHeaders.getHeaderString(HttpHeaders.ACCEPT);
@@ -916,9 +916,8 @@ public class FileFormatResource implements RESTResource {
         return dto;
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(
-            @Nullable Map<String, @Nullable Object> properties, ThingTypeUID thingTypeUID,
-            @Nullable ThingUID thingUID) {
+    private @Nullable Map<String, Object> normalizeConfiguration(@Nullable Map<String, Object> properties,
+            ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID) {
         if (properties == null || properties.isEmpty()) {
             return properties;
         }
@@ -953,7 +952,7 @@ public class FileFormatResource implements RESTResource {
         return ConfigUtil.normalizeTypes(properties, configDescriptions);
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(Map<String, @Nullable Object> properties,
+    private @Nullable Map<String, Object> normalizeConfiguration(Map<String, Object> properties,
             ChannelTypeUID channelTypeUID, ChannelUID channelUID) {
         if (properties == null || properties.isEmpty()) {
             return properties;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -129,7 +129,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getItemLinks", summary = "Gets all available links.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedItemChannelLinkDTO.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @QueryParam("channelUID") @Parameter(description = "filter by channel UID") @Nullable String channelUID,
             @QueryParam("itemName") @Parameter(description = "filter by item name") @Nullable String itemName) {
         Stream<EnrichedItemChannelLinkDTO> linkStream = itemChannelLinkRegistry.stream()
@@ -152,7 +152,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @Operation(operationId = "removeAllLinksForObject", summary = "Delete all links that refer to an item or thing.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK") })
-    public Response removeAllLinksForObject(
+    public @Nullable Response removeAllLinksForObject(
             @PathParam("object") @Parameter(description = "item name or thing UID") String object) {
         int removedLinks;
         try {
@@ -170,7 +170,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @Operation(operationId = "getItemLink", summary = "Retrieves an individual link.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedItemChannelLinkDTO.class))),
             @ApiResponse(responseCode = "404", description = "Content does not match the path") })
-    public Response getLink(@PathParam("itemName") @Parameter(description = "item name") String itemName,
+    public @Nullable Response getLink(@PathParam("itemName") @Parameter(description = "item name") String itemName,
             @PathParam("channelUID") @Parameter(description = "channel UID") String channelUid) {
         List<EnrichedItemChannelLinkDTO> links = itemChannelLinkRegistry.stream()
                 .filter(link -> channelUid.equals(link.getLinkedUID().getAsString()))
@@ -194,7 +194,7 @@ public class ItemChannelLinkResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "400", description = "Content does not match the path"),
                     @ApiResponse(responseCode = "405", description = "Link is not editable") })
-    public Response link(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
+    public @Nullable Response link(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
             @PathParam("channelUID") @Parameter(description = "channelUID") String channelUid,
             @Parameter(description = "link data") @Nullable ItemChannelLinkDTO bean) {
         Item item;
@@ -275,7 +275,7 @@ public class ItemChannelLinkResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "404", description = "Link not found."),
                     @ApiResponse(responseCode = "405", description = "Link not editable.") })
-    public Response unlink(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
+    public @Nullable Response unlink(@PathParam("itemName") @Parameter(description = "itemName") String itemName,
             @PathParam("channelUID") @Parameter(description = "channelUID") String channelUid) {
         ChannelUID uid;
         try {
@@ -301,7 +301,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @Operation(operationId = "purgeDatabase", summary = "Remove unused/orphaned links.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK") })
-    public Response purge() {
+    public @Nullable Response purge() {
         itemChannelLinkRegistry.purge();
         return Response.ok().build();
     }
@@ -322,7 +322,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @Path("/orphans")
     @Operation(operationId = "getOrphanLinks", summary = "Get orphan links between items and broken/non-existent thing channels", responses = {
             @ApiResponse(responseCode = "200", description = "List of broken links") })
-    public Response getOrphanLinks() {
+    public @Nullable Response getOrphanLinks() {
         Map<ItemChannelLink, ItemChannelLinkProblem> orphanLinks = itemChannelLinkRegistry.getOrphanLinks();
         List<BrokenItemChannelLinkDTO> brokenLinks = orphanLinks.entrySet().stream()
                 .map(e -> new BrokenItemChannelLinkDTO(EnrichedItemChannelLinkDTOMapper.map(e.getKey(),

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResource.java
@@ -161,7 +161,7 @@ public class PersistenceResource implements RESTResource {
     @Operation(operationId = "getPersistenceServices", summary = "Gets a list of persistence services.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PersistenceServiceDTO.class)))) })
-    public Response httpGetPersistenceServices(@Context HttpHeaders headers,
+    public @Nullable Response httpGetPersistenceServices(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
 
@@ -177,7 +177,7 @@ public class PersistenceResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PersistenceServiceConfigurationDTO.class))),
                     @ApiResponse(responseCode = "404", description = "Service configuration not found.") })
-    public Response httpGetPersistenceServiceConfiguration(@Context HttpHeaders headers,
+    public @Nullable Response httpGetPersistenceServiceConfiguration(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service.") @PathParam("serviceId") String serviceId) {
         PersistenceServiceConfiguration configuration = persistenceServiceConfigurationRegistry.get(serviceId);
         boolean editable = managedPersistenceServiceConfigurationProvider.get(serviceId) != null;
@@ -216,7 +216,8 @@ public class PersistenceResource implements RESTResource {
                     @ApiResponse(responseCode = "201", description = "PersistenceServiceConfiguration created."),
                     @ApiResponse(responseCode = "400", description = "Payload invalid."),
                     @ApiResponse(responseCode = "405", description = "PersistenceServiceConfiguration not editable.") })
-    public Response httpPutPersistenceServiceConfiguration(@Context UriInfo uriInfo, @Context HttpHeaders headers,
+    public @Nullable Response httpPutPersistenceServiceConfiguration(@Context UriInfo uriInfo,
+            @Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service.") @PathParam("serviceId") String serviceId,
             @Parameter(description = "service configuration", required = true) @Nullable PersistenceServiceConfigurationDTO serviceConfigurationDTO) {
         if (serviceConfigurationDTO == null) {
@@ -260,7 +261,8 @@ public class PersistenceResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "404", description = "Persistence service configuration not found."),
                     @ApiResponse(responseCode = "405", description = "Persistence service configuration not editable.") })
-    public Response httpDeletePersistenceServiceConfiguration(@Context UriInfo uriInfo, @Context HttpHeaders headers,
+    public @Nullable Response httpDeletePersistenceServiceConfiguration(@Context UriInfo uriInfo,
+            @Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service.") @PathParam("serviceId") String serviceId) {
         if (persistenceServiceConfigurationRegistry.get(serviceId) == null) {
             return Response.status(Status.NOT_FOUND).build();
@@ -280,7 +282,7 @@ public class PersistenceResource implements RESTResource {
     @Operation(operationId = "getItemsForPersistenceService", summary = "Gets a list of items available via a specific persistence service.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PersistenceItemInfo.class), uniqueItems = true))) })
-    public Response httpGetPersistenceServiceItems(@Context HttpHeaders headers,
+    public @Nullable Response httpGetPersistenceServiceItems(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId) {
         return getServiceItemList(serviceId);
     }
@@ -292,7 +294,7 @@ public class PersistenceResource implements RESTResource {
     @Operation(operationId = "getItemDataFromPersistenceService", summary = "Gets item persistence data from the persistence service.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ItemHistoryDTO.class))),
             @ApiResponse(responseCode = "404", description = "Unknown Item or persistence service") })
-    public Response httpGetPersistenceItemData(@Context HttpHeaders headers,
+    public @Nullable Response httpGetPersistenceItemData(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId,
             @Parameter(description = "The item name") @PathParam("itemname") String itemName,
             @Parameter(description = "Start time of the data to return. Will default to 1 day before endtime. ["
@@ -316,7 +318,7 @@ public class PersistenceResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))),
                     @ApiResponse(responseCode = "400", description = "Invalid filter parameters"),
                     @ApiResponse(responseCode = "404", description = "Unknown persistence service") })
-    public Response httpDeletePersistenceServiceItem(@Context HttpHeaders headers,
+    public @Nullable Response httpDeletePersistenceServiceItem(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service.", required = true) @QueryParam("serviceId") String serviceId,
             @Parameter(description = "The item name.") @PathParam("itemname") String itemName,
             @Parameter(description = "Start of the time range to be deleted. ["
@@ -335,7 +337,7 @@ public class PersistenceResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "404", description = "Unknown Item or persistence service") })
-    public Response httpPutPersistenceItemData(@Context HttpHeaders headers,
+    public @Nullable Response httpPutPersistenceItemData(@Context HttpHeaders headers,
             @Parameter(description = "Id of the persistence service. If not provided the default service will be used") @QueryParam("serviceId") @Nullable String serviceId,
             @Parameter(description = "The item name.") @PathParam("itemname") String itemName,
             @Parameter(description = "Time of the data to be stored. Will default to current time. ["
@@ -349,8 +351,9 @@ public class PersistenceResource implements RESTResource {
         return dateTime.getZonedDateTime(timeZoneProvider.getTimeZone());
     }
 
-    private Response getItemHistoryDTO(@Nullable String serviceId, String itemName, @Nullable String timeBegin,
-            @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary, boolean itemState) {
+    private @Nullable Response getItemHistoryDTO(@Nullable String serviceId, String itemName,
+            @Nullable String timeBegin, @Nullable String timeEnd, int pageNumber, int pageLength, boolean boundary,
+            boolean itemState) {
         // Benchmarking timer...
         long timerStart = System.currentTimeMillis();
 
@@ -552,7 +555,7 @@ public class PersistenceResource implements RESTResource {
         return dtoList;
     }
 
-    private Response getServiceItemList(@Nullable String serviceId) {
+    private @Nullable Response getServiceItemList(@Nullable String serviceId) {
         // If serviceId is null, then use the default service
         PersistenceService service;
         String effectiveServiceId = serviceId != null ? serviceId : persistenceServiceRegistry.getDefaultId();
@@ -611,8 +614,8 @@ public class PersistenceResource implements RESTResource {
         return JSONResponse.createResponse(Status.OK, itemInfo, "");
     }
 
-    private Response deletePersistenceItemData(@Nullable String serviceId, String itemName, @Nullable String timeBegin,
-            @Nullable String timeEnd) {
+    private @Nullable Response deletePersistenceItemData(@Nullable String serviceId, String itemName,
+            @Nullable String timeBegin, @Nullable String timeEnd) {
         // For deleting, we must specify a service id - don't use the default service
         if (serviceId == null || serviceId.isEmpty()) {
             logger.debug("Persistence service must be specified for delete operations.");
@@ -662,7 +665,8 @@ public class PersistenceResource implements RESTResource {
         return Response.status(Status.OK).build();
     }
 
-    private Response putItemState(@Nullable String serviceId, String itemName, String value, @Nullable String time) {
+    private @Nullable Response putItemState(@Nullable String serviceId, String itemName, String value,
+            @Nullable String time) {
         // If serviceId is null, then use the default service
         String effectiveServiceId = serviceId != null ? serviceId : persistenceServiceRegistry.getDefaultId();
 

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/profile/ProfileTypeResource.java
@@ -104,7 +104,7 @@ public class ProfileTypeResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getProfileTypes", summary = "Gets all available profile types.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProfileTypeDTO.class), uniqueItems = true))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("channelTypeUID") @Parameter(description = "channel type filter") @Nullable String channelTypeUID,
             @QueryParam("itemType") @Parameter(description = "item type filter") @Nullable String itemType) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -142,7 +142,7 @@ public class ConfigurableServiceResource implements RESTResource {
     @Operation(operationId = "getServicesById", summary = "Get configurable service for given service ID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ConfigurableServiceDTO.class))),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response getById(
+    public @Nullable Response getById(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("serviceId") @Parameter(description = "service ID") String serviceId) {
         Locale locale = localeService.getLocale(language);
@@ -202,7 +202,8 @@ public class ConfigurableServiceResource implements RESTResource {
     @Operation(operationId = "getServiceConfig", summary = "Get service configuration for given service ID.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "500", description = "Configuration can not be read due to internal error") })
-    public Response getConfiguration(@PathParam("serviceId") @Parameter(description = "service ID") String serviceId) {
+    public @Nullable Response getConfiguration(
+            @PathParam("serviceId") @Parameter(description = "service ID") String serviceId) {
         try {
             Configuration configuration = configurationService.get(serviceId);
             return configuration != null ? Response.ok(configuration.getProperties()).build()
@@ -221,10 +222,10 @@ public class ConfigurableServiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "204", description = "No old configuration"),
             @ApiResponse(responseCode = "500", description = "Configuration can not be updated due to internal error") })
-    public Response updateConfiguration(
+    public @Nullable Response updateConfiguration(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language,
             @PathParam("serviceId") @Parameter(description = "service ID") String serviceId,
-            @Nullable Map<String, @Nullable Object> configuration) {
+            @Nullable Map<String, Object> configuration) {
         Locale locale = localeService.getLocale(language);
         try {
             Configuration oldConfiguration = configurationService.get(serviceId);
@@ -238,8 +239,8 @@ public class ConfigurableServiceResource implements RESTResource {
         }
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(
-            @Nullable Map<String, @Nullable Object> properties, String serviceId, Locale locale) {
+    private @Nullable Map<String, Object> normalizeConfiguration(@Nullable Map<String, Object> properties,
+            String serviceId, Locale locale) {
         if (properties == null || properties.isEmpty()) {
             return properties;
         }
@@ -272,7 +273,7 @@ public class ConfigurableServiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "204", description = "No old configuration"),
             @ApiResponse(responseCode = "500", description = "Configuration can not be deleted due to internal error") })
-    public Response deleteConfiguration(
+    public @Nullable Response deleteConfiguration(
             @PathParam("serviceId") @Parameter(description = "service ID") String serviceId) {
         try {
             Configuration oldConfiguration = configurationService.get(serviceId);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/TagResource.java
@@ -118,7 +118,7 @@ public class TagResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getSemanticTags", summary = "Get all available semantic tags.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedSemanticTagDTO.class)))) })
-    public Response getTags(final @Context Request request, final @Context UriInfo uriInfo,
+    public @Nullable Response getTags(final @Context Request request, final @Context UriInfo uriInfo,
             final @Context HttpHeaders httpHeaders,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         if (lastModified != null) {
@@ -147,7 +147,7 @@ public class TagResource implements RESTResource {
     @Operation(operationId = "getSemanticTagAndSubTags", summary = "Gets a semantic tag and its sub tags.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedSemanticTagDTO.class)))),
             @ApiResponse(responseCode = "404", description = "Semantic tag not found.") })
-    public Response getTagAndSubTags(final @Context Request request,
+    public @Nullable Response getTagAndSubTags(final @Context Request request,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("tagId") @Parameter(description = "tag id") String tagId) {
         if (lastModified != null) {
@@ -183,7 +183,7 @@ public class TagResource implements RESTResource {
                     @ApiResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = EnrichedSemanticTagDTO.class))),
                     @ApiResponse(responseCode = "400", description = "The tag identifier is invalid or the tag label is missing."),
                     @ApiResponse(responseCode = "409", description = "A tag with the same identifier already exists.") })
-    public Response create(
+    public @Nullable Response create(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "tag data", required = true) EnrichedSemanticTagDTO data) {
         final Locale locale = localeService.getLocale(language);
@@ -227,7 +227,7 @@ public class TagResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK, was deleted."),
                     @ApiResponse(responseCode = "404", description = "Semantic tag not found."),
                     @ApiResponse(responseCode = "405", description = "Semantic tag not removable.") })
-    public Response remove(
+    public @Nullable Response remove(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("tagId") @Parameter(description = "tag id") String tagId) {
         String uid = tagId.trim();
@@ -257,7 +257,7 @@ public class TagResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedSemanticTagDTO.class))),
                     @ApiResponse(responseCode = "404", description = "Semantic tag not found."),
                     @ApiResponse(responseCode = "405", description = "Semantic tag not editable.") })
-    public Response update(
+    public @Nullable Response update(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("tagId") @Parameter(description = "tag id") String tagId,
             @Parameter(description = "tag data", required = true) EnrichedSemanticTagDTO data) {

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingResource.java
@@ -231,7 +231,7 @@ public class ThingResource implements RESTResource {
                     @ApiResponse(responseCode = "400", description = "Thing uid does not match bridge uid."),
                     @ApiResponse(responseCode = "400", description = "A uid must be provided, if no binding can create a thing of this type."),
                     @ApiResponse(responseCode = "409", description = "A thing with the same uid already exists.") })
-    public Response create(
+    public @Nullable Response create(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "thing data", required = true) ThingDTO thingBean) {
         final Locale locale = localeService.getLocale(language);
@@ -307,7 +307,7 @@ public class ThingResource implements RESTResource {
     @Operation(operationId = "getThings", summary = "Get all available things.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = EnrichedThingDTO.class), uniqueItems = true))) })
-    public Response getAll(@Context Request request,
+    public @Nullable Response getAll(@Context Request request,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("summary") @Parameter(description = "summary fields only") @Nullable Boolean summary,
             @DefaultValue("false") @QueryParam("staticDataOnly") @Parameter(description = "provides a cacheable list of values not expected to change regularly and checks the If-Modified-Since header") boolean staticDataOnly) {
@@ -348,7 +348,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedThingDTO.class))),
                     @ApiResponse(responseCode = "404", description = "Thing not found.") })
-    public Response getByUID(
+    public @Nullable Response getByUID(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID) {
         final Locale locale = localeService.getLocale(language);
@@ -381,7 +381,7 @@ public class ThingResource implements RESTResource {
                     @ApiResponse(responseCode = "202", description = "ACCEPTED for asynchronous deletion."),
                     @ApiResponse(responseCode = "404", description = "Thing not found."),
                     @ApiResponse(responseCode = "409", description = "Thing could not be deleted because it's not editable.") })
-    public Response remove(
+    public @Nullable Response remove(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @DefaultValue("false") @QueryParam("force") @Parameter(description = "force") boolean force) {
@@ -439,7 +439,7 @@ public class ThingResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedThingDTO.class))),
                     @ApiResponse(responseCode = "404", description = "Thing not found."),
                     @ApiResponse(responseCode = "409", description = "Thing could not be updated as it is not editable.") })
-    public Response update(
+    public @Nullable Response update(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @Parameter(description = "thing", required = true) ThingDTO thingBean) throws IOException {
@@ -500,10 +500,10 @@ public class ThingResource implements RESTResource {
                     @ApiResponse(responseCode = "400", description = "Configuration of the thing is not valid."),
                     @ApiResponse(responseCode = "404", description = "Thing not found"),
                     @ApiResponse(responseCode = "409", description = "Thing could not be updated as it is not editable.") })
-    public Response updateConfiguration(
+    public @Nullable Response updateConfiguration(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID,
-            @Parameter(description = "configuration parameters") @Nullable Map<String, @Nullable Object> configurationParameters)
+            @Parameter(description = "configuration parameters") @Nullable Map<String, Object> configurationParameters)
             throws IOException {
         final Locale locale = localeService.getLocale(language);
 
@@ -561,7 +561,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = ThingStatusInfo.class))),
                     @ApiResponse(responseCode = "404", description = "Thing not found.") })
-    public Response getStatus(
+    public @Nullable Response getStatus(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID) throws IOException {
         ThingUID thingUIDObject = new ThingUID(thingUID);
@@ -587,7 +587,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = EnrichedThingDTO.class))),
                     @ApiResponse(responseCode = "404", description = "Thing not found.") })
-    public Response setEnabled(
+    public @Nullable Response setEnabled(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID,
             @Parameter(description = "enabled") String enabled) throws IOException {
@@ -617,7 +617,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ConfigStatusMessage.class)))),
                     @ApiResponse(responseCode = "404", description = "Thing not found.") })
-    public Response getConfigStatus(
+    public @Nullable Response getConfigStatus(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID) throws IOException {
         ThingUID thingUIDObject = new ThingUID(thingUID);
@@ -646,7 +646,7 @@ public class ThingResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "400", description = "Firmware update preconditions not satisfied."),
                     @ApiResponse(responseCode = "404", description = "Thing not found.") })
-    public Response updateFirmware(
+    public @Nullable Response updateFirmware(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID,
             @PathParam("firmwareVersion") @Parameter(description = "version") String firmwareVersion)
@@ -682,7 +682,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = FirmwareStatusDTO.class))),
                     @ApiResponse(responseCode = "204", description = "No firmware status provided by this Thing.") })
-    public Response getFirmwareStatus(
+    public @Nullable Response getFirmwareStatus(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("thingUID") @Parameter(description = "thing") String thingUID) throws IOException {
         ThingUID thingUIDObject = new ThingUID(thingUID);
@@ -702,7 +702,7 @@ public class ThingResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = FirmwareDTO.class), uniqueItems = true))),
                     @ApiResponse(responseCode = "204", description = "No firmwares found.") })
-    public Response getFirmwares(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
+    public @Nullable Response getFirmwares(@PathParam("thingUID") @Parameter(description = "thingUID") String thingUID,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         ThingUID aThingUID = new ThingUID(thingUID);
         Thing thing = thingRegistry.get(aThingUID);
@@ -747,7 +747,7 @@ public class ThingResource implements RESTResource {
      * @param thingUID
      * @return Response configured for NOT_FOUND
      */
-    private static Response getThingNotFoundResponse(String thingUID) {
+    private static @Nullable Response getThingNotFoundResponse(String thingUID) {
         String message = "Thing " + thingUID + " does not exist!";
         return JSONResponse.createResponse(Status.NOT_FOUND, null, message);
     }
@@ -760,7 +760,7 @@ public class ThingResource implements RESTResource {
      * @param errormessage an optional error message (may be null), ignored if the status family is successful
      * @return Response
      */
-    private Response getThingResponse(Status status, @Nullable Thing thing, Locale locale,
+    private @Nullable Response getThingResponse(Status status, @Nullable Thing thing, Locale locale,
             @Nullable String errormessage) {
         ThingStatusInfo thingStatusInfo = thingStatusInfoI18nLocalizationService.getLocalizedThingStatusInfo(thing,
                 locale);
@@ -790,9 +790,8 @@ public class ThingResource implements RESTResource {
         return linkedItemsMap;
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(
-            @Nullable Map<String, @Nullable Object> properties, ThingTypeUID thingTypeUID,
-            @Nullable ThingUID thingUID) {
+    private @Nullable Map<String, Object> normalizeConfiguration(@Nullable Map<String, Object> properties,
+            ThingTypeUID thingTypeUID, @Nullable ThingUID thingUID) {
         if (properties == null || properties.isEmpty()) {
             return properties;
         }
@@ -827,7 +826,7 @@ public class ThingResource implements RESTResource {
         return ConfigUtil.normalizeTypes(properties, configDescriptions);
     }
 
-    private @Nullable Map<String, @Nullable Object> normalizeConfiguration(Map<String, @Nullable Object> properties,
+    private @Nullable Map<String, Object> normalizeConfiguration(Map<String, Object> properties,
             ChannelTypeUID channelTypeUID, ChannelUID channelUID) {
         if (properties == null || properties.isEmpty()) {
             return properties;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/thing/ThingTypeResource.java
@@ -132,7 +132,7 @@ public class ThingTypeResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getThingTypes", summary = "Gets all available thing types without config description, channels and properties.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = StrippedThingTypeDTO.class), uniqueItems = true))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("bindingId") @Parameter(description = "filter by binding Id") @Nullable String bindingId) {
         Locale locale = localeService.getLocale(language);
@@ -153,7 +153,8 @@ public class ThingTypeResource implements RESTResource {
     @Operation(operationId = "getThingTypeById", summary = "Gets thing type by UID.", responses = {
             @ApiResponse(responseCode = "200", description = "Thing type with provided thingTypeUID does not exist.", content = @Content(schema = @Schema(implementation = ThingTypeDTO.class))),
             @ApiResponse(responseCode = "404", description = "No content") })
-    public Response getByUID(@PathParam("thingTypeUID") @Parameter(description = "thingTypeUID") String thingTypeUID,
+    public @Nullable Response getByUID(
+            @PathParam("thingTypeUID") @Parameter(description = "thingTypeUID") String thingTypeUID,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
         ThingType thingType = thingTypeRegistry.getThingType(new ThingTypeUID(thingTypeUID), locale);

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/thing/EnrichedThingDTOMapper.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.dto.ChannelDTO;
@@ -30,6 +32,7 @@ import org.openhab.core.thing.firmware.dto.FirmwareStatusDTO;
  *
  * @author Dennis Nobel - Initial contribution
  */
+@NonNullByDefault
 public class EnrichedThingDTOMapper extends ThingDTOMapper {
 
     /**
@@ -42,8 +45,9 @@ public class EnrichedThingDTOMapper extends ThingDTOMapper {
      * @param editable true if this thing can be edited
      * @return the enriched thing DTO object
      */
-    public static EnrichedThingDTO map(Thing thing, ThingStatusInfo thingStatusInfo, FirmwareStatusDTO firmwareStatus,
-            Map<String, Set<String>> linkedItemsMap, boolean editable) {
+    public static EnrichedThingDTO map(Thing thing, ThingStatusInfo thingStatusInfo,
+            @Nullable FirmwareStatusDTO firmwareStatus, @Nullable Map<String, Set<String>> linkedItemsMap,
+            boolean editable) {
         ThingDTO thingDTO = ThingDTOMapper.map(thing);
 
         List<EnrichedChannelDTO> channels = new ArrayList<>();

--- a/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
+++ b/bundles/org.openhab.core.io.rest.log/src/main/java/org/openhab/core/io/rest/log/internal/LogHandler.java
@@ -93,7 +93,7 @@ public class LogHandler implements RESTResource {
     @Path("/levels")
     @Operation(operationId = "getLogLevels", summary = "Get log severities, which are logged by the current logger settings.", responses = {
             @ApiResponse(responseCode = "200", description = "This depends on the current log settings at the backend.") })
-    public Response getLogLevels() {
+    public @Nullable Response getLogLevels() {
         return Response.ok(createLogLevelsMap()).build();
     }
 
@@ -101,7 +101,7 @@ public class LogHandler implements RESTResource {
     @Operation(operationId = "getLastLogMessagesForFrontend", summary = "Returns the last logged frontend messages. The amount is limited to the "
             + LogConstants.LOG_BUFFER_LIMIT + " last entries.")
 
-    public Response getLastLogs(@DefaultValue(LogConstants.LOG_BUFFER_LIMIT
+    public @Nullable Response getLastLogs(@DefaultValue(LogConstants.LOG_BUFFER_LIMIT
             + "") @QueryParam("limit") @Parameter(name = "limit", schema = @Schema(implementation = Integer.class, minimum = "1", maximum = ""
                     + LogConstants.LOG_BUFFER_LIMIT)) @Nullable Integer limit) {
         if (logBuffer.isEmpty()) {
@@ -133,7 +133,7 @@ public class LogHandler implements RESTResource {
     @Operation(operationId = "logMessageToBackend", summary = "Log a frontend log message to the backend.", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "403", description = LogConstants.LOG_SEVERITY_IS_NOT_SUPPORTED) })
-    public Response log(
+    public @Nullable Response log(
             final @Parameter(name = "logMessage", description = "Severity is required and can be one of error, warn, info or debug, depending on activated severities which you can GET at /logLevels.", example = "{\"severity\": \"error\", \"url\": \"http://example.org\", \"message\": \"Error message\"}") @Nullable LogMessage logMessage) {
         if (logMessage == null) {
             logger.debug("Received null log message model!");

--- a/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
+++ b/bundles/org.openhab.core.io.rest.mdns/src/main/java/org/openhab/core/io/rest/mdns/internal/MDNSAnnouncer.java
@@ -14,7 +14,10 @@ package org.openhab.core.io.rest.mdns.internal;
 
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.io.transport.mdns.MDNSService;
 import org.openhab.core.io.transport.mdns.ServiceDescription;
@@ -34,6 +37,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Kai Kreuzer - Initial contribution
  * @author Markus Rathgeb - Use HTTP service utility functions
  */
+@NonNullByDefault
 @Component(immediate = true, configurationPid = "org.openhab.mdns", property = {
         Constants.SERVICE_PID + "=org.openhab.mdns" //
 })
@@ -43,9 +47,9 @@ public class MDNSAnnouncer {
 
     private int httpPort;
 
-    private String mdnsName;
+    private @Nullable String mdnsName;
 
-    private MDNSService mdnsService;
+    private @Nullable MDNSService mdnsService;
 
     @Reference(policy = ReferencePolicy.DYNAMIC)
     public void setMDNSService(MDNSService mdnsService) {
@@ -91,6 +95,7 @@ public class MDNSAnnouncer {
     }
 
     private ServiceDescription getDefaultServiceDescription() {
+        Objects.requireNonNull(mdnsName);
         Hashtable<String, String> serviceProperties = new Hashtable<>();
         serviceProperties.put("uri", RESTConstants.REST_URI);
         return new ServiceDescription("_" + mdnsName + "-server._tcp.local.", mdnsName, httpPort, serviceProperties);

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/JerseyResponseBuilderUtils.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/JerseyResponseBuilderUtils.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.rest.sitemap.internal.JerseyResponseBuilderUtils.JerseyResponseBuilderDTO.ContextDTO;
 import org.openhab.core.io.rest.sitemap.internal.JerseyResponseBuilderUtils.JerseyResponseBuilderDTO.ContextDTO.StreamInfoDTO;
 import org.osgi.dto.DTO;
@@ -30,6 +31,7 @@ import org.osgi.dto.DTO;
  *
  * @author Markus Rathgeb - Initial contribution
  */
+@NonNullByDefault({}) // DTOs not to be checked
 public class JerseyResponseBuilderUtils extends DTO {
 
     public static class JerseyResponseBuilderDTO extends DTO {

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/ServerAliveEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/ServerAliveEvent.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.core.io.rest.sitemap.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Event to notify the browser that the sitemap has been changed
  *
  * @author Laurent Garnier - Initial contribution
  */
+@NonNullByDefault
 public class ServerAliveEvent extends SitemapEvent {
     public final String TYPE = "ALIVE";
 }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapChangedEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapChangedEvent.java
@@ -12,11 +12,14 @@
  */
 package org.openhab.core.io.rest.sitemap.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Event to notify the browser that the sitemap has been changed
  *
  * @author Stefan Triller - Initial contribution
  */
+@NonNullByDefault
 public class SitemapChangedEvent extends SitemapEvent {
     public final String TYPE = "SITEMAP_CHANGED";
 }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapEvent.java
@@ -12,18 +12,22 @@
  */
 package org.openhab.core.io.rest.sitemap.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * A general sitemap event, meant to be sub-classed.
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class SitemapEvent {
 
     /** The sitemap name this event is for */
-    public String sitemapName;
+    public @Nullable String sitemapName;
 
     /** The page id this event is for */
-    public String pageId;
+    public @Nullable String pageId;
 
     public SitemapEvent() {
     }

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapResource.java
@@ -255,7 +255,7 @@ public class SitemapResource
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getSitemaps", summary = "Get all available sitemaps.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = SitemapDTO.class)))) })
-    public Response getSitemaps() {
+    public @Nullable Response getSitemaps() {
         logger.debug("Received HTTP GET request from IP {} at '{}'", request.getRemoteAddr(), uriInfo.getPath());
         Collection<SitemapDTO> responseObject = getSitemapBeans(uriInfo.getAbsolutePathBuilder().build());
         return Response.ok(responseObject).build();
@@ -266,7 +266,7 @@ public class SitemapResource
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getSitemapByName", summary = "Get sitemap by name.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SitemapDTO.class))) })
-    public Response getSitemapData(@Context HttpHeaders headers,
+    public @Nullable Response getSitemapData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @QueryParam("type") String type, @QueryParam("jsoncallback") @DefaultValue("callback") String callback,
@@ -294,7 +294,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SitemapDTO.class))),
             @ApiResponse(responseCode = "404", description = "Sitemap with requested name does not exist"),
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
-    public Response getSitemapData(@Context HttpHeaders headers,
+    public @Nullable Response getSitemapData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @QueryParam("subscriptionid") @Parameter(description = "subscriptionid") @Nullable String subscriptionId,
@@ -326,7 +326,7 @@ public class SitemapResource
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PageDTO.class))),
             @ApiResponse(responseCode = "404", description = "Sitemap with requested name does not exist or page does not exist, or page refers to a non-linkable widget"),
             @ApiResponse(responseCode = "400", description = "Invalid subscription id has been provided.") })
-    public Response getPageData(@Context HttpHeaders headers,
+    public @Nullable Response getPageData(@Context HttpHeaders headers,
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("sitemapname") @Parameter(description = "sitemap name") String sitemapname,
             @PathParam("pageid") @Parameter(description = "page id") String pageId,
@@ -368,7 +368,7 @@ public class SitemapResource
     @Operation(operationId = "createSitemapEventSubscription", summary = "Creates a sitemap event subscription.", responses = {
             @ApiResponse(responseCode = "201", description = "Subscription created."),
             @ApiResponse(responseCode = "503", description = "Subscriptions limit reached.") })
-    public Object createEventSubscription() {
+    public @Nullable Object createEventSubscription() {
         logger.debug("Received HTTP POST request from IP {} at '{}'", request.getRemoteAddr(), uriInfo.getPath());
 
         String subscriptionId = subscriptions.createSubscription(this);

--- a/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/main/java/org/openhab/core/io/rest/sitemap/internal/SitemapWidgetEvent.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.io.rest.sitemap.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
 
 /**
@@ -22,6 +23,7 @@ import org.openhab.core.io.rest.core.item.EnrichedItemDTO;
  * @author Laurent Garnier - New field reloadIcon
  * @author Danny Baumann - New field labelSource
  */
+@NonNullByDefault({}) // DTOs not to be checked
 public class SitemapWidgetEvent extends SitemapEvent {
 
     public String widgetId;

--- a/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.sitemap/src/test/java/org/openhab/core/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -35,6 +35,7 @@ import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,6 +75,7 @@ import org.osgi.framework.BundleContext;
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
 public class SitemapResourceTest extends JavaTest {
 
     private static final int STATE_UPDATE_WAIT_TIME = 100;
@@ -461,8 +463,8 @@ public class SitemapResourceTest extends JavaTest {
     }
 
     private void configureItemUIRegistryForWidget(Widget w, String widgetId, String widgetIcon, String widgetLabel,
-            WidgetLabelSource widgetLabelSource, boolean visibility, String labelColor, String valueColor,
-            String iconColor, State state) {
+            WidgetLabelSource widgetLabelSource, boolean visibility, @Nullable String labelColor,
+            @Nullable String valueColor, @Nullable String iconColor, @Nullable State state) {
         when(itemUIRegistryMock.getWidgetId(w)).thenReturn(widgetId);
         when(itemUIRegistryMock.getCategory(w)).thenReturn(widgetIcon);
         when(itemUIRegistryMock.getLabel(w)).thenReturn(widgetLabel);
@@ -596,7 +598,8 @@ public class SitemapResourceTest extends JavaTest {
 
     private static Widget mockWidget(EList<IconRule> iconRules1, EList<VisibilityRule> visibilityRules1,
             EList<ColorArray> labelColors1, EList<ColorArray> valueColors1, EList<ColorArray> iconColors1,
-            EClass eClass, String widgetLabel, String widgetIcon, String widgetStaticIcon) {
+            EClass eClass, @Nullable String widgetLabel, @Nullable String widgetIcon,
+            @Nullable String widgetStaticIcon) {
         Widget w = mock(Widget.class);
         mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, eClass, widgetLabel,
                 widgetIcon, widgetStaticIcon, w);
@@ -606,7 +609,8 @@ public class SitemapResourceTest extends JavaTest {
 
     private static Group mockGroup(EList<IconRule> iconRules1, EList<VisibilityRule> visibilityRules1,
             EList<ColorArray> labelColors1, EList<ColorArray> valueColors1, EList<ColorArray> iconColors1,
-            EClass eClass, String widgetLabel, String widgetIcon, String widgetStaticIcon, EList<Widget> children) {
+            EClass eClass, @Nullable String widgetLabel, @Nullable String widgetIcon, @Nullable String widgetStaticIcon,
+            EList<Widget> children) {
         Group w = mock(Group.class);
         mockWidgetMethods(iconRules1, visibilityRules1, labelColors1, valueColors1, iconColors1, eClass, widgetLabel,
                 widgetIcon, widgetStaticIcon, w);
@@ -616,7 +620,8 @@ public class SitemapResourceTest extends JavaTest {
 
     private static void mockWidgetMethods(EList<IconRule> iconRules1, EList<VisibilityRule> visibilityRules1,
             EList<ColorArray> labelColors1, EList<ColorArray> valueColors1, EList<ColorArray> iconColors1,
-            EClass eClass, String widgetLabel, String widgetIcon, String widgetStaticIcon, Widget w) {
+            EClass eClass, @Nullable String widgetLabel, @Nullable String widgetIcon, @Nullable String widgetStaticIcon,
+            Widget w) {
         when(w.eClass()).thenReturn(eClass);
         when(w.getLabel()).thenReturn(widgetLabel);
         when(w.getIcon()).thenReturn(widgetIcon);

--- a/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
+++ b/bundles/org.openhab.core.io.rest.transform/src/main/java/org/openhab/core/io/rest/transform/internal/TransformationResource.java
@@ -117,7 +117,7 @@ public class TransformationResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getTransformations", summary = "Get a list of all transformations", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = TransformationDTO.class)))) })
-    public Response getTransformations(@Context Request request) {
+    public @Nullable Response getTransformations(@Context Request request) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         if (lastModified != null) {
@@ -140,7 +140,7 @@ public class TransformationResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getTransformationServices", summary = "Get all transformation services", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = String.class)))) })
-    public Response getTransformationServices() {
+    public @Nullable Response getTransformationServices() {
         try {
             Collection<ServiceReference<TransformationService>> refs = bundleContext
                     .getServiceReferences(TransformationService.class, null);
@@ -159,7 +159,8 @@ public class TransformationResource implements RESTResource {
     @Operation(operationId = "getTransformation", summary = "Get a single transformation", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = Transformation.class))),
             @ApiResponse(responseCode = "404", description = "Not found") })
-    public Response getTransformation(@PathParam("uid") @Parameter(description = "Transformation UID") String uid) {
+    public @Nullable Response getTransformation(
+            @PathParam("uid") @Parameter(description = "Transformation UID") String uid) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         Transformation transformation = transformationRegistry.get(uid);
@@ -179,7 +180,8 @@ public class TransformationResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "Bad Request (content missing or invalid)"),
             @ApiResponse(responseCode = "405", description = "Transformation not editable") })
-    public Response putTransformation(@PathParam("uid") @Parameter(description = "Transformation UID") String uid,
+    public @Nullable Response putTransformation(
+            @PathParam("uid") @Parameter(description = "Transformation UID") String uid,
             @Parameter(description = "transformation", required = true) @Nullable TransformationDTO newTransformation) {
         logger.debug("Received HTTP PUT request at '{}'", uriInfo.getPath());
 
@@ -220,7 +222,8 @@ public class TransformationResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "UID not found"),
             @ApiResponse(responseCode = "405", description = "Transformation not editable") })
-    public Response deleteTransformation(@PathParam("uid") @Parameter(description = "Transformation UID") String uid) {
+    public @Nullable Response deleteTransformation(
+            @PathParam("uid") @Parameter(description = "Transformation UID") String uid) {
         logger.debug("Received HTTP DELETE request at '{}'", uriInfo.getPath());
 
         Transformation oldTransformation = transformationRegistry.get(uid);

--- a/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
+++ b/bundles/org.openhab.core.io.rest.ui/src/main/java/org/openhab/core/io/rest/ui/internal/UIResource.java
@@ -116,7 +116,7 @@ public class UIResource implements RESTResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(operationId = "getUITiles", summary = "Get all registered UI tiles.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = TileDTO.class)))) })
-    public Response getAll() {
+    public @Nullable Response getAll() {
         Stream<TileDTO> tiles = tileProvider.getTiles().map(this::toTileDTO);
         return Response.ok(new Stream2JSONInputStream(tiles)).build();
     }
@@ -126,7 +126,7 @@ public class UIResource implements RESTResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @Operation(operationId = "getRegisteredUIComponentsInNamespace", summary = "Get all registered UI components in the specified namespace.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = RootUIComponent.class)))) })
-    public Response getAllComponents(@Context Request request, @PathParam("namespace") String namespace,
+    public @Nullable Response getAllComponents(@Context Request request, @PathParam("namespace") String namespace,
             @QueryParam("summary") @Parameter(description = "summary fields only") @Nullable Boolean summary) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
         Stream<RootUIComponent> components = registry.getAll().stream();
@@ -177,7 +177,7 @@ public class UIResource implements RESTResource {
     @Operation(operationId = "getUIComponentInNamespace", summary = "Get a specific UI component in the specified namespace.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RootUIComponent.class))),
             @ApiResponse(responseCode = "404", description = "Component not found") })
-    public Response getComponentByUID(@PathParam("namespace") String namespace,
+    public @Nullable Response getComponentByUID(@PathParam("namespace") String namespace,
             @PathParam("componentUID") String componentUID) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
         RootUIComponent component = registry.get(componentUID);
@@ -195,7 +195,7 @@ public class UIResource implements RESTResource {
     @Operation(operationId = "addUIComponentToNamespace", summary = "Add a UI component in the specified namespace.", security = {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RootUIComponent.class))) })
-    public Response addComponent(@PathParam("namespace") String namespace, RootUIComponent component) {
+    public @Nullable Response addComponent(@PathParam("namespace") String namespace, RootUIComponent component) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
         component.updateTimestamp();
         RootUIComponent createdComponent = registry.add(component);
@@ -211,7 +211,7 @@ public class UIResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RootUIComponent.class))),
                     @ApiResponse(responseCode = "404", description = "Component not found") })
-    public Response updateComponent(@PathParam("namespace") String namespace,
+    public @Nullable Response updateComponent(@PathParam("namespace") String namespace,
             @PathParam("componentUID") String componentUID, RootUIComponent component) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
         RootUIComponent existingComponent = registry.get(componentUID);
@@ -235,7 +235,7 @@ public class UIResource implements RESTResource {
             @SecurityRequirement(name = "oauth2", scopes = { "admin" }) }, responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "404", description = "Component not found") })
-    public Response deleteComponent(@PathParam("namespace") String namespace,
+    public @Nullable Response deleteComponent(@PathParam("namespace") String namespace,
             @PathParam("componentUID") String componentUID) {
         UIComponentRegistry registry = componentRegistryFactory.getRegistry(namespace);
         RootUIComponent component = registry.get(componentUID);

--- a/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/org.openhab.core.io.rest.voice/src/main/java/org/openhab/core/io/rest/voice/internal/VoiceResource.java
@@ -109,7 +109,7 @@ public class VoiceResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getVoiceInterpreters", summary = "Get the list of all interpreters.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = HumanLanguageInterpreterDTO.class)))) })
-    public Response getInterpreters(
+    public @Nullable Response getInterpreters(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language) {
         final Locale locale = localeService.getLocale(language);
         List<HumanLanguageInterpreterDTO> dtos = voiceManager.getHLIs().stream().map(hli -> HLIMapper.map(hli, locale))
@@ -123,7 +123,7 @@ public class VoiceResource implements RESTResource {
     @Operation(operationId = "getVoiceInterpreterByUID", summary = "Gets a single interpreter.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = HumanLanguageInterpreterDTO.class)))),
             @ApiResponse(responseCode = "404", description = "Interpreter not found") })
-    public Response getInterpreter(
+    public @Nullable Response getInterpreter(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @PathParam("id") @Parameter(description = "interpreter id") String id) {
         final Locale locale = localeService.getLocale(language);
@@ -144,7 +144,7 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "No human language interpreter was found."),
             @ApiResponse(responseCode = "400", description = "interpretation exception occurs") })
-    public Response interpret(
+    public @Nullable Response interpret(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "text to interpret", required = true) String text,
             @PathParam("ids") @Parameter(description = "comma separated list of interpreter ids") List<String> ids) {
@@ -181,7 +181,7 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "404", description = "No human language interpreter was found."),
             @ApiResponse(responseCode = "400", description = "interpretation exception occurs") })
-    public Response interpret(
+    public @Nullable Response interpret(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @Parameter(description = "text to interpret", required = true) String text) {
         final Locale locale = localeService.getLocale(language);
@@ -203,7 +203,7 @@ public class VoiceResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getVoices", summary = "Get the list of all voices.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = VoiceDTO.class)))) })
-    public Response getVoices() {
+    public @Nullable Response getVoices() {
         List<VoiceDTO> dtos = voiceManager.getAllVoices().stream().map(VoiceMapper::map).toList();
         return Response.ok(dtos).build();
     }
@@ -214,7 +214,7 @@ public class VoiceResource implements RESTResource {
     @Operation(operationId = "getDefaultVoice", summary = "Gets the default voice.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = VoiceDTO.class))),
             @ApiResponse(responseCode = "404", description = "No default voice was found.") })
-    public Response getDefaultVoice() {
+    public @Nullable Response getDefaultVoice() {
         Voice voice = voiceManager.getDefaultVoice();
         if (voice == null) {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Default voice not found");
@@ -229,7 +229,7 @@ public class VoiceResource implements RESTResource {
     @Consumes(MediaType.TEXT_PLAIN)
     @Operation(operationId = "textToSpeech", summary = "Speaks a given text with a given voice through the given audio sink.", responses = {
             @ApiResponse(responseCode = "200", description = "OK") })
-    public Response say(@Parameter(description = "text to speak", required = true) String text,
+    public @Nullable Response say(@Parameter(description = "text to speak", required = true) String text,
             @QueryParam("voiceid") @Parameter(description = "voice id") @Nullable String voiceId,
             @QueryParam("sinkid") @Parameter(description = "audio sink id") @Nullable String sinkId,
             @QueryParam("volume") @Parameter(description = "volume level") @Nullable String volume) {
@@ -248,7 +248,7 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "One of the given ids is wrong."),
             @ApiResponse(responseCode = "400", description = "Services are missing or language is not supported by services or dialog processing is already started for the audio source.") })
-    public Response startDialog(
+    public @Nullable Response startDialog(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("sourceId") @Parameter(description = "source ID") @Nullable String sourceId,
             @QueryParam("ksId") @Parameter(description = "keywork spotter ID") @Nullable String ksId,
@@ -330,7 +330,7 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "No audio source was found."),
             @ApiResponse(responseCode = "400", description = "No dialog processing is started for the audio source.") })
-    public Response stopDialog(
+    public @Nullable Response stopDialog(
             @QueryParam("sourceId") @Parameter(description = "source ID") @Nullable String sourceId) {
         AudioSource source = null;
         if (sourceId != null) {
@@ -354,7 +354,7 @@ public class VoiceResource implements RESTResource {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "404", description = "One of the given ids is wrong."),
             @ApiResponse(responseCode = "400", description = "Services are missing or language is not supported by services or dialog processing is already started for the audio source.") })
-    public Response listenAndAnswer(
+    public @Nullable Response listenAndAnswer(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
             @QueryParam("sourceId") @Parameter(description = "source ID") @Nullable String sourceId,
             @QueryParam("sttId") @Parameter(description = "Speech-to-Text ID") @Nullable String sttId,

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/JSONResponse.java
@@ -25,6 +25,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.StreamingOutput;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.DateTimeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +44,7 @@ import com.google.gson.stream.JsonWriter;
  * @author Henning Treu - Provide streaming capabilities
  * @author Jörg Sautter - Improve streaming capabilities
  */
+@NonNullByDefault
 public class JSONResponse {
 
     private static final JSONResponse INSTANCE = new JSONResponse();
@@ -65,7 +68,7 @@ public class JSONResponse {
      * @param errormessage
      * @return Response containing a status and the errormessage in JSON format
      */
-    public static Response createErrorResponse(Response.StatusType status, String errormessage) {
+    public static Response createErrorResponse(Response.StatusType status, @Nullable String errormessage) {
         return createResponse(status, null, errormessage);
     }
 
@@ -78,7 +81,8 @@ public class JSONResponse {
      * @param errormessage an optional error message (may be null), ignored if the status family is successful
      * @return Response configure for error or success
      */
-    public static Response createResponse(Response.StatusType status, Object entity, String errormessage) {
+    public static Response createResponse(Response.StatusType status, @Nullable Object entity,
+            @Nullable String errormessage) {
         if (status.getFamily() != Response.Status.Family.SUCCESSFUL) {
             return INSTANCE.createErrorResponse(status, entity, errormessage);
         }
@@ -92,7 +96,7 @@ public class JSONResponse {
      * @param status
      * @return ResponseBuilder configured for "Content-Type" MediaType.APPLICATION_JSON
      */
-    private ResponseBuilder responseBuilder(Response.StatusType status) {
+    private @Nullable ResponseBuilder responseBuilder(Response.StatusType status) {
         return Response.status(status).header("Content-Type", MediaType.APPLICATION_JSON);
     }
 
@@ -105,7 +109,8 @@ public class JSONResponse {
      * @param ex
      * @return
      */
-    private JsonElement createErrorJson(String message, Response.StatusType status, Object entity, Exception ex) {
+    private JsonElement createErrorJson(@Nullable String message, Response.StatusType status, @Nullable Object entity,
+            @Nullable Exception ex) {
         JsonObject resultJson = new JsonObject();
         JsonObject errorJson = new JsonObject();
         resultJson.add(JSON_KEY_ERROR, errorJson);
@@ -137,14 +142,15 @@ public class JSONResponse {
         return resultJson;
     }
 
-    private Response createErrorResponse(Response.StatusType status, Object entity, String errormessage) {
+    private Response createErrorResponse(Response.StatusType status, @Nullable Object entity,
+            @Nullable String errormessage) {
         ResponseBuilder rp = responseBuilder(status);
         JsonElement errorJson = createErrorJson(errormessage, status, entity, null);
         rp.entity(errorJson);
         return rp.build();
     }
 
-    private Response createResponse(Response.StatusType status, final Object entity) {
+    private Response createResponse(Response.StatusType status, final @Nullable Object entity) {
         ResponseBuilder rp = responseBuilder(status);
 
         if (entity == null) {
@@ -185,7 +191,7 @@ public class JSONResponse {
         private final Logger logger = LoggerFactory.getLogger(ExceptionMapper.class);
 
         @Override
-        public Response toResponse(Exception e) {
+        public @Nullable Response toResponse(@Nullable Exception e) {
             logger.debug("Exception during REST handling.", e);
 
             Response.StatusType status = Response.Status.INTERNAL_SERVER_ERROR;

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/RootResource.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.LocaleProvider;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.i18n.UnitProvider;
@@ -100,7 +101,7 @@ public class RootResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getRoot", summary = "Gets information about the runtime, the API version and links to resources.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = RootBean.class))) })
-    public Response getRoot(@Context UriInfo uriInfo) {
+    public @Nullable Response getRoot(@Context UriInfo uriInfo) {
         // key: path, value: name (this way we could ensure that ever path is added only once).
         final Map<String, String> collectedLinks = new HashMap<>();
 

--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/resources/SystemInfoResource.java
@@ -96,7 +96,7 @@ public class SystemInfoResource implements RESTResource, ConfigurationListener {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getSystemInformation", summary = "Gets information about the system.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SystemInfoBean.class))) })
-    public Response getSystemInfo(@Context UriInfo uriInfo) {
+    public @Nullable Response getSystemInfo(@Context UriInfo uriInfo) {
         final SystemInfoBean bean = new SystemInfoBean(startLevelService.getStartLevel());
         return Response.ok(bean).build();
     }
@@ -106,7 +106,7 @@ public class SystemInfoResource implements RESTResource, ConfigurationListener {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getUoMInformation", summary = "Get all supported dimensions and their system units.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UoMInfoBean.class))) })
-    public Response getUoMInfo(final @Context Request request, final @Context UriInfo uriInfo) {
+    public @Nullable Response getUoMInfo(final @Context Request request, final @Context UriInfo uriInfo) {
         if (lastModified != null) {
             Response.ResponseBuilder responseBuilder = request.evaluatePreconditions(lastModified);
             if (responseBuilder != null) {

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSClient.java
@@ -20,12 +20,15 @@ import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This interface defines how to get an JmDNS instance
  * to access Bonjour/MDNS
  *
  * @author Tobias Br�utigam - Initial contribution
  */
+@NonNullByDefault
 public interface MDNSClient {
 
     /**

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/MDNSService.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.transport.mdns;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This interface defines how to use JmDNS based service discovery
  * to register and unregister services on Bonjour/MDNS
@@ -19,6 +21,7 @@ package org.openhab.core.io.transport.mdns;
  * @author Victor Belov - Initial contribution
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public interface MDNSService {
 
     /**

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/ServiceDescription.java
@@ -14,17 +14,21 @@ package org.openhab.core.io.transport.mdns;
 
 import java.util.Hashtable;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This is a simple data container to keep all details of a service description together.
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class ServiceDescription {
 
-    public String serviceType;
-    public String serviceName;
+    public @Nullable String serviceType;
+    public @Nullable String serviceName;
     public int servicePort;
-    public Hashtable<String, String> serviceProperties;
+    public @Nullable Hashtable<String, String> serviceProperties;
 
     /**
      * Constructor for a {@link ServiceDescription}, which takes all details as parameters
@@ -34,7 +38,7 @@ public class ServiceDescription {
      * @param servicePort Int service port, like 8080
      * @param serviceProperties Hashtable service props, like url = "/rest"
      */
-    public ServiceDescription(String serviceType, String serviceName, int servicePort,
+    public ServiceDescription(@Nullable String serviceType, @Nullable String serviceName, int servicePort,
             Hashtable<String, String> serviceProperties) {
         this.serviceType = serviceType;
         this.serviceName = serviceName;
@@ -53,7 +57,7 @@ public class ServiceDescription {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSActivator.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSActivator.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.transport.mdns.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -22,6 +24,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public final class MDNSActivator implements BundleActivator {
 
     private final Logger logger = LoggerFactory.getLogger(MDNSActivator.class);
@@ -30,7 +33,7 @@ public final class MDNSActivator implements BundleActivator {
      * Called whenever the OSGi framework starts our bundle
      */
     @Override
-    public void start(BundleContext context) throws Exception {
+    public void start(@Nullable BundleContext context) throws Exception {
         logger.debug("mDNS service has been started.");
     }
 
@@ -38,7 +41,7 @@ public final class MDNSActivator implements BundleActivator {
      * Called whenever the OSGi framework stops our bundle
      */
     @Override
-    public void stop(BundleContext context) throws Exception {
+    public void stop(@Nullable BundleContext context) throws Exception {
         logger.debug("mDNS service has been stopped.");
     }
 }

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSClientImpl.java
@@ -30,6 +30,7 @@ import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.transport.mdns.MDNSClient;
 import org.openhab.core.io.transport.mdns.ServiceDescription;
 import org.openhab.core.net.CidrAddress;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Add NetworkAddressChangeListener to handle interface changes
  */
 @Component(immediate = true, service = MDNSClient.class)
+@NonNullByDefault
 public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener {
     private final Logger logger = LoggerFactory.getLogger(MDNSClientImpl.class);
 

--- a/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.mdns/src/main/java/org/openhab/core/io/transport/mdns/internal/MDNSServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.mdns.MDNSClient;
 import org.openhab.core.io.transport.mdns.MDNSService;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
  * @author Victor Belov - Initial contribution
  */
 @Component(immediate = true)
+@NonNullByDefault
 public class MDNSServiceImpl implements MDNSService {
     private final Logger logger = LoggerFactory.getLogger(MDNSServiceImpl.class);
 

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusLibraryWrapper.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusLibraryWrapper.java
@@ -16,8 +16,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.transport.modbus.AsyncModbusReadResult;
 import org.openhab.core.io.transport.modbus.BitArray;
 import org.openhab.core.io.transport.modbus.ModbusReadCallback;
@@ -193,19 +193,19 @@ public class ModbusLibraryWrapper {
         ModbusTransaction transaction = endpoint.accept(new ModbusSlaveEndpointVisitor<>() {
 
             @Override
-            public @NonNull ModbusTransaction visit(ModbusTCPSlaveEndpoint modbusIPSlavePoolingKey) {
+            public @Nullable ModbusTransaction visit(ModbusTCPSlaveEndpoint modbusIPSlavePoolingKey) {
                 ModbusTCPTransaction transaction = new ModbusTCPTransaction();
                 transaction.setReconnecting(false);
                 return transaction;
             }
 
             @Override
-            public @NonNull ModbusTransaction visit(ModbusSerialSlaveEndpoint modbusSerialSlavePoolingKey) {
+            public @Nullable ModbusTransaction visit(ModbusSerialSlaveEndpoint modbusSerialSlavePoolingKey) {
                 return new ModbusSerialTransaction();
             }
 
             @Override
-            public @NonNull ModbusTransaction visit(ModbusUDPSlaveEndpoint modbusUDPSlavePoolingKey) {
+            public @Nullable ModbusTransaction visit(ModbusUDPSlaveEndpoint modbusUDPSlavePoolingKey) {
                 return new ModbusUDPTransaction();
             }
         });

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/ModbusManagerImpl.java
@@ -32,7 +32,6 @@ import javax.imageio.IIOException;
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.SwallowedExceptionListener;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
@@ -308,7 +307,7 @@ public class ModbusManagerImpl implements ModbusManager {
             .accept(new ModbusSlaveEndpointVisitor<EndpointPoolConfiguration>() {
 
                 @Override
-                public @NonNull EndpointPoolConfiguration visit(ModbusTCPSlaveEndpoint modbusIPSlavePoolingKey) {
+                public @Nullable EndpointPoolConfiguration visit(ModbusTCPSlaveEndpoint modbusIPSlavePoolingKey) {
                     EndpointPoolConfiguration endpointPoolConfig = new EndpointPoolConfiguration();
                     endpointPoolConfig.setInterTransactionDelayMillis(DEFAULT_TCP_INTER_TRANSACTION_DELAY_MILLIS);
                     endpointPoolConfig.setConnectMaxTries(Modbus.DEFAULT_RETRIES);
@@ -317,7 +316,8 @@ public class ModbusManagerImpl implements ModbusManager {
                 }
 
                 @Override
-                public @NonNull EndpointPoolConfiguration visit(ModbusSerialSlaveEndpoint modbusSerialSlavePoolingKey) {
+                public @Nullable EndpointPoolConfiguration visit(
+                        ModbusSerialSlaveEndpoint modbusSerialSlavePoolingKey) {
                     EndpointPoolConfiguration endpointPoolConfig = new EndpointPoolConfiguration();
                     // never "disconnect" (close/open serial port) serial connection between borrows
                     endpointPoolConfig.setReconnectAfterMillis(-1);
@@ -328,7 +328,7 @@ public class ModbusManagerImpl implements ModbusManager {
                 }
 
                 @Override
-                public @NonNull EndpointPoolConfiguration visit(ModbusUDPSlaveEndpoint modbusUDPSlavePoolingKey) {
+                public @Nullable EndpointPoolConfiguration visit(ModbusUDPSlaveEndpoint modbusUDPSlavePoolingKey) {
                     EndpointPoolConfiguration endpointPoolConfig = new EndpointPoolConfiguration();
                     endpointPoolConfig.setInterTransactionDelayMillis(DEFAULT_TCP_INTER_TRANSACTION_DELAY_MILLIS);
                     endpointPoolConfig.setConnectMaxTries(Modbus.DEFAULT_RETRIES);
@@ -458,7 +458,7 @@ public class ModbusManagerImpl implements ModbusManager {
      * @throws PollTaskUnregistered
      */
     private <R, C extends ModbusResultCallback, F extends ModbusFailureCallback<R>, T extends TaskWithEndpoint<R, C, F>> Optional<ModbusSlaveConnection> getConnection(
-            AggregateStopWatch timer, boolean oneOffTask, @NonNull T task) throws PollTaskUnregistered {
+            AggregateStopWatch timer, boolean oneOffTask, T task) throws PollTaskUnregistered {
         KeyedObjectPool<ModbusSlaveEndpoint, @Nullable ModbusSlaveConnection> connectionPool = this.connectionPool;
         if (connectionPool == null) {
             return Optional.empty();

--- a/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionEvictionPolicy.java
+++ b/bundles/org.openhab.core.io.transport.modbus/src/main/java/org/openhab/core/io/transport/modbus/internal/pooling/ModbusSlaveConnectionEvictionPolicy.java
@@ -15,6 +15,7 @@ package org.openhab.core.io.transport.modbus.internal.pooling;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.EvictionConfig;
 import org.apache.commons.pool2.impl.EvictionPolicy;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.transport.modbus.internal.pooling.ModbusSlaveConnectionFactoryImpl.PooledConnection;
 
 import net.wimpi.modbus.net.ModbusSlaveConnection;
@@ -26,6 +27,7 @@ import net.wimpi.modbus.net.ModbusSlaveConnection;
  *
  * @author Sami Salonen - Initial contribution
  */
+@NonNullByDefault({})
 public class ModbusSlaveConnectionEvictionPolicy implements EvictionPolicy<ModbusSlaveConnection> {
 
     @Override

--- a/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/console/SerialCommandExtension.java
+++ b/bundles/org.openhab.core.io.transport.serial/src/main/java/org/openhab/core/io/transport/serial/internal/console/SerialCommandExtension.java
@@ -17,6 +17,7 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.console.Console;
 import org.openhab.core.io.console.extensions.AbstractConsoleCommandExtension;
@@ -34,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Markus Rathgeb - Initial contribution
  */
 @Component(service = ConsoleCommandExtension.class)
+@NonNullByDefault
 public class SerialCommandExtension extends AbstractConsoleCommandExtension {
 
     private static final String CMD_SERIAL = "serial";

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOParticipant.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.io.transport.upnp;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The {@link UpnpIOParticipant} is an interface that needs to
  * be implemented by classes that wants to participate in
@@ -19,6 +21,7 @@ package org.openhab.core.io.transport.upnp;
  *
  * @author Karel Goderis - Initial contribution
  */
+@NonNullByDefault
 public interface UpnpIOParticipant {
 
     /** Get the UDN of the participant **/

--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/UpnpIOService.java
@@ -15,6 +15,9 @@ package org.openhab.core.io.transport.upnp;
 import java.net.URL;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link UpnpIOService} is an interface that described the
  * UPNP IO Service.
@@ -22,6 +25,7 @@ import java.util.Map;
  * @author Karel Goderis - Initial contribution
  * @author Kai Kreuzer - added descriptor url retrieval
  */
+@NonNullByDefault
 public interface UpnpIOService {
 
     /**
@@ -33,7 +37,7 @@ public interface UpnpIOService {
      * @param inputs a map of {variable,values} to parameterize the Action that will be invoked
      */
     Map<String, String> invokeAction(UpnpIOParticipant participant, String serviceID, String actionID,
-            Map<String, String> inputs);
+            @Nullable Map<String, String> inputs);
 
     /**
      * Invoke an UPNP Action using the specified namespace and serviceID
@@ -92,6 +96,7 @@ public interface UpnpIOService {
      * @param participant the participant whom's descriptor url is requested
      * @return the url of the descriptor as provided by the upnp device
      */
+    @Nullable
     URL getDescriptorURL(UpnpIOParticipant participant);
 
     /**

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
@@ -85,7 +85,7 @@ public class LoggerResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getLogger", summary = "Get all loggers", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoggerBean.class))) })
-    public Response getLoggers(@Context UriInfo uriInfo) {
+    public @Nullable Response getLoggers(@Context UriInfo uriInfo) {
         final LoggerBean bean = new LoggerBean(logService.getLevel("ALL"));
         return Response.ok(bean).build();
     }
@@ -96,7 +96,8 @@ public class LoggerResource implements RESTResource {
     @Operation(operationId = "putLogger", summary = "Modify or add logger", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
             @ApiResponse(responseCode = "400", description = "Payload is invalid.") })
-    public Response putLoggers(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+    public @Nullable Response putLoggers(
+            @PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
             @Parameter(description = "logger", required = true) LoggerBean.@Nullable LoggerInfo logger,
             @Context UriInfo uriInfo) {
         if (logger == null || !BUNDLE_REGEX.matcher(logger.loggerName).matches() || !LOG_LEVELS.contains(logger.level)
@@ -112,7 +113,8 @@ public class LoggerResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getLogger", summary = "Get a single logger.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoggerBean.LoggerInfo.class))) })
-    public Response getLogger(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+    public @Nullable Response getLogger(
+            @PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
             @Context UriInfo uriInfo) {
         final LoggerBean bean = new LoggerBean(logService.getLevel(loggerName));
         return Response.ok(bean).build();
@@ -122,7 +124,8 @@ public class LoggerResource implements RESTResource {
     @Path("/{loggerName: \\w(%20|[\\w.-])*}")
     @Operation(operationId = "removeLogger", summary = "Remove a single logger.", responses = {
             @ApiResponse(responseCode = "200", description = "OK") })
-    public Response removeLogger(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
+    public @Nullable Response removeLogger(
+            @PathParam("loggerName") @Parameter(description = "logger name") String loggerName,
             @Context UriInfo uriInfo) {
         logService.setLevel(loggerName, "DEFAULT");
         return Response.ok(null, MediaType.TEXT_PLAIN).build();

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngine.java
@@ -16,12 +16,15 @@ import java.security.Principal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.karaf.jaas.boot.principal.GroupPrincipal;
 import org.apache.karaf.jaas.boot.principal.RolePrincipal;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 import org.apache.karaf.jaas.modules.BackingEngine;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.ManagedUser;
 import org.openhab.core.auth.Role;
 import org.openhab.core.auth.User;
@@ -32,6 +35,7 @@ import org.openhab.core.auth.UserRegistry;
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 public class ManagedUserBackingEngine implements BackingEngine {
 
     private final UserRegistry userRegistry;
@@ -41,22 +45,27 @@ public class ManagedUserBackingEngine implements BackingEngine {
     }
 
     @Override
-    public void addUser(String username, String password) {
+    public void addUser(@Nullable String username, @Nullable String password) {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(password);
         userRegistry.register(username, password, new HashSet<>(Set.of(Role.USER)));
     }
 
     @Override
-    public void deleteUser(String username) {
+    public void deleteUser(@Nullable String username) {
+        Objects.requireNonNull(username);
         userRegistry.remove(username);
     }
 
     @Override
+    @NonNullByDefault({})
     public List<UserPrincipal> listUsers() {
         return userRegistry.getAll().stream().map(u -> new UserPrincipal(u.getName())).toList();
     }
 
     @Override
-    public UserPrincipal lookupUser(String username) {
+    public @Nullable UserPrincipal lookupUser(@Nullable String username) {
+        Objects.requireNonNull(username);
         User user = userRegistry.get(username);
         if (user != null) {
             return new UserPrincipal(user.getName());
@@ -65,32 +74,35 @@ public class ManagedUserBackingEngine implements BackingEngine {
     }
 
     @Override
-    public List<GroupPrincipal> listGroups(UserPrincipal user) {
+    @NonNullByDefault({})
+    public List<GroupPrincipal> listGroups(@Nullable UserPrincipal user) {
         return List.of();
     }
 
     @Override
+    @NonNullByDefault({})
     public Map<GroupPrincipal, String> listGroups() {
         return Map.of();
     }
 
     @Override
-    public void addGroup(String username, String group) {
+    public void addGroup(@Nullable String username, @Nullable String group) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void createGroup(String group) {
+    public void createGroup(@Nullable String group) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteGroup(String username, String group) {
+    public void deleteGroup(@Nullable String username, @Nullable String group) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<RolePrincipal> listRoles(Principal principal) {
+    @NonNullByDefault({})
+    public List<RolePrincipal> listRoles(@Nullable Principal principal) {
         User user = userRegistry.get(principal.getName());
         if (user != null) {
             return user.getRoles().stream().map(r -> new RolePrincipal(r)).toList();
@@ -99,7 +111,9 @@ public class ManagedUserBackingEngine implements BackingEngine {
     }
 
     @Override
-    public void addRole(String username, String role) {
+    public void addRole(@Nullable String username, @Nullable String role) {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(role);
         User user = userRegistry.get(username);
         if (user instanceof ManagedUser managedUser) {
             managedUser.getRoles().add(role);
@@ -108,7 +122,8 @@ public class ManagedUserBackingEngine implements BackingEngine {
     }
 
     @Override
-    public void deleteRole(String username, String role) {
+    public void deleteRole(@Nullable String username, @Nullable String role) {
+        Objects.requireNonNull(username);
         User user = userRegistry.get(username);
         if (user instanceof ManagedUser managedUser) {
             managedUser.getRoles().remove(role);
@@ -117,12 +132,12 @@ public class ManagedUserBackingEngine implements BackingEngine {
     }
 
     @Override
-    public void addGroupRole(String group, String role) {
+    public void addGroupRole(@Nullable String group, @Nullable String role) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteGroupRole(String group, String role) {
+    public void deleteGroupRole(@Nullable String group, @Nullable String role) {
         throw new UnsupportedOperationException();
     }
 }

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserBackingEngineFactory.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import org.apache.karaf.jaas.modules.BackingEngine;
 import org.apache.karaf.jaas.modules.BackingEngineFactory;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.UserRegistry;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -26,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 @Component(service = BackingEngineFactory.class)
 public class ManagedUserBackingEngineFactory implements BackingEngineFactory {
 
@@ -41,6 +43,7 @@ public class ManagedUserBackingEngineFactory implements BackingEngineFactory {
         return ManagedUserRealm.MODULE_CLASS;
     }
 
+    @NonNullByDefault({})
     @Override
     public BackingEngine build(Map<String, ?> options) {
         return new ManagedUserBackingEngine(userRegistry);

--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/jaas/ManagedUserRealm.java
@@ -21,6 +21,7 @@ import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 import org.apache.karaf.jaas.boot.ProxyLoginModule;
 import org.apache.karaf.jaas.config.JaasRealm;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.UserRegistry;
 import org.osgi.service.component.annotations.Component;
 
@@ -29,6 +30,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Yannick Schaus - initial contribution
  */
+@NonNullByDefault
 @Component(service = JaasRealm.class)
 @Service
 public class ManagedUserRealm implements JaasRealm {

--- a/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
+++ b/bundles/org.openhab.core.test.magic/src/main/java/org/openhab/core/magic/binding/internal/MagicServiceConfig.java
@@ -16,6 +16,8 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.magic.binding.MagicService;
 
 /**
@@ -23,26 +25,27 @@ import org.openhab.core.magic.binding.MagicService;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class MagicServiceConfig {
-    public String text;
+    public @Nullable String text;
     public boolean bool;
-    public BigDecimal decimal;
-    public Integer integer;
+    public @Nullable BigDecimal decimal;
+    public @Nullable Integer integer;
 
-    public String textAdvanced;
+    public @Nullable String textAdvanced;
     public boolean booleanAdvanced;
-    public BigDecimal decimalAdvanced;
-    public Integer integerAdvanced;
+    public @Nullable BigDecimal decimalAdvanced;
+    public @Nullable Integer integerAdvanced;
 
-    public String requiredTextParameter;
-    public String verifiedTextParameter;
-    public String selectLimited;
-    public String selectVariable;
+    public @Nullable String requiredTextParameter;
+    public @Nullable String verifiedTextParameter;
+    public @Nullable String selectLimited;
+    public @Nullable String selectVariable;
 
-    public List<String> multiselectTextLimit;
-    public List<BigDecimal> multiselectIntegerLimit;
+    public @Nullable List<String> multiselectTextLimit;
+    public @Nullable List<BigDecimal> multiselectIntegerLimit;
 
-    public BigDecimal selectDecimalLimit;
+    public @Nullable BigDecimal selectDecimalLimit;
 
     @Override
     public String toString() {

--- a/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
+++ b/bundles/org.openhab.core.test/src/main/java/org/openhab/core/test/SyntheticBundleInstaller.java
@@ -33,6 +33,8 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.ReadyMarkerUtils;
 import org.openhab.core.service.ReadyService;
@@ -58,6 +60,7 @@ import org.osgi.framework.ServiceReference;
  * @author Dimitar Ivanov - The extension to include can be configured or default ones can be used; update method is
  *         introduced
  */
+@NonNullByDefault
 public class SyntheticBundleInstaller {
 
     private static final int WAIT_TIMOUT = 30; // [seconds]
@@ -363,7 +366,7 @@ public class SyntheticBundleInstaller {
             String path = url.getPath();
             URI baseURI = url.toURI();
 
-            List<URL> list = collectEntries(bundle, path, extensionsToInclude);
+            List<@Nullable URL> list = collectEntries(bundle, path, extensionsToInclude);
             for (URL entryURL : list) {
                 String fileEntry = convertToFileEntry(baseURI, entryURL);
                 result.add(fileEntry);
@@ -372,13 +375,13 @@ public class SyntheticBundleInstaller {
         return result;
     }
 
-    private static URL getBaseURL(Bundle bundle, String bundleName) {
+    private static @Nullable URL getBaseURL(Bundle bundle, String bundleName) {
         Enumeration<URL> entries = bundle.findEntries("/", bundleName, true);
         return entries != null ? entries.nextElement() : null;
     }
 
-    private static List<URL> collectEntries(Bundle bundle, String path, Set<String> extensionsToInclude) {
-        List<URL> result = new ArrayList<>();
+    private static List<@Nullable URL> collectEntries(Bundle bundle, String path, Set<String> extensionsToInclude) {
+        List<@Nullable URL> result = new ArrayList<>();
         for (String filePattern : extensionsToInclude) {
             Enumeration<URL> entries = bundle.findEntries(path, filePattern, true);
             if (entries != null) {
@@ -394,7 +397,7 @@ public class SyntheticBundleInstaller {
         return relativeURI.toString();
     }
 
-    private static Manifest getManifest(Bundle bundle, String bundlePath) throws IOException {
+    private static @Nullable Manifest getManifest(Bundle bundle, String bundlePath) throws IOException {
         String filePath = bundlePath + "META-INF/MANIFEST.MF";
         URL resource = bundle.getResource(filePath);
         if (resource == null) {

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/ChannelUID.java
@@ -72,7 +72,7 @@ public class ChannelUID extends UID {
      * @param groupId the channel's group id
      * @param id the channel's id
      */
-    public ChannelUID(ThingUID thingUID, String groupId, String id) {
+    public ChannelUID(ThingUID thingUID, @Nullable String groupId, String id) {
         super(toSegments(thingUID, groupId, id));
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/dto/ThingDTOMapper.java
@@ -82,7 +82,11 @@ public class ThingDTOMapper {
     private static Map<String, Object> toMap(Configuration configuration) {
         Map<String, Object> configurationMap = new HashMap<>(configuration.keySet().size());
         for (String key : configuration.keySet()) {
-            configurationMap.put(key, configuration.get(key));
+            // should be non-null, as key exists and entires are not-null
+            Object value = configuration.get(key);
+            if (value != null) {
+                configurationMap.put(key, value);
+            }
         }
         return configurationMap;
     }

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateProgressInfo.java
@@ -36,9 +36,9 @@ public final class FirmwareUpdateProgressInfo {
 
     private final String firmwareVersion;
 
-    private final ProgressStep progressStep;
+    private final @Nullable ProgressStep progressStep;
 
-    private final Collection<ProgressStep> sequence;
+    private final @Nullable Collection<ProgressStep> sequence;
 
     private final boolean pending;
 
@@ -58,8 +58,8 @@ public final class FirmwareUpdateProgressInfo {
         progress = null;
     }
 
-    private FirmwareUpdateProgressInfo(ThingUID thingUID, String firmwareVersion, ProgressStep progressStep,
-            Collection<ProgressStep> sequence, boolean pending, int progress) {
+    private FirmwareUpdateProgressInfo(ThingUID thingUID, String firmwareVersion, @Nullable ProgressStep progressStep,
+            @Nullable Collection<ProgressStep> sequence, boolean pending, int progress) {
         Objects.requireNonNull(thingUID, "ThingUID must not be null.");
         Objects.requireNonNull(firmwareVersion, "Firmware version must not be null.");
 
@@ -89,12 +89,13 @@ public final class FirmwareUpdateProgressInfo {
      * @throws IllegalArgumentException if sequence is null or empty or progress is not between 0 and 100
      */
     public static FirmwareUpdateProgressInfo createFirmwareUpdateProgressInfo(ThingUID thingUID, String firmwareVersion,
-            ProgressStep progressStep, Collection<ProgressStep> sequence, boolean pending, int progress) {
+            @Nullable ProgressStep progressStep, @Nullable Collection<ProgressStep> sequence, boolean pending,
+            int progress) {
         return new FirmwareUpdateProgressInfo(thingUID, firmwareVersion, progressStep, sequence, pending, progress);
     }
 
-    private FirmwareUpdateProgressInfo(ThingUID thingUID, String firmwareVersion, ProgressStep progressStep,
-            Collection<ProgressStep> sequence, boolean pending) {
+    private FirmwareUpdateProgressInfo(ThingUID thingUID, String firmwareVersion, @Nullable ProgressStep progressStep,
+            @Nullable Collection<ProgressStep> sequence, boolean pending) {
         Objects.requireNonNull(thingUID, "ThingUID must not be null.");
         Objects.requireNonNull(firmwareVersion, "Firmware version must not be null.");
 
@@ -124,8 +125,8 @@ public final class FirmwareUpdateProgressInfo {
      * @throws IllegalArgumentException if sequence is null or empty
      */
     public static FirmwareUpdateProgressInfo createFirmwareUpdateProgressInfo(ThingUID thingUID,
-            ThingTypeUID thingTypeUID, String firmwareVersion, ProgressStep progressStep,
-            Collection<ProgressStep> sequence, boolean pending) {
+            ThingTypeUID thingTypeUID, String firmwareVersion, @Nullable ProgressStep progressStep,
+            @Nullable Collection<ProgressStep> sequence, boolean pending) {
         return new FirmwareUpdateProgressInfo(thingUID, firmwareVersion, progressStep, sequence, pending);
     }
 
@@ -143,7 +144,7 @@ public final class FirmwareUpdateProgressInfo {
      *
      * @return the current progress step (not null)
      */
-    public ProgressStep getProgressStep() {
+    public @Nullable ProgressStep getProgressStep() {
         return progressStep;
     }
 
@@ -152,7 +153,7 @@ public final class FirmwareUpdateProgressInfo {
      *
      * @return the sequence (not null)
      */
-    public Collection<ProgressStep> getSequence() {
+    public @Nullable Collection<ProgressStep> getSequence() {
         return sequence;
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfo.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateResultInfo.java
@@ -71,7 +71,7 @@ public final class FirmwareUpdateResultInfo {
      * @throws IllegalArgumentException if error message is null or empty for erroneous firmware updates
      */
     public static FirmwareUpdateResultInfo createFirmwareUpdateResultInfo(ThingUID thingUID,
-            FirmwareUpdateResult result, String errorMessage) {
+            FirmwareUpdateResult result, @Nullable String errorMessage) {
         return new FirmwareUpdateResultInfo(thingUID, result, errorMessage);
     }
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -14,7 +14,10 @@ package org.openhab.core.thing.i18n;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.i18n.I18nUtil;
 import org.openhab.core.i18n.TranslationProvider;
 import org.openhab.core.thing.Thing;
@@ -50,10 +53,11 @@ import org.osgi.service.component.annotations.Reference;
  * @author Henning Sudbrock - Permit translations from thing handler parent bundles
  */
 @Component(service = ThingStatusInfoI18nLocalizationService.class)
+@NonNullByDefault
 public final class ThingStatusInfoI18nLocalizationService {
 
-    private TranslationProvider i18nProvider;
-    private BundleResolver bundleResolver;
+    private @Nullable TranslationProvider i18nProvider;
+    private @Nullable BundleResolver bundleResolver;
 
     /**
      * Localizes the {@link ThingStatusInfo} for the given thing.
@@ -67,7 +71,7 @@ public final class ThingStatusInfoI18nLocalizationService {
      *         </ul>
      * @throws IllegalArgumentException if given thing is null
      */
-    public ThingStatusInfo getLocalizedThingStatusInfo(Thing thing, Locale locale) {
+    public ThingStatusInfo getLocalizedThingStatusInfo(@Nullable Thing thing, @Nullable Locale locale) {
         if (thing == null) {
             throw new IllegalArgumentException("Thing must not be null.");
         }
@@ -111,14 +115,14 @@ public final class ThingStatusInfoI18nLocalizationService {
      * the given thingHandler and its parent classes. The description may contain arguments that may also need
      * translation (see class JavaDoc for an example); those arguments are translated in the same way.
      */
-    private String translateDescription(String description, Locale locale, ThingHandler thingHandler) {
+    private String translateDescription(String description, @Nullable Locale locale, ThingHandler thingHandler) {
         ParsedDescription parsedDescription = new ParsedDescription(description);
 
         Object[] translatedArgs = null;
         if (parsedDescription.args != null) {
             translatedArgs = Arrays.stream(parsedDescription.args).map(arg -> {
                 if (I18nUtil.isConstant(arg)) {
-                    return getTranslationForClass(arg, locale, thingHandler.getClass());
+                    return getTranslationForClass(Objects.requireNonNull(arg), locale, thingHandler.getClass());
                 } else {
                     return arg;
                 }
@@ -133,7 +137,8 @@ public final class ThingStatusInfoI18nLocalizationService {
      * given class; if there is no translation look up the translation in the bundle in the parent class, and so
      * forth. If no translation is found for the bundle of any parent class, return the i18n constant.
      */
-    private String getTranslationForClass(String i18nConstant, Locale locale, Class<?> clazz, Object... args) {
+    private String getTranslationForClass(String i18nConstant, @Nullable Locale locale, @Nullable Class<?> clazz,
+            Object... args) {
         if (clazz == null) {
             return i18nConstant;
         }
@@ -162,7 +167,7 @@ public final class ThingStatusInfoI18nLocalizationService {
         private static final int LIMIT = 2;
 
         private final String key;
-        private final String[] args;
+        private final String @Nullable [] args;
 
         private ParsedDescription(String description) {
             String[] parts = description.split("\\s+", LIMIT);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingFactoryHelper.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.core.ConfigDescriptionRegistry;
 import org.openhab.core.config.core.ConfigUtil;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author Simon Kaufmann - Initial contribution
  * @author Kai Kreuzer - Changed creation of channels to not require a thing type
  */
+@NonNullByDefault
 public class ThingFactoryHelper {
 
     private static Logger logger = LoggerFactory.getLogger(ThingFactoryHelper.class);
@@ -62,7 +64,7 @@ public class ThingFactoryHelper {
      * @return a list of {@link Channel}s
      */
     public static List<Channel> createChannels(ThingType thingType, ThingUID thingUID,
-            ConfigDescriptionRegistry configDescriptionRegistry) {
+            @Nullable ConfigDescriptionRegistry configDescriptionRegistry) {
         List<Channel> channels = new ArrayList<>();
         List<ChannelDefinition> channelDefinitions = thingType.getChannelDefinitions();
         for (ChannelDefinition channelDefinition : channelDefinitions) {
@@ -133,8 +135,8 @@ public class ThingFactoryHelper {
         }
     }
 
-    private static Channel createChannel(ChannelDefinition channelDefinition, ThingUID thingUID, String groupId,
-            ConfigDescriptionRegistry configDescriptionRegistry) {
+    private static @Nullable Channel createChannel(ChannelDefinition channelDefinition, ThingUID thingUID,
+            @Nullable String groupId, @Nullable ConfigDescriptionRegistry configDescriptionRegistry) {
         final ChannelUID channelUID = new ChannelUID(thingUID, groupId, channelDefinition.getId());
         final ChannelBuilder channelBuilder = createChannelBuilder(channelUID, channelDefinition,
                 configDescriptionRegistry);
@@ -146,7 +148,7 @@ public class ThingFactoryHelper {
     }
 
     public static ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelType channelType,
-            ConfigDescriptionRegistry configDescriptionRegistry) {
+            @Nullable ConfigDescriptionRegistry configDescriptionRegistry) {
         final ChannelBuilder channelBuilder = ChannelBuilder.create(channelUID, channelType.getItemType()) //
                 .withType(channelType.getUID()) //
                 .withDefaultTags(channelType.getTags()) //
@@ -169,8 +171,8 @@ public class ThingFactoryHelper {
         return channelBuilder;
     }
 
-    public static ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelDefinition channelDefinition,
-            ConfigDescriptionRegistry configDescriptionRegistry) {
+    public static @Nullable ChannelBuilder createChannelBuilder(ChannelUID channelUID,
+            ChannelDefinition channelDefinition, @Nullable ConfigDescriptionRegistry configDescriptionRegistry) {
         ChannelType channelType = withChannelTypeRegistry(channelTypeRegistry -> (channelTypeRegistry != null)
                 ? channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID())
                 : null);

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/ThingStorageEntity.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.thing.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.dto.ThingDTO;
 
 /**
@@ -20,6 +21,7 @@ import org.openhab.core.thing.dto.ThingDTO;
  * @author Jan N. Klug - Initial contribution
  * @author Andrew Fiddian-Green - Added semanticEquipmentTag
  */
+@NonNullByDefault
 public class ThingStorageEntity extends ThingDTO {
     public boolean isBridge = false;
 

--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/internal/firmware/ProgressCallbackImpl.java
@@ -17,6 +17,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.Event;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TranslationProvider;
@@ -39,6 +41,7 @@ import org.osgi.framework.Bundle;
  * @author Christoph Knauf - Introduced pending, canceled, update and InternalState
  * @author Dimitar Ivanov - Callback contains firmware domain object
  */
+@NonNullByDefault
 final class ProgressCallbackImpl implements ProgressCallback {
 
     private static final String UPDATE_CANCELED_MESSAGE_KEY = "update-canceled";
@@ -52,12 +55,12 @@ final class ProgressCallbackImpl implements ProgressCallback {
     private final BundleResolver bundleResolver;
     private final ThingUID thingUID;
     private final Firmware firmware;
-    private final Locale locale;
+    private final @Nullable Locale locale;
 
-    private Collection<ProgressStep> sequence;
-    private Iterator<ProgressStep> progressIterator;
-    private ProgressStep current;
-    private Integer progress;
+    private @Nullable Collection<ProgressStep> sequence;
+    private @Nullable Iterator<ProgressStep> progressIterator;
+    private @Nullable ProgressStep current;
+    private @Nullable Integer progress;
 
     private enum InternalState {
         FINISHED,
@@ -66,11 +69,11 @@ final class ProgressCallbackImpl implements ProgressCallback {
         INITIALIZED
     }
 
-    private InternalState state;
+    private @Nullable InternalState state;
 
     ProgressCallbackImpl(FirmwareUpdateHandler firmwareUpdateHandler, EventPublisher eventPublisher,
             TranslationProvider i18nProvider, BundleResolver bundleResolver, ThingUID thingUID, Firmware firmware,
-            Locale locale) {
+            @Nullable Locale locale) {
         this.firmwareUpdateHandler = firmwareUpdateHandler;
         ParameterChecks.checkNotNull(eventPublisher, "Event publisher");
         this.eventPublisher = eventPublisher;
@@ -113,7 +116,7 @@ final class ProgressCallbackImpl implements ProgressCallback {
     }
 
     @Override
-    public void failed(String errorMessageKey, Object... arguments) {
+    public void failed(@Nullable String errorMessageKey, Object... arguments) {
         if (this.state == InternalState.FINISHED) {
             throw new IllegalStateException("Update is finished.");
         }
@@ -187,12 +190,12 @@ final class ProgressCallbackImpl implements ProgressCallback {
         postResultInfoEvent(FirmwareUpdateResult.ERROR, errorMessage);
     }
 
-    private String getMessage(Class<?> clazz, String errorMessageKey, Object... arguments) {
+    private @Nullable String getMessage(Class<?> clazz, String errorMessageKey, Object... arguments) {
         Bundle bundle = bundleResolver.resolveBundle(clazz);
         return i18nProvider.getText(bundle, errorMessageKey, null, locale, arguments);
     }
 
-    private void postResultInfoEvent(FirmwareUpdateResult result, String message) {
+    private void postResultInfoEvent(FirmwareUpdateResult result, @Nullable String message) {
         post(FirmwareEventFactory.createFirmwareUpdateResultInfoEvent(
                 FirmwareUpdateResultInfo.createFirmwareUpdateResultInfo(thingUID, result, message)));
     }
@@ -213,6 +216,7 @@ final class ProgressCallbackImpl implements ProgressCallback {
         eventPublisher.post(event);
     }
 
+    @Nullable
     ProgressStep getCurrentStep() {
         if (current != null) {
             return current;

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemHysteresisStateProfileTest.java
@@ -215,9 +215,13 @@ public class SystemHysteresisStateProfileTest {
     }
 
     private StateProfile initProfile(@Nullable Object lower, @Nullable Object upper, boolean inverted) {
-        final Map<String, @Nullable Object> properties = new HashMap<>(2);
-        properties.put("lower", lower);
-        properties.put("upper", upper);
+        final Map<String, Object> properties = new HashMap<>(2);
+        if (lower != null) {
+            properties.put("lower", lower);
+        }
+        if (upper != null) {
+            properties.put("upper", upper);
+        }
         properties.put("inverted", inverted);
         when(mockContext.getConfiguration()).thenReturn(new Configuration(properties));
         return new SystemHysteresisStateProfile(mockCallback, mockContext);

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemRangeStateProfileTest.java
@@ -207,9 +207,13 @@ public class SystemRangeStateProfileTest {
     }
 
     private StateProfile initProfile(@Nullable Object lower, @Nullable Object upper, boolean inverted) {
-        final Map<String, @Nullable Object> properties = new HashMap<>(2);
-        properties.put(SystemRangeStateProfile.LOWER_PARAM, lower);
-        properties.put(SystemRangeStateProfile.UPPER_PARAM, upper);
+        final Map<String, Object> properties = new HashMap<>(2);
+        if (lower != null) {
+            properties.put(SystemRangeStateProfile.LOWER_PARAM, lower);
+        }
+        if (upper != null) {
+            properties.put(SystemRangeStateProfile.UPPER_PARAM, upper);
+        }
         properties.put(SystemRangeStateProfile.INVERTED_PARAM, inverted);
         when(contextMock.getConfiguration()).thenReturn(new Configuration(properties));
         return new SystemRangeStateProfile(callbackMock, contextMock);

--- a/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
+++ b/bundles/org.openhab.core.ui.icon/src/main/java/org/openhab/core/ui/icon/internal/IconSetResource.java
@@ -91,7 +91,7 @@ public class IconSetResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getIconSets", summary = "Gets all icon sets.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = IconSet.class)))) })
-    public Response getAll(
+    public @Nullable Response getAll(
             @HeaderParam("Accept-Language") @Parameter(description = "language") @Nullable String language) {
         Locale locale = localeService.getLocale(language);
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/RootUIComponent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/RootUIComponent.java
@@ -55,7 +55,7 @@ public class RootUIComponent extends UIComponent implements Identifiable<String>
      *
      * @param name the name of the UI component to render on client frontends, ie. "oh-block"
      */
-    public RootUIComponent(String name) {
+    public RootUIComponent(@Nullable String name) {
         super(name);
         this.uid = UUID.randomUUID().toString();
         this.props = new ConfigDescriptionDTO(null, new ArrayList<>(), new ArrayList<>());
@@ -67,7 +67,7 @@ public class RootUIComponent extends UIComponent implements Identifiable<String>
      * @param uid the UID of the new card
      * @param name the name of the UI component to render on client frontends, ie. "oh-block"
      */
-    public RootUIComponent(String uid, String name) {
+    public RootUIComponent(String uid, @Nullable String name) {
         super(name);
         this.uid = uid;
         this.props = new ConfigDescriptionDTO(null, new ArrayList<>(), new ArrayList<>());

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/components/UIComponent.java
@@ -16,6 +16,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * A UIComponent represents a piece of UI element for a client frontend to render; it is kept very simple and delegates
@@ -30,11 +34,15 @@ import java.util.Map;
  *
  * @author Yannick Schaus - Initial contribution
  */
+@NonNullByDefault
 public class UIComponent {
+    @Nullable
     String component;
 
+    @Nullable
     Map<String, Object> config;
 
+    @Nullable
     Map<String, List<UIComponent>> slots = null;
 
     /**
@@ -49,7 +57,7 @@ public class UIComponent {
      *
      * @param componentType type of the component as known to the frontend
      */
-    public UIComponent(String componentType) {
+    public UIComponent(@Nullable String componentType) {
         this.component = componentType;
         this.config = new HashMap<>();
     }
@@ -59,7 +67,7 @@ public class UIComponent {
      *
      * @return the component type
      */
-    public String getType() {
+    public @Nullable String getType() {
         return component;
     }
 
@@ -68,7 +76,7 @@ public class UIComponent {
      *
      * @return the component type
      */
-    public String getComponent() {
+    public @Nullable String getComponent() {
         return component;
     }
 
@@ -77,7 +85,7 @@ public class UIComponent {
      *
      * @param component the component type
      */
-    public void setComponent(String component) {
+    public void setComponent(@Nullable String component) {
         this.component = component;
     }
 
@@ -86,7 +94,7 @@ public class UIComponent {
      *
      * @return the map of configuration parameters
      */
-    public Map<String, Object> getConfig() {
+    public @Nullable Map<String, Object> getConfig() {
         return config;
     }
 
@@ -95,7 +103,7 @@ public class UIComponent {
      *
      * @param config the map of configuration parameters
      */
-    public void setConfig(Map<String, Object> config) {
+    public void setConfig(@Nullable Map<String, Object> config) {
         this.config = config;
     }
 
@@ -106,6 +114,7 @@ public class UIComponent {
      * @param value the parameter value
      */
     public void addConfig(String key, Object value) {
+        Objects.requireNonNull(config);
         this.config.put(key, value);
     }
 
@@ -114,7 +123,7 @@ public class UIComponent {
      *
      * @return the slots and their sub-components
      */
-    public Map<String, List<UIComponent>> getSlots() {
+    public @Nullable Map<String, List<UIComponent>> getSlots() {
         return slots;
     }
 
@@ -123,7 +132,7 @@ public class UIComponent {
      *
      * @param slots the slots and their sub-components
      */
-    public void setSlots(Map<String, List<UIComponent>> slots) {
+    public void setSlots(@Nullable Map<String, List<UIComponent>> slots) {
         this.slots = slots;
     }
 
@@ -149,7 +158,7 @@ public class UIComponent {
      * @param slotName the name of the slot
      * @return the list of sub-components in the slot
      */
-    public List<UIComponent> getSlot(String slotName) {
+    public @Nullable List<UIComponent> getSlot(String slotName) {
         return this.slots.get(slotName);
     }
 

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/UIActivator.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/UIActivator.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.ui.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -20,15 +22,16 @@ import org.osgi.framework.BundleContext;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public final class UIActivator implements BundleActivator {
 
-    private static BundleContext context;
+    private static @Nullable BundleContext context;
 
     /**
      * Called whenever the OSGi framework starts our bundle
      */
     @Override
-    public void start(BundleContext bc) throws Exception {
+    public void start(@Nullable BundleContext bc) throws Exception {
         context = bc;
     }
 
@@ -36,11 +39,11 @@ public final class UIActivator implements BundleActivator {
      * Called whenever the OSGi framework stops our bundle
      */
     @Override
-    public void stop(BundleContext bc) throws Exception {
+    public void stop(@Nullable BundleContext bc) throws Exception {
         context = null;
     }
 
-    public static BundleContext getContext() {
+    public static @Nullable BundleContext getContext() {
         return context;
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/AsyncProxyServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/AsyncProxyServlet.java
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -29,6 +31,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
  *
  * @author John Cocula - Initial contribution
  */
+@NonNullByDefault
 public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet {
 
     @Serial
@@ -41,7 +44,7 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
     }
 
     @Override
-    public String getServletInfo() {
+    public @Nullable String getServletInfo() {
         return "Proxy (async)";
     }
 
@@ -49,13 +52,14 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
      * Override <code>newHttpClient</code> so we can proxy to HTTPS URIs.
      */
     @Override
-    protected HttpClient newHttpClient() {
+    protected @Nullable HttpClient newHttpClient() {
         return new HttpClient(new SslContextFactory.Client());
     }
 
     @Override
-    protected void sendProxyRequest(HttpServletRequest clientRequest, HttpServletResponse proxyResponse,
-            Request proxyRequest) {
+    protected void sendProxyRequest(@Nullable HttpServletRequest clientRequest,
+            @Nullable HttpServletResponse proxyResponse, @Nullable Request proxyRequest) {
+        Objects.requireNonNull(clientRequest);
         if (service.proxyingVideoWidget(clientRequest)) {
             // We disable the timeout for video
             proxyRequest.timeout(0, TimeUnit.MILLISECONDS);
@@ -72,19 +76,26 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
      * Add Basic Authentication header to request if user and password are specified in URI.
      */
     @Override
-    protected void copyRequestHeaders(HttpServletRequest clientRequest, Request proxyRequest) {
+    protected void copyRequestHeaders(@Nullable HttpServletRequest clientRequest, @Nullable Request proxyRequest) {
+        Objects.requireNonNull(clientRequest);
+        Objects.requireNonNull(proxyRequest);
+
         super.copyRequestHeaders(clientRequest, proxyRequest);
 
         service.maybeAppendAuthHeader(service.uriFromRequest(clientRequest), proxyRequest);
     }
 
     @Override
-    protected String rewriteTarget(HttpServletRequest request) {
+    protected @Nullable String rewriteTarget(@Nullable HttpServletRequest request) {
+        Objects.requireNonNull(request);
         return Objects.toString(service.uriFromRequest(request), null);
     }
 
     @Override
-    protected void onProxyRewriteFailed(HttpServletRequest request, HttpServletResponse response) {
+    protected void onProxyRewriteFailed(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response) {
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(response);
+
         service.sendError(request, response);
     }
 }

--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/BlockingProxyServlet.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/proxy/BlockingProxyServlet.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serial;
 import java.net.URI;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -24,6 +25,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
@@ -40,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * @author Svilen Valkanov - Replaced Apache HttpClient with Jetty
  * @author John Cocula - refactored to support alternate implementation
  */
+@NonNullByDefault
 public class BlockingProxyServlet extends HttpServlet {
 
     private final Logger logger = LoggerFactory.getLogger(BlockingProxyServlet.class);
@@ -66,13 +70,16 @@ public class BlockingProxyServlet extends HttpServlet {
     }
 
     @Override
-    public String getServletInfo() {
+    public @Nullable String getServletInfo() {
         return "Proxy (blocking)";
     }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+    protected void doGet(@Nullable HttpServletRequest request, @Nullable HttpServletResponse response)
             throws ServletException, IOException {
+        Objects.requireNonNull(request);
+        Objects.requireNonNull(response);
+
         URI uri = service.uriFromRequest(request);
 
         if (uri == null) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ASTNode.java
@@ -12,20 +12,24 @@
  */
 package org.openhab.core.voice.text;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Abstract syntax tree node. Result of parsing an expression.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public class ASTNode {
 
     private boolean success = false;
-    private ASTNode[] children;
-    private TokenList remainingTokens;
+    private ASTNode @Nullable [] children;
+    private @Nullable TokenList remainingTokens;
 
-    private String name;
-    private Object value;
-    private Object tag;
+    private @Nullable String name;
+    private @Nullable Object value;
+    private @Nullable Object tag;
 
     public ASTNode() {
     }
@@ -36,7 +40,7 @@ public class ASTNode {
      * @param children the node's children
      * @param remainingTokens remaining token list starting with the first token that was not covered/consumed
      */
-    public ASTNode(ASTNode[] children, TokenList remainingTokens) {
+    public ASTNode(ASTNode @Nullable [] children, @Nullable TokenList remainingTokens) {
         this.success = true;
         this.children = children;
         this.remainingTokens = remainingTokens;
@@ -48,7 +52,7 @@ public class ASTNode {
      * @param name the name that's used for looking up the tree
      * @return first node with the given name or null, if none was found
      */
-    public ASTNode findNode(String name) {
+    public @Nullable ASTNode findNode(String name) {
         if (this.name != null && this.name.equals(name)) {
             return this;
         }
@@ -88,7 +92,7 @@ public class ASTNode {
      * @param name the name of the named node to be found
      * @return the value of the resulting node as {@code String[]} or null if not found
      */
-    public String[] findValueAsStringArray(String name) {
+    public String @Nullable [] findValueAsStringArray(String name) {
         ASTNode node = findNode(name);
         return node == null ? null : node.getValueAsStringArray();
     }
@@ -100,7 +104,7 @@ public class ASTNode {
      * @param name the name of the named node to be found
      * @return the value of the resulting node as {@link String} or null if not found
      */
-    public String findValueAsString(String name) {
+    public @Nullable String findValueAsString(String name) {
         ASTNode node = findNode(name);
         return node == null ? null : node.getValueAsString();
     }
@@ -112,7 +116,7 @@ public class ASTNode {
      * @param cls the node's value has to be assignable to a reference of this class to match during search
      * @return the value of the resulting node. Null, if not found or the value does not match {@code cls}.
      */
-    public Object findValue(String name, Class<?> cls) {
+    public @Nullable Object findValue(String name, Class<?> cls) {
         ASTNode node = findNode(name);
         return node == null ? null
                 : ((node.value != null && cls.isAssignableFrom(node.value.getClass())) ? node.value : null);
@@ -124,7 +128,7 @@ public class ASTNode {
      * @param name the name of the named node to be found
      * @return the value of the resulting node. Null, if not found.
      */
-    public Object findValue(String name) {
+    public @Nullable Object findValue(String name) {
         ASTNode node = findNode(name);
         return node == null ? null : node.value;
     }
@@ -146,7 +150,7 @@ public class ASTNode {
     /**
      * @return the children
      */
-    public ASTNode[] getChildren() {
+    public ASTNode @Nullable [] getChildren() {
         return children;
     }
 
@@ -160,56 +164,56 @@ public class ASTNode {
     /**
      * @return the remainingTokens
      */
-    public TokenList getRemainingTokens() {
+    public @Nullable TokenList getRemainingTokens() {
         return remainingTokens;
     }
 
     /**
      * @param remainingTokens the remainingTokens to set
      */
-    public void setRemainingTokens(TokenList remainingTokens) {
+    public void setRemainingTokens(@Nullable TokenList remainingTokens) {
         this.remainingTokens = remainingTokens;
     }
 
     /**
      * @return the name
      */
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
     /**
      * @param name the name to set
      */
-    public void setName(String name) {
+    public void setName(@Nullable String name) {
         this.name = name;
     }
 
     /**
      * @return the value
      */
-    public Object getValue() {
+    public @Nullable Object getValue() {
         return value;
     }
 
     /**
      * @param value the value to set
      */
-    public void setValue(Object value) {
+    public void setValue(@Nullable Object value) {
         this.value = value;
     }
 
     /**
      * @return the tag
      */
-    public Object getTag() {
+    public @Nullable Object getTag() {
         return tag;
     }
 
     /**
      * @param tag the tag to set
      */
-    public void setTag(Object tag) {
+    public void setTag(@Nullable Object tag) {
         this.tag = tag;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -680,7 +680,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected Expression tag(@Nullable String name, Object expression, @Nullable Object tag) {
-        return new ExpressionLet(name, exp(expression), null, tag);
+        return new ExpressionLet(name, Objects.requireNonNull(exp(expression)), null, tag);
     }
 
     /**
@@ -747,7 +747,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected ExpressionCardinality opt(Object expression) {
-        return new ExpressionCardinality(exp(expression), false, true);
+        return new ExpressionCardinality(Objects.requireNonNull(exp(expression)), false, true);
     }
 
     /**
@@ -759,7 +759,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected ExpressionCardinality star(Object expression) {
-        return new ExpressionCardinality(exp(expression), false, false);
+        return new ExpressionCardinality(Objects.requireNonNull(exp(expression)), false, false);
     }
 
     /**
@@ -771,7 +771,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
      * @return resulting expression
      */
     protected ExpressionCardinality plus(Object expression) {
-        return new ExpressionCardinality(exp(expression), true, false);
+        return new ExpressionCardinality(Objects.requireNonNull(exp(expression)), true, false);
     }
 
     /**
@@ -999,8 +999,8 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         return new ArrayList<>(itemsData.keySet());
     }
 
-    @Nullable
-    private Item filterMatchedItemsByLocation(Map<Item, ItemInterpretationMetadata> itemsData, String locationContext) {
+    private @Nullable Item filterMatchedItemsByLocation(Map<Item, ItemInterpretationMetadata> itemsData,
+            String locationContext) {
         var itemsFilteredByLocation = itemsData.entrySet().stream()
                 .filter(entry -> entry.getValue().locationParentNames.contains(locationContext)).toList();
         if (itemsFilteredByLocation.size() != 1) {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Expression.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/Expression.java
@@ -17,11 +17,14 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Base class for all expressions.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public abstract class Expression {
 
     Expression() {

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionAlternatives.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionAlternatives.java
@@ -17,11 +17,14 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Expression that successfully parses, if one of the given alternative expressions matches. This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 final class ExpressionAlternatives extends Expression {
 
     private List<Expression> subExpressions;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionCardinality.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionCardinality.java
@@ -17,12 +17,16 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Expression that successfully parses, if a given expression occurs or repeats with a specified cardinality. This class
  * is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public final class ExpressionCardinality extends Expression {
 
     private Expression subExpression;
@@ -47,7 +51,7 @@ public final class ExpressionCardinality extends Expression {
         TokenList list = tokenList;
         ASTNode node = new ASTNode(), cr;
         List<ASTNode> nodes = new ArrayList<>();
-        List<Object> values = new ArrayList<>();
+        List<@Nullable Object> values = new ArrayList<>();
         while ((cr = subExpression.parse(language, list)).isSuccess()) {
             nodes.add(cr);
             values.add(cr.getValue());

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionIdentifier.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionIdentifier.java
@@ -16,15 +16,19 @@ import java.util.HashSet;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Expression that successfully parses, if a thing identifier token is found. This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public final class ExpressionIdentifier extends Expression {
 
     private AbstractRuleBasedInterpreter interpreter;
-    private Expression stopper;
+    private @Nullable Expression stopper;
 
     /**
      * Constructs a new instance.
@@ -41,7 +45,7 @@ public final class ExpressionIdentifier extends Expression {
      * @param interpreter the interpreter it belongs to. Used for dynamically fetching item name tokens
      * @param stopper Expression that should not match, if the current token should be accepted as identifier
      */
-    public ExpressionIdentifier(AbstractRuleBasedInterpreter interpreter, Expression stopper) {
+    public ExpressionIdentifier(AbstractRuleBasedInterpreter interpreter, @Nullable Expression stopper) {
         this.interpreter = interpreter;
         this.stopper = stopper;
     }
@@ -84,7 +88,7 @@ public final class ExpressionIdentifier extends Expression {
     /**
      * @return the stopper expression
      */
-    public Expression getStopper() {
+    public @Nullable Expression getStopper() {
         return stopper;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionLet.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionLet.java
@@ -16,18 +16,22 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * Expression that decorates the resulting (proxied) AST node of a given expression by a name, value and tag.
  * This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public final class ExpressionLet extends Expression {
 
     private Expression subExpression;
-    private String name;
-    private Object value;
-    private Object tag;
+    private @Nullable String name;
+    private @Nullable Object value;
+    private @Nullable Object tag;
 
     /**
      * Constructs a new instance.
@@ -45,7 +49,7 @@ public final class ExpressionLet extends Expression {
      * @param subExpression the expression who's resulting node should be altered
      * @param value the value that should be set on the node. Null, if the node's value should not be changed.
      */
-    public ExpressionLet(Expression subExpression, Object value) {
+    public ExpressionLet(Expression subExpression, @Nullable Object value) {
         this(null, subExpression, value, null);
     }
 
@@ -57,7 +61,8 @@ public final class ExpressionLet extends Expression {
      * @param value the value that should be set on the node. Null, if the node's value should not be changed.
      * @param tag the tag that should be set on the node. Null, if the node's tag should not be changed.
      */
-    public ExpressionLet(String name, Expression subExpression, Object value, Object tag) {
+    public ExpressionLet(@Nullable String name, Expression subExpression, @Nullable Object value,
+            @Nullable Object tag) {
         if (name != null) {
             this.name = name;
         }
@@ -110,21 +115,21 @@ public final class ExpressionLet extends Expression {
     /**
      * @return the name
      */
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
     /**
      * @return the value
      */
-    public Object getValue() {
+    public @Nullable Object getValue() {
         return value;
     }
 
     /**
      * @return the tag
      */
-    public Object getTag() {
+    public @Nullable Object getTag() {
         return tag;
     }
 }

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionMatch.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionMatch.java
@@ -15,11 +15,14 @@ package org.openhab.core.voice.text;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Expression that successfully parses, if a given string constant is found. This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public final class ExpressionMatch extends Expression {
 
     private String pattern;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionSequence.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/ExpressionSequence.java
@@ -17,11 +17,14 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Expression that successfully parses, if a sequence of given expressions is matching. This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public final class ExpressionSequence extends Expression {
 
     private List<Expression> subExpressions;

--- a/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/TokenList.java
+++ b/bundles/org.openhab.core.voice/src/main/java/org/openhab/core/voice/text/TokenList.java
@@ -14,11 +14,15 @@ package org.openhab.core.voice.text;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * A helper to parse a sequence of tokens. This class is immutable.
  *
  * @author Tilman Kamp - Initial contribution
  */
+@NonNullByDefault
 public class TokenList {
 
     private List<String> list;
@@ -48,7 +52,7 @@ public class TokenList {
      *
      * @return the first token of the list
      */
-    public String head() {
+    public @Nullable String head() {
         return (list.isEmpty() || head < 0 || head >= list.size()) ? null : list.get(head);
     }
 
@@ -57,7 +61,7 @@ public class TokenList {
      *
      * @return the last token of the list
      */
-    public String tail() {
+    public @Nullable String tail() {
         return (list.isEmpty() || tail < 0 || tail >= list.size()) ? null : list.get(tail);
     }
 
@@ -113,7 +117,7 @@ public class TokenList {
      * @return First token, if it is equal to one of the alternatives or if no alternatives were provided.
      *         Null otherwise. Always null, if there is no first token (if the list is empty).
      */
-    public String peekHead(String... alternatives) {
+    public @Nullable String peekHead(String... alternatives) {
         return peek(head, alternatives);
     }
 
@@ -125,7 +129,7 @@ public class TokenList {
      * @return Last token, if it is equal to one of the alternatives or if no alternatives were provided.
      *         Null otherwise. Always null, if there is no last token (if the list is empty).
      */
-    public String peekTail(String... alternatives) {
+    public @Nullable String peekTail(String... alternatives) {
         return peek(tail, alternatives);
     }
 
@@ -147,7 +151,7 @@ public class TokenList {
         return new TokenList(list, head, tail - 1);
     }
 
-    private String peek(int index, String... alternatives) {
+    private @Nullable String peek(int index, String... alternatives) {
         return splice(index, alternatives);
     }
 
@@ -155,7 +159,7 @@ public class TokenList {
         return splice(index, alternatives) != null;
     }
 
-    private String splice(int index, String... alternatives) {
+    private @Nullable String splice(int index, String... alternatives) {
         if (index < head || index > tail || head > tail) {
             return null;
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PendingToken.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/PendingToken.java
@@ -37,10 +37,8 @@ public class PendingToken {
     private String redirectUri;
     private String scope;
 
-    @Nullable
-    private String codeChallenge;
-    @Nullable
-    private String codeChallengeMethod;
+    private @Nullable String codeChallenge;
+    private @Nullable String codeChallengeMethod;
 
     /**
      * Constructs a pending token.

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/auth/client/oauth2/AccessTokenResponse.java
@@ -17,6 +17,9 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This is the Access Token Response, a simple value-object that holds the result of the
  * from an Access Token Request, as listed in RFC 6749:
@@ -28,6 +31,7 @@ import java.util.Objects;
  * @author Michael Bock - Initial contribution
  * @author Gary Tse - Adaptation for Eclipse SmartHome
  */
+@NonNullByDefault
 public final class AccessTokenResponse implements Serializable, Cloneable {
 
     /**
@@ -46,14 +50,14 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.4">rfc6749 section-1.4</a>
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.3">rfc6749 section-10.3</a>
      */
-    private String accessToken;
+    private @Nullable String accessToken;
 
     /**
      * Token type. e.g. Bearer, MAC
      *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-7.1">rfc6749 section-7.1</a>
      */
-    private String tokenType;
+    private @Nullable String tokenType;
 
     /**
      * Number of seconds that this OAuthToken is valid for since the time it was created.
@@ -74,7 +78,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.5">rfc6749 section-1.5</a>
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.4">rfc6749 section-10.4</a>
      */
-    private String refreshToken;
+    private @Nullable String refreshToken;
 
     /**
      * A space-delimited case-sensitive un-ordered string. This may be used
@@ -83,7 +87,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      *
      * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.3">rfc6749 section-3.3</a>
      */
-    private String scope;
+    private @Nullable String scope;
 
     /**
      * If the {@code state} parameter was present in the access token request.
@@ -91,7 +95,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      *
      * <a href="https://tools.ietf.org/html/rfc6749#section-4.2.2">rfc6749 section-4.2.2</a>
      */
-    private String state;
+    private @Nullable String state;
 
     /**
      * Created datetime of this access token. This is generated locally
@@ -100,7 +104,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * This should be slightly later than the actual time the access token
      * is produced at the server.
      */
-    private Instant createdOn;
+    private @Nullable Instant createdOn;
 
     /**
      * Calculate if the token is expired against the given time.
@@ -117,19 +121,19 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
                 || createdOn.plusSeconds(expiresIn).minusSeconds(tokenExpiresInBuffer).isBefore(givenTime);
     }
 
-    public String getAccessToken() {
+    public @Nullable String getAccessToken() {
         return accessToken;
     }
 
-    public void setAccessToken(String accessToken) {
+    public void setAccessToken(@Nullable String accessToken) {
         this.accessToken = accessToken;
     }
 
-    public String getTokenType() {
+    public @Nullable String getTokenType() {
         return tokenType;
     }
 
-    public void setTokenType(String tokenType) {
+    public void setTokenType(@Nullable String tokenType) {
         this.tokenType = tokenType;
     }
 
@@ -141,35 +145,35 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
         this.expiresIn = expiresIn;
     }
 
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
         return refreshToken;
     }
 
-    public void setRefreshToken(String refreshToken) {
+    public void setRefreshToken(@Nullable String refreshToken) {
         this.refreshToken = refreshToken;
     }
 
-    public String getScope() {
+    public @Nullable String getScope() {
         return scope;
     }
 
-    public void setScope(String scope) {
+    public void setScope(@Nullable String scope) {
         this.scope = scope;
     }
 
-    public String getState() {
+    public @Nullable String getState() {
         return state;
     }
 
-    public void setState(String state) {
+    public void setState(@Nullable String state) {
         this.state = state;
     }
 
-    public Instant getCreatedOn() {
+    public @Nullable Instant getCreatedOn() {
         return createdOn;
     }
 
-    public void setCreatedOn(Instant createdOn) {
+    public void setCreatedOn(@Nullable Instant createdOn) {
         this.createdOn = createdOn;
     }
 
@@ -188,7 +192,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
     }
 
     @Override
-    public boolean equals(Object thatAuthTokenObj) {
+    public boolean equals(@Nullable Object thatAuthTokenObj) {
         if (this == thatAuthTokenObj) {
             return true;
         }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/ThreadPoolManager.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.PoolBasedSequentialScheduledExecutorService.BasePoolExecutor;
 import org.openhab.core.internal.common.WrappedScheduledExecutorService;
 import org.osgi.framework.Constants;
@@ -59,6 +61,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  */
 @Component(configurationPid = ThreadPoolManager.CONFIGURATION_PID)
+@NonNullByDefault
 public class ThreadPoolManager {
 
     public static final String CONFIGURATION_PID = "org.openhab.threadpool";
@@ -244,6 +247,7 @@ public class ThreadPoolManager {
         }
 
         @Override
+        @NonNullByDefault({})
         public List<Runnable> shutdownNow() {
             logger.warn("shutdownNow() invoked on a shared thread pool '{}'. This is a bug, please submit a bug report",
                     threadPoolName, new IllegalStateException());
@@ -261,44 +265,48 @@ public class ThreadPoolManager {
         }
 
         @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        public boolean awaitTermination(long timeout, @Nullable TimeUnit unit) throws InterruptedException {
             return delegate.awaitTermination(timeout, unit);
         }
 
         @Override
-        public <T> Future<T> submit(Callable<T> task) {
+        public <T> Future<T> submit(@Nullable Callable<T> task) {
             return delegate.submit(task);
         }
 
         @Override
-        public <T> Future<T> submit(Runnable task, T result) {
+        public <T> Future<T> submit(@Nullable Runnable task, T result) {
             return delegate.submit(task, result);
         }
 
         @Override
-        public Future<?> submit(Runnable task) {
+        public Future<?> submit(@Nullable Runnable task) {
             return delegate.submit(task);
         }
 
         @Override
+        @NonNullByDefault({})
         public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
             return delegate.invokeAll(tasks);
         }
 
         @Override
+        @NonNullByDefault({})
         public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
                 throws InterruptedException {
             return delegate.invokeAll(tasks, timeout, unit);
         }
 
         @Override
-        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+        @NonNullByDefault({})
+        public <T> T invokeAny(@Nullable Collection<? extends Callable<T>> tasks)
                 throws InterruptedException, ExecutionException {
             return delegate.invokeAny(tasks);
         }
 
         @Override
-        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        @NonNullByDefault({})
+        public <T> T invokeAny(@Nullable Collection<? extends Callable<T>> tasks, long timeout, @Nullable TimeUnit unit)
                 throws InterruptedException, ExecutionException, TimeoutException {
             return delegate.invokeAny(tasks, timeout, unit);
         }
@@ -353,6 +361,7 @@ public class ThreadPoolManager {
         }
 
         @Override
+        @NonNullByDefault({})
         public BlockingQueue<Runnable> getQueue() {
             return new ArrayBlockingQueue<Runnable>(1) {
                 public int remainingCapacity() {
@@ -376,23 +385,24 @@ public class ThreadPoolManager {
         }
 
         @Override
-        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        public ScheduledFuture<?> schedule(@Nullable Runnable command, long delay, @Nullable TimeUnit unit) {
             return delegate.schedule(command, delay, unit);
         }
 
         @Override
-        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        public <V> ScheduledFuture<V> schedule(@Nullable Callable<V> callable, long delay, @Nullable TimeUnit unit) {
             return delegate.schedule(callable, delay, unit);
         }
 
         @Override
-        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        public ScheduledFuture<?> scheduleAtFixedRate(@Nullable Runnable command, long initialDelay, long period,
+                @Nullable TimeUnit unit) {
             return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
         }
 
         @Override
-        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
-                TimeUnit unit) {
+        public ScheduledFuture<?> scheduleWithFixedDelay(@Nullable Runnable command, long initialDelay, long delay,
+                @Nullable TimeUnit unit) {
             return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
         }
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/Invocation.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/Invocation.java
@@ -15,8 +15,10 @@ package org.openhab.core.internal.common;
 import java.lang.reflect.Method;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -24,6 +26,7 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  * @author Simon Kaufmann - Initial contribution
  */
+@NonNullByDefault
 class Invocation implements Callable<Object> {
 
     private final Method method;
@@ -31,8 +34,7 @@ class Invocation implements Callable<Object> {
     private final AbstractInvocationHandler<?> invocationHandler;
     private final Deque<Invocation> invocationStack = new LinkedList<>();
 
-    @Nullable
-    private Thread thread;
+    private @Nullable Thread thread;
 
     Invocation(AbstractInvocationHandler<?> invocationHandler, Method method, @Nullable Object @Nullable [] args) {
         this.method = method;
@@ -49,14 +51,17 @@ class Invocation implements Callable<Object> {
     @Override
     public Object call() throws Exception {
         thread = Thread.currentThread();
-        return invocationHandler.invokeDirect(this);
+        // TODO check incompatible null annotations, Callable requires non-null return type but
+        // AbstractInvocationHandler clearly returns null on error
+        return Objects.requireNonNull(invocationHandler.invokeDirect(this));
     }
 
     Method getMethod() {
         return method;
     }
 
-    Object[] getArgs() {
+    @Nullable
+    Object @Nullable [] getArgs() {
         return args;
     }
 

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/items/ExpireManager.java
@@ -94,7 +94,7 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
     private @Nullable ScheduledFuture<?> expireJob;
 
     @Activate
-    public ExpireManager(Map<String, @Nullable Object> configuration, final @Reference EventPublisher eventPublisher,
+    public ExpireManager(Map<String, Object> configuration, final @Reference EventPublisher eventPublisher,
             final @Reference MetadataRegistry metadataRegistry, final @Reference ItemRegistry itemRegistry) {
         this.eventPublisher = eventPublisher;
         this.metadataRegistry = metadataRegistry;
@@ -104,7 +104,7 @@ public class ExpireManager implements EventSubscriber, RegistryChangeListener<It
     }
 
     @Modified
-    protected void modified(Map<String, @Nullable Object> configuration) {
+    protected void modified(Map<String, Object> configuration) {
         Object valueEnabled = configuration.get(PROPERTY_ENABLED);
         if (valueEnabled != null) {
             enabled = Boolean.parseBoolean(valueEnabled.toString());

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/BundleResolverImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/service/BundleResolverImpl.java
@@ -29,8 +29,7 @@ import org.osgi.service.component.annotations.Component;
 public class BundleResolverImpl implements BundleResolver {
 
     @Override
-    @Nullable
-    public Bundle resolveBundle(Class<?> clazz) {
+    public @Nullable Bundle resolveBundle(Class<?> clazz) {
         return FrameworkUtil.getBundle(clazz);
     }
 }

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AbstractTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AbstractTestAgent.java
@@ -14,8 +14,11 @@ package org.openhab.core.auth.oauth2client.test.internal;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
 import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.auth.client.oauth2.OAuthException;
@@ -29,25 +32,26 @@ import org.slf4j.LoggerFactory;
  *
  * @author Gary Tse - Initial contribution
  */
+@NonNullByDefault
 public abstract class AbstractTestAgent implements TestAgent {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractTestAgent.class);
 
-    public String handle;
+    public String handle = "";
 
-    protected String tokenUrl;
-    protected String clientId;
+    protected String tokenUrl = "";
+    protected String clientId = "";
 
-    protected String authUrl;
-    protected String redirectUri;
+    protected String authUrl = "";
+    protected String redirectUri = "";
 
-    protected String clientSecret;
-    protected String username;
-    protected String password;
-    protected String scope;
+    protected String clientSecret = "";
+    protected String username = "";
+    protected String password = "";
+    protected String scope = "";
 
-    protected OAuthFactory oauthFactory;
-    protected OAuthClientService oauthClientService;
+    protected @Nullable OAuthFactory oauthFactory;
+    protected @Nullable OAuthClientService oauthClientService;
 
     public void activate(Map<String, Object> properties) {
         tokenUrl = getProperty(properties, "TOKEN_URL");
@@ -96,7 +100,7 @@ public abstract class AbstractTestAgent implements TestAgent {
     }
 
     @Override
-    public OAuthClientService testGetClient(String handle) throws OAuthException {
+    public @Nullable OAuthClientService testGetClient(@Nullable String handle) throws OAuthException {
         logger.debug("test GetClient handle: {}", handle);
         if (handle == null) {
             if (this.handle == null) {
@@ -140,7 +144,7 @@ public abstract class AbstractTestAgent implements TestAgent {
     @Override
     public AccessTokenResponse testGetCachedAccessToken() throws OAuthException, IOException, OAuthResponseException {
         logger.debug("test getCachedAccessToken");
-        return oauthClientService.getAccessTokenResponse();
+        return Objects.requireNonNull(oauthClientService.getAccessTokenResponse());
     }
 
     @Override
@@ -150,7 +154,7 @@ public abstract class AbstractTestAgent implements TestAgent {
     }
 
     @Override
-    public String testGetAuthorizationUrl(String state) throws OAuthException {
+    public @Nullable String testGetAuthorizationUrl(@Nullable String state) throws OAuthException {
         logger.debug("test getAuthorizationUrl {}", state);
         return oauthClientService.getAuthorizationUrl(redirectUri, scope, state);
     }

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AuthorizationCodeTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/AuthorizationCodeTestAgent.java
@@ -14,6 +14,7 @@ package org.openhab.core.auth.oauth2client.test.internal;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.client.oauth2.OAuthFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Initial contribution
  */
 @Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, name = "AuthorizationCodeTestAgent", configurationPid = "AuthorizationCodeTestAgent")
+@NonNullByDefault
 public class AuthorizationCodeTestAgent extends AbstractTestAgent implements TestAgent {
 
     public static final String CONFIGURATION_PID = "AuthorizationCodeTestAgent";

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/ResourceOwnerTestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/ResourceOwnerTestAgent.java
@@ -14,6 +14,7 @@ package org.openhab.core.auth.oauth2client.test.internal;
 
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.client.oauth2.OAuthFactory;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Initial contribution
  */
 @Component(immediate = true, configurationPolicy = ConfigurationPolicy.REQUIRE, name = "ResourceOwnerTestAgent", configurationPid = "ResourceOwnerTestAgent")
+@NonNullByDefault
 public class ResourceOwnerTestAgent extends AbstractTestAgent implements TestAgent {
 
     public static final String CONFIGURATION_PID = "ResourceOwnerTestAgent";

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/TestAgent.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/TestAgent.java
@@ -14,6 +14,8 @@ package org.openhab.core.auth.oauth2client.test.internal;
 
 import java.io.IOException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
 import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.auth.client.oauth2.OAuthException;
@@ -24,6 +26,7 @@ import org.openhab.core.auth.client.oauth2.OAuthResponseException;
  *
  * @author Gary Tse - Initial contribution
  */
+@NonNullByDefault
 public interface TestAgent {
 
     OAuthClientService testCreateClient();
@@ -31,7 +34,8 @@ public interface TestAgent {
     AccessTokenResponse testGetAccessTokenByResourceOwnerPasswordCredentials()
             throws OAuthException, IOException, OAuthResponseException;
 
-    OAuthClientService testGetClient(String handle) throws OAuthException;
+    @Nullable
+    OAuthClientService testGetClient(@Nullable String handle) throws OAuthException;
 
     AccessTokenResponse testGetAccessTokenByAuthorizationCode(String code)
             throws OAuthException, IOException, OAuthResponseException;
@@ -40,7 +44,8 @@ public interface TestAgent {
 
     AccessTokenResponse testGetCachedAccessToken() throws OAuthException, IOException, OAuthResponseException;
 
-    String testGetAuthorizationUrl(String state) throws OAuthException;
+    @Nullable
+    String testGetAuthorizationUrl(@Nullable String state) throws OAuthException;
 
     void close();
 

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
@@ -15,6 +15,8 @@ package org.openhab.core.auth.oauth2client.test.internal.console;
 import java.io.IOException;
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.auth.client.oauth2.AccessTokenResponse;
 import org.openhab.core.auth.client.oauth2.OAuthClientService;
 import org.openhab.core.auth.client.oauth2.OAuthException;
@@ -34,6 +36,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Gary Tse - Initial contribution
  */
+@NonNullByDefault
 @Component(immediate = true, name = "ConsoleOAuthCommandExtension")
 public class ConsoleOAuthCommandExtension extends AbstractConsoleCommandExtension implements ConsoleCommandExtension {
 
@@ -42,9 +45,9 @@ public class ConsoleOAuthCommandExtension extends AbstractConsoleCommandExtensio
                 + "The commands in oauth requires oauth provider data to be inputted in configuration admin.");
     }
 
-    private AuthorizationCodeTestAgent authorizationCodeTestAgent;
-    private ResourceOwnerTestAgent resourceOwnerTestAgent;
-    private Console console;
+    private @Nullable AuthorizationCodeTestAgent authorizationCodeTestAgent;
+    private @Nullable ResourceOwnerTestAgent resourceOwnerTestAgent;
+    private @Nullable Console console;
 
     @Override
     public void execute(String[] args, Console console) {
@@ -116,7 +119,7 @@ public class ConsoleOAuthCommandExtension extends AbstractConsoleCommandExtensio
         }
     }
 
-    private AbstractTestAgent getTestAgent(String name) {
+    private @Nullable AbstractTestAgent getTestAgent(String name) {
         if ("Code".equals(name)) {
             return authorizationCodeTestAgent;
         } else if ("ResourceOwner".equals(name)) {

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
@@ -128,7 +128,7 @@ public class DynamicThingUpdateOSGiTest extends JavaOSGiTest {
         final String cfgIpAddressValue = "127.0.0.1";
 
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_ID).build();
-        thing.getConfiguration().put(cfgIpAddressKey, null);
+        thing.getConfiguration().put(cfgIpAddressKey, "");
         managedThingProvider.add(thing);
         waitForAssert(() -> {
             assertNotNull(callback);

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/service/ConfigurableServiceResourceOSGiTest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openhab.core.io.rest.core.service.ConfigurableServiceDTO;
@@ -136,7 +135,7 @@ public class ConfigurableServiceResourceOSGiTest extends JavaOSGiTest {
         Response response = configurableServiceResource.getConfiguration("id");
         assertThat(response.getStatus(), is(200));
 
-        Map<String, @Nullable Object> newConfiguration = new HashMap<>();
+        Map<String, Object> newConfiguration = new HashMap<>();
         newConfiguration.put("a", "b");
         response = configurableServiceResource.updateConfiguration("en", "id", newConfiguration);
         assertThat(response.getStatus(), is(204));

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/Constants.java
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.firmware.Firmware;
@@ -26,6 +27,7 @@ import org.openhab.core.thing.binding.firmware.FirmwareBuilder;
 /**
  * @author Thomas Höfer - Initial contribution
  */
+@NonNullByDefault
 public class Constants {
 
     public static final String UNKNOWN = "unknown";


### PR DESCRIPTION
This basically removes all CheckStyle warnings "NullAnnotationsCheck: Classes/Interfaces/Enums should be annotated with `@NonNullByDefault`.
Annotations are now there for all "non-DTO" classes.

It was not an easy task to get everything sound and accepted by the compiler, without requiring bigger changes in the add-ons or webui repo (of course cannot tell much about other bindings, not part of the repo, but breaking things should be avoided if possible.)

The biggest decision to be made in this PR is then handling of properties / `Configuration` data. At some places, this seems to be written in a way values could be `@Nullable`, but most of the time is seems used only with non-null values. I played both to the end, leading to much more efforts getting the non-null for values in place (not to speak about the add-ons repo, here many bindings just did not compile anymore).

This is not somehow only half part of the story, leaving a lot of warnings about null mismatches or dead code during compilation. But for now, I tried the keep the impact to active code as minimal as possible (I have a feeling this should be handled in a separate PR).

Just to give you an impression how the SAT report now looks like (including #4863 and using the unreleased snapshot of SAT which does no longer warn about SimplifyBooleanReturns:
![grafik](https://github.com/user-attachments/assets/de3260b2-63ea-406b-91c3-f1a87afd8ede)
