### PR TITLE
Item REST endpoint include item parents

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/item/EnrichedItemDTO.java
@@ -25,6 +25,7 @@ import org.openhab.core.types.StateDescription;
  * @author Dennis Nobel - Initial contribution
  * @author Kai Kreuzer - Added metadata
  * @author Mark Herwege - Added default unit symbol
+ * @author Mark Herwege - Added parent groups
  */
 public class EnrichedItemDTO extends ItemDTO {
 
@@ -38,6 +39,7 @@ public class EnrichedItemDTO extends ItemDTO {
     public Long lastStateChange;
     public String unitSymbol;
     public Map<String, Object> metadata;
+    public EnrichedItemDTO[] parents = null;
     public Boolean editable;
 
     public EnrichedItemDTO(ItemDTO itemDTO, String link, String state, String lastState, Long lastStateUpdate,


### PR DESCRIPTION
I UI PR to be able to show the semantic tree of an item in the item detail screen.

For this, the item semantic model needs to be requested from the REST API. The current approach is to request the static data for all items, but this may lead to high volumes of data repeatedly being passed over the network (the caching does not always work when proxies are involved).
As the idea is to show a tree only involving the item with its parents (recursive) and children recursive), I have extended the item REST endpoint with a parents parameter (members are already retrieved recursively). This way the semantic model for a single item can be retrieved with the minimum amount of traffic.

Relates to https://github.com/openhab/openhab-webui/pull/3227

@ghys FYI