### PR TITLE
Upgrade Jollyday to 1.5.4

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -360,7 +360,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.4</version>
       <scope>compile</scope>
     </dependency>
 

--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -958,7 +958,7 @@
     <dependency>
       <groupId>de.focus-shift</groupId>
       <artifactId>jollyday-jackson</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.4</version>
       <scope>compile</scope>
     </dependency>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -175,12 +175,12 @@
 	</feature>
 
 	<feature name="openhab.tp-jollyday" description="Jollyday library" version="${project.version}">
-		<capability>openhab.tp;feature=jollyday;version=1.5.0</capability>
+		<capability>openhab.tp;feature=jollyday;version=1.5.4</capability>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<feature dependency="true">spifly</feature>
 		<bundle>mvn:org.threeten/threeten-extra/1.8.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-core/1.5.0</bundle>
-		<bundle>mvn:de.focus-shift/jollyday-jackson/1.5.0</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-core/1.5.4</bundle>
+		<bundle>mvn:de.focus-shift/jollyday-jackson/1.5.4</bundle>
 	</feature>
 
 	<feature name="openhab.tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">

--- a/itests/org.openhab.core.automation.integration.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.integration.tests/itest.bndrun
@@ -81,6 +81,6 @@ Fragment-Host: org.openhab.core.automation
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)',\
-	org.openhab.core.semantics;version='[5.0.0,5.0.1)'
+	org.openhab.core.semantics;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.core.tests/itest.bndrun
@@ -81,6 +81,6 @@ Fragment-Host: org.openhab.core.automation
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)',\
-	org.openhab.core.semantics;version='[5.0.0,5.0.1)'
+	org.openhab.core.semantics;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.script.tests/itest.bndrun
@@ -78,6 +78,6 @@ Fragment-Host: org.openhab.core.automation.module.script
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)',\
-	org.openhab.core.semantics;version='[5.0.0,5.0.1)'
+	org.openhab.core.semantics;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.module.timer.tests/itest.bndrun
@@ -81,6 +81,6 @@ Fragment-Host: org.openhab.core.automation
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)',\
-	org.openhab.core.semantics;version='[5.0.0,5.0.1)'
+	org.openhab.core.semantics;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.automation.tests/itest.bndrun
+++ b/itests/org.openhab.core.automation.tests/itest.bndrun
@@ -81,6 +81,6 @@ Fragment-Host: org.openhab.core.automation
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)',\
-	org.openhab.core.semantics;version='[5.0.0,5.0.1)'
+	org.openhab.core.semantics;version='[5.0.0,5.0.1)',\
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
+++ b/itests/org.openhab.core.config.discovery.usbserial.linuxsysfs.tests/itest.bndrun
@@ -29,7 +29,6 @@ Fragment-Host: org.openhab.core.config.discovery.usbserial.linuxsysfs
 	org.mockito.mockito-core;version='[4.11.0,4.11.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	javax.measure.unit-api;version='[2.2.0,2.2.1)',\
-	org.apiguardian.api;version='[1.1.2,1.1.3)',\
 	tech.units.indriya;version='[2.2.2,2.2.3)',\
 	uom-lib-common;version='[2.2.0,2.2.1)',\
 	io.methvin.directory-watcher;version='[0.18.0,0.18.1)',\

--- a/itests/org.openhab.core.ephemeris.tests/itest.bndrun
+++ b/itests/org.openhab.core.ephemeris.tests/itest.bndrun
@@ -74,5 +74,5 @@ feature.openhab-config: \
 	biz.aQute.tester.junit-platform;version='[7.1.0,7.1.1)',\
 	org.osgi.service.cm;version='[1.6.0,1.6.1)',\
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.model.item.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.item.tests/itest.bndrun
@@ -128,5 +128,5 @@ Fragment-Host: org.openhab.core.model.item
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.model.rule.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.rule.tests/itest.bndrun
@@ -130,5 +130,5 @@ Fragment-Host: org.openhab.core.model.rule.runtime
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.model.script.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.script.tests/itest.bndrun
@@ -134,5 +134,5 @@ Fragment-Host: org.openhab.core.model.script
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'

--- a/itests/org.openhab.core.model.thing.tests/itest.bndrun
+++ b/itests/org.openhab.core.model.thing.tests/itest.bndrun
@@ -137,5 +137,5 @@ Fragment-Host: org.openhab.core.model.thing
 	org.ops4j.pax.logging.pax-logging-api;version='[2.2.8,2.2.9)',\
 	com.fasterxml.jackson.dataformat.jackson-dataformat-yaml;version='[2.18.2,2.18.3)',\
 	org.yaml.snakeyaml;version='[2.3.0,2.3.1)',\
-	de.focus_shift.jollyday-core;version='[1.5.0,1.5.1)',\
-	de.focus_shift.jollyday-jackson;version='[1.5.0,1.5.1)'
+	de.focus_shift.jollyday-core;version='[1.5.4,1.5.5)',\
+	de.focus_shift.jollyday-jackson;version='[1.5.4,1.5.5)'


### PR DESCRIPTION
Upgrades Jollyday from 1.5.0 to 1.5.4.

For release notes, see:

https://github.com/focus-shift/jollyday/releases