### PR TITLE
[automation] Extend provider script extension for metadata & ItemChannelLinks

### DIFF
--- a/bom/openhab-core/pom.xml
+++ b/bom/openhab-core/pom.xml
@@ -414,6 +414,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.automation.module.script.providersupport</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.automation.module.script.rulesupport</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/bundles/org.openhab.core.automation.module.script.providersupport/.classpath
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/.classpath
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="annotationpath" value="target/dependency"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.automation.module.script.providersupport/.project
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.automation.module.script.providersupport</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.automation.module.script.providersupport/NOTICE
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/NOTICE
@@ -1,0 +1,14 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core
+

--- a/bundles/org.openhab.core.automation.module.script.providersupport/pom.xml
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.automation.module.script.providersupport</artifactId>
+
+  <name>openHAB Core :: Bundles :: Automation Script ProviderSupport</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.automation.module.script</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistry.java
@@ -13,15 +13,15 @@
 package org.openhab.core.automation.module.script.providersupport.internal;
 
 /**
- * Interface to be implemented by all {@link org.openhab.core.common.registry.Registry} delegates that are used to
+ * Interface to be implemented by all {@link org.openhab.core.common.registry.Registry} (delegates) that are used to
  * provide openHAB entities from scripts.
  *
  * @author Florian Hotze - Initial contribution
  */
-public interface ProviderRegistryDelegate {
+public interface ProviderRegistry {
 
     /**
-     * Removes all elements that are provided by the script the {@link ProviderRegistryDelegate} instance is bound to.
+     * Removes all elements that are provided by the script the {@link ProviderRegistry} instance is bound to.
      * To be called when the script is unloaded or reloaded.
      */
     void removeAllAddedByScript();

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistryDelegate.java
@@ -1,5 +1,23 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.core.automation.module.script.providersupport.internal;
 
+/**
+ * Interface to be implemented by all {@link org.openhab.core.common.registry.Registry} delegates that are used to
+ * provide openHAB entities from scripts.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
 public interface ProviderRegistryDelegate {
 
     /**

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderRegistryDelegate.java
@@ -1,0 +1,10 @@
+package org.openhab.core.automation.module.script.providersupport.internal;
+
+public interface ProviderRegistryDelegate {
+
+    /**
+     * Removes all elements that are provided by the script the {@link ProviderRegistryDelegate} instance is bound to.
+     * To be called when the script is unloaded or reloaded.
+     */
+    void removeAllAddedByScript();
+}

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderScriptExtension.java
@@ -49,7 +49,7 @@ public class ProviderScriptExtension implements ScriptExtensionProvider {
     private static final String METADATA_REGISTRY_NAME = "metadataRegistry";
     private static final String THING_REGISTRY_NAME = "thingRegistry";
 
-    private final Map<String, Map<String, ProviderRegistryDelegate>> registryCache = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, ProviderRegistry>> registryCache = new ConcurrentHashMap<>();
 
     private final ItemRegistry itemRegistry;
     private final ScriptedItemProvider itemProvider;
@@ -88,10 +88,10 @@ public class ProviderScriptExtension implements ScriptExtensionProvider {
 
     @Override
     public @Nullable Object get(String scriptIdentifier, String type) throws IllegalArgumentException {
-        Map<String, ProviderRegistryDelegate> registries = Objects
+        Map<String, ProviderRegistry> registries = Objects
                 .requireNonNull(registryCache.computeIfAbsent(scriptIdentifier, k -> new HashMap<>()));
 
-        ProviderRegistryDelegate registry = registries.get(type);
+        ProviderRegistry registry = registries.get(type);
         if (registry != null) {
             return registry;
         }
@@ -132,9 +132,9 @@ public class ProviderScriptExtension implements ScriptExtensionProvider {
 
     @Override
     public void unload(String scriptIdentifier) {
-        Map<String, ProviderRegistryDelegate> registries = registryCache.remove(scriptIdentifier);
+        Map<String, ProviderRegistry> registries = registryCache.remove(scriptIdentifier);
         if (registries != null) {
-            for (ProviderRegistryDelegate registry : registries.values()) {
+            for (ProviderRegistry registry : registries.values()) {
                 registry.removeAllAddedByScript();
             }
         }

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderScriptExtension.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/internal/ProviderScriptExtension.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.internal;
+package org.openhab.core.automation.module.script.providersupport.internal;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -22,10 +22,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.module.script.ScriptExtensionProvider;
-import org.openhab.core.automation.module.script.rulesupport.shared.ProviderItemRegistryDelegate;
-import org.openhab.core.automation.module.script.rulesupport.shared.ProviderThingRegistryDelegate;
-import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedItemProvider;
-import org.openhab.core.automation.module.script.rulesupport.shared.ScriptedThingProvider;
+import org.openhab.core.automation.module.script.providersupport.shared.ProviderItemRegistryDelegate;
+import org.openhab.core.automation.module.script.providersupport.shared.ProviderThingRegistryDelegate;
+import org.openhab.core.automation.module.script.providersupport.shared.ScriptedItemProvider;
+import org.openhab.core.automation.module.script.providersupport.shared.ScriptedThingProvider;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.thing.ThingRegistry;
 import org.osgi.service.component.annotations.Activate;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
@@ -90,7 +90,7 @@ public class ProviderItemChannelLinkRegistry implements Registry<ItemChannelLink
                             + ") already exists.");
         }
 
-        itemChannelLinkRegistry.add(element);
+        scriptedProvider.add(element);
         uids.add(uid);
 
         return element;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemChannelLinkRegistry.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.providersupport.shared;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
+import org.openhab.core.common.registry.Registry;
+import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkRegistry;
+
+/**
+ * The {@link ProviderItemChannelLinkRegistry} is implementing a {@link Registry} to provide a comfortable way to
+ * provide {@link ItemChannelLink}s from scripts without worrying about the need to remove them again when the script is
+ * unloaded.
+ * Nonetheless, using the {@link #addPermanent(ItemChannelLink)} method it is still possible to them permanently.
+ * <p>
+ * Use a new instance of this class for each {@link javax.script.ScriptEngine}.
+ * <p>
+ * ATTENTION: This class does not provide the same methods as {@link ItemChannelLinkRegistry}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class ProviderItemChannelLinkRegistry implements Registry<ItemChannelLink, String>, ProviderRegistry {
+    private final ItemChannelLinkRegistry itemChannelLinkRegistry;
+
+    private final Set<String> uids = new HashSet<>();
+
+    private final ScriptedItemChannelLinkProvider itemChannelLinkProvider;
+
+    public ProviderItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry,
+            ScriptedItemChannelLinkProvider itemChannelLinkProvider) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+        this.itemChannelLinkProvider = itemChannelLinkProvider;
+    }
+
+    @Override
+    public void addRegistryChangeListener(RegistryChangeListener<ItemChannelLink> listener) {
+        itemChannelLinkRegistry.addRegistryChangeListener(listener);
+    }
+
+    @Override
+    public Collection<ItemChannelLink> getAll() {
+        return itemChannelLinkRegistry.getAll();
+    }
+
+    @Override
+    public Stream<ItemChannelLink> stream() {
+        return itemChannelLinkRegistry.stream();
+    }
+
+    @Override
+    public @Nullable ItemChannelLink get(String key) {
+        return itemChannelLinkRegistry.get(key);
+    }
+
+    @Override
+    public void removeRegistryChangeListener(RegistryChangeListener<ItemChannelLink> listener) {
+        itemChannelLinkRegistry.removeRegistryChangeListener(listener);
+    }
+
+    @Override
+    public ItemChannelLink add(ItemChannelLink element) {
+        String uid = element.getUID();
+        // Check for item->channel link already existing here because the item->channel link might exist in a different
+        // provider, so we need to
+        // check the registry and not only the provider itself
+        if (get(uid) != null) {
+            throw new IllegalArgumentException(
+                    "Cannot add item->channel link, because an item->channel link with same UID (" + uid
+                            + ") already exists.");
+        }
+
+        itemChannelLinkRegistry.add(element);
+        uids.add(uid);
+
+        return element;
+    }
+
+    /**
+     * Adds an {@link ItemChannelLink} permanently to the registry.
+     * This {@link ItemChannelLink} will be kept in the registry even if the script is unloaded
+     * 
+     * @param element the {@link ItemChannelLink} to be added (must not be null)
+     * @return the added {@link ItemChannelLink}
+     */
+    public ItemChannelLink addPermanent(ItemChannelLink element) {
+        return itemChannelLinkRegistry.add(element);
+    }
+
+    @Override
+    public @Nullable ItemChannelLink update(ItemChannelLink element) {
+        if (uids.contains(element.getUID())) {
+            return itemChannelLinkProvider.update(element);
+        }
+        return itemChannelLinkRegistry.update(element);
+    }
+
+    @Override
+    public @Nullable ItemChannelLink remove(String key) {
+        if (uids.contains(key)) {
+            return itemChannelLinkProvider.remove(key);
+        }
+        return itemChannelLinkRegistry.remove(key);
+    }
+
+    public int removeLinksForThing(ThingUID thingUID) {
+        int removedLinks = 0;
+        Collection<ItemChannelLink> itemChannelLinks = getAll();
+        for (ItemChannelLink itemChannelLink : itemChannelLinks) {
+            if (itemChannelLink.getLinkedUID().getThingUID().equals(thingUID)) {
+                this.remove(itemChannelLink.getUID());
+                removedLinks++;
+            }
+        }
+        return removedLinks;
+    }
+
+    public int removeLinksForItem(String itemName) {
+        int removedLinks = 0;
+        Collection<ItemChannelLink> itemChannelLinks = getAll();
+        for (ItemChannelLink itemChannelLink : itemChannelLinks) {
+            if (itemChannelLink.getItemName().equals(itemName)) {
+                this.remove(itemChannelLink.getUID());
+                removedLinks++;
+            }
+        }
+        return removedLinks;
+    }
+
+    @Override
+    public void removeAllAddedByScript() {
+        for (String uid : uids) {
+            itemChannelLinkProvider.remove(uid);
+        }
+        uids.clear();
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.shared;
+package org.openhab.core.automation.module.script.providersupport.shared;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
@@ -44,11 +44,11 @@ public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegis
 
     private final Set<String> items = new HashSet<>();
 
-    private final ScriptedItemProvider itemProvider;
+    private final ScriptedItemProvider scriptedProvider;
 
-    public ProviderItemRegistryDelegate(ItemRegistry itemRegistry, ScriptedItemProvider itemProvider) {
+    public ProviderItemRegistryDelegate(ItemRegistry itemRegistry, ScriptedItemProvider scriptedProvider) {
         this.itemRegistry = itemRegistry;
-        this.itemProvider = itemProvider;
+        this.scriptedProvider = scriptedProvider;
     }
 
     @Override
@@ -86,7 +86,7 @@ public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegis
                     "Cannot add item, because an item with same name (" + itemName + ") already exists.");
         }
 
-        itemProvider.add(element);
+        scriptedProvider.add(element);
         items.add(itemName);
 
         return element;
@@ -106,7 +106,7 @@ public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegis
     @Override
     public @Nullable Item update(Item element) {
         if (items.contains(element.getName())) {
-            return itemProvider.update(element);
+            return scriptedProvider.update(element);
         }
         return itemRegistry.update(element);
     }
@@ -114,7 +114,7 @@ public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegis
     @Override
     public @Nullable Item remove(String key) {
         if (items.remove(key)) {
-            return itemProvider.remove(key);
+            return scriptedProvider.remove(key);
         }
 
         return itemRegistry.remove(key);
@@ -179,7 +179,7 @@ public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegis
     @Override
     public void removeAllAddedByScript() {
         for (String item : items) {
-            itemProvider.remove(item);
+            scriptedProvider.remove(item);
         }
         items.clear();
     }

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
@@ -39,7 +39,7 @@ import org.openhab.core.items.ItemRegistry;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegistryDelegate {
+public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegistry {
     private final ItemRegistry itemRegistry;
 
     private final Set<String> items = new HashSet<>();

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderItemRegistryDelegate.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
@@ -38,7 +39,7 @@ import org.openhab.core.items.ItemRegistry;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public class ProviderItemRegistryDelegate implements ItemRegistry {
+public class ProviderItemRegistryDelegate implements ItemRegistry, ProviderRegistryDelegate {
     private final ItemRegistry itemRegistry;
 
     private final Set<String> items = new HashSet<>();
@@ -175,10 +176,7 @@ public class ProviderItemRegistryDelegate implements ItemRegistry {
         }
     }
 
-    /**
-     * Removes all items that are provided by this script.
-     * To be called when the script is unloaded or reloaded.
-     */
+    @Override
     public void removeAllAddedByScript() {
         for (String item : items) {
             itemProvider.remove(item);

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
@@ -41,12 +41,12 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
 
     private final Set<MetadataKey> metadataKeys = new HashSet<>();
 
-    private final ScriptedMetadataProvider metadataProvider;
+    private final ScriptedMetadataProvider scriptedProvider;
 
     public ProviderMetadataRegistryDelegate(MetadataRegistry metadataRegistry,
-            ScriptedMetadataProvider metadataProvider) {
+            ScriptedMetadataProvider scriptedProvider) {
         this.metadataRegistry = metadataRegistry;
-        this.metadataProvider = metadataProvider;
+        this.scriptedProvider = scriptedProvider;
     }
 
     @Override
@@ -84,7 +84,7 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
                     "Cannot add metadata, because metadata with same name (" + key + ") already exists.");
         }
 
-        metadataProvider.add(element);
+        scriptedProvider.add(element);
         metadataKeys.add(key);
 
         return element;
@@ -104,7 +104,7 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
     @Override
     public @Nullable Metadata update(Metadata element) {
         if (metadataKeys.contains(element.getUID())) {
-            return metadataProvider.update(element);
+            return scriptedProvider.update(element);
         }
         return metadataRegistry.update(element);
     }
@@ -112,7 +112,7 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
     @Override
     public @Nullable Metadata remove(MetadataKey key) {
         if (metadataKeys.contains(key)) {
-            return metadataProvider.remove(key);
+            return scriptedProvider.remove(key);
         }
         return metadataRegistry.remove(key);
     }
@@ -129,8 +129,8 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
 
     @Override
     public void removeItemMetadata(String itemname) {
-        if (metadataProvider.getAll().stream().anyMatch(MetadataPredicates.ofItem(itemname))) {
-            metadataProvider.removeItemMetadata(itemname);
+        if (scriptedProvider.getAll().stream().anyMatch(MetadataPredicates.ofItem(itemname))) {
+            scriptedProvider.removeItemMetadata(itemname);
             return;
         }
         metadataRegistry.removeItemMetadata(itemname);
@@ -139,7 +139,7 @@ public class ProviderMetadataRegistryDelegate implements MetadataRegistry, Provi
     @Override
     public void removeAllAddedByScript() {
         for (MetadataKey key : metadataKeys) {
-            metadataProvider.remove(key);
+            scriptedProvider.remove(key);
         }
         metadataKeys.clear();
     }

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.providersupport.shared;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
+import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataPredicates;
+import org.openhab.core.items.MetadataRegistry;
+
+/**
+ * The {@link ProviderMetadataRegistryDelegate} is wrapping a {@link MetadataRegistry} to provide a comfortable way to
+ * provide items from scripts without worrying about the need to remove metadata again when the script is unloaded.
+ * Nonetheless, using the {@link #addPermanent(Metadata)} method it is still possible to add metadata permanently.
+ * <p>
+ * Use a new instance of this class for each {@link javax.script.ScriptEngine}.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+public class ProviderMetadataRegistryDelegate implements MetadataRegistry, ProviderRegistryDelegate {
+    private final MetadataRegistry metadataRegistry;
+
+    private final Set<MetadataKey> metadataKeys = new HashSet<>();
+
+    private final ScriptedMetadataProvider metadataProvider;
+
+    public ProviderMetadataRegistryDelegate(MetadataRegistry metadataRegistry,
+            ScriptedMetadataProvider metadataProvider) {
+        this.metadataRegistry = metadataRegistry;
+        this.metadataProvider = metadataProvider;
+    }
+
+    @Override
+    public void addRegistryChangeListener(RegistryChangeListener<Metadata> listener) {
+        metadataRegistry.addRegistryChangeListener(listener);
+    }
+
+    @Override
+    public Collection<Metadata> getAll() {
+        return metadataRegistry.getAll();
+    }
+
+    @Override
+    public Stream<Metadata> stream() {
+        return metadataRegistry.stream();
+    }
+
+    @Override
+    public @Nullable Metadata get(MetadataKey key) {
+        return metadataRegistry.get(key);
+    }
+
+    @Override
+    public void removeRegistryChangeListener(RegistryChangeListener<Metadata> listener) {
+        metadataRegistry.removeRegistryChangeListener(listener);
+    }
+
+    @Override
+    public Metadata add(Metadata element) {
+        MetadataKey key = element.getUID();
+        // Check for metadata already existing here because the metadata might exist in a different provider, so we need
+        // to check the registry and not only the provider itself
+        if (get(key) != null) {
+            throw new IllegalArgumentException(
+                    "Cannot add metadata, because metadata with same name (" + key + ") already exists.");
+        }
+
+        metadataProvider.add(element);
+        metadataKeys.add(key);
+
+        return element;
+    }
+
+    /**
+     * Adds metadata permanently to the registry.
+     * This metadata will be kept in the registry even if the script is unloaded.
+     * 
+     * @param element the metadata to be added (must not be null)
+     * @return the added metadata
+     */
+    public Metadata addPermanent(Metadata element) {
+        return metadataRegistry.add(element);
+    }
+
+    @Override
+    public @Nullable Metadata update(Metadata element) {
+        if (metadataKeys.contains(element.getUID())) {
+            return metadataProvider.update(element);
+        }
+        return metadataRegistry.update(element);
+    }
+
+    @Override
+    public @Nullable Metadata remove(MetadataKey key) {
+        if (metadataKeys.contains(key)) {
+            return metadataProvider.remove(key);
+        }
+        return metadataRegistry.remove(key);
+    }
+
+    @Override
+    public boolean isInternalNamespace(String namespace) {
+        return metadataRegistry.isInternalNamespace(namespace);
+    }
+
+    @Override
+    public Collection<String> getAllNamespaces(String itemname) {
+        return metadataRegistry.getAllNamespaces(itemname);
+    }
+
+    @Override
+    public void removeItemMetadata(String itemname) {
+        if (metadataProvider.getAll().stream().anyMatch(MetadataPredicates.ofItem(itemname))) {
+            metadataProvider.removeItemMetadata(itemname);
+            return;
+        }
+        metadataRegistry.removeItemMetadata(itemname);
+    }
+
+    @Override
+    public void removeAllAddedByScript() {
+        for (MetadataKey key : metadataKeys) {
+            metadataProvider.remove(key);
+        }
+        metadataKeys.clear();
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderMetadataRegistryDelegate.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.items.Metadata;
 import org.openhab.core.items.MetadataKey;
@@ -36,7 +36,7 @@ import org.openhab.core.items.MetadataRegistry;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public class ProviderMetadataRegistryDelegate implements MetadataRegistry, ProviderRegistryDelegate {
+public class ProviderMetadataRegistryDelegate implements MetadataRegistry, ProviderRegistry {
     private final MetadataRegistry metadataRegistry;
 
     private final Set<MetadataKey> metadataKeys = new HashSet<>();

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistry;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Channel;
@@ -40,7 +40,7 @@ import org.openhab.core.thing.ThingUID;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderRegistryDelegate {
+public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderRegistry {
     private final ThingRegistry thingRegistry;
 
     private final Set<ThingUID> things = new HashSet<>();

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
@@ -45,11 +45,11 @@ public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderReg
 
     private final Set<ThingUID> things = new HashSet<>();
 
-    private final ScriptedThingProvider thingProvider;
+    private final ScriptedThingProvider scriptedProvider;
 
-    public ProviderThingRegistryDelegate(ThingRegistry thingRegistry, ScriptedThingProvider thingProvider) {
+    public ProviderThingRegistryDelegate(ThingRegistry thingRegistry, ScriptedThingProvider scriptedProvider) {
         this.thingRegistry = thingRegistry;
-        this.thingProvider = thingProvider;
+        this.scriptedProvider = scriptedProvider;
     }
 
     @Override
@@ -82,7 +82,7 @@ public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderReg
                     "Cannot add Thing, because a Thing with same UID (" + thingUID + ") already exists.");
         }
 
-        thingProvider.add(element);
+        scriptedProvider.add(element);
         things.add(thingUID);
 
         return element;
@@ -102,7 +102,7 @@ public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderReg
     @Override
     public @Nullable Thing update(Thing element) {
         if (things.contains(element.getUID())) {
-            return thingProvider.update(element);
+            return scriptedProvider.update(element);
         }
 
         return thingRegistry.update(element);
@@ -135,7 +135,7 @@ public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderReg
     @Override
     public void removeAllAddedByScript() {
         for (ThingUID thing : things) {
-            thingProvider.remove(thing);
+            scriptedProvider.remove(thing);
         }
         things.clear();
     }
@@ -143,7 +143,7 @@ public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderReg
     @Override
     public @Nullable Thing forceRemove(ThingUID thingUID) {
         if (things.remove(thingUID)) {
-            return thingProvider.remove(thingUID);
+            return scriptedProvider.remove(thingUID);
         }
 
         return thingRegistry.forceRemove(thingUID);

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.shared;
+package org.openhab.core.automation.module.script.providersupport.shared;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ProviderThingRegistryDelegate.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.module.script.providersupport.internal.ProviderRegistryDelegate;
 import org.openhab.core.common.registry.RegistryChangeListener;
 import org.openhab.core.config.core.Configuration;
 import org.openhab.core.thing.Channel;
@@ -39,7 +40,7 @@ import org.openhab.core.thing.ThingUID;
  * @author Florian Hotze - Initial contribution
  */
 @NonNullByDefault
-public class ProviderThingRegistryDelegate implements ThingRegistry {
+public class ProviderThingRegistryDelegate implements ThingRegistry, ProviderRegistryDelegate {
     private final ThingRegistry thingRegistry;
 
     private final Set<ThingUID> things = new HashSet<>();
@@ -131,10 +132,7 @@ public class ProviderThingRegistryDelegate implements ThingRegistry {
         return thingRegistry.remove(thingUID);
     }
 
-    /**
-     * Removes all Things that are provided by this script.
-     * To be called when the script is unloaded or reloaded.
-     */
+    @Override
     public void removeAllAddedByScript() {
         for (ThingUID thing : things) {
             thingProvider.remove(thing);

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemChannelLinkProvider.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.providersupport.shared;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.registry.AbstractProvider;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.thing.link.ItemChannelLink;
+import org.openhab.core.thing.link.ItemChannelLinkProvider;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This {@link ItemChannelLinkProvider} keeps {@link ItemChannelLink}s provided by scripts during runtime.
+ * This ensures that {@link ItemChannelLink}s are not kept on reboot, but have to be provided by the scripts again.
+ *
+ * @author Florian Hotze - Initial contribution
+ */
+@NonNullByDefault
+@Component(immediate = true, service = { ScriptedItemChannelLinkProvider.class, ItemChannelLinkProvider.class })
+public class ScriptedItemChannelLinkProvider extends AbstractProvider<ItemChannelLink>
+        implements ItemChannelLinkProvider, ManagedProvider<ItemChannelLink, String> {
+    private final Logger logger = LoggerFactory.getLogger(ScriptedItemChannelLinkProvider.class);
+    private final Map<String, ItemChannelLink> itemChannelLinks = new HashMap<>();
+
+    @Override
+    public Collection<ItemChannelLink> getAll() {
+        return itemChannelLinks.values();
+    }
+
+    @Override
+    public @Nullable ItemChannelLink get(String key) {
+        return itemChannelLinks.get(key);
+    }
+
+    @Override
+    public void add(ItemChannelLink itemChannelLink) {
+        if (get(itemChannelLink.getUID()) != null) {
+            throw new IllegalArgumentException(
+                    "Cannot add item->channel link, because an item->channel link with same UID ("
+                            + itemChannelLink.getUID() + ") already exists.");
+        }
+        itemChannelLinks.put(itemChannelLink.getUID(), itemChannelLink);
+
+        notifyListenersAboutAddedElement(itemChannelLink);
+    }
+
+    @Override
+    public @Nullable ItemChannelLink update(ItemChannelLink itemChannelLink) {
+        ItemChannelLink oldItemChannelLink = itemChannelLinks.get(itemChannelLink.getUID());
+        if (oldItemChannelLink != null) {
+            itemChannelLinks.put(itemChannelLink.getUID(), itemChannelLink);
+            notifyListenersAboutUpdatedElement(oldItemChannelLink, itemChannelLink);
+        } else {
+            logger.warn("Cannot update item->channel link with UID '{}', because it does not exist.",
+                    itemChannelLink.getUID());
+        }
+        return oldItemChannelLink;
+    }
+
+    @Override
+    public @Nullable ItemChannelLink remove(String key) {
+        ItemChannelLink itemChannelLink = itemChannelLinks.get(key);
+        if (itemChannelLink != null) {
+            notifyListenersAboutRemovedElement(itemChannelLink);
+        }
+        return itemChannelLink;
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemChannelLinkProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemChannelLinkProvider.java
@@ -76,7 +76,7 @@ public class ScriptedItemChannelLinkProvider extends AbstractProvider<ItemChanne
 
     @Override
     public @Nullable ItemChannelLink remove(String key) {
-        ItemChannelLink itemChannelLink = itemChannelLinks.get(key);
+        ItemChannelLink itemChannelLink = itemChannelLinks.remove(key);
         if (itemChannelLink != null) {
             notifyListenersAboutRemovedElement(itemChannelLink);
         }

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedItemProvider.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.shared;
+package org.openhab.core.automation.module.script.providersupport.shared;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedMetadataProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedMetadataProvider.java
@@ -73,7 +73,7 @@ public class ScriptedMetadataProvider extends AbstractProvider<Metadata> impleme
             metadataStorage.put(metadata.getUID(), metadata);
             notifyListenersAboutUpdatedElement(oldMetadata, metadata);
         } else {
-            logger.warn("Could not update metadata with UID {}, because it does not exist", metadata.getUID());
+            logger.warn("Could not update metadata with UID '{}', because it does not exist", metadata.getUID());
         }
         return oldMetadata;
     }

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedMetadataProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedMetadataProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.providersupport.shared;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.registry.AbstractProvider;
+import org.openhab.core.items.ManagedMetadataProvider;
+import org.openhab.core.items.Metadata;
+import org.openhab.core.items.MetadataKey;
+import org.openhab.core.items.MetadataPredicates;
+import org.openhab.core.items.MetadataProvider;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This {@link org.openhab.core.items.MetadataProvider} keeps metadata provided by scripts during runtime.
+ * This ensures that metadata is not kept on reboot, but has to be provided by the scripts again.
+ *
+ * @author Florian Hotze
+ */
+@NonNullByDefault
+@Component(immediate = true, service = { ScriptedMetadataProvider.class, MetadataProvider.class })
+public class ScriptedMetadataProvider extends AbstractProvider<Metadata> implements ManagedMetadataProvider {
+    private final Logger logger = LoggerFactory.getLogger(ScriptedMetadataProvider.class);
+    private final Map<MetadataKey, Metadata> metadataStorage = new HashMap<>();
+
+    @Override
+    public void removeItemMetadata(String name) {
+        getAll().stream().filter(MetadataPredicates.ofItem(name)).map(Metadata::getUID).forEach(this::remove);
+    }
+
+    @Override
+    public Collection<Metadata> getAll() {
+        return metadataStorage.values();
+    }
+
+    @Override
+    public @Nullable Metadata get(MetadataKey metadataKey) {
+        return metadataStorage.get(metadataKey);
+    }
+
+    @Override
+    public void add(Metadata metadata) {
+        if (metadataStorage.containsKey(metadata.getUID())) {
+            throw new IllegalArgumentException("Cannot add metadata, because metadata with the same UID ("
+                    + metadata.getUID() + ") already exists");
+        }
+        metadataStorage.put(metadata.getUID(), metadata);
+
+        notifyListenersAboutAddedElement(metadata);
+    }
+
+    @Override
+    public @Nullable Metadata update(Metadata metadata) {
+        Metadata oldMetadata = metadataStorage.get(metadata.getUID());
+        if (oldMetadata != null) {
+            metadataStorage.put(metadata.getUID(), metadata);
+            notifyListenersAboutUpdatedElement(oldMetadata, metadata);
+        } else {
+            logger.warn("Could not update metadata with UID {}, because it does not exist", metadata.getUID());
+        }
+        return oldMetadata;
+    }
+
+    @Override
+    public @Nullable Metadata remove(MetadataKey metadataKey) {
+        Metadata metadata = metadataStorage.remove(metadataKey);
+        if (metadata != null) {
+            notifyListenersAboutRemovedElement(metadata);
+        }
+        return metadata;
+    }
+}

--- a/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedThingProvider.java
+++ b/bundles/org.openhab.core.automation.module.script.providersupport/src/main/java/org/openhab/core/automation/module/script/providersupport/shared/ScriptedThingProvider.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.openhab.core.automation.module.script.rulesupport.shared;
+package org.openhab.core.automation.module.script.providersupport.shared;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -952,7 +952,7 @@ public class ItemResource implements RESTResource {
     public Response getSemanticsHealth(@Context HttpHeaders headers) {
         List<ItemSemanticsProblem> semanticsProblems = this.itemRegistry.stream().flatMap(item -> {
             return semanticsService.getItemSemanticsProblems(item).stream()
-                    .map(p -> p.setEditable(isEditable(p.item())));
+                    .map(p -> p.setEditable(isItemEditable(p.item())));
         }).toList();
         return JSONResponse.createResponse(Status.OK, semanticsProblems, null);
     }
@@ -1061,7 +1061,11 @@ public class ItemResource implements RESTResource {
     }
 
     private boolean isEditable(EnrichedItemDTO item) {
-        return managedItemProvider.get(item.name) != null;
+        return isItemEditable(item.name);
+    }
+
+    private boolean isItemEditable(String itemName) {
+        return managedItemProvider.get(itemName) != null;
     }
 
     private boolean isEditable(MetadataKey metadataKey) {

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -26,6 +26,7 @@
     <module>org.openhab.core.automation</module>
     <module>org.openhab.core.automation.module.media</module>
     <module>org.openhab.core.automation.module.script</module>
+    <module>org.openhab.core.automation.module.script.providersupport</module>
     <module>org.openhab.core.automation.module.script.rulesupport</module>
     <module>org.openhab.core.automation.rest</module>
     <module>org.openhab.core.config.core</module>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -142,6 +142,12 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.module.script/${project.version}</bundle>
 	</feature>
 
+	<feature name="openhab-core-automation-module-script-providersupport" version="${project.version}">
+		<feature>openhab-core-base</feature>
+		<feature dependency="true">openhab-core-automation-module-script</feature>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.automation.module.script.providersupport/${project.version}</bundle>
+	</feature>
+
 	<feature name="openhab-core-automation-module-script-rulesupport" version="${project.version}">
 		<feature>openhab-core-base</feature>
 		<feature dependency="true">openhab-core-automation-module-script</feature>
@@ -448,6 +454,7 @@
 		<feature>openhab-core-auth-jaas</feature>
 		<feature>openhab-core-automation-rest</feature>
 		<feature>openhab-core-automation-module-script</feature>
+		<feature>openhab-core-automation-module-script-providersupport</feature>
 		<feature>openhab-core-automation-module-script-rulesupport</feature>
 		<feature>openhab-core-automation-module-media</feature>
 		<feature>openhab-core-io-console-karaf</feature>


### PR DESCRIPTION
Follow-up for #4513.

This moves the newly added provider script extension to a new package and etxends it with support for providing item metadata & ItemChannelLinks.