### PR TITLE
Refactor timestamps to `Instant` in discovery methods

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -352,8 +352,22 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      * as timestamp.
      *
      * @param timestamp timestamp, older results will be removed
+     * @deprecated Use {@link #removeOlderResults(Instant)} instead.
      */
+    @Deprecated(since = "5.0", forRemoval = true)
     protected void removeOlderResults(long timestamp) {
+        removeOlderResults(Instant.ofEpochMilli(timestamp));
+    }
+
+    /**
+     * Call to remove all results of all {@link #supportedThingTypes} that are
+     * older than the given timestamp. To remove all left over results after a
+     * full scan, this method could be called {@link #getTimeOfLastScan()}
+     * as timestamp.
+     *
+     * @param timestamp timestamp, older results will be removed
+     */
+    protected void removeOlderResults(Instant timestamp) {
         removeOlderResults(timestamp, null, null);
     }
 
@@ -365,8 +379,23 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *
      * @param timestamp timestamp, older results will be removed
      * @param bridgeUID if not {@code null} only results of that bridge are being removed
+     * @deprecated Use {@link #removeOlderResults(Instant, ThingUID)} instead.
      */
+    @Deprecated(since = "5.0", forRemoval = true)
     protected void removeOlderResults(long timestamp, @Nullable ThingUID bridgeUID) {
+        removeOlderResults(Instant.ofEpochMilli(timestamp), null);
+    }
+
+    /**
+     * Call to remove all results of all {@link #supportedThingTypes} that are
+     * older than the given timestamp. To remove all left over results after a
+     * full scan, this method could be called {@link #getTimeOfLastScan()}
+     * as timestamp.
+     *
+     * @param timestamp timestamp, older results will be removed
+     * @param bridgeUID if not {@code null} only results of that bridge are being removed
+     */
+    protected void removeOlderResults(Instant timestamp, @Nullable ThingUID bridgeUID) {
         removeOlderResults(timestamp, null, bridgeUID);
     }
 
@@ -381,8 +410,27 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            {@link DiscoveryService#getSupportedThingTypes()} will be used
      *            instead
      * @param bridgeUID if not {@code null} only results of that bridge are being removed
+     * @deprecated Use {@link #removeOlderResults(Instant, Collection, ThingUID)} instead.
      */
+    @Deprecated(since = "5.0", forRemoval = true)
     protected void removeOlderResults(long timestamp, @Nullable Collection<ThingTypeUID> thingTypeUIDs,
+            @Nullable ThingUID bridgeUID) {
+        removeOlderResults(Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
+    }
+
+    /**
+     * Call to remove all results of the given types that are older than the
+     * given timestamp. To remove all left over results after a full scan, this
+     * method could be called {@link #getTimeOfLastScan()} as timestamp.
+     *
+     * @param timestamp timestamp, older results will be removed
+     * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
+     *            {@code ThingType}s will be removed; if {@code null} then
+     *            {@link DiscoveryService#getSupportedThingTypes()} will be used
+     *            instead
+     * @param bridgeUID if not {@code null} only results of that bridge are being removed
+     */
+    protected void removeOlderResults(Instant timestamp, @Nullable Collection<ThingTypeUID> thingTypeUIDs,
             @Nullable ThingUID bridgeUID) {
         Collection<ThingUID> removedThings = null;
 
@@ -485,9 +533,20 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      * Get the timestamp of the last call of {@link #startScan()}.
      *
      * @return timestamp as long
+     * @deprecated Use {@link #getTimeOfLastScan} instead.
      */
+    @Deprecated(since = "5.0", forRemoval = true)
     protected long getTimestampOfLastScan() {
         return Instant.MIN.equals(timestampOfLastScan) ? 0 : timestampOfLastScan.toEpochMilli();
+    }
+
+    /**
+     * Get the timestamp of the last call of {@link #startScan()}.
+     *
+     * @return timestamp as {@link Instant}
+     */
+    protected Instant getTimeOfLastScan() {
+        return timestampOfLastScan;
     }
 
     private String inferKey(DiscoveryResult discoveryResult, String lastSegment) {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -362,7 +362,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * Call to remove all results of all {@link #supportedThingTypes} that are
      * older than the given timestamp. To remove all left over results after a
-     * full scan, this method could be called {@link #getTimeOfLastScan()}
+     * full scan, this method could be called {@link #getTimestampOfLastScan()}
      * as timestamp.
      *
      * @param timestamp timestamp, older results will be removed
@@ -389,7 +389,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * Call to remove all results of all {@link #supportedThingTypes} that are
      * older than the given timestamp. To remove all left over results after a
-     * full scan, this method could be called {@link #getTimeOfLastScan()}
+     * full scan, this method could be called {@link #getTimestampOfLastScan()}
      * as timestamp.
      *
      * @param timestamp timestamp, older results will be removed
@@ -421,7 +421,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * Call to remove all results of the given types that are older than the
      * given timestamp. To remove all left over results after a full scan, this
-     * method could be called {@link #getTimeOfLastScan()} as timestamp.
+     * method could be called {@link #getTimestampOfLastScan()} as timestamp.
      *
      * @param timestamp timestamp, older results will be removed
      * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
@@ -532,20 +532,9 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * Get the timestamp of the last call of {@link #startScan()}.
      *
-     * @return timestamp as long
-     * @deprecated Use {@link #getTimeOfLastScan} instead.
-     */
-    @Deprecated(since = "5.0", forRemoval = true)
-    protected long getTimestampOfLastScan() {
-        return Instant.MIN.equals(timestampOfLastScan) ? 0 : timestampOfLastScan.toEpochMilli();
-    }
-
-    /**
-     * Get the timestamp of the last call of {@link #startScan()}.
-     *
      * @return timestamp as {@link Instant}
      */
-    protected Instant getTimeOfLastScan() {
+    protected Instant getTimestampOfLastScan() {
         return timestampOfLastScan;
     }
 

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.config.discovery;
 
+import java.time.Instant;
 import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -72,6 +73,28 @@ public interface DiscoveryListener {
      * @return collection of thing UIDs of all removed things
      */
     @Nullable
+    default Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return removeOlderResults(source, timestamp.toEpochMilli(), thingTypeUIDs, bridgeUID);
+    }
+
+    /**
+     * Removes all results belonging to one of the given types that are older
+     * than the given timestamp.
+     *
+     * @param source the discovery service which is the source of this event (not
+     *            null)
+     * @param timestamp timestamp, all <b>older</b> results will be removed
+     * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
+     *            {@code ThingType}s will be removed; if {@code null} then
+     *            {@link DiscoveryService#getSupportedThingTypes()} will be used
+     *            instead
+     * @param bridgeUID if not {@code null} only results of that bridge are being removed
+     * @return collection of thing UIDs of all removed things
+     * @deprecated Use {@link #removeOlderResults(DiscoveryService, Instant, Collection, ThingUID)} instead.
+     */
+    @Nullable
+    @Deprecated(since = "5.0", forRemoval = true)
     Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
             @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID);
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.config.discovery;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -121,10 +122,19 @@ public interface DiscoveryResult {
     ThingUID getBridgeUID();
 
     /**
-     * Returns the timestamp of this result object.
+     * Returns the creation time of this result object.
+     *
+     * @return timestamp
+     */
+    Instant getCreationTime();
+
+    /**
+     * Returns the creation time of this result object.
      *
      * @return timestamp as long
+     * @deprecated Use {@link #getCreationTime} instead.
      */
+    @Deprecated(since = "5.0", forRemoval = true)
     long getTimestamp();
 
     /**

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -216,7 +216,12 @@ public class DiscoveryResultImpl implements DiscoveryResult {
 
     @Override
     public long getTimestamp() {
-        return Instant.MIN.equals(timestamp) ? 0 : timestamp.toEpochMilli();
+        return getCreationTime().toEpochMilli();
+    }
+
+    @Override
+    public Instant getCreationTime() {
+        return timestamp;
     }
 
     @Override

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.config.discovery.internal;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -288,6 +289,12 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
 
     @Override
     public @Nullable Collection<ThingUID> removeOlderResults(final DiscoveryService source, final long timestamp,
+            final @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return removeOlderResults(source, Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
+    }
+
+    @Override
+    public @Nullable Collection<ThingUID> removeOlderResults(final DiscoveryService source, final Instant timestamp,
             final @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         Set<ThingUID> removedResults = new HashSet<>();
         for (final DiscoveryListener listener : listeners) {

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -14,7 +14,6 @@ package org.openhab.core.config.discovery.internal.console;
 
 import static org.openhab.core.config.discovery.inbox.InboxPredicates.*;
 
-import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -199,7 +198,7 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
             ThingUID bridgeId = discoveryResult.getBridgeUID();
             Map<String, Object> properties = discoveryResult.getProperties();
             String representationProperty = discoveryResult.getRepresentationProperty();
-            String timestamp = Instant.ofEpochMilli(discoveryResult.getTimestamp()).toString();
+            String timestamp = discoveryResult.getCreationTime().toString();
             String timeToLive = discoveryResult.getTimeToLive() == DiscoveryResult.TTL_UNLIMITED ? "UNLIMITED"
                     : "" + discoveryResult.getTimeToLive();
             console.println(String.format(

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
@@ -191,6 +192,12 @@ public class AbstractDiscoveryServiceTest implements DiscoveryListener {
 
     @Override
     public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+    }
+
+    @Override
+    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return null;
     }
 
     @Override

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -210,7 +210,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
     @Test
     public void testRemoveOlderResults() {
         discoveryServiceRegistry.addDiscoveryListener(discoveryListenerMock);
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
 
         waitForAssert(() -> {
             verify(discoveryListenerMock, times(1)).removeOlderResults(any(DiscoveryService.class), any(Instant.class),
@@ -236,7 +236,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         assertThat(inbox.getAll().size(), is(2));
         // should not remove anything
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
 
         // start discovery again
@@ -247,7 +247,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         assertThat(inbox.getAll().size(), is(3));
         // should remove one entry
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
     }
 
@@ -281,11 +281,11 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove no entry, as there is no older entry discovery of this specific discovery service
         anotherDiscoveryServiceMockForBinding1
-                .removeOlderResults(anotherDiscoveryServiceMockForBinding1.getTimeOfLastScan());
+                .removeOlderResults(anotherDiscoveryServiceMockForBinding1.getTimestampOfLastScan());
         assertThat(inbox.getAll().size(), is(3));
 
         // should remove only one entry
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
 
         anotherDiscoveryServiceMockForBinding1.abortScan();
@@ -309,13 +309,13 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should not remove anything
         discoveryServiceMockForBinding3Bridge1.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge1.getTimeOfLastScan(),
+                discoveryServiceMockForBinding3Bridge1.getTimestampOfLastScan(),
                 discoveryServiceMockForBinding3Bridge1.getBridge());
         assertThat(inbox.getAll().size(), is(2));
 
         // should not remove anything
         discoveryServiceMockForBinding3Bridge2.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge2.getTimeOfLastScan(),
+                discoveryServiceMockForBinding3Bridge2.getTimestampOfLastScan(),
                 discoveryServiceMockForBinding3Bridge2.getBridge());
         assertThat(inbox.getAll().size(), is(2));
 
@@ -333,7 +333,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove only 1 entry (of bridge1)
         discoveryServiceMockForBinding3Bridge1.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge1.getTimeOfLastScan(),
+                discoveryServiceMockForBinding3Bridge1.getTimestampOfLastScan(),
                 discoveryServiceMockForBinding3Bridge1.getBridge());
         assertThat(inbox.getAll().size(), is(3));
         assertThat(inbox.getAll().stream().filter(r -> BRIDGE_UID_1.equals(r.getBridgeUID())).count(), is(1L));
@@ -341,7 +341,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove only 1 entry (of bridge2)
         discoveryServiceMockForBinding3Bridge2.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge2.getTimeOfLastScan(),
+                discoveryServiceMockForBinding3Bridge2.getTimestampOfLastScan(),
                 discoveryServiceMockForBinding3Bridge2.getBridge());
         assertThat(inbox.getAll().size(), is(2));
         assertThat(inbox.getAll().stream().filter(r -> BRIDGE_UID_1.equals(r.getBridgeUID())).count(), is(1L));

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -209,11 +210,11 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
     @Test
     public void testRemoveOlderResults() {
         discoveryServiceRegistry.addDiscoveryListener(discoveryListenerMock);
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
 
         waitForAssert(() -> {
-            verify(discoveryListenerMock, times(1)).removeOlderResults(any(DiscoveryService.class), anyLong(), any(),
-                    any());
+            verify(discoveryListenerMock, times(1)).removeOlderResults(any(DiscoveryService.class), any(Instant.class),
+                    any(), any());
         });
         verifyNoMoreInteractions(discoveryListenerMock);
     }
@@ -235,7 +236,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         assertThat(inbox.getAll().size(), is(2));
         // should not remove anything
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
 
         // start discovery again
@@ -246,7 +247,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         assertThat(inbox.getAll().size(), is(3));
         // should remove one entry
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
     }
 
@@ -280,11 +281,11 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove no entry, as there is no older entry discovery of this specific discovery service
         anotherDiscoveryServiceMockForBinding1
-                .removeOlderResults(anotherDiscoveryServiceMockForBinding1.getTimestampOfLastScan());
+                .removeOlderResults(anotherDiscoveryServiceMockForBinding1.getTimeOfLastScan());
         assertThat(inbox.getAll().size(), is(3));
 
         // should remove only one entry
-        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan());
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimeOfLastScan());
         assertThat(inbox.getAll().size(), is(2));
 
         anotherDiscoveryServiceMockForBinding1.abortScan();
@@ -308,13 +309,13 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should not remove anything
         discoveryServiceMockForBinding3Bridge1.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge1.getTimestampOfLastScan(),
+                discoveryServiceMockForBinding3Bridge1.getTimeOfLastScan(),
                 discoveryServiceMockForBinding3Bridge1.getBridge());
         assertThat(inbox.getAll().size(), is(2));
 
         // should not remove anything
         discoveryServiceMockForBinding3Bridge2.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge2.getTimestampOfLastScan(),
+                discoveryServiceMockForBinding3Bridge2.getTimeOfLastScan(),
                 discoveryServiceMockForBinding3Bridge2.getBridge());
         assertThat(inbox.getAll().size(), is(2));
 
@@ -332,7 +333,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove only 1 entry (of bridge1)
         discoveryServiceMockForBinding3Bridge1.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge1.getTimestampOfLastScan(),
+                discoveryServiceMockForBinding3Bridge1.getTimeOfLastScan(),
                 discoveryServiceMockForBinding3Bridge1.getBridge());
         assertThat(inbox.getAll().size(), is(3));
         assertThat(inbox.getAll().stream().filter(r -> BRIDGE_UID_1.equals(r.getBridgeUID())).count(), is(1L));
@@ -340,7 +341,7 @@ public class DiscoveryServiceRegistryOSGiTest extends JavaOSGiTest {
 
         // should remove only 1 entry (of bridge2)
         discoveryServiceMockForBinding3Bridge2.removeOlderResults(
-                discoveryServiceMockForBinding3Bridge2.getTimestampOfLastScan(),
+                discoveryServiceMockForBinding3Bridge2.getTimeOfLastScan(),
                 discoveryServiceMockForBinding3Bridge2.getBridge());
         assertThat(inbox.getAll().size(), is(2));
         assertThat(inbox.getAll().stream().filter(r -> BRIDGE_UID_1.equals(r.getBridgeUID())).count(), is(1L));

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -1019,7 +1019,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatRemoveOlderResultsOnlyRemovesResultsFromTheSameDiscoveryService() {
         inbox.thingDiscovered(discoveryService1, testDiscoveryResult);
-        long now = Instant.now().toEpochMilli() + 1;
+        Instant now = Instant.now().plusMillis(1);
         assertThat(inbox.getAll().size(), is(1));
 
         // should not remove a result
@@ -1034,7 +1034,7 @@ public class InboxOSGiTest extends JavaOSGiTest {
     @Test
     public void assertThatRemoveOlderResultsRemovesResultsWithoutAsource() {
         inbox.add(testDiscoveryResult);
-        long now = Instant.now().toEpochMilli() + 1;
+        Instant now = Instant.now().plusMillis(1);
         assertThat(inbox.getAll().size(), is(1));
 
         // should remove a result


### PR DESCRIPTION
Continuation of #4026, this time finishing the job by changing the API.

Methods related to discovery now use `Instant` rather than `long` for timestamps. This provides type safety, clarity and integration with the modern `java.time` API.

I have kept all existing methods, but immediately deprecated them. The `Instant` overload for `removeOlderResults` in the `DiscoveryListener` interface has a default implementation delegating to the `long` overload, so it is non-breaking now since an implementation is not required.

The proposed next phases:
1. Refactor add-ons to use the new methods. Prepared here: openhab/openhab-addons#18838.
2. Minor release: Invert the delegation: Make the `long` method a default method delegating to `Instant`.
   Make the `Instant` method abstract — implementors must now provide it.
3. Major release: Remove the deprecated `long` method entirely from the interface.
   Implementors who didn’t remove `@Override` on the legacy method in previous phase will get a compile error.