### PR TITLE
Move expire's Duration parser to a separate utility class and support `ms` for milliseconds

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/DurationUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/DurationUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.util;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Static utility methods that are helpful when dealing with {@link Duration}.
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@NonNullByDefault
+public class DurationUtils {
+
+    private static final Pattern DURATION_PATTERN = Pattern
+            .compile("(?:([0-9]+)D)?\\s*(?:([0-9]+)H)?\\s*(?:([0-9]+)M)?\\s*(?:([0-9]+)S)?", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Parses a duration string in ISO-8601 format or a custom format like
+     * "1d 1h 15m 30s" where 'd' stands for days, 'h' for hours,
+     * 'm' for minutes, and 's' for seconds.
+     *
+     * @param durationString the string representation of the duration
+     * @return a Duration object representing the parsed duration
+     * @throws IllegalArgumentException if the string cannot be parsed into a valid duration
+     */
+    public static Duration parse(String durationString) throws IllegalArgumentException {
+        try {
+            return Duration.parse(durationString);
+        } catch (Exception e) {
+            // ignore
+        }
+
+        Matcher m = DURATION_PATTERN.matcher(durationString);
+        if (!m.matches() || (m.group(1) == null && m.group(2) == null && m.group(3) == null && m.group(4) == null)) {
+            throw new IllegalArgumentException(
+                    "Invalid duration: " + durationString + ". Expected something like: '1d 1h 15m 30s'");
+        }
+
+        Duration duration = Duration.ZERO;
+        if (m.group(1) != null) {
+            duration = duration.plus(Duration.ofDays(Long.parseLong(m.group(1))));
+        }
+        if (m.group(2) != null) {
+            duration = duration.plus(Duration.ofHours(Long.parseLong(m.group(2))));
+        }
+        if (m.group(3) != null) {
+            duration = duration.plus(Duration.ofMinutes(Long.parseLong(m.group(3))));
+        }
+        if (m.group(4) != null) {
+            duration = duration.plus(Duration.ofSeconds(Long.parseLong(m.group(4))));
+        }
+        return duration;
+    }
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/util/DurationUtils.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/util/DurationUtils.java
@@ -13,6 +13,7 @@
 package org.openhab.core.util;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,13 +27,20 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class DurationUtils {
 
-    private static final Pattern DURATION_PATTERN = Pattern
-            .compile("(?:([0-9]+)D)?\\s*(?:([0-9]+)H)?\\s*(?:([0-9]+)M)?\\s*(?:([0-9]+)S)?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DURATION_PATTERN = Pattern.compile(
+            "(?:([0-9]+)D)?\\s*(?:([0-9]+)H)?\\s*(?:([0-9]+)M)?\\s*(?:([0-9]+)S)?\\s*(?:([0-9]+)MS)?",
+            Pattern.CASE_INSENSITIVE);
+    private static final ChronoUnit[] DURATION_UNITS = { ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.MINUTES,
+            ChronoUnit.SECONDS, ChronoUnit.MILLIS };
 
     /**
      * Parses a duration string in ISO-8601 format or a custom format like
-     * "1d 1h 15m 30s" where 'd' stands for days, 'h' for hours,
-     * 'm' for minutes, and 's' for seconds.
+     * "1d 1h 15m 30s 500ms" where
+     * 'd' stands for days,
+     * 'h' for hours,
+     * 'm' for minutes,
+     * 's' for seconds, and
+     * 'ms' for milliseconds.
      *
      * @param durationString the string representation of the duration
      * @return a Duration object representing the parsed duration
@@ -46,23 +54,19 @@ public class DurationUtils {
         }
 
         Matcher m = DURATION_PATTERN.matcher(durationString);
-        if (!m.matches() || (m.group(1) == null && m.group(2) == null && m.group(3) == null && m.group(4) == null)) {
-            throw new IllegalArgumentException(
-                    "Invalid duration: " + durationString + ". Expected something like: '1d 1h 15m 30s'");
+        if (!m.matches() || (m.group(1) == null && m.group(2) == null && m.group(3) == null && m.group(4) == null
+                && m.group(5) == null)) {
+            throw new IllegalArgumentException("Invalid duration: " + durationString
+                    + ". Expected an ISO8601 duration or something like: '1d 1h 15m 30s 300ms'");
         }
 
         Duration duration = Duration.ZERO;
-        if (m.group(1) != null) {
-            duration = duration.plus(Duration.ofDays(Long.parseLong(m.group(1))));
-        }
-        if (m.group(2) != null) {
-            duration = duration.plus(Duration.ofHours(Long.parseLong(m.group(2))));
-        }
-        if (m.group(3) != null) {
-            duration = duration.plus(Duration.ofMinutes(Long.parseLong(m.group(3))));
-        }
-        if (m.group(4) != null) {
-            duration = duration.plus(Duration.ofSeconds(Long.parseLong(m.group(4))));
+        for (int i = 0; i < DURATION_UNITS.length; i++) {
+            String value = m.group(i + 1);
+            if (value != null) {
+                long amount = Long.parseLong(value);
+                duration = duration.plus(amount, DURATION_UNITS[i]);
+            }
         }
         return duration;
     }

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/util/DurationUtilsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/util/DurationUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DurationUtils}
+ *
+ * @author Jimmy Tanagra - Initial contribution
+ */
+@NonNullByDefault
+public class DurationUtilsTest {
+
+    @Test
+    public void testParseISO8601() {
+        assertEquals(0, DurationUtils.parse("PT0S").toMillis());
+        assertEquals(300, DurationUtils.parse("PT0.3S").toMillis());
+        assertEquals(1000, DurationUtils.parse("PT1S").toMillis());
+        assertEquals(60000, DurationUtils.parse("PT1M").toMillis());
+        assertEquals(3600000, DurationUtils.parse("PT1H").toMillis());
+        assertEquals(86400000, DurationUtils.parse("P1D").toMillis());
+
+        // Mixed units
+        assertEquals(61000, DurationUtils.parse("PT1M1S").toMillis());
+        assertEquals(3661000, DurationUtils.parse("PT1H1M1S").toMillis());
+    }
+
+    @Test
+    public void testParseCustom() {
+        assertEquals(350, DurationUtils.parse("350ms").toMillis());
+        assertEquals(1000, DurationUtils.parse("1s").toMillis());
+        assertEquals(60000, DurationUtils.parse("1m").toMillis());
+        assertEquals(3600000, DurationUtils.parse("1h").toMillis());
+        assertEquals(86400000, DurationUtils.parse("1d").toMillis());
+
+        // Mixed units
+        assertEquals(61000, DurationUtils.parse("1m 1s").toMillis());
+        assertEquals(3661000, DurationUtils.parse("1h 1m 1s").toMillis());
+        assertEquals(3661000, DurationUtils.parse("1h1m1s").toMillis());
+    }
+}


### PR DESCRIPTION
so it can be used elsewhere

This was prompted by the need to standardize Duration parsing across openHAB, including addons, such as in https://github.com/openhab/openhab-addons/pull/18301