### PR TITLE
AbstractRegistry: hide exception stacktrace on IAE when adding an element.

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -201,6 +201,12 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
         }
         try {
             onAddElement(element);
+        } catch (final IllegalArgumentException ex) {
+            logger.warn("Cannot add \"{}\" with key \"{}\": {}", element.getClass().getSimpleName(), uid,
+                    ex.getMessage());
+            logger.debug("Cannot add \"{}\" with key \"{}\": {}", element.getClass().getSimpleName(), uid,
+                    ex.getMessage(), ex);
+            return false;
         } catch (final RuntimeException ex) {
             logger.warn("Cannot add \"{}\" with key \"{}\": {}", element.getClass().getSimpleName(), uid,
                     ex.getMessage(), ex);


### PR DESCRIPTION
Hide the scary stacktrace from user. The message is sufficient to describe the problem, which is usually a syntax error, e.g. not satisfying the regex check.
