### PR TITLE
Fix streaming of m3u audio streams

### DIFF
--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -101,6 +101,7 @@ public class URLAudioStream extends AudioStream implements ClonableAudioStream {
                 default:
                     break;
             }
+            streamUrl = new URI(url).toURL();
             URLConnection connection = streamUrl.openConnection();
             if ("unknown/unknown".equals(connection.getContentType())) {
                 // Java does not parse non-standard headers used by SHOUTCast


### PR DESCRIPTION
[This line](https://github.com/openhab/openhab-core/commit/7492d1cd148611b94e866aaa6aacbdf0501e6e54#diff-aa531653dfcdb134f6e257b5413e787892f302501e3498f4df86db0eaadea6e8L101) in a clean-up PR caused a regression when trying to stream m3u urls that are e.g. very common for Internet radio streams - the stream was simply not played and no error was shown.

This PR fixes this regression by correctly initializing the correct input stream.