### PR TITLE
WARN log when an object with same ID is added to a registry by a seco…

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -192,7 +192,7 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
         E existingElement = identifierToElement.get(uid);
         if (existingElement != null) {
             Provider<E> existingElementProvider = elementToProvider.get(existingElement);
-            logger.debug(
+            logger.warn(
                     "Cannot add \"{}\" with key \"{}\". It exists already from provider \"{}\"! Failed to add a second with the same UID from provider \"{}\"!",
                     element.getClass().getSimpleName(), uid,
                     existingElementProvider != null ? existingElementProvider.getClass().getSimpleName() : null,
@@ -249,7 +249,7 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
             }
             Provider<E> elementProvider = elementToProvider.get(existingElement);
             if (elementProvider != null && !elementProvider.equals(provider)) {
-                logger.error(
+                logger.debug(
                         "Provider '{}' is not allowed to remove element '{}' with key '{}' from the registry because it was added by provider '{}'.",
                         provider.getClass().getSimpleName(), element.getClass().getSimpleName(), uid,
                         elementProvider.getClass().getSimpleName());


### PR DESCRIPTION
…nd provider

Log was existing but at DEBUG level, meaning the general user was not informed that he defined the same object (thing, item, ...) at different places (providers) like for example an item in Main UI and an item in config file with same name.

Fix #4810
