### PR TITLE
Remove deprecated discovery methods

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -352,20 +352,6 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      * as timestamp.
      *
      * @param timestamp timestamp, older results will be removed
-     * @deprecated Use {@link #removeOlderResults(Instant)} instead.
-     */
-    @Deprecated(since = "5.0", forRemoval = true)
-    protected void removeOlderResults(long timestamp) {
-        removeOlderResults(Instant.ofEpochMilli(timestamp));
-    }
-
-    /**
-     * Call to remove all results of all {@link #supportedThingTypes} that are
-     * older than the given timestamp. To remove all left over results after a
-     * full scan, this method could be called {@link #getTimestampOfLastScan()}
-     * as timestamp.
-     *
-     * @param timestamp timestamp, older results will be removed
      */
     protected void removeOlderResults(Instant timestamp) {
         removeOlderResults(timestamp, null, null);
@@ -379,43 +365,9 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *
      * @param timestamp timestamp, older results will be removed
      * @param bridgeUID if not {@code null} only results of that bridge are being removed
-     * @deprecated Use {@link #removeOlderResults(Instant, ThingUID)} instead.
-     */
-    @Deprecated(since = "5.0", forRemoval = true)
-    protected void removeOlderResults(long timestamp, @Nullable ThingUID bridgeUID) {
-        removeOlderResults(Instant.ofEpochMilli(timestamp), null);
-    }
-
-    /**
-     * Call to remove all results of all {@link #supportedThingTypes} that are
-     * older than the given timestamp. To remove all left over results after a
-     * full scan, this method could be called {@link #getTimestampOfLastScan()}
-     * as timestamp.
-     *
-     * @param timestamp timestamp, older results will be removed
-     * @param bridgeUID if not {@code null} only results of that bridge are being removed
      */
     protected void removeOlderResults(Instant timestamp, @Nullable ThingUID bridgeUID) {
         removeOlderResults(timestamp, null, bridgeUID);
-    }
-
-    /**
-     * Call to remove all results of the given types that are older than the
-     * given timestamp. To remove all left over results after a full scan, this
-     * method could be called {@link #getTimestampOfLastScan()} as timestamp.
-     *
-     * @param timestamp timestamp, older results will be removed
-     * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
-     *            {@code ThingType}s will be removed; if {@code null} then
-     *            {@link DiscoveryService#getSupportedThingTypes()} will be used
-     *            instead
-     * @param bridgeUID if not {@code null} only results of that bridge are being removed
-     * @deprecated Use {@link #removeOlderResults(Instant, Collection, ThingUID)} instead.
-     */
-    @Deprecated(since = "5.0", forRemoval = true)
-    protected void removeOlderResults(long timestamp, @Nullable Collection<ThingTypeUID> thingTypeUIDs,
-            @Nullable ThingUID bridgeUID) {
-        removeOlderResults(Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
     }
 
     /**

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
@@ -73,10 +73,8 @@ public interface DiscoveryListener {
      * @return collection of thing UIDs of all removed things
      */
     @Nullable
-    default Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return removeOlderResults(source, timestamp.toEpochMilli(), thingTypeUIDs, bridgeUID);
-    }
+    Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID);
 
     /**
      * Removes all results belonging to one of the given types that are older
@@ -95,6 +93,8 @@ public interface DiscoveryListener {
      */
     @Nullable
     @Deprecated(since = "5.0", forRemoval = true)
-    Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID);
+    default Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
+            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
+        return removeOlderResults(source, Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
+    }
 }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryResult.java
@@ -129,15 +129,6 @@ public interface DiscoveryResult {
     Instant getCreationTime();
 
     /**
-     * Returns the creation time of this result object.
-     *
-     * @return timestamp as long
-     * @deprecated Use {@link #getCreationTime} instead.
-     */
-    @Deprecated(since = "5.0", forRemoval = true)
-    long getTimestamp();
-
-    /**
      * Returns the time to live in seconds for this entry.
      *
      * @return time to live in seconds

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryResultImpl.java
@@ -215,11 +215,6 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     }
 
     @Override
-    public long getTimestamp() {
-        return getCreationTime().toEpochMilli();
-    }
-
-    @Override
     public Instant getCreationTime() {
         return timestamp;
     }

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -288,12 +288,6 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
     }
 
     @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(final DiscoveryService source, final long timestamp,
-            final @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return removeOlderResults(source, Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
-    }
-
-    @Override
     public @Nullable Collection<ThingUID> removeOlderResults(final DiscoveryService source, final Instant timestamp,
             final @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         Set<ThingUID> removedResults = new HashSet<>();

--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/internal/PersistentInbox.java
@@ -412,12 +412,6 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
     }
 
     @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return removeOlderResults(source, Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
-    }
-
-    @Override
     public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
             @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
         Set<ThingUID> removedThings = new HashSet<>();

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/AbstractDiscoveryServiceTest.java
@@ -200,12 +200,6 @@ public class AbstractDiscoveryServiceTest implements DiscoveryListener {
         return null;
     }
 
-    @Override
-    public @Nullable Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return null;
-    }
-
     @Test
     public void testDiscoveryResults() {
         TestDiscoveryService discoveryService = new TestDiscoveryService(i18nProvider, localeProvider);


### PR DESCRIPTION
Continuation of #4866:
- Remove unused deprecated methods.
- Interface `DiscoveryListener`: Switch `long` and `Instant` overloads, so that `Instant` is now abstract and `long` has a default implementation delegating to the other. This makes it possible to remove the old method in implementations while keeping the new one (previously it was the other way around).

Neither of these changes are breaking at this moment in time, since openhab/openhab-addons#18838 is already merged. All `DiscoveryListener` implementations currently implements both `removeOlderResults` methods.

Final cleanup steps after this:
- Remove all `removeOlderResults(long)` implementations in addons. They are no longer needed after this PR, since the interface has a default implementation. Prepared in openhab/openhab-addons#18895.
- Remove the deprecated `long` method entirely from the `DiscoveryListener` interface.