### PR TITLE
Remove deprecated discovery method from interface

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/DiscoveryListener.java
@@ -75,26 +75,4 @@ public interface DiscoveryListener {
     @Nullable
     Collection<ThingUID> removeOlderResults(DiscoveryService source, Instant timestamp,
             @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID);
-
-    /**
-     * Removes all results belonging to one of the given types that are older
-     * than the given timestamp.
-     *
-     * @param source the discovery service which is the source of this event (not
-     *            null)
-     * @param timestamp timestamp, all <b>older</b> results will be removed
-     * @param thingTypeUIDs collection of {@code ThingType}s, only results of these
-     *            {@code ThingType}s will be removed; if {@code null} then
-     *            {@link DiscoveryService#getSupportedThingTypes()} will be used
-     *            instead
-     * @param bridgeUID if not {@code null} only results of that bridge are being removed
-     * @return collection of thing UIDs of all removed things
-     * @deprecated Use {@link #removeOlderResults(DiscoveryService, Instant, Collection, ThingUID)} instead.
-     */
-    @Nullable
-    @Deprecated(since = "5.0", forRemoval = true)
-    default Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
-            @Nullable Collection<ThingTypeUID> thingTypeUIDs, @Nullable ThingUID bridgeUID) {
-        return removeOlderResults(source, Instant.ofEpochMilli(timestamp), thingTypeUIDs, bridgeUID);
-    }
 }


### PR DESCRIPTION
This finally removes the `removeOlderResults(long)` overload from the `DiscoveryListener` interface. See previous steps:
- openhab/openhab-addons#18845
- openhab/openhab-addons#18890
- #4866
- openhab/openhab-addons#18838
- #4883
- openhab/openhab-addons#18895