### PR TITLE
Log the link in the ScriptProfile execution error message

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/profile/ScriptProfile.java
@@ -185,9 +185,11 @@ public class ScriptProfile implements TimeSeriesProfile {
                 return transformationService.transform(script, input.toFullString());
             } catch (TransformationException e) {
                 if (e.getCause() instanceof ScriptException) {
-                    logger.error("Failed to process script '{}': {}", script, e.getCause().getMessage());
+                    logger.error("Failed to process script '{}' in link '{}': {}", script,
+                            callback.getItemChannelLink(), e.getCause().getMessage());
                 } else {
-                    logger.error("Failed to process script '{}': {}", script, e.getMessage());
+                    logger.error("Failed to process script '{}' in link '{}': {}", script,
+                            callback.getItemChannelLink(), e.getMessage());
                 }
             }
         }


### PR DESCRIPTION
Log before:

```
14:41:27.373 [ERROR] [n.module.script.profile.ScriptProfile] - Failed to process script 'asdf.rb': Could not get script for UID 'asdf.rb'.
```

After:
```
14:41:27.373 [ERROR] [n.module.script.profile.ScriptProfile] - Failed to process script 'asdf.rb' in link 'Bed_Room_Light_Power -> mqtt:topic:bedroom-light:switch2': Could not get script for UID 'asdf.rb'.
```