### PR TITLE
Yaml Model Repository: skip non-existent paths during the initial scan instead of logging a warning

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -130,7 +130,10 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         // read initial contents
         WATCHED_PATHS.forEach(watchPath -> {
             Path fullPath = mainWatchPath.resolve(watchPath);
-            if (!Files.exists(fullPath) || !Files.isDirectory(fullPath)) {
+            if (!Files.exists(fullPath)) {
+                return;
+            } else if (!Files.isDirectory(fullPath)) {
+                logger.warn("Expecting '{}' to be a directory, but it's a file. Ignoring it.", fullPath);
                 return;
             }
             try {

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -130,6 +130,9 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
         // read initial contents
         WATCHED_PATHS.forEach(watchPath -> {
             Path fullPath = mainWatchPath.resolve(watchPath);
+            if (!Files.exists(fullPath) || !Files.isDirectory(fullPath)) {
+                return;
+            }
             try {
                 Files.walkFileTree(fullPath, new SimpleFileVisitor<>() {
                     @Override

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -150,7 +150,14 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                     @Override
                     public FileVisitResult visitFileFailed(@NonNullByDefault({}) Path file,
                             @NonNullByDefault({}) IOException exc) throws IOException {
-                        logger.warn("Failed to process {}: {}", file.toAbsolutePath(), exc.getMessage());
+                        String message = exc.getMessage();
+                        if (file.toString().equals(message)) {
+                            // If the message is just the path, we do not need to log it again.
+                            // This is the case for FileNotFoundException, AccessDeniedException, etc.
+                            // Instead of the path, we log the exception class to provide additional details.
+                            message = exc.getClass().getSimpleName();
+                        }
+                        logger.warn("Failed to process {}: {}", file.toAbsolutePath(), message);
                         return FileVisitResult.CONTINUE;
                     }
                 });


### PR DESCRIPTION
Resolve an issue reported in https://community.openhab.org/t/openhab-5-0-milestone-discussion/162686/277

