### PR TITLE
Registry: Avoid warn log when adding ActionType/Metadata several times

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/common/registry/AbstractRegistry.java
@@ -192,11 +192,20 @@ public abstract class AbstractRegistry<@NonNull E extends Identifiable<K>, @NonN
         E existingElement = identifierToElement.get(uid);
         if (existingElement != null) {
             Provider<E> existingElementProvider = elementToProvider.get(existingElement);
-            logger.warn(
-                    "Cannot add \"{}\" with key \"{}\". It exists already from provider \"{}\"! Failed to add a second with the same UID from provider \"{}\"!",
-                    element.getClass().getSimpleName(), uid,
-                    existingElementProvider != null ? existingElementProvider.getClass().getSimpleName() : null,
-                    provider.getClass().getSimpleName());
+            String elementClassName = element.getClass().getSimpleName();
+            if ("ActionType".equals(elementClassName) || "Metadata".equals(elementClassName)) {
+                logger.debug(
+                        "Cannot add \"{}\" with key \"{}\". It exists already from provider \"{}\"! Failed to add a second with the same UID from provider \"{}\"!",
+                        elementClassName, uid,
+                        existingElementProvider != null ? existingElementProvider.getClass().getSimpleName() : null,
+                        provider.getClass().getSimpleName());
+            } else {
+                logger.warn(
+                        "Cannot add \"{}\" with key \"{}\". It exists already from provider \"{}\"! Failed to add a second with the same UID from provider \"{}\"!",
+                        elementClassName, uid,
+                        existingElementProvider != null ? existingElementProvider.getClass().getSimpleName() : null,
+                        provider.getClass().getSimpleName());
+            }
             return false;
         }
         try {


### PR DESCRIPTION
Fix openhab/openhab-addons#18945
Regression from #4880

For Metadata, it was reported on the community forum, it occured when an item is linked to several channels.
