### PR TITLE
DSL Item: fix item name validation pattern

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/Items.xtext
@@ -17,9 +17,9 @@ ModelItem:
 	(ModelNormalItem | ModelGroupItem) name=ID
 	(label=STRING)?
 	('<' icon=Icon '>')?
-	('(' groups+=ID (',' groups+=ID)* ')')? 
+	('(' groups+=ID (',' groups+=ID)* ')')?
 	('[' tags+=(ID|STRING) (',' tags+=(ID|STRING))* ']')?
-	('{' bindings+=ModelBinding (',' bindings+=ModelBinding)* '}')? 
+	('{' bindings+=ModelBinding (',' bindings+=ModelBinding)* '}')?
 ;
 
 ModelGroupItem:
@@ -56,7 +56,7 @@ ValueType returns ecore::EJavaObject:
     STRING | NUMBER | BOOLEAN
 ;
 
-BOOLEAN returns ecore::EBoolean: 
+BOOLEAN returns ecore::EBoolean:
     'true' | 'false'
 ;
 
@@ -68,7 +68,7 @@ Icon:
 	(ID ':' (ID ':')?)? ID
 ;
 
-terminal ID: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;
+terminal ID: '^'?('a'..'z'|'A'..'Z'|'_') ('a'..'z'|'A'..'Z'|'_'|'0'..'9')*;
 
 terminal STRING:
 			'"' ( '\\' ('b'|'t'|'n'|'f'|'r'|'u'|'"'|"'"|'\\') | !('\\'|'"') )* '"' |


### PR DESCRIPTION
Item names must not start with a digit, and must not contain a dash.

The looser check done here in the past didn't cause a problem because the item name is also checked by the AbstractRegistry and will be rejected from being added to the registry if it doesn't conform to the required syntax.

Since it has been like this for a long time, perhaps wait until after 5.0 before merging this in case it causes some unexpected issues.