### PR TITLE
Restrict CORS logging to a single time

### DIFF
--- a/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
+++ b/bundles/org.openhab.core.io.rest/src/main/java/org/openhab/core/io/rest/internal/filter/CorsFilter.java
@@ -78,6 +78,8 @@ public class CorsFilter implements ContainerResponseFilter {
 
     static final String ACCEPTED_HTTP_METHODS = String.join(HEADERS_SEPARATOR, ACCEPTED_HTTP_METHODS_LIST);
 
+    static boolean hasLogged;
+
     private final transient Logger logger = LoggerFactory.getLogger(CorsFilter.class);
 
     private boolean isEnabled;
@@ -183,8 +185,9 @@ public class CorsFilter implements ContainerResponseFilter {
             this.isEnabled = "true".equalsIgnoreCase(corsPropertyValue);
         }
 
-        if (this.isEnabled) {
-            logger.info("enabled CORS for REST API.");
+        if (this.isEnabled && !hasLogged) {
+            logger.info("Enabled CORS for REST API.");
+            hasLogged = true;
         }
     }
 }


### PR DESCRIPTION
Currently, if CORS is enabled by configuration, the startup log is cluttered with such log messages:

```
09:46:24.421 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.421 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.425 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.439 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.444 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.456 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.462 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.466 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.473 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.479 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.485 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.492 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.497 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.506 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.526 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.537 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.551 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.567 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
09:46:24.583 [INFO ] [e.io.rest.internal.filter.CorsFilter] - enabled CORS for REST API.
```

This PR makes sure that there is only one such message logged and the rest is suppressed.