### PR TITLE
Prevent file system access for WatchService DELETE events in FolderObserver

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/folder/FolderObserver.java
@@ -255,7 +255,19 @@ public class FolderObserver implements WatchService.WatchEventListener {
     }
 
     private void checkPath(final Path path, final WatchService.Kind kind) {
+        String fileName = path.getFileName().toString();
         try {
+            // Checking isHidden() on a deleted file will throw an IOException on some file systems,
+            // so deal with deletion first.
+            if (kind == DELETE) {
+                synchronized (FolderObserver.class) {
+                    modelRepository.removeModel(fileName);
+                    namePathMap.remove(fileName);
+                    logger.debug("Removed '{}' model ", fileName);
+                }
+                return;
+            }
+
             if (Files.isHidden(path)) {
                 // we omit parsing of hidden files possibly created by editors or operating systems
                 if (logger.isDebugEnabled()) {
@@ -265,7 +277,6 @@ public class FolderObserver implements WatchService.WatchEventListener {
             }
 
             synchronized (FolderObserver.class) {
-                String fileName = path.getFileName().toString();
                 if (kind == CREATE || kind == MODIFY) {
                     String extension = getExtension(fileName);
                     if (parsers.contains(extension)) {
@@ -286,10 +297,6 @@ public class FolderObserver implements WatchService.WatchEventListener {
                                     path.toAbsolutePath());
                         }
                     }
-                } else if (kind == WatchService.Kind.DELETE) {
-                    modelRepository.removeModel(fileName);
-                    namePathMap.remove(fileName);
-                    logger.debug("Removed '{}' model ", fileName);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
This is a bugfix that has been separated out from #4633 since it's clear that it won't be a part of 5.0.

The bug is that on some file systems, NTFS/FAT/FAT32 in particular, file system access is needed to determine if a file or folder is hidden, since this is stored as a file attribute. On *nix based systems, "hidden" is determined simply by if the file/folder name starts with '.', so no file system access is required to make this determination.

As of today, `FolderObserver` evaluates the "hidden status" of the file/folder (for excluding hidden files from processing) before looking at what kind of event it is. This will lead to a `FileNotFoundException` for `DELETE` events since the file/holder has already been deleted, and thus its attributes can't be read. The exception prevents the even from being processed, so in effect all `DELETE` events fail on Windows.

This PR fixes the issue by making sure that the "hidden status" is only checked for files that do exist.