### PR TITLE
AbstractScriptModuleHandler: Recompile scripts on dependency change

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
@@ -105,7 +105,7 @@ public class ScriptModuleHandlerFactory extends BaseModuleHandlerFactory impleme
             try {
                 handler.compile();
             } catch (ScriptException e) {
-                logger.error("Failed to recompile action for rule {}: {}", handler.getRuleUID(), e.getMessage());
+                logger.error("Failed to recompile script for rule {}: {}", handler.getRuleUID(), e.getMessage());
             }
         }
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/factory/ScriptModuleHandlerFactory.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.script.ScriptException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.automation.Action;
@@ -100,6 +102,11 @@ public class ScriptModuleHandlerFactory extends BaseModuleHandlerFactory impleme
         if (handler != null) {
             logger.debug("Resetting script engine for script {}", engineIdentifier);
             handler.resetScriptEngine();
+            try {
+                handler.compile();
+            } catch (ScriptException e) {
+                logger.error("Failed to recompile action for rule {}: {}", handler.getRuleUID(), e.getMessage());
+            }
         }
     }
 }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -91,7 +91,7 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
             }
             try {
                 setExecutionContext(scriptEngine, context);
-                Object result = eval(scriptEngine, script);
+                Object result = eval(scriptEngine);
                 resultMap.put("result", result);
                 resetExecutionContext(scriptEngine, context);
             } finally { // Make sure that Lock is unlocked regardless of an exception being thrown or not to avoid

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -75,7 +75,7 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
             }
             try {
                 setExecutionContext(scriptEngine, context);
-                Object returnVal = eval(scriptEngine, script);
+                Object returnVal = eval(scriptEngine);
                 if (returnVal instanceof Boolean boolean1) {
                     result = boolean1;
                 } else {


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-addons/issues/19091.

When a script's dependency changes, it should recompile the compiled script similarly to resetting the engine for uncompiled scripts. Fixing this behaviour fixes an issue where compiled scripts stopped working after a dependency changed.

This also simplifies the code a bit.