### PR TITLE
Marketplace fixes

### DIFF
--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBlockLibaryAddonHandler.java
@@ -84,7 +84,9 @@ public class CommunityBlockLibaryAddonHandler implements MarketplaceAddonHandler
             } else if (yamlContent != null) {
                 addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
-                throw new IllegalArgumentException("Couldn't find the block library in the add-on entry");
+                logger.error("Block library {} has neither download URL nor embedded content", addon.getUid());
+                throw new MarketplaceHandlerException("Block library has neither download URL nor embedded content",
+                        null);
             }
         } catch (IOException e) {
             logger.error("Block library from marketplace cannot be downloaded: {}", e.getMessage());

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -30,6 +30,8 @@ import org.openhab.core.common.ThreadPoolManager;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link MarketplaceAddonHandler} implementation, which handles add-ons as jar files (specifically, OSGi
@@ -47,6 +49,7 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
     private static final List<String> SUPPORTED_EXT_TYPES = List.of("automation", "binding", "misc", "persistence",
             "transformation", "ui", "voice");
 
+    private final Logger logger = LoggerFactory.getLogger(CommunityBundleAddonHandler.class);
     private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
     private final BundleContext bundleContext;
@@ -74,9 +77,15 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
 
     @Override
     public void install(Addon addon) throws MarketplaceHandlerException {
+        Object urlObject = addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY);
+        if (!(urlObject instanceof String)) {
+            logger.error("Bundle {} has no JAR download URL", addon.getUid());
+            throw new MarketplaceHandlerException("Bundle has no JAR download URL", null);
+        }
+
         URL sourceUrl;
         try {
-            sourceUrl = (new URI((String) addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY))).toURL();
+            sourceUrl = new URI((String) urlObject).toURL();
         } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityBundleAddonHandler.java
@@ -78,14 +78,14 @@ public class CommunityBundleAddonHandler extends MarketplaceBundleInstaller impl
     @Override
     public void install(Addon addon) throws MarketplaceHandlerException {
         Object urlObject = addon.getProperties().get(JAR_DOWNLOAD_URL_PROPERTY);
-        if (!(urlObject instanceof String)) {
+        if (!(urlObject instanceof String urlString)) {
             logger.error("Bundle {} has no JAR download URL", addon.getUid());
             throw new MarketplaceHandlerException("Bundle has no JAR download URL", null);
         }
 
         URL sourceUrl;
         try {
-            sourceUrl = new URI((String) urlObject).toURL();
+            sourceUrl = new URI(urlString).toURL();
         } catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
             throw new MarketplaceHandlerException("Malformed source URL: " + e.getMessage(), e);
         }

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityMarketplaceAddonService.java
@@ -437,9 +437,18 @@ public class CommunityMarketplaceAddonService extends AbstractRemoteAddonService
         boolean installed = addonHandlers.stream()
                 .anyMatch(handler -> handler.supports(type, contentType) && handler.isInstalled(uid));
 
+        String title = topic.title;
+        int compatibilityStart = topic.title.lastIndexOf("["); // version range always starts with [
+        if (topic.title.lastIndexOf(" ") < compatibilityStart) { // check includes [ not present
+            String potentialRange = topic.title.substring(compatibilityStart);
+            Matcher matcher = BundleVersion.RANGE_PATTERN.matcher(potentialRange);
+            if (matcher.matches()) {
+                title = topic.title.substring(0, compatibilityStart).trim();
+            }
+        }
+
         Addon.Builder builder = Addon.create(uid).withType(type).withId(id).withContentType(contentType)
-                .withLabel(topic.title).withImageLink(topic.imageUrl)
-                .withLink(COMMUNITY_TOPIC_URL + topic.id.toString())
+                .withLabel(title).withImageLink(topic.imageUrl).withLink(COMMUNITY_TOPIC_URL + topic.id.toString())
                 .withAuthor(topic.postStream.posts[0].displayUsername).withMaturity(maturity)
                 .withDetailedDescription(detailedDescription).withInstalled(installed).withProperties(properties);
 

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityRuleTemplateAddonHandler.java
@@ -82,6 +82,10 @@ public class CommunityRuleTemplateAddonHandler implements MarketplaceAddonHandle
                 marketplaceRuleTemplateProvider.addTemplateAsJSON(addon.getUid(), jsonContent);
             } else if (yamlContent != null) {
                 marketplaceRuleTemplateProvider.addTemplateAsYAML(addon.getUid(), yamlContent);
+            } else {
+                logger.error("Rule template {} has neither download URL nor embedded content", addon.getUid());
+                throw new MarketplaceHandlerException("Rule template has neither download URL nor embedded content",
+                        null);
             }
         } catch (IOException e) {
             logger.error("Rule template from marketplace cannot be downloaded: {}", e.getMessage());

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityTransformationAddonHandler.java
@@ -109,8 +109,9 @@ public class CommunityTransformationAddonHandler implements MarketplaceAddonHand
             } else if (jsonContent != null) {
                 persistedTransformation = addTransformationFromJSON(addon.getUid(), jsonContent);
             } else {
-                throw new IllegalArgumentException(
-                        "Couldn't find the transformation in the add-on entry. The starting code fence may not be marked as ```yaml");
+                logger.error("Transformation {} has neither download URL nor embedded content", addon.getUid());
+                throw new MarketplaceHandlerException("Transformation has neither download URL nor embedded content",
+                        null);
             }
             Transformation transformation = map(persistedTransformation);
 

--- a/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
+++ b/bundles/org.openhab.core.addon.marketplace/src/main/java/org/openhab/core/addon/marketplace/internal/community/CommunityUIWidgetAddonHandler.java
@@ -87,8 +87,8 @@ public class CommunityUIWidgetAddonHandler implements MarketplaceAddonHandler {
             } else if (yamlContent != null) {
                 addWidgetAsYAML(addon.getUid(), yamlContent);
             } else {
-                throw new IllegalArgumentException(
-                        "Couldn't find the widget in the add-on entry. The starting code fence may not be marked as ```yaml");
+                logger.error("UI Widget {} has neither download URL nor embedded content", addon.getUid());
+                throw new MarketplaceHandlerException("UI Widget has neither download URL nor embedded content", null);
             }
         } catch (IOException e) {
             logger.error("Widget from marketplace cannot be downloaded: {}", e.getMessage());


### PR DESCRIPTION
This is a bugfix of an issue reported in the [5.0 Milestone discussion thread](https://community.openhab.org/t/openhab-5-0-milestone-discussion/162686/365).

Handling of the lack of an installation source have also been unified among the different community marketplace handlers.

In addition, I've included an old fix I've had lying around that removes the forum compatibility range from the title of installed add-ons.