### PR TITLE
YAML config enhance hashCode() and add new unit tests

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlGroupDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlGroupDTO.java
@@ -68,9 +68,13 @@ public class YamlGroupDTO {
         return function != null ? function.toUpperCase() : DEFAULT_FUNCTION;
     }
 
+    public @NonNull List<@NonNull String> getParameters() {
+        return parameters == null ? List.of() : parameters;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(getBaseType(), getFunction());
+        return Objects.hash(getBaseType(), getFunction(), getParameters());
     }
 
     @Override
@@ -82,6 +86,6 @@ public class YamlGroupDTO {
         }
         YamlGroupDTO other = (YamlGroupDTO) obj;
         return Objects.equals(getBaseType(), other.getBaseType()) && Objects.equals(getFunction(), other.getFunction())
-                && YamlElementUtils.equalsListStrings(parameters, other.parameters);
+                && Objects.equals(getParameters(), other.getParameters());
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemDTO.java
@@ -250,9 +250,18 @@ public class YamlItemDTO implements YamlElement, Cloneable {
         return YamlElementUtils.getItemTypeWithDimension(type, dimension);
     }
 
+    public @NonNull List<@NonNull String> getGroups() {
+        return groups == null ? List.of() : groups;
+    }
+
+    public @NonNull Set<@NonNull String> getTags() {
+        return tags == null ? Set.of() : tags;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(name, getType(), label, icon);
+        return Objects.hash(name, getType(), group, label, icon, format, unit, autoupdate, getGroups(), getTags(),
+                channel);
     }
 
     @Override
@@ -267,9 +276,9 @@ public class YamlItemDTO implements YamlElement, Cloneable {
                 && Objects.equals(group, other.group) && Objects.equals(label, other.label)
                 && Objects.equals(icon, other.icon) && Objects.equals(format, other.format)
                 && Objects.equals(unit, other.unit) && Objects.equals(autoupdate, other.autoupdate)
-                && YamlElementUtils.equalsListStrings(groups, other.groups)
-                && YamlElementUtils.equalsSetStrings(tags, other.tags) && Objects.equals(channel, other.channel)
-                && equalsChannels(channels, other.channels) && equalsMetadata(metadata, other.metadata);
+                && Objects.equals(getGroups(), other.getGroups()) && Objects.equals(getTags(), other.getTags())
+                && Objects.equals(channel, other.channel) && equalsChannels(channels, other.channels)
+                && equalsMetadata(metadata, other.metadata);
     }
 
     private boolean equalsChannels(@Nullable Map<@NonNull String, @NonNull Map<@NonNull String, @NonNull Object>> first,

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/YamlItemProvider.java
@@ -181,9 +181,7 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
                     if (baseItem != null) {
                         GroupFunctionDTO groupFunctionDto = new GroupFunctionDTO();
                         groupFunctionDto.name = groupDTO.getFunction();
-                        groupFunctionDto.params = groupDTO.parameters != null
-                                ? groupDTO.parameters.toArray(new String[0])
-                                : new String[0];
+                        groupFunctionDto.params = groupDTO.getParameters().toArray(new String[0]);
                         item = new GroupItem(name, baseItem, ItemDTOMapper.mapFunction(baseItem, groupFunctionDto));
                     } else {
                         item = new GroupItem(name);
@@ -203,15 +201,11 @@ public class YamlItemProvider extends AbstractProvider<Item> implements ItemProv
             genericItem.setLabel(itemDTO.label);
             genericItem.setCategory(itemDTO.icon);
 
-            if (itemDTO.tags != null) {
-                for (String tag : itemDTO.tags) {
-                    genericItem.addTag(tag);
-                }
+            for (String tag : itemDTO.getTags()) {
+                genericItem.addTag(tag);
             }
-            if (itemDTO.groups != null) {
-                for (String groupName : itemDTO.groups) {
-                    genericItem.addGroupName(groupName);
-                }
+            for (String groupName : itemDTO.getGroups()) {
+                genericItem.addGroupName(groupName);
             }
         }
 

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/things/YamlThingDTO.java
@@ -144,7 +144,7 @@ public class YamlThingDTO implements YamlElement, Cloneable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(uid, bridge, label, location);
+        return Objects.hash(uid, isBridge(), bridge, label, location);
     }
 
     @Override

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/YamlElementUtils.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/util/YamlElementUtils.java
@@ -51,22 +51,6 @@ public class YamlElementUtils {
                 : first.equals(second);
     }
 
-    public static boolean equalsListStrings(@Nullable List<String> first, @Nullable List<String> second) {
-        if (first != null && second != null) {
-            return Arrays.equals(first.toArray(), second.toArray());
-        } else {
-            return first == null && second == null;
-        }
-    }
-
-    public static boolean equalsSetStrings(@Nullable Set<String> first, @Nullable Set<String> second) {
-        if (first != null && second != null) {
-            return first.size() != second.size() ? false : first.containsAll(second);
-        } else {
-            return first == null && second == null;
-        }
-    }
-
     public static @Nullable String getAdjustedItemType(@Nullable String type) {
         return type == null ? null : StringUtils.capitalize(type);
     }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlGroupDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlGroupDTOTest.java
@@ -100,22 +100,27 @@ public class YamlGroupDTOTest {
         gr1.type = "String";
         gr2.type = "String";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr1.type = "String";
         gr2.type = "Number";
         assertFalse(gr1.equals(gr2));
         gr1.type = "Number";
         gr2.type = "Number";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr2.type = "number";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr1.dimension = "Temperature";
         assertFalse(gr1.equals(gr2));
         gr2.dimension = "Humidity";
         assertFalse(gr1.equals(gr2));
         gr2.dimension = "Temperature";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr2.dimension = "temperature";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
 
         gr1.function = "or";
         gr2.function = null;
@@ -126,10 +131,13 @@ public class YamlGroupDTOTest {
         gr1.function = "or";
         gr2.function = "or";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr2.function = "Or";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
         gr2.function = "OR";
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
 
         gr1.parameters = List.of("ON", "OFF");
         gr2.parameters = null;
@@ -143,5 +151,6 @@ public class YamlGroupDTOTest {
         assertFalse(gr1.equals(gr2));
         gr1.parameters = List.of("ON", "OFF");
         assertTrue(gr1.equals(gr2));
+        assertEquals(gr1.hashCode(), gr2.hashCode());
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlItemDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlItemDTOTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -127,40 +128,77 @@ public class YamlItemDTOTest {
         assertFalse(item1.equals(item2));
         item2.name = "item-name";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.type = "Number";
-        item1.dimension = "Temperature";
+        item2.type = "String";
+        assertFalse(item1.equals(item2));
         item2.type = "Number";
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item2.type = "number";
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.dimension = "Temperature";
+        assertFalse(item1.equals(item2));
+        item2.dimension = "Humidity";
+        assertFalse(item1.equals(item2));
         item2.dimension = "Temperature";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.label = "A label";
         item2.label = "A label";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.icon = "oh:classic:temperature";
         item2.icon = "oh:classic:temperature";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.groups = List.of("group1", "group2");
         item2.groups = List.of("group1", "group2");
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.tags = Set.of("Tag1", "Tag 2");
         item2.tags = Set.of("Tag1", "Tag 2");
         assertTrue(item1.equals(item2));
-        item2.tags = Set.of("Tag 2", "Tag1");
-        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
 
         item1.group = new YamlGroupDTO();
         item1.group.type = "Switch";
         item1.group.function = "OR";
         item1.group.parameters = List.of("ON", "OFF");
+        assertFalse(item1.equals(item2));
         item2.group = new YamlGroupDTO();
         item2.group.type = "Switch";
         item2.group.function = "OR";
         item2.group.parameters = List.of("ON", "OFF");
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+
+        item1.channel = "binding:type:uid:channelid";
+        item2.channel = "binding:type:uid:channelid";
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+
+        item1.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        item2.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+
+        YamlMetadataDTO md = new YamlMetadataDTO();
+        md.value = "value";
+        md.config = Map.of("param", 50);
+        item1.metadata = Map.of("namespace", md);
+        YamlMetadataDTO md2 = new YamlMetadataDTO();
+        md2.value = "value";
+        md2.config = Map.of("param", 50);
+        item2.metadata = Map.of("namespace", md2);
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
     @Test
@@ -176,6 +214,7 @@ public class YamlItemDTOTest {
         item1.label = null;
         item2.label = null;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.label = "A label";
         item2.label = null;
         assertFalse(item1.equals(item2));
@@ -188,6 +227,7 @@ public class YamlItemDTOTest {
         item1.label = "A label";
         item2.label = "A label";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
     @Test
@@ -203,6 +243,7 @@ public class YamlItemDTOTest {
         item1.icon = null;
         item2.icon = null;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.icon = "humidity";
         item2.icon = null;
         assertFalse(item1.equals(item2));
@@ -215,6 +256,7 @@ public class YamlItemDTOTest {
         item1.icon = "humidity";
         item2.icon = "humidity";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
     @Test
@@ -230,6 +272,7 @@ public class YamlItemDTOTest {
         item1.format = null;
         item2.format = null;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.format = "%.1f °C";
         item2.format = null;
         assertFalse(item1.equals(item2));
@@ -242,6 +285,7 @@ public class YamlItemDTOTest {
         item1.format = "%.1f °C";
         item2.format = "%.1f °C";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
     @Test
@@ -257,6 +301,7 @@ public class YamlItemDTOTest {
         item1.unit = null;
         item2.unit = null;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.unit = "°C";
         item2.unit = null;
         assertFalse(item1.equals(item2));
@@ -269,6 +314,7 @@ public class YamlItemDTOTest {
         item1.unit = "°C";
         item2.unit = "°C";
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
     @Test
@@ -284,6 +330,7 @@ public class YamlItemDTOTest {
         item1.autoupdate = null;
         item2.autoupdate = null;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.autoupdate = false;
         item2.autoupdate = true;
         assertFalse(item1.equals(item2));
@@ -305,96 +352,186 @@ public class YamlItemDTOTest {
         item1.autoupdate = false;
         item2.autoupdate = false;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
         item1.autoupdate = true;
         item2.autoupdate = true;
         assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
     }
 
-    // @Test
-    // public void testEqualsWithConfigurations() throws IOException {
-    // YamlThingDTO th1 = new YamlThingDTO();
-    // YamlThingDTO th2 = new YamlThingDTO();
-    //
-    // th1.uid = "binding:type:id";
-    // th2.uid = "binding:type:id";
-    //
-    // th1.config = null;
-    // th2.config = null;
-    // assertTrue(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = null;
-    // assertFalse(th1.equals(th2));
-    // th1.config = null;
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "other value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 25, "param3", true, "param4", List.of("val 1", "val 2"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", false, "param4", List.of("val 1", "val 2"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "value 2"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1"));
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", 75);
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true);
-    // assertFalse(th1.equals(th2));
-    // th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
-    // assertTrue(th1.equals(th2));
-    // }
-    //
-    // @Test
-    // public void testEqualsWithChannels() throws IOException {
-    // YamlThingDTO th1 = new YamlThingDTO();
-    // th1.uid = "binding:type:id";
-    // YamlThingDTO th2 = new YamlThingDTO();
-    // th2.uid = "binding:type:id";
-    //
-    // YamlChannelDTO ch1 = new YamlChannelDTO();
-    // ch1.type = "channel-type";
-    // YamlChannelDTO ch2 = new YamlChannelDTO();
-    // ch2.type = "channel-other-type";
-    // YamlChannelDTO ch3 = new YamlChannelDTO();
-    // ch3.type = "channel-type";
-    // YamlChannelDTO ch4 = new YamlChannelDTO();
-    // ch4.type = "channel-other-type";
-    //
-    // th1.channels = Map.of("channel1", ch1);
-    // th2.channels = Map.of("channel1", ch3);
-    // assertTrue(th1.equals(th2));
-    //
-    // th1.channels = Map.of("channel1", ch1, "channel2", ch2);
-    // th2.channels = Map.of("channel1", ch3, "channel2", ch4);
-    // assertTrue(th1.equals(th2));
-    //
-    // th1.channels = Map.of("channel1", ch1);
-    // th2.channels = null;
-    // assertFalse(th1.equals(th2));
-    //
-    // th1.channels = null;
-    // th2.channels = Map.of("channel1", ch3);
-    // assertFalse(th1.equals(th2));
-    //
-    // th1.channels = Map.of("channel1", ch1, "channel2", ch2);
-    // th2.channels = Map.of("channel1", ch3);
-    // assertFalse(th1.equals(th2));
-    //
-    // th1.channels = Map.of("channel1", ch1);
-    // th2.channels = Map.of("channel1", ch4);
-    // assertFalse(th1.equals(th2));
-    //
-    // th1.channels = Map.of("channel", ch1);
-    // th2.channels = Map.of("channel1", ch3);
-    // assertFalse(th1.equals(th2));
-    // }
+    @Test
+    public void testEqualsWithGroups() throws IOException {
+        YamlItemDTO item1 = new YamlItemDTO();
+        YamlItemDTO item2 = new YamlItemDTO();
+
+        item1.name = "item-name";
+        item2.name = "item-name";
+        item1.type = "Number";
+        item2.type = "Number";
+
+        item1.groups = null;
+        item2.groups = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.groups = List.of();
+        item2.groups = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.groups = null;
+        item2.groups = List.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.groups = List.of();
+        item2.groups = List.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.groups = List.of("group1", "group2");
+        item2.groups = null;
+        assertFalse(item1.equals(item2));
+        item2.groups = List.of();
+        assertFalse(item1.equals(item2));
+        item2.groups = List.of("group1");
+        assertFalse(item1.equals(item2));
+        item2.groups = List.of("group1", "group2", "group3");
+        assertFalse(item1.equals(item2));
+        item2.groups = List.of("group2", "group1");
+        assertFalse(item1.equals(item2));
+        item2.groups = List.of("group1", "group2");
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithTags() throws IOException {
+        YamlItemDTO item1 = new YamlItemDTO();
+        YamlItemDTO item2 = new YamlItemDTO();
+
+        item1.name = "item-name";
+        item2.name = "item-name";
+        item1.type = "Number";
+        item2.type = "Number";
+
+        item1.tags = null;
+        item2.tags = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.tags = Set.of();
+        item2.tags = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.tags = null;
+        item2.tags = Set.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.tags = Set.of();
+        item2.tags = Set.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.tags = Set.of("tag1", "tag2");
+        item2.tags = null;
+        assertFalse(item1.equals(item2));
+        item2.tags = Set.of();
+        assertFalse(item1.equals(item2));
+        item2.tags = Set.of("tag1");
+        assertFalse(item1.equals(item2));
+        item2.tags = Set.of("tag1", "tag2", "tag3");
+        assertFalse(item1.equals(item2));
+        item2.tags = Set.of("tag1", "tag2");
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item2.tags = Set.of("tag2", "tag1");
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithChannels() throws IOException {
+        YamlItemDTO item1 = new YamlItemDTO();
+        YamlItemDTO item2 = new YamlItemDTO();
+
+        item1.name = "item-name";
+        item2.name = "item-name";
+        item1.type = "Number";
+        item2.type = "Number";
+
+        item1.channel = "binding:type:uid:channelid";
+        assertFalse(item1.equals(item2));
+        item2.channel = "binding:type:uid2:channelid";
+        assertFalse(item1.equals(item2));
+        item2.channel = "binding:type:uid:channelid";
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+
+        item1.channels = null;
+        item2.channels = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.channels = Map.of();
+        item2.channels = Map.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        item2.channels = null;
+        assertFalse(item1.equals(item2));
+        item2.channels = Map.of();
+        assertFalse(item1.equals(item2));
+        item2.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.channels = Map.of("binding:type:uid:channelid2",
+                Map.of("profile", "anyprofile", "param", "profile param"));
+        item2.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        assertFalse(item1.equals(item2));
+        item2.channels = Map.of("binding:type:uid:channelid2",
+                Map.of("profile", "anyprofile", "param", "profile param"));
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        item2.channels = Map.of("binding:type:uid:channelid2", Map.of(), "binding:type:uid:channelid3", Map.of());
+        assertFalse(item1.equals(item2));
+        item1.channels = Map.of("binding:type:uid:channelid2", Map.of(), "binding:type:uid:channelid3", Map.of());
+        item2.channels = Map.of("binding:type:uid:channelid2", Map.of());
+        assertFalse(item1.equals(item2));
+    }
+
+    @Test
+    public void testEqualsWithMetadata() throws IOException {
+        YamlItemDTO item1 = new YamlItemDTO();
+        YamlItemDTO item2 = new YamlItemDTO();
+
+        item1.name = "item-name";
+        item2.name = "item-name";
+        item1.type = "Number";
+        item2.type = "Number";
+
+        YamlMetadataDTO md1 = new YamlMetadataDTO();
+        md1.value = "value";
+        md1.config = Map.of("param", 50);
+        YamlMetadataDTO md2 = new YamlMetadataDTO();
+        md2.value = "value";
+        md2.config = Map.of("param", "parameter value");
+        YamlMetadataDTO md3 = new YamlMetadataDTO();
+        md3.value = "value";
+        md3.config = Map.of("param", 50);
+
+        item1.metadata = null;
+        item2.metadata = null;
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.metadata = Map.of();
+        item2.metadata = Map.of();
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item1.metadata = Map.of("namespace", md1);
+        assertFalse(item1.equals(item2));
+        item2.metadata = Map.of("namespace2", md3);
+        assertFalse(item1.equals(item2));
+        item2.metadata = Map.of("namespace", md2);
+        assertFalse(item1.equals(item2));
+        item2.metadata = Map.of("namespace", md3);
+        assertTrue(item1.equals(item2));
+        assertEquals(item1.hashCode(), item2.hashCode());
+        item2.metadata = Map.of("namespace", md3, "namespace2", md2);
+        assertFalse(item1.equals(item2));
+    }
 }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlMetadataDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/items/YamlMetadataDTOTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.model.yaml.internal.items;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@link YamlMetadataDTOTest} contains tests for the {@link YamlMetadataDTO} class.
+ *
+ * @author Laurent Garnier - Initial contribution
+ */
+@NonNullByDefault
+public class YamlMetadataDTOTest {
+
+    @Test
+    public void testGetValue() throws IOException {
+        YamlMetadataDTO md = new YamlMetadataDTO();
+        md.value = null;
+        assertEquals("", md.getValue());
+        md.value = "value";
+        assertEquals("value", md.getValue());
+    }
+
+    @Test
+    public void testEquals() throws IOException {
+        YamlMetadataDTO md1 = new YamlMetadataDTO();
+        YamlMetadataDTO md2 = new YamlMetadataDTO();
+
+        md1.value = null;
+        md2.value = null;
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+        md1.value = null;
+        md2.value = "";
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+        md1.value = "";
+        md2.value = null;
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+        md1.value = "value";
+        md2.value = null;
+        assertFalse(md1.equals(md2));
+        md2.value = "other value";
+        assertFalse(md1.equals(md2));
+        md2.value = "value";
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+
+        md1.config = Map.of("param", 50);
+        md2.config = Map.of("param", 50);
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithConfigurations() throws IOException {
+        YamlMetadataDTO md1 = new YamlMetadataDTO();
+        YamlMetadataDTO md2 = new YamlMetadataDTO();
+
+        md1.value = "value";
+        md2.value = "value";
+
+        md1.config = null;
+        md2.config = null;
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+        md1.config = Map.of("param1", "value", "param2", 50, "param3", true);
+        md2.config = null;
+        assertFalse(md1.equals(md2));
+        md1.config = null;
+        md2.config = Map.of("param1", "value", "param2", 50, "param3", true);
+        assertFalse(md1.equals(md2));
+        md1.config = Map.of("param1", "value", "param2", 50, "param3", true);
+        md2.config = Map.of("param1", "other value", "param2", 50, "param3", true);
+        assertFalse(md1.equals(md2));
+        md2.config = Map.of("param1", "value", "param2", 25, "param3", true);
+        assertFalse(md1.equals(md2));
+        md2.config = Map.of("param1", "value", "param2", 50, "param3", false);
+        assertFalse(md1.equals(md2));
+        md2.config = Map.of("param1", "value", "param2", 50);
+        assertFalse(md1.equals(md2));
+        md2.config = Map.of("param1", "value", "param2", 50, "param3", true);
+        assertTrue(md1.equals(md2));
+        assertEquals(md1.hashCode(), md2.hashCode());
+    }
+}

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlChannelDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlChannelDTOTest.java
@@ -81,28 +81,34 @@ public class YamlChannelDTOTest {
         ch1.type = "channel-type";
         ch2.type = "channel-type";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.type = null;
         ch1.itemType = "String";
         ch2.type = null;
         ch2.itemType = "String";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "trigger";
         ch2.kind = "TRIGGER";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.label = "A label";
         ch2.label = "A label";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.description = "A description";
         ch2.description = "A description";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         ch2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
     }
 
     @Test
@@ -113,6 +119,7 @@ public class YamlChannelDTOTest {
         ch1.type = "channel-type";
         ch2.type = "channel-type";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch2.type = "channel-type2";
         assertFalse(ch1.equals(ch2));
 
@@ -121,22 +128,27 @@ public class YamlChannelDTOTest {
         ch2.type = null;
         ch2.itemType = "String";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch1.itemType = "String";
         ch2.itemType = "Number";
         assertFalse(ch1.equals(ch2));
         ch1.itemType = "Number";
         ch2.itemType = "Number";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch2.itemType = "number";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch1.itemDimension = "Temperature";
         assertFalse(ch1.equals(ch2));
         ch2.itemDimension = "Humidity";
         assertFalse(ch1.equals(ch2));
         ch2.itemDimension = "Temperature";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch2.itemDimension = "temperature";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.type = "channel-type";
         ch1.itemType = null;
@@ -159,18 +171,22 @@ public class YamlChannelDTOTest {
         ch2.itemType = "Switch";
         ch2.kind = "state";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "trigger";
         ch2.kind = "trigger";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "trigger";
         ch2.kind = "Trigger";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "Trigger";
         ch2.kind = "TRIGGER";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "state";
         ch2.kind = "trigger";
@@ -191,10 +207,12 @@ public class YamlChannelDTOTest {
         ch1.kind = null;
         ch2.kind = "state";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
 
         ch1.kind = "state";
         ch2.kind = null;
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
     }
 
     @Test
@@ -208,6 +226,7 @@ public class YamlChannelDTOTest {
         ch1.label = null;
         ch2.label = null;
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch1.label = "A label";
         ch2.label = null;
         assertFalse(ch1.equals(ch2));
@@ -220,6 +239,7 @@ public class YamlChannelDTOTest {
         ch1.label = "A label";
         ch2.label = "A label";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
     }
 
     @Test
@@ -233,6 +253,7 @@ public class YamlChannelDTOTest {
         ch1.description = null;
         ch2.description = null;
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch1.description = "A description";
         ch2.description = null;
         assertFalse(ch1.equals(ch2));
@@ -245,6 +266,7 @@ public class YamlChannelDTOTest {
         ch1.description = "A description";
         ch2.description = "A description";
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
     }
 
     @Test
@@ -258,6 +280,7 @@ public class YamlChannelDTOTest {
         ch1.config = null;
         ch2.config = null;
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
         ch1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         ch2.config = null;
         assertFalse(ch1.equals(ch2));
@@ -288,5 +311,6 @@ public class YamlChannelDTOTest {
         ch1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         ch2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         assertTrue(ch1.equals(ch2));
+        assertEquals(ch1.hashCode(), ch2.hashCode());
     }
 }

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingDTOTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/things/YamlThingDTOTest.java
@@ -89,26 +89,32 @@ public class YamlThingDTOTest {
         assertFalse(th1.equals(th2));
         th2.uid = "binding:type:id";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.isBridge = true;
         th2.isBridge = true;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.bridge = "binding:bridge:idBridge";
         th2.bridge = "binding:bridge:idBridge";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.label = "A label";
         th2.label = "A label";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.location = "A location";
         th2.location = "A location";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         YamlChannelDTO ch1 = new YamlChannelDTO();
         ch1.type = "channel-type";
@@ -117,6 +123,7 @@ public class YamlThingDTOTest {
         th1.channels = Map.of("channel", ch1);
         th2.channels = Map.of("channel", ch2);
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -130,6 +137,7 @@ public class YamlThingDTOTest {
         th1.label = null;
         th2.label = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.label = "A label";
         th2.label = null;
         assertFalse(th1.equals(th2));
@@ -142,6 +150,7 @@ public class YamlThingDTOTest {
         th1.label = "A label";
         th2.label = "A label";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -155,6 +164,7 @@ public class YamlThingDTOTest {
         th1.location = null;
         th2.location = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.location = "A location";
         th2.location = null;
         assertFalse(th1.equals(th2));
@@ -167,6 +177,7 @@ public class YamlThingDTOTest {
         th1.location = "A location";
         th2.location = "A location";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -180,6 +191,7 @@ public class YamlThingDTOTest {
         th1.isBridge = null;
         th2.isBridge = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.isBridge = false;
         th2.isBridge = true;
         assertFalse(th1.equals(th2));
@@ -195,15 +207,19 @@ public class YamlThingDTOTest {
         th1.isBridge = false;
         th2.isBridge = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.isBridge = null;
         th2.isBridge = false;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.isBridge = false;
         th2.isBridge = false;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.isBridge = true;
         th2.isBridge = true;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -217,6 +233,7 @@ public class YamlThingDTOTest {
         th1.bridge = null;
         th2.bridge = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.bridge = "binding:bridge:idBridge";
         th2.bridge = null;
         assertFalse(th1.equals(th2));
@@ -229,6 +246,7 @@ public class YamlThingDTOTest {
         th1.bridge = "binding:bridge:idBridge";
         th2.bridge = "binding:bridge:idBridge";
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -242,6 +260,7 @@ public class YamlThingDTOTest {
         th1.config = null;
         th2.config = null;
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
         th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         th2.config = null;
         assertFalse(th1.equals(th2));
@@ -272,6 +291,7 @@ public class YamlThingDTOTest {
         th1.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         th2.config = Map.of("param1", "value", "param2", 50, "param3", true, "param4", List.of("val 1", "val 2"));
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
     }
 
     @Test
@@ -293,10 +313,12 @@ public class YamlThingDTOTest {
         th1.channels = Map.of("channel1", ch1);
         th2.channels = Map.of("channel1", ch3);
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.channels = Map.of("channel1", ch1, "channel2", ch2);
         th2.channels = Map.of("channel1", ch3, "channel2", ch4);
         assertTrue(th1.equals(th2));
+        assertEquals(th1.hashCode(), th2.hashCode());
 
         th1.channels = Map.of("channel1", ch1);
         th2.channels = null;


### PR DESCRIPTION
Reduce potential collisions in hashCode()

Make identical a null list/set and an empty list/set

Test hashCode in addition to equals in unit tests.
Add new tests for YamlItemDTO (equals/hashCode)

Related to #4936