### PR TITLE
Add jackson-datatype-jdk8 bundle to Jackson feature

### DIFF
--- a/bom/runtime/pom.xml
+++ b/bom/runtime/pom.xml
@@ -1009,6 +1009,12 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <version>${jackson.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>
       <scope>compile</scope>

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -88,6 +88,7 @@
 		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.19.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.19.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.19.2</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.19.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.19.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.19.2</bundle>
 		<bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.19.2</bundle>


### PR DESCRIPTION
It is required by the Jinja transformation.
Because it uses the same version of OHC and is missing in the feature, it needs to be manually uploaded each time Jackson is upgraded.

Fixes #4399

---

Jinjava [depends on it](https://github.com/HubSpot/jinjava/blob/b97bc5c095aa263604c32571aa7a2b6152f470c8/src/main/java/com/hubspot/jinjava/JinjavaConfig.java#L162) and throws a NoClassDefFoundError without it:

```
java.lang.NoClassDefFoundError: com/fasterxml/jackson/datatype/jdk8/Jdk8Module
	at com.hubspot.jinjava.Jinjava.<init>(Jinjava.java:76)
	at org.openhab.transform.jinja.internal.JinjaTransformationService.<init>(JinjaTransformationService.java:49)
	at org.openhab.transform.jinja.internal.JinjaTransformationServiceTest.init(JinjaTransformationServiceTest.java:30)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.datatype.jdk8.Jdk8Module
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 6 more
```
