### PR TITLE
Persistence extensions: preserve item unit in results

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -75,6 +75,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - add Riemann sum methods
  * @author Jörg Sautter - use Instant instead of ZonedDateTime in Riemann sum methods
  * @author Mark Herwege - handle timeseries update
+ * @author Mark Herwege - use base unit for calculations and results
  */
 @Component(immediate = true)
 @NonNullByDefault
@@ -1173,6 +1174,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
      * @return the variance between then and now, or <code>null</code> if <code>timestamp</code> is in the future, if
@@ -1186,6 +1191,10 @@ public class PersistenceExtensions {
     /**
      * Gets the variance of the state of the given {@link Item} since a certain point in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
@@ -1203,6 +1212,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
      * @return the variance between now and then, or <code>null</code> if <code>timestamp</code> is in the past, if
@@ -1216,6 +1229,10 @@ public class PersistenceExtensions {
     /**
      * Gets the variance of the state of the given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
@@ -1232,6 +1249,10 @@ public class PersistenceExtensions {
      * Gets the variance of the state of the given {@link Item} between two points in time.
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param begin the point in time from which to compute
@@ -1252,6 +1273,10 @@ public class PersistenceExtensions {
      * Gets the variance of the state of the given {@link Item} between two certain point in time.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param begin the point in time from which to compute the variance
      * @param end the end time for the computation
@@ -1271,6 +1296,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
      * @param serviceId the name of the {@link PersistenceService} to use
@@ -1286,6 +1315,10 @@ public class PersistenceExtensions {
     /**
      * Gets the variance of the state of the given {@link Item} since a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time from which to compute the variance
@@ -1306,6 +1339,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
      * @param serviceId the name of the {@link PersistenceService} to use
@@ -1321,6 +1358,10 @@ public class PersistenceExtensions {
     /**
      * Gets the variance of the state of the given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param timestamp the point in time to which to compute the variance
@@ -1341,6 +1382,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the variance for
      * @param begin the point in time from which to compute the variance
      * @param end the end time for the computation
@@ -1356,6 +1401,10 @@ public class PersistenceExtensions {
     /**
      * Gets the variance of the state of the given {@link Item} between two points in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the variance for
      * @param begin the point in time from which to compute
@@ -1396,8 +1445,7 @@ public class PersistenceExtensions {
             it = result.iterator();
         }
         Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-        Unit<?> unit = (baseItem instanceof NumberItem numberItem)
-                && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit() : null;
+        Unit<?> unit = (baseItem instanceof NumberItem numberItem) ? numberItem.getUnit() : null;
 
         BigDecimal average = average(beginTime, endTime, it, unit, type);
         if (average != null) {
@@ -1432,6 +1480,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1449,6 +1501,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} since a certain point in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1470,6 +1526,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1487,6 +1547,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1508,6 +1572,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1526,6 +1594,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} between two points in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1549,6 +1621,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1567,6 +1643,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} since a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1590,6 +1670,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1608,6 +1692,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1631,6 +1719,10 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
      *
@@ -1652,6 +1744,10 @@ public class PersistenceExtensions {
     /**
      * Gets the standard deviation of the state of the given {@link Item} between two points in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * <b>Note:</b> If you need variance and standard deviation at the same time do not query both as it is a costly
      * operation. Get the variance only, it is the squared deviation.
@@ -1679,21 +1775,23 @@ public class PersistenceExtensions {
             return null;
         }
         State variance = internalVarianceBetween(item, begin, end, type, effectiveServiceId);
+        if (variance == null) {
+            return null;
+        }
 
-        if (variance != null) {
-            DecimalType dt = variance.as(DecimalType.class);
-            // avoid ArithmeticException if variance is less than zero
-            if (dt != null && DecimalType.ZERO.compareTo(dt) <= 0) {
-                BigDecimal deviation = dt.toBigDecimal().sqrt(MathContext.DECIMAL64);
-                Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-                Unit<?> unit = (baseItem instanceof NumberItem numberItem)
-                        && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit()
-                                : null;
-                if (unit != null) {
-                    return new QuantityType<>(deviation, unit);
-                } else {
-                    return new DecimalType(deviation);
-                }
+        Unit<?> varianceUnit = (variance instanceof QuantityType<?> quantity) ? quantity.getUnit() : null;
+        DecimalType dt = variance.as(DecimalType.class);
+
+        // avoid ArithmeticException if variance is less than zero
+        if (dt != null && DecimalType.ZERO.compareTo(dt) <= 0) {
+            BigDecimal deviation = dt.toBigDecimal().sqrt(MathContext.DECIMAL64);
+
+            Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
+            Unit<?> unit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
+            if (varianceUnit != null && unit != null) {
+                return (new QuantityType<>(deviation, varianceUnit.root(2))).toUnit(unit);
+            } else {
+                return new DecimalType(deviation);
             }
         }
         return null;
@@ -1953,9 +2051,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} since a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time from which to search for the riemannSum value
@@ -1970,9 +2074,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} since a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time from which to search for the riemannSum value
@@ -1989,9 +2099,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} until a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time to which to search for the riemannSum value
@@ -2006,9 +2122,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} until a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time to which to search for the riemannSum value
@@ -2025,9 +2147,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} between two certain points in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param begin the point in time from which to start the summation
@@ -2043,9 +2171,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} between two certain points in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param begin the point in time from which to start the summation
@@ -2064,9 +2198,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} since a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time from which to search for the riemannSum value
@@ -2083,9 +2223,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} since a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time from which to search for the riemannSum value
@@ -2105,9 +2251,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} until a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time to which to search for the riemannSum value
@@ -2124,9 +2276,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} until a certain point in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param timestamp the point in time to which to search for the riemannSum value
@@ -2146,9 +2304,15 @@ public class PersistenceExtensions {
      * Gets the Riemann sum of the states of a given {@link Item} between two certain points in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
      * A left approximation type is used for the Riemann sum.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param begin the point in time from which to start the summation
@@ -2166,9 +2330,15 @@ public class PersistenceExtensions {
     /**
      * Gets the Riemann sum of the states of a given {@link Item} between two certain points in time.
      * This can be used as an approximation for integrating the curve represented by discrete values.
-     * The time dimension in the result is in seconds, therefore if you do not use QuantityType results, you may have to
+     *
+     * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
+     * you may have to
      * multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the riemannSum value for
      * @param begin the point in time from which to start the summation
@@ -2208,8 +2378,7 @@ public class PersistenceExtensions {
         }
 
         Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-        Unit<?> unit = (baseItem instanceof NumberItem numberItem)
-                && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit() : null;
+        Unit<?> unit = (baseItem instanceof NumberItem numberItem) ? numberItem.getUnit() : null;
         BigDecimal sum = riemannSum(beginTime.toInstant(), endTime.toInstant(), it, unit, type).scaleByPowerOfTen(-3);
         if (unit != null) {
             return new QuantityType<>(sum, unit.multiply(Units.SECOND));
@@ -2463,6 +2632,10 @@ public class PersistenceExtensions {
      * value.
      * The default persistence service is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item for which we will sum its persisted state values since <code>timestamp</code>
      * @param timestamp the point in time from which to start the summation
      * @return the sum of the state values since <code>timestamp</code>, or null if <code>timestamp</code> is in the
@@ -2478,6 +2651,10 @@ public class PersistenceExtensions {
      * value.
      * The default persistence service is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
      * @param timestamp the point in time to which to start the summation
      * @return the sum of the state values until <code>timestamp</code>, or null if <code>timestamp</code> is in the
@@ -2492,6 +2669,10 @@ public class PersistenceExtensions {
      * This method does not calculate a Riemann sum and therefore cannot be used as an approximation for the integral
      * value.
      * The default persistence service is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the item for which we will sum its persisted state values between <code>begin</code> and
      *            <code>end</code>
@@ -2511,6 +2692,10 @@ public class PersistenceExtensions {
      * value.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item for which we will sum its persisted state values since <code>timestamp</code>
      * @param timestamp the point in time from which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
@@ -2527,6 +2712,10 @@ public class PersistenceExtensions {
      * value.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item for which we will sum its persisted state values to <code>timestamp</code>
      * @param timestamp the point in time to which to start the summation
      * @param serviceId the name of the {@link PersistenceService} to use
@@ -2542,6 +2731,10 @@ public class PersistenceExtensions {
      * This method does not calculate a Riemann sum and therefore cannot be used as an approximation for the integral
      * value.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the item for which we will sum its persisted state values between <code>begin</code> and
      *            <code>end</code>
@@ -2567,8 +2760,7 @@ public class PersistenceExtensions {
             Iterator<HistoricItem> it = result.iterator();
 
             Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-            Unit<?> unit = (baseItem instanceof NumberItem numberItem)
-                    && (numberItem.getUnit() instanceof Unit<?> numberItemUnit) ? numberItemUnit.getSystemUnit() : null;
+            Unit<?> unit = baseItem instanceof NumberItem numberItem ? numberItem.getUnit() : null;
             BigDecimal sum = BigDecimal.ZERO;
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();
@@ -2701,10 +2893,10 @@ public class PersistenceExtensions {
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {
-            valueStart = getItemValue(item);
+            valueStart = getItemValue(item, unit);
         }
         if (begin != null && end == null && begin.isBefore(ZonedDateTime.now())) {
-            valueStop = getItemValue(item);
+            valueStop = getItemValue(item, unit);
         }
 
         if (valueStart != null && valueStop != null) {
@@ -2719,6 +2911,10 @@ public class PersistenceExtensions {
      * The default {@link PersistenceService} is used.
      *
      * This method has been deprecated and {@link #evolutionRateSince(Item, ZonedDateTime)} should be used instead.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the item to get the evolution rate value for
      * @param timestamp the point in time from which to compute the evolution rate
@@ -2739,6 +2935,10 @@ public class PersistenceExtensions {
      * Gets the evolution rate of the state of a given {@link Item} since a certain point in time.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item to get the evolution rate value for
      * @param timestamp the point in time from which to compute the evolution rate
      * @return the evolution rate in percent (positive and negative) between now and then, or <code>null</code> if
@@ -2754,6 +2954,10 @@ public class PersistenceExtensions {
     /**
      * Gets the evolution rate of the state of a given {@link Item} until a certain point in time.
      * The default {@link PersistenceService} is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the item to get the evolution rate value for
      * @param timestamp the point in time to which to compute the evolution rate
@@ -2773,6 +2977,10 @@ public class PersistenceExtensions {
      *
      * This method has been deprecated and {@link #evolutionRateBetween(Item, ZonedDateTime, ZonedDateTime)} should be
      * used instead.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the item to get the evolution rate value for
      * @param begin the beginning point in time
@@ -2794,6 +3002,10 @@ public class PersistenceExtensions {
      * Gets the evolution rate of the state of a given {@link Item} between two points in time.
      * The default {@link PersistenceService} is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the item to get the evolution rate value for
      * @param begin the beginning point in time
      * @param end the end point in time
@@ -2813,6 +3025,10 @@ public class PersistenceExtensions {
      *
      * This method has been deprecated and {@link #evolutionRateSince(Item, ZonedDateTime, String)} should be used
      * instead.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the evolution rate value for
      * @param timestamp the point in time from which to compute the evolution rate
@@ -2835,6 +3051,10 @@ public class PersistenceExtensions {
      * Gets the evolution rate of the state of a given {@link Item} since a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the evolution rate value for
      * @param timestamp the point in time from which to compute the evolution rate
      * @param serviceId the name of the {@link PersistenceService} to use
@@ -2853,6 +3073,10 @@ public class PersistenceExtensions {
     /**
      * Gets the evolution rate of the state of a given {@link Item} until a certain point in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the evolution rate value for
      * @param timestamp the point in time to which to compute the evolution rate
@@ -2876,6 +3100,10 @@ public class PersistenceExtensions {
      * This method has been deprecated and {@link #evolutionRateBetween(Item, ZonedDateTime, ZonedDateTime, String)}
      * should be used instead.
      *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
+     *
      * @param item the {@link Item} to get the evolution rate value for
      * @param begin the beginning point in time
      * @param end the end point in time
@@ -2898,6 +3126,10 @@ public class PersistenceExtensions {
     /**
      * Gets the evolution rate of the state of a given {@link Item} between two points in time.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
+     *
+     * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
+     * configured unit.
+     * For temperatures, this will give different results for different configured units.
      *
      * @param item the {@link Item} to get the evolution rate value for
      * @param begin the beginning point in time
@@ -2938,10 +3170,10 @@ public class PersistenceExtensions {
         }
 
         if (begin == null && end != null && end.isAfter(ZonedDateTime.now())) {
-            valueStart = getItemValue(item);
+            valueStart = getItemValue(item, unit);
         }
         if (begin != null && end == null && begin.isBefore(ZonedDateTime.now())) {
-            valueStop = getItemValue(item);
+            valueStop = getItemValue(item, unit);
         }
 
         if (valueStart != null && valueStop != null && !valueStart.equals(DecimalType.ZERO)) {
@@ -3514,16 +3746,12 @@ public class PersistenceExtensions {
         return null;
     }
 
-    private static @Nullable DecimalType getItemValue(Item item) {
-        Item baseItem = item instanceof GroupItem groupItem ? groupItem.getBaseItem() : item;
-        if (baseItem instanceof NumberItem numberItem) {
-            Unit<?> unit = numberItem.getUnit();
-            if (unit != null) {
-                QuantityType<?> qt = item.getStateAs(QuantityType.class);
-                qt = (qt != null) ? qt.toUnit(unit) : qt;
-                if (qt != null) {
-                    return new DecimalType(qt.toBigDecimal());
-                }
+    private static @Nullable DecimalType getItemValue(Item item, @Nullable Unit<?> unit) {
+        if (unit != null) {
+            QuantityType<?> qt = item.getStateAs(QuantityType.class);
+            qt = (qt != null) ? qt.toUnit(unit) : qt;
+            if (qt != null) {
+                return new DecimalType(qt.toBigDecimal());
             }
         }
         return item.getStateAs(DecimalType.class);

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -2075,8 +2075,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2100,8 +2099,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2123,8 +2121,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2148,8 +2145,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2172,8 +2168,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2199,8 +2194,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2224,8 +2218,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2252,8 +2245,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2277,8 +2269,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2305,8 +2296,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s
@@ -2331,8 +2321,7 @@ public class PersistenceExtensions {
      * This can be used as an approximation for integrating the curve represented by discrete values.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s

--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -2053,8 +2053,7 @@ public class PersistenceExtensions {
      * A left approximation type is used for the Riemann sum.
      *
      * <b>Note:</b> The time dimension in the result is in seconds, therefore if you do not use QuantityType results,
-     * you may have to
-     * multiply or divide to get the result in the expected scale.
+     * you may have to multiply or divide to get the result in the expected scale.
      * The default {@link PersistenceService} is used.
      *
      * <b>Note:</b> If the {@link Item} has a dimension, the calculation will be done using the {@link Item}'s

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -45,9 +45,11 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.items.ItemUtil;
 import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.library.dimension.EnergyPrice;
 import org.openhab.core.library.types.ArithmeticGroupFunction;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.library.unit.CurrencyUnits;
 import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.persistence.HistoricItem;
@@ -73,6 +75,7 @@ import org.openhab.core.types.TimeSeries.Policy;
  * @author Mark Herwege - Implement aliases
  * @author Mark Herwege - Add Riemann sum methods
  * @author Mark Herwege - Make tests less impacted by the current time for slow builds, improves test reliability
+ * @author Mark Herwege - use base unit for calculations and results
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -83,8 +86,7 @@ public class PersistenceExtensionsTest {
     public static final String TEST_QUANTITY_NUMBER = "testQuantityNumber";
     public static final String TEST_GROUP_QUANTITY_NUMBER = "testGroupQuantityNumber";
     public static final String TEST_SWITCH = "testSwitch";
-
-    public static final double KELVIN_OFFSET = 273.15;
+    public static final String TEST_ENERGYPRICE_QUANTITY_NUMBER = "testEnergyPriceQuantityItem";
 
     private @Mock @NonNullByDefault({}) PersistenceManager persistenceManagerMock;
     private @Mock @NonNullByDefault({}) ItemRegistry itemRegistryMock;
@@ -93,17 +95,22 @@ public class PersistenceExtensionsTest {
 
     private @Mock @NonNullByDefault({}) PersistenceServiceConfigurationRegistry persistenceServiceConfigurationRegistryMock;
 
-    private @NonNullByDefault({}) GenericItem numberItem, quantityItem, groupQuantityItem, switchItem;
+    private @NonNullByDefault({}) GenericItem numberItem, quantityItem, groupQuantityItem, switchItem,
+            energyPriceQuantityItem;
 
     @BeforeEach
     public void setUp() {
         when(unitProviderMock.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+        when(unitProviderMock.getUnit(EnergyPrice.class)).thenReturn(CurrencyUnits.BASE_ENERGY_PRICE);
 
         CoreItemFactory itemFactory = new CoreItemFactory(unitProviderMock);
         numberItem = itemFactory.createItem(CoreItemFactory.NUMBER, TEST_NUMBER);
         quantityItem = itemFactory.createItem(CoreItemFactory.NUMBER + ItemUtil.EXTENSION_SEPARATOR + "Temperature",
                 TEST_QUANTITY_NUMBER);
         switchItem = itemFactory.createItem(CoreItemFactory.SWITCH, TEST_SWITCH);
+        energyPriceQuantityItem = itemFactory.createItem(
+                CoreItemFactory.NUMBER + ItemUtil.EXTENSION_SEPARATOR + "EnergyPrice",
+                TEST_ENERGYPRICE_QUANTITY_NUMBER);
 
         GenericItem baseItem = itemFactory
                 .createItem(CoreItemFactory.NUMBER + ItemUtil.EXTENSION_SEPARATOR + "Temperature", "testGroupBaseItem");
@@ -115,11 +122,13 @@ public class PersistenceExtensionsTest {
         quantityItem.setState(new QuantityType<Temperature>(STATE, SIUnits.CELSIUS));
         groupQuantityItem.setState(new QuantityType<Temperature>(STATE, SIUnits.CELSIUS));
         switchItem.setState(SWITCH_STATE);
+        energyPriceQuantityItem.setState(new QuantityType<EnergyPrice>(STATE, CurrencyUnits.BASE_ENERGY_PRICE));
 
         when(itemRegistryMock.get(TEST_NUMBER)).thenReturn(numberItem);
         when(itemRegistryMock.get(TEST_QUANTITY_NUMBER)).thenReturn(quantityItem);
         when(itemRegistryMock.get(TEST_SWITCH)).thenReturn(switchItem);
         when(itemRegistryMock.get(TEST_GROUP_QUANTITY_NUMBER)).thenReturn(groupQuantityItem);
+        when(itemRegistryMock.get(TEST_ENERGYPRICE_QUANTITY_NUMBER)).thenReturn(energyPriceQuantityItem);
 
         when(persistenceServiceConfigurationRegistryMock.get(anyString())).thenReturn(null);
         when(timeZoneProviderMock.getTimeZone()).thenReturn(ZoneId.systemDefault());
@@ -343,6 +352,15 @@ public class PersistenceExtensionsTest {
                 SERVICE_ID);
         assertNotNull(historicItem);
         assertEquals(switchValue(SWITCH_ON_INTERMEDIATE_3), historicItem.getState());
+    }
+
+    @Test
+    public void testPersistedStateEnergyPriceQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.persistedState(energyPriceQuantityItem,
+                ZonedDateTime.of(HISTORIC_END, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertEquals(new QuantityType<>(value(HISTORIC_END), CurrencyUnits.BASE_ENERGY_PRICE), historicItem.getState());
     }
 
     @Test
@@ -633,6 +651,17 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testMaximumBetweenEnergyPriceQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.maximumBetween(energyPriceQuantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_2), CurrencyUnits.BASE_ENERGY_PRICE)));
+    }
+
+    @Test
     public void testMinimumSinceDecimalType() {
         HistoricItem historicItem = PersistenceExtensions.minimumSince(numberItem,
                 ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
@@ -894,6 +923,17 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testMinimumBetweenEnergyPriceQuantityType() {
+        HistoricItem historicItem = PersistenceExtensions.minimumBetween(energyPriceQuantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(historicItem);
+        assertThat(historicItem.getState(), is(instanceOf(QuantityType.class)));
+        assertThat(historicItem.getState(),
+                is(new QuantityType<>(value(HISTORIC_INTERMEDIATE_VALUE_1), CurrencyUnits.BASE_ENERGY_PRICE)));
+    }
+
+    @Test
     public void testVarianceSinceDecimalType() {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
@@ -998,7 +1038,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceSince(quantityItem, startStored);
@@ -1021,7 +1061,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceUntil(quantityItem, endStored);
@@ -1043,7 +1083,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1056,7 +1096,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1071,7 +1111,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored);
@@ -1093,7 +1133,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceSince(groupQuantityItem, startStored);
@@ -1116,7 +1156,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceUntil(groupQuantityItem, endStored);
@@ -1138,7 +1178,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1151,7 +1191,7 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1166,11 +1206,32 @@ public class PersistenceExtensionsTest {
         qt = variance.as(QuantityType.class);
         assertNotNull(qt);
         assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-        assertEquals(Units.KELVIN.multiply(Units.KELVIN), qt.getUnit());
+        assertEquals(SIUnits.CELSIUS.multiply(SIUnits.CELSIUS), qt.getUnit());
 
         // default persistence service
         variance = PersistenceExtensions.varianceBetween(groupQuantityItem, startStored, endStored);
         assertNull(variance);
+    }
+
+    @Test
+    public void testVarianceBetweenEnergyPriceQuantityType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+
+        double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
+                / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
+
+        State variance = PersistenceExtensions.varianceBetween(energyPriceQuantityItem, startStored, endStored,
+                SERVICE_ID);
+        assertNotNull(variance);
+        QuantityType<?> qt = variance.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE.multiply(CurrencyUnits.BASE_ENERGY_PRICE), qt.getUnit());
     }
 
     @Test
@@ -1278,7 +1339,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(quantityItem, startStored);
@@ -1301,7 +1362,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationUntil(quantityItem, endStored);
@@ -1323,7 +1384,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1336,7 +1397,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1351,7 +1412,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored);
@@ -1373,7 +1434,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationSince(groupQuantityItem, startStored);
@@ -1396,7 +1457,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationUntil(groupQuantityItem, endStored);
@@ -1418,7 +1479,7 @@ public class PersistenceExtensionsTest {
         QuantityType<?> qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1431,7 +1492,7 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
@@ -1446,11 +1507,31 @@ public class PersistenceExtensionsTest {
         qt = deviation.as(QuantityType.class);
         assertNotNull(qt);
         assertEquals(expected, qt.doubleValue(), 0.01);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(groupQuantityItem, startStored, endStored);
         assertNull(deviation);
+    }
+
+    @Test
+    public void testDeviationBetweenEnergyPriceQuantityType() {
+        ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+
+        double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
+                .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
+                .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
+        State deviation = PersistenceExtensions.deviationBetween(energyPriceQuantityItem, startStored, endStored,
+                SERVICE_ID);
+        assertNotNull(deviation);
+        QuantityType<?> qt = deviation.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(expected, qt.doubleValue(), 0.01);
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE, qt.getUnit());
     }
 
     @Test
@@ -1597,33 +1678,33 @@ public class PersistenceExtensionsTest {
                     ZoneId.systemDefault());
             ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                     ZoneId.systemDefault());
-            double expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+            double expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
             State sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
             QuantityType<?> qt = sum.as(QuantityType.class);
             assertNotNull(qt);
             assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+            assertEquals(SIUnits.CELSIUS.multiply(Units.SECOND), qt.getUnit());
 
             beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-            expected = testRiemannSumCelsius(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
+            expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
             qt = sum.as(QuantityType.class);
             assertNotNull(qt);
             assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+            assertEquals(SIUnits.CELSIUS.multiply(Units.SECOND), qt.getUnit());
 
             beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-            expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
+            expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
             qt = sum.as(QuantityType.class);
             assertNotNull(qt);
             assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
-            assertEquals(Units.KELVIN.multiply(Units.SECOND), qt.getUnit());
+            assertEquals(SIUnits.CELSIUS.multiply(Units.SECOND), qt.getUnit());
 
             // default persistence service
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type);
@@ -1720,6 +1801,25 @@ public class PersistenceExtensionsTest {
         DecimalType dt = sum.as(DecimalType.class);
         assertNotNull(dt);
         assertThat(dt.doubleValue(), is(closeTo(0, 0.01)));
+    }
+
+    @Test
+    public void testRiemannSumBetweenEnergyPriceQuantityType() {
+        for (RiemannType type : RiemannType.values()) {
+            ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                    ZoneId.systemDefault());
+            ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                    ZoneId.systemDefault());
+            double expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
+            State sum = PersistenceExtensions.riemannSumBetween(energyPriceQuantityItem, beginStored, endStored, type,
+                    SERVICE_ID);
+
+            assertNotNull(sum);
+            QuantityType<?> qt = sum.as(QuantityType.class);
+            assertNotNull(qt);
+            assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+            assertEquals(CurrencyUnits.BASE_ENERGY_PRICE.multiply(Units.SECOND), qt.getUnit());
+        }
     }
 
     @Test
@@ -2091,6 +2191,23 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testAverageBetweenEnergyPriceQuantityType() {
+        ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        State average = PersistenceExtensions.averageBetween(energyPriceQuantityItem, beginStored, endStored,
+                SERVICE_ID);
+
+        assertNotNull(average);
+        QuantityType<?> qt = average.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE, qt.getUnit());
+    }
+
+    @Test
     public void testMedianSinceDecimalType() {
         ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expected = testMedian(BEFORE_START, null);
@@ -2336,6 +2453,22 @@ public class PersistenceExtensionsTest {
     }
 
     @Test
+    public void testMedianBetweenEnergyPriceQuantityType() {
+        ZonedDateTime beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
+                ZoneId.systemDefault());
+        double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
+        State median = PersistenceExtensions.medianBetween(energyPriceQuantityItem, beginStored, endStored, SERVICE_ID);
+
+        assertNotNull(median);
+        QuantityType<?> qt = median.as(QuantityType.class);
+        assertNotNull(qt);
+        assertThat(qt.doubleValue(), is(closeTo(expected, 0.01)));
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE, qt.getUnit());
+    }
+
+    @Test
     public void testSumSinceDecimalType() {
         State sum = PersistenceExtensions.sumSince(numberItem,
                 ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
@@ -2417,18 +2550,16 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum()
-                + (HISTORIC_END - HISTORIC_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         sum = PersistenceExtensions.sumSince(quantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum()
-                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(quantityItem,
@@ -2443,9 +2574,8 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum()
-                + (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(quantityItem,
@@ -2455,45 +2585,38 @@ public class PersistenceExtensionsTest {
 
     @Test
     public void testSumBetweenQuantityType() {
-        State sum = PersistenceExtensions.sumBetween(groupQuantityItem,
+        State sum = PersistenceExtensions.sumBetween(quantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum()
-                        + (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET,
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
                 qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
-        sum = PersistenceExtensions.sumBetween(groupQuantityItem,
+        sum = PersistenceExtensions.sumBetween(quantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum()
-                        + (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1) * KELVIN_OFFSET,
+        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
                 qt.doubleValue(), 0.001);
 
-        sum = PersistenceExtensions.sumBetween(groupQuantityItem,
+        sum = PersistenceExtensions.sumBetween(quantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream
-                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
-                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
-                .sum()
-                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 2)
-                        * KELVIN_OFFSET,
+        assertEquals(
+                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
                 qt.doubleValue(), 0.001);
 
         // default persistence service
-        sum = PersistenceExtensions.sumBetween(groupQuantityItem,
+        sum = PersistenceExtensions.sumBetween(quantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
 
@@ -2507,18 +2630,16 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum()
-                + (HISTORIC_END - HISTORIC_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_START, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum()
-                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
@@ -2533,9 +2654,8 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum()
-                + (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1) * KELVIN_OFFSET, qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3).sum(), qt.doubleValue(), 0.001);
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         // default persistence service
         sum = PersistenceExtensions.sumSince(groupQuantityItem,
@@ -2551,11 +2671,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         QuantityType<?> qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum()
-                        + (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1) * KELVIN_OFFSET,
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
                 qt.doubleValue(), 0.001);
-        assertEquals(Units.KELVIN, qt.getUnit());
+        assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
@@ -2563,9 +2681,7 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(
-                IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum()
-                        + (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1) * KELVIN_OFFSET,
+        assertEquals(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4).sum(),
                 qt.doubleValue(), 0.001);
 
         sum = PersistenceExtensions.sumBetween(groupQuantityItem,
@@ -2574,12 +2690,9 @@ public class PersistenceExtensionsTest {
         assertNotNull(sum);
         qt = sum.as(QuantityType.class);
         assertNotNull(qt);
-        assertEquals(IntStream
-                .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
-                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
-                .sum()
-                + (HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 2)
-                        * KELVIN_OFFSET,
+        assertEquals(
+                IntStream.concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
+                        IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)).sum(),
                 qt.doubleValue(), 0.001);
 
         // default persistence service
@@ -2588,6 +2701,19 @@ public class PersistenceExtensionsTest {
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()));
 
         assertNull(sum);
+    }
+
+    @Test
+    public void testSumBetweenEnergyPriceQuantityType() {
+        State sum = PersistenceExtensions.sumBetween(energyPriceQuantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(sum);
+        QuantityType<?> qt = sum.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2).sum(),
+                qt.doubleValue(), 0.001);
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE, qt.getUnit());
     }
 
     @Test
@@ -2756,6 +2882,15 @@ public class PersistenceExtensionsTest {
         assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1, qt.doubleValue(), 0.001);
         assertEquals(SIUnits.CELSIUS, qt.getUnit());
 
+        delta = PersistenceExtensions.deltaBetween(energyPriceQuantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(delta);
+        qt = delta.as(QuantityType.class);
+        assertNotNull(qt);
+        assertEquals(HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1, qt.doubleValue(), 0.001);
+        assertEquals(CurrencyUnits.BASE_ENERGY_PRICE, qt.getUnit());
+
         delta = PersistenceExtensions.deltaBetween(numberItem,
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
@@ -2879,6 +3014,15 @@ public class PersistenceExtensionsTest {
                 0.001)));
 
         rate = PersistenceExtensions.evolutionRateBetween(quantityItem,
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
+                ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
+        assertNotNull(rate);
+        // ((now - then) / then) * 100
+        assertThat(rate.doubleValue(), is(closeTo(
+                100.0 * (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1) / HISTORIC_INTERMEDIATE_VALUE_1,
+                0.001)));
+
+        rate = PersistenceExtensions.evolutionRateBetween(energyPriceQuantityItem,
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                 ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()), SERVICE_ID);
         assertNotNull(rate);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -49,6 +49,7 @@ import org.openhab.core.types.State;
  * @author Kai Kreuzer - Initial contribution
  * @author Mark Herwege - Allow future values
  * @author Mark Herwege - Adapt test expected value logic for Riemann sums
+ * @author Mark Herwege - use base unit for calculations and results
  */
 @NonNullByDefault
 public class TestPersistenceService implements QueryablePersistenceService {
@@ -87,8 +88,6 @@ public class TestPersistenceService implements QueryablePersistenceService {
     static final int FUTURE_END = BASE_VALUE + 75; // 2100
     static final int AFTER_END = BASE_VALUE + 85; // 2110
     static final DecimalType STATE = new DecimalType(HISTORIC_END);
-
-    static final double KELVIN_OFFSET = 273.15;
 
     private final ItemRegistry itemRegistry;
 
@@ -234,33 +233,20 @@ public class TestPersistenceService implements QueryablePersistenceService {
     }
 
     static DecimalType value(long year) {
-        return value(year, false);
-    }
-
-    private static DecimalType value(long year, boolean kelvinOffset) {
         if (year < HISTORIC_START) {
             return DecimalType.ZERO;
         } else if (year <= HISTORIC_END) {
-            return new DecimalType(year + (kelvinOffset ? KELVIN_OFFSET : 0));
+            return new DecimalType(year);
         } else if (year < FUTURE_START) {
-            return new DecimalType(HISTORIC_END + (kelvinOffset ? KELVIN_OFFSET : 0));
+            return new DecimalType(HISTORIC_END);
         } else if (year <= FUTURE_END) {
-            return new DecimalType(year + (kelvinOffset ? KELVIN_OFFSET : 0));
+            return new DecimalType(year);
         } else {
-            return new DecimalType(FUTURE_END + (kelvinOffset ? KELVIN_OFFSET : 0));
+            return new DecimalType(FUTURE_END);
         }
     }
 
     static double testRiemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
-        return testRiemannSum(beginYear, endYear, type, false);
-    }
-
-    static double testRiemannSumCelsius(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type) {
-        return testRiemannSum(beginYear, endYear, type, true);
-    }
-
-    private static double testRiemannSum(@Nullable Integer beginYear, @Nullable Integer endYear, RiemannType type,
-            boolean kelvinOffset) {
         ZonedDateTime now = ZonedDateTime.now();
         int begin = beginYear != null ? (beginYear < HISTORIC_START ? HISTORIC_START : beginYear) : now.getYear() + 1;
         int end = endYear != null ? endYear : now.getYear();
@@ -277,7 +263,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 }
                 while (index < end) {
                     int bucketStart = index;
-                    double value = value(index, kelvinOffset).doubleValue();
+                    double value = value(index).doubleValue();
                     while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
                         index++;
                     }
@@ -307,7 +293,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                         index++;
                     }
                     index++;
-                    double value = value(index, kelvinOffset).doubleValue();
+                    double value = value(index).doubleValue();
                     duration += Duration
                             .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                                     ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
@@ -329,12 +315,12 @@ public class TestPersistenceService implements QueryablePersistenceService {
                 }
                 while (index < end) {
                     int bucketStart = index;
-                    double value = value(index, kelvinOffset).doubleValue();
+                    double value = value(index).doubleValue();
                     while ((index < end - 1) && (value(index).longValue() == value(index + 1).longValue())) {
                         index++;
                     }
                     index++;
-                    value = (value + value(index, kelvinOffset).doubleValue()) / 2.0;
+                    value = (value + value(index).doubleValue()) / 2.0;
                     duration += Duration
                             .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                                     ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
@@ -351,7 +337,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
             case MIDPOINT:
                 int nextIndex = begin;
                 boolean startBucket = true;
-                double startValue = value(begin, kelvinOffset).doubleValue();
+                double startValue = value(begin).doubleValue();
                 if (beginYear == null) {
                     duration = Duration.between(now, ZonedDateTime.of(begin, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
                             .toSeconds();
@@ -362,7 +348,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                         index++;
                     }
                     index++;
-                    double value = value(index, kelvinOffset).doubleValue();
+                    double value = value(index).doubleValue();
                     duration += Duration
                             .between(ZonedDateTime.of(bucketStart, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()),
                                     ZonedDateTime.of(index, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault()))
@@ -390,7 +376,7 @@ public class TestPersistenceService implements QueryablePersistenceService {
                     sum += value * (duration + nextDuration) / 2.0;
                     duration = 0;
                 }
-                double endValue = value(end, kelvinOffset).doubleValue();
+                double endValue = value(end).doubleValue();
                 long endDuration = nextDuration;
                 sum += endValue * endDuration / 2.0;
                 break;


### PR DESCRIPTION
See discussion: https://community.openhab.org/t/javascript-persistance-totals-off/165099

Many of the persistence extensions are internally converting to the system unit to make them indepent of unit offsets. The Quantity results returned where in this system unit, and not in the item unit. Typically, persisted values are stored in the item unit.

This PR tries to return the item unit (or a unit derived from it) as much as possible.

- `sumSince`, `sumUntil` and `sumBetween` will now always return the result in the item unit.
- `riemannSumSince`, `riemannSumUntil` `riemannSumBetween` will return the result in item unit * `s`.
- `varianceSince`, `varianceUntil` and `varianceBetween` return the result in item unit ^2.
- `deviationSince`, `deviationUntil` and `deviationBetween` return the result in item unit.

Depending on the item unit, the resulting unit may get simplified automatically. This does not happen for pre-defined composed units (such as `kWh/s` will not automatically eliminate the time dimension, but `kW * h / s` will).

The changes in this PR are changing the results of the `riemannSum`, `variance`, and `deviation` extensions for Temperatures as they will now be calculated using the item unit, and not the system unit for temperatures (K). I thought long about this, but I believe most people will expect these calculations not to be done in `K`. Note that `evolutionRate` was already doing the calculation in the item unit, making the persistence extension inconsistent.