### PR TITLE
[rules actions] Add new HTTP actions for images

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/actions/HTTP.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Jan N. Klug - add timeout methods
+ * @author Dan Cunningham - add image download methods
  */
 public class HTTP {
 


### PR DESCRIPTION
 This adds new functions for downloading images to image Items. This is useful for exposing images to push notifications, updating album art, showing camera snapshots in the Main UI, etc...

I went back and forth if this was a new "Image" action space, or part of the HTTP actions, in the end i think it belongs as additional HTTP actions (since it also mostly wraps HTTPUtils.java)