### PR TITLE
Use felix.http.servlet-api 1.2.0

### DIFF
--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -326,7 +326,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.http.servlet-api</artifactId>
-      <version>1.1.2</version>
+      <version>1.2.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bom/compile/pom.xml
+++ b/bom/compile/pom.xml
@@ -328,6 +328,12 @@
       <artifactId>org.apache.felix.http.servlet-api</artifactId>
       <version>1.2.0</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-servlet-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.aries.spec</groupId>


### PR DESCRIPTION
We had different versions in compile bom and runtime.
Sync to 1.2.0.

Refs https://github.com/openhab/openhab-core/issues/4949