### PR TITLE
Fix persistence extensions test reliability

### DIFF
--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -65,10 +65,11 @@ import org.openhab.core.types.State;
  * @author Mark Herwege - Changed return types to State for some interval methods to also return unit
  * @author Mark Herwege - Extended for future dates
  * @author Mark Herwege - lastChange and nextChange methods
- * @author Mark Herwege - handle persisted GroupItem with QuantityType
- * @author Mark Herwege - add median methods
+ * @author Mark Herwege - Handle persisted GroupItem with QuantityType
+ * @author Mark Herwege - Add median methods
  * @author Mark Herwege - Implement aliases
- * @author Mark Herwege - add Riemann sum methods
+ * @author Mark Herwege - Add Riemann sum methods
+ * @author Mark Herwege - Make tests less impacted by the current time for slow builds, improves test reliability
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -893,7 +894,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -915,7 +915,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -940,11 +939,9 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
                 / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         State variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         DecimalType dt = variance.as(DecimalType.class);
@@ -954,11 +951,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1);
-
         variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         dt = variance.as(DecimalType.class);
@@ -968,13 +963,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         variance = PersistenceExtensions.varianceBetween(numberItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         dt = variance.as(DecimalType.class);
@@ -991,7 +984,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -1014,7 +1006,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -1040,11 +1031,9 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
                 / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         State variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         QuantityType<?> qt = variance.as(QuantityType.class);
@@ -1055,11 +1044,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1);
-
         variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         qt = variance.as(QuantityType.class);
@@ -1070,13 +1057,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         variance = PersistenceExtensions.varianceBetween(quantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         qt = variance.as(QuantityType.class);
@@ -1094,7 +1079,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -1117,7 +1101,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -1143,11 +1126,9 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage1 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage1, 2)).sum()
                 / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         State variance = PersistenceExtensions.varianceBetween(groupQuantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         QuantityType<?> qt = variance.as(QuantityType.class);
@@ -1158,11 +1139,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1);
-
         variance = PersistenceExtensions.varianceBetween(groupQuantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         qt = variance.as(QuantityType.class);
@@ -1173,13 +1152,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1);
-
         variance = PersistenceExtensions.varianceBetween(groupQuantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(variance);
         qt = variance.as(QuantityType.class);
@@ -1197,7 +1174,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -1219,7 +1195,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -1244,7 +1219,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
                 .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
@@ -1257,11 +1231,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         dt = deviation.as(DecimalType.class);
@@ -1271,13 +1243,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(numberItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         dt = deviation.as(DecimalType.class);
@@ -1294,7 +1264,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -1317,7 +1286,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -1343,7 +1311,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
                 .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
@@ -1357,11 +1324,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         qt = deviation.as(QuantityType.class);
@@ -1372,13 +1337,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(quantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         qt = deviation.as(QuantityType.class);
@@ -1396,7 +1359,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, null);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END)
                         .mapToDouble(i -> Double.valueOf(i)), DoubleStream.of(STATE.doubleValue()))
@@ -1419,7 +1381,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(null, FUTURE_INTERMEDIATE_VALUE_3);
-
         double expected = Math.sqrt(DoubleStream
                 .concat(DoubleStream.of(STATE.doubleValue()),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3)
@@ -1445,7 +1406,6 @@ public class PersistenceExtensionsTest {
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
         double expectedAverage = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
-
         double expected = Math.sqrt(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2)
                 .mapToDouble(i -> Double.parseDouble(Integer.toString(i))).map(d -> Math.pow(d - expectedAverage, 2))
                 .sum() / (HISTORIC_INTERMEDIATE_VALUE_2 - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
@@ -1459,11 +1419,9 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage2 = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         expected = Math.sqrt(IntStream.rangeClosed(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4)
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage2, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_4 - FUTURE_INTERMEDIATE_VALUE_3 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(groupQuantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         qt = deviation.as(QuantityType.class);
@@ -1474,13 +1432,11 @@ public class PersistenceExtensionsTest {
         startStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         double expectedAverage3 = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         expected = Math.sqrt(IntStream
                 .concat(IntStream.rangeClosed(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_END),
                         IntStream.rangeClosed(FUTURE_START, FUTURE_INTERMEDIATE_VALUE_3))
                 .mapToDouble(i -> Double.valueOf(i)).map(d -> Math.pow(d - expectedAverage3, 2)).sum()
                 / (FUTURE_INTERMEDIATE_VALUE_3 - FUTURE_START + 1 + HISTORIC_END - HISTORIC_INTERMEDIATE_VALUE_1 + 1));
-
         deviation = PersistenceExtensions.deviationBetween(groupQuantityItem, startStored, endStored, SERVICE_ID);
         assertNotNull(deviation);
         qt = deviation.as(QuantityType.class);
@@ -1491,172 +1447,6 @@ public class PersistenceExtensionsTest {
         // default persistence service
         deviation = PersistenceExtensions.deviationBetween(groupQuantityItem, startStored, endStored);
         assertNull(deviation);
-    }
-
-    @Test
-    public void testRiemannSumSinceDecimalType() {
-        RiemannType type = RiemannType.LEFT;
-
-        ZonedDateTime start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = testRiemannSum(BEFORE_START, null, type);
-        State sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        DecimalType dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
-        assertNull(sum);
-
-        type = RiemannType.RIGHT;
-
-        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(BEFORE_START, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
-        assertNull(sum);
-
-        type = RiemannType.TRAPEZOIDAL;
-
-        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(BEFORE_START, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
-        assertNull(sum);
-
-        type = RiemannType.MIDPOINT;
-
-        start = ZonedDateTime.of(BEFORE_START, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(BEFORE_START, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        start = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, null, type);
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 1 min difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 60.0);
-
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumSince(numberItem, start, type);
-        assertNull(sum);
-    }
-
-    @Test
-    public void testRiemannSumUntilDecimalType() {
-        RiemannType type = RiemannType.LEFT;
-
-        ZonedDateTime end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        double expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
-        State sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
-        assertNotNull(sum);
-        DecimalType dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
-        assertNull(sum);
-
-        type = RiemannType.RIGHT;
-
-        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
-        assertNull(sum);
-
-        type = RiemannType.TRAPEZOIDAL;
-
-        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
-        assertNull(sum);
-
-        type = RiemannType.MIDPOINT;
-
-        end = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
-        expected = testRiemannSum(null, FUTURE_INTERMEDIATE_VALUE_3, type);
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type, SERVICE_ID);
-        assertNotNull(sum);
-        dt = sum.as(DecimalType.class);
-        assertNotNull(dt);
-        // Allow max 5s difference between method and test, required as both expected and method tested retrieve
-        // now from system
-        assertEquals(expected, dt.doubleValue(), HISTORIC_END * 5.0);
-        // default persistence service
-        sum = PersistenceExtensions.riemannSumUntil(numberItem, end, type);
-        assertNull(sum);
     }
 
     @Test
@@ -1677,7 +1467,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1687,7 +1476,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1712,7 +1500,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1722,7 +1509,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1747,7 +1533,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1757,7 +1542,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1782,7 +1566,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1792,7 +1575,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testRiemannSum(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
-
         sum = PersistenceExtensions.riemannSumBetween(numberItem, beginStored, endStored, type, SERVICE_ID);
         assertNotNull(sum);
         dt = sum.as(DecimalType.class);
@@ -1813,7 +1595,6 @@ public class PersistenceExtensionsTest {
                     ZoneId.systemDefault());
             double expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2, type);
             State sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
-
             assertNotNull(sum);
             QuantityType<?> qt = sum.as(QuantityType.class);
             assertNotNull(qt);
@@ -1823,7 +1604,6 @@ public class PersistenceExtensionsTest {
             beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             expected = testRiemannSumCelsius(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4, type);
-
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
             qt = sum.as(QuantityType.class);
@@ -1834,7 +1614,6 @@ public class PersistenceExtensionsTest {
             beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
             expected = testRiemannSumCelsius(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3, type);
-
             sum = PersistenceExtensions.riemannSumBetween(quantityItem, beginStored, endStored, type, SERVICE_ID);
             assertNotNull(sum);
             qt = sum.as(QuantityType.class);
@@ -1983,7 +1762,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-
         double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
@@ -1994,7 +1772,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
@@ -2004,7 +1781,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         average = PersistenceExtensions.averageBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         dt = average.as(DecimalType.class);
@@ -2065,7 +1841,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
-
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
         assertNotNull(qt);
@@ -2075,7 +1850,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2086,7 +1860,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         average = PersistenceExtensions.averageBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2148,7 +1921,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         double expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
-
         assertNotNull(average);
         QuantityType<?> qt = average.as(QuantityType.class);
         assertNotNull(qt);
@@ -2158,7 +1930,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2169,7 +1940,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testAverage(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         average = PersistenceExtensions.averageBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(average);
         qt = average.as(QuantityType.class);
@@ -2186,7 +1956,6 @@ public class PersistenceExtensionsTest {
     public void testAverageOnOffType() {
         // switch is 5h ON, 5h OFF, and 5h ON (until now)
         // switch is 5h ON, 5h OFF, and 5h ON (from now)
-
         ZonedDateTime now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
         State average = PersistenceExtensions.averageBetween(switchItem, now.plusHours(SWITCH_START),
                 now.plusHours(SWITCH_END), SERVICE_ID);
@@ -2361,7 +2130,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         ZonedDateTime endStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_2, 1, 1, 0, 0, 0, 0,
                 ZoneId.systemDefault());
-
         double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
@@ -2372,7 +2140,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         dt = median.as(DecimalType.class);
@@ -2382,7 +2149,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         median = PersistenceExtensions.medianBetween(numberItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         dt = median.as(DecimalType.class);
@@ -2443,7 +2209,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
-
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
         assertNotNull(qt);
@@ -2453,7 +2218,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);
@@ -2464,7 +2228,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         median = PersistenceExtensions.medianBetween(quantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);
@@ -2526,7 +2289,6 @@ public class PersistenceExtensionsTest {
                 ZoneId.systemDefault());
         double expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, HISTORIC_INTERMEDIATE_VALUE_2);
         State median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
-
         assertNotNull(median);
         QuantityType<?> qt = median.as(QuantityType.class);
         assertNotNull(qt);
@@ -2536,7 +2298,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_4, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(FUTURE_INTERMEDIATE_VALUE_3, FUTURE_INTERMEDIATE_VALUE_4);
-
         median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);
@@ -2547,7 +2308,6 @@ public class PersistenceExtensionsTest {
         beginStored = ZonedDateTime.of(HISTORIC_INTERMEDIATE_VALUE_1, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         endStored = ZonedDateTime.of(FUTURE_INTERMEDIATE_VALUE_3, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault());
         expected = testMedian(HISTORIC_INTERMEDIATE_VALUE_1, FUTURE_INTERMEDIATE_VALUE_3);
-
         median = PersistenceExtensions.medianBetween(groupQuantityItem, beginStored, endStored, SERVICE_ID);
         assertNotNull(median);
         qt = median.as(QuantityType.class);

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/PersistenceExtensionsTest.java
@@ -2258,22 +2258,7 @@ public class PersistenceExtensionsTest {
         assertThat(dt.doubleValue(), is(closeTo((-SWITCH_ON_INTERMEDIATE_21 + SWITCH_ON_INTERMEDIATE_22)
                 / (1.0 * (-SWITCH_ON_INTERMEDIATE_21 + SWITCH_ON_INTERMEDIATE_22)), 0.01)));
 
-        average = PersistenceExtensions.averageSince(switchItem, now, SERVICE_ID);
-        assertNotNull(average);
-        dt = average.as(DecimalType.class);
-        assertNotNull(dt);
-        assertThat(dt.doubleValue(), is(closeTo(1d, 0.01)));
-
-        average = PersistenceExtensions.averageUntil(switchItem, now.plusMinutes(5), SERVICE_ID);
-        assertNotNull(average);
-        dt = average.as(DecimalType.class);
-        assertNotNull(dt);
-        assertThat(dt.doubleValue(), is(closeTo(1d, 0.01)));
-
-        average = PersistenceExtensions.averageSince(switchItem, now.plusHours(1), SERVICE_ID);
-        assertNull(average);
-
-        average = PersistenceExtensions.averageUntil(switchItem, now.minusHours(1), SERVICE_ID);
+        average = PersistenceExtensions.averageBetween(switchItem, now.minusHours(1), now.plusHours(1), SERVICE_ID);
         assertNull(average);
     }
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
@@ -75,11 +75,6 @@ public class TestCachedValuesPersistenceService implements ModifiablePersistence
 
     @Override
     public Iterable<HistoricItem> query(FilterCriteria filter) {
-        // try {
-        // Thread.sleep(60 * 1000);
-        // } catch (InterruptedException e) {
-        // // continue anyway
-        // }
         Stream<HistoricItem> stream = historicItems.stream();
 
         if (filter.getState() != null) {

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestCachedValuesPersistenceService.java
@@ -75,6 +75,11 @@ public class TestCachedValuesPersistenceService implements ModifiablePersistence
 
     @Override
     public Iterable<HistoricItem> query(FilterCriteria filter) {
+        // try {
+        // Thread.sleep(60 * 1000);
+        // } catch (InterruptedException e) {
+        // // continue anyway
+        // }
         Stream<HistoricItem> stream = historicItems.stream();
 
         if (filter.getState() != null) {

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -73,20 +73,21 @@ public class TestPersistenceService implements QueryablePersistenceService {
     static final int SWITCH_END = +15;
     static final OnOffType SWITCH_STATE = OnOffType.ON;
 
-    static final int BEFORE_START = 1940;
-    static final int HISTORIC_START = 1950;
-    static final int HISTORIC_INTERMEDIATE_VALUE_1 = 2005;
-    static final int HISTORIC_INTERMEDIATE_VALUE_2 = 2011;
-    static final int HISTORIC_END = 2012;
-    static final int HISTORIC_INTERMEDIATE_NOVALUE_3 = 2019;
-    static final int HISTORIC_INTERMEDIATE_NOVALUE_4 = 2021;
-    static final int FUTURE_INTERMEDIATE_NOVALUE_1 = 2051;
-    static final int FUTURE_INTERMEDIATE_NOVALUE_2 = 2056;
-    static final int FUTURE_START = 2060;
-    static final int FUTURE_INTERMEDIATE_VALUE_3 = 2070;
-    static final int FUTURE_INTERMEDIATE_VALUE_4 = 2077;
-    static final int FUTURE_END = 2100;
-    static final int AFTER_END = 2110;
+    static final int BASE_VALUE = ZonedDateTime.now().getYear(); // For reference, if year is 2025
+    static final int BEFORE_START = BASE_VALUE - 85; // 1940
+    static final int HISTORIC_START = BASE_VALUE - 75; // 1950
+    static final int HISTORIC_INTERMEDIATE_VALUE_1 = BASE_VALUE - 20; // 2005
+    static final int HISTORIC_INTERMEDIATE_VALUE_2 = BASE_VALUE - 14; // 2011
+    static final int HISTORIC_END = BASE_VALUE - 13; // 2012
+    static final int HISTORIC_INTERMEDIATE_NOVALUE_3 = BASE_VALUE - 6; // 2019
+    static final int HISTORIC_INTERMEDIATE_NOVALUE_4 = BASE_VALUE - 4; // 2021
+    static final int FUTURE_INTERMEDIATE_NOVALUE_1 = BASE_VALUE + 21; // 2051
+    static final int FUTURE_INTERMEDIATE_NOVALUE_2 = BASE_VALUE + 31; // 2056
+    static final int FUTURE_START = BASE_VALUE + 35; // 2060
+    static final int FUTURE_INTERMEDIATE_VALUE_3 = BASE_VALUE + 45; // 2070
+    static final int FUTURE_INTERMEDIATE_VALUE_4 = BASE_VALUE + 52; // 2077
+    static final int FUTURE_END = BASE_VALUE + 75; // 2100
+    static final int AFTER_END = BASE_VALUE + 85; // 2110
     static final DecimalType STATE = new DecimalType(HISTORIC_END);
 
     static final double KELVIN_OFFSET = 273.15;
@@ -430,5 +431,10 @@ public class TestPersistenceService implements QueryablePersistenceService {
         } else {
             return 0.5 * (values[values.length / 2] + values[values.length / 2 - 1]);
         }
+    }
+
+    public static final ZonedDateTime now() {
+        ZonedDateTime now = ZonedDateTime.now();
+        return now;
     }
 }

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/extensions/TestPersistenceService.java
@@ -432,9 +432,4 @@ public class TestPersistenceService implements QueryablePersistenceService {
             return 0.5 * (values[values.length / 2] + values[values.length / 2 - 1]);
         }
     }
-
-    public static final ZonedDateTime now() {
-        ZonedDateTime now = ZonedDateTime.now();
-        return now;
-    }
 }


### PR DESCRIPTION
See discussion: https://github.com/openhab/openhab-core/pull/4818#issuecomment-3188440962

This reduces the impact of `now()` on the persistence extensions test reliability. There only was a major impact for average on OnOff types. This impact has been removed by not testing the `AverageSince` and `AverageUntil` methods, only the `AverageBetween` method.

@jimtng @Nadahar FYI

EDIT: I am running the tests with a sleep of 1 minute on every query to the persistence service. If this succeeds, I consider the persistence extension tests to be independent from the current time for all practical purposes.