### PR TITLE
Revert "Add ItemChannelLinkRegistry to DefaultScriptScopeProvider"

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/defaultscope/DefaultScriptScopeProvider.java
@@ -59,7 +59,6 @@ import org.openhab.core.library.unit.SIUnits;
 import org.openhab.core.library.unit.Units;
 import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.thing.binding.ThingActions;
-import org.openhab.core.thing.link.ItemChannelLinkRegistry;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
@@ -92,8 +91,7 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
     @Activate
     public DefaultScriptScopeProvider(final @Reference ItemRegistry itemRegistry,
             final @Reference ThingRegistry thingRegistry, final @Reference RuleRegistry ruleRegistry,
-            final @Reference EventPublisher eventPublisher,
-            final @Reference ItemChannelLinkRegistry itemChannelLinkRegistry) {
+            final @Reference EventPublisher eventPublisher) {
         this.busEvent = new ScriptBusEventImpl(itemRegistry, eventPublisher);
         this.thingActions = new ScriptThingActionsImpl(thingRegistry);
 
@@ -173,7 +171,6 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements.put("items", new ItemRegistryDelegate(itemRegistry));
         elements.put("ir", itemRegistry);
         elements.put("itemRegistry", itemRegistry);
-        elements.put("itemChannelLinkRegistry", itemChannelLinkRegistry);
         elements.put("things", thingRegistry);
         elements.put("rules", ruleRegistry);
         elements.put("events", busEvent);


### PR DESCRIPTION
Reverts openhab/openhab-core#4937

See https://github.com/openhab/openhab-addons/issues/19197