### PR TITLE
Persistence extensions query optimization

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/extensions/PersistenceExtensions.java
@@ -1932,7 +1932,6 @@ public class PersistenceExtensions {
             return null;
         }
         return sum.divide(totalDuration, MathContext.DECIMAL64);
-
     }
 
     /**


### PR DESCRIPTION
When working on https://github.com/openhab/openhab-core/pull/4964, running Persistence Extension tests with a very long sleep, I noticed some of the extensions where doing queries for the same data twice. This was because these did calculations on results of multiple base calculations and each of them was executed separately and then combined.

This PR optimizes this and does the query only once.