### PR TITLE
Apply blocked task logging to scheduled executor service

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
@@ -48,7 +48,7 @@ public class WrappedScheduledExecutorService extends ScheduledThreadPoolExecutor
 
     private static final Duration DEFAULT_TIMEOUT = Duration.ofMillis(5000);
 
-    private final Set<TimedAbstractTask> runningTasks;;
+    private final Set<TimedAbstractTask> runningTasks;
 
     public WrappedScheduledExecutorService(int corePoolSize, ThreadFactory threadFactory) {
         super(corePoolSize, threadFactory);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/common/WrappedScheduledExecutorService.java
@@ -71,6 +71,7 @@ public class WrappedScheduledExecutorService extends ScheduledThreadPoolExecutor
 
         protected void clockStart() {
             extendTimeout();
+            logLongRunningTasks();
             runningTasks.add(this);
         }
 
@@ -193,7 +194,7 @@ public class WrappedScheduledExecutorService extends ScheduledThreadPoolExecutor
         super.close();
     }
 
-    private void logLongRunningTasks() {
+    private synchronized void logLongRunningTasks() {
         runningTasks.stream().filter(t -> Instant.now().isAfter(t.timeout)).forEach(t -> {
             logger.debug("Scheduled task is taking more than {}; it was created here: ", DEFAULT_TIMEOUT,
                     t.stackTraceHolder);


### PR DESCRIPTION
In #4948 we added logging to the scheduler to identify tasks that take too long. The existing code uses a `try .. finally` structure so if a task is fully blocked the `finally` never gets called and nothing gets logged. This PR extends the functionality to also log fully blocked tasks.

Note to reviewer: A possible solution could be to employ an independent monitor thread to check the state of the tasks. But that would impose some overhead. So instead we check the state of the tasks whenever a) a new task is scheduled, and b) when such a task is run (or called). Reason for using a) and b) is that some tasks may be created via (say) `scheduleWithFixedDelay()` so a) is done once, and b) is done repeatedly thereafter, thus giving more opportunities to log blocked tasks.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
