### PR TITLE
Fix ActionHandler nullness annotation

### DIFF
--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/PlayActionHandler.java
@@ -61,7 +61,7 @@ public class PlayActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
         try {
             audioManager.playFile(sound, sink, volume);
         } catch (AudioException e) {

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SayActionHandler.java
@@ -56,7 +56,7 @@ public class SayActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
         voiceManager.say(text, null, sink, volume);
         return null;
     }

--- a/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SynthesizeActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.media/src/main/java/org/openhab/core/automation/module/media/internal/SynthesizeActionHandler.java
@@ -54,7 +54,7 @@ public class SynthesizeActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
         audioManager.playMelody(melody, sink, volume);
         return null;
     }

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/delegates/SimpleActionHandlerDelegate.java
@@ -44,7 +44,7 @@ public class SimpleActionHandlerDelegate extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, @Nullable Object> inputs) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, @Nullable Object> inputs) {
         Set<String> keys = new HashSet<>(inputs.keySet());
 
         Map<String, @Nullable Object> extendedInputs = new HashMap<>(inputs);
@@ -60,7 +60,7 @@ public class SimpleActionHandlerDelegate extends BaseActionModuleHandler {
         }
 
         Object result = actionHandler.execute(module, extendedInputs);
-        Map<String, Object> resultMap = new HashMap<>();
+        Map<String, @Nullable Object> resultMap = new HashMap<>();
         resultMap.put("result", result);
         return resultMap;
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -71,8 +71,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(final Map<String, Object> context) {
-        Map<String, Object> resultMap = new HashMap<>();
+    public @Nullable Map<String, @Nullable Object> execute(final Map<String, Object> context) {
+        Map<String, @Nullable Object> resultMap = new HashMap<>();
 
         if (script.isEmpty()) {
             return resultMap;

--- a/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
+++ b/bundles/org.openhab.core.automation.rest/src/main/java/org/openhab/core/automation/rest/internal/ThingActionsResource.java
@@ -254,7 +254,7 @@ public class ThingActionsResource implements RESTResource {
         }
 
         try {
-            Map<String, Object> returnValue = Objects.requireNonNullElse(
+            Map<String, @Nullable Object> returnValue = Objects.requireNonNullElse(
                     handler.execute(actionInputsHelper.mapSerializedInputsToActionInputs(actionType, actionInputs)),
                     Map.of());
             moduleHandlerFactory.ungetHandler(action, ruleUID, handler);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/handler/ActionHandler.java
@@ -48,5 +48,5 @@ public interface ActionHandler extends ModuleHandler {
      * @return a map with the {@code outputs} which are the result of the {@link Action}'s execution (may be null).
      */
     @Nullable
-    Map<String, Object> execute(Map<String, Object> context);
+    Map<String, @Nullable Object> execute(Map<String, Object> context);
 }

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/RuleEngineImpl.java
@@ -181,7 +181,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * The context map of a {@link Rule} is cleaned when the execution is completed. The relation is
      * {@link Rule}'s UID to Rule context map.
      */
-    private final Map<String, Map<String, Object>> contextMap = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, @Nullable Object>> contextMap = new ConcurrentHashMap<>();
 
     /**
      * This field holds reference to {@link ModuleTypeRegistry}. The {@link RuleEngineImpl} needs it to auto-map
@@ -1089,9 +1089,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     @Override
-    public Map<String, Object> runNow(String ruleUID, boolean considerConditions,
+    public Map<String, @Nullable Object> runNow(String ruleUID, boolean considerConditions,
             @Nullable Map<String, Object> context) {
-        Map<String, Object> returnContext = new HashMap<>();
+        Map<String, @Nullable Object> returnContext = new HashMap<>();
         final WrappedRule rule = getManagedRule(ruleUID);
         if (rule == null) {
             logger.warn("Failed to execute rule '{}': Invalid Rule UID", ruleUID);
@@ -1129,7 +1129,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     }
 
     @Override
-    public Map<String, Object> runNow(String ruleUID) {
+    public Map<String, @Nullable Object> runNow(String ruleUID) {
         return runNow(ruleUID, false, null);
     }
 
@@ -1139,7 +1139,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param ruleUID the UID of the rule whose context must be cleared.
      */
     protected void clearContext(String ruleUID) {
-        Map<String, Object> context = contextMap.get(ruleUID);
+        Map<String, @Nullable Object> context = contextMap.get(ruleUID);
         if (context != null) {
             context.clear();
         }
@@ -1163,7 +1163,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
      * @param outputs new output values.
      */
     private void updateContext(String ruleUID, String moduleUID, @Nullable Map<String, ?> outputs) {
-        Map<String, Object> context = getContext(ruleUID, null);
+        Map<String, @Nullable Object> context = getContext(ruleUID, null);
         if (outputs != null) {
             for (Map.Entry<String, ?> entry : outputs.entrySet()) {
                 String key = moduleUID + OUTPUT_SEPARATOR + entry.getKey();
@@ -1175,8 +1175,8 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
     /**
      * @return copy of current context in rule engine
      */
-    private Map<String, Object> getContext(String ruleUID, @Nullable Set<Connection> connections) {
-        Map<String, Object> context = contextMap.computeIfAbsent(ruleUID, k -> new HashMap<>());
+    private Map<String, @Nullable Object> getContext(String ruleUID, @Nullable Set<Connection> connections) {
+        Map<String, @Nullable Object> context = contextMap.computeIfAbsent(ruleUID, k -> new HashMap<>());
         if (context == null) {
             throw new IllegalStateException("context cannot be null at that point - please report a bug.");
         }
@@ -1257,7 +1257,7 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             }
             final Condition condition = wrappedCondition.unwrap();
             ConditionHandler tHandler = wrappedCondition.getModuleHandler();
-            Map<String, Object> context = getContext(ruleUID, wrappedCondition.getConnections());
+            Map<String, @Nullable Object> context = getContext(ruleUID, wrappedCondition.getConnections());
             if (tHandler != null && !tHandler.isSatisfied(Collections.unmodifiableMap(context))) {
                 logger.debug("The condition '{}' of rule '{}' is unsatisfied.", condition.getId(), ruleUID);
                 return false;
@@ -1312,9 +1312,9 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             final Action action = wrappedAction.unwrap();
             ActionHandler aHandler = wrappedAction.getModuleHandler();
             if (aHandler != null) {
-                Map<String, Object> context = getContext(ruleUID, wrappedAction.getConnections());
+                Map<String, @Nullable Object> context = getContext(ruleUID, wrappedAction.getConnections());
                 try {
-                    Map<String, ?> outputs = aHandler.execute(Collections.unmodifiableMap(context));
+                    Map<String, @Nullable ?> outputs = aHandler.execute(Collections.unmodifiableMap(context));
                     if (outputs != null) {
                         context = getContext(ruleUID, null);
                         updateContext(ruleUID, action.getId(), outputs);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/composite/CompositeActionHandler.java
@@ -64,16 +64,17 @@ public class CompositeActionHandler extends AbstractCompositeModuleHandler<Actio
      * @see org.openhab.core.automation.handler.ActionHandler#execute(java.util.Map)
      */
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
-        final Map<String, Object> result = new HashMap<>();
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
+        final Map<String, @Nullable Object> result = new HashMap<>();
         final List<Action> children = getChildren();
         final Map<String, Object> compositeContext = getCompositeContext(context);
         for (Action child : children) {
             ActionHandler childHandler = moduleHandlerMap.get(child);
             Map<String, Object> childContext = Collections.unmodifiableMap(getChildContext(child, compositeContext));
-            Map<String, Object> childResults = childHandler == null ? null : childHandler.execute(childContext);
+            Map<String, @Nullable Object> childResults = childHandler == null ? null
+                    : childHandler.execute(childContext);
             if (childResults != null) {
-                for (Entry<String, Object> childResult : childResults.entrySet()) {
+                for (Entry<String, @Nullable Object> childResult : childResults.entrySet()) {
                     String childOuputName = child.getId() + "." + childResult.getKey();
                     Output output = compositeOutputs.get(childOuputName);
                     if (output != null) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/AnnotationActionHandler.java
@@ -70,8 +70,8 @@ public class AnnotationActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
-        Map<String, Object> output = new HashMap<>();
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
+        Map<String, @Nullable Object> output = new HashMap<>();
 
         Annotation[][] annotations = method.getParameterAnnotations();
         List<@Nullable Object> args = new ArrayList<>();

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemCommandActionHandler.java
@@ -58,7 +58,7 @@ public class ItemCommandActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> inputs) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> inputs) {
         String itemName = (String) module.getConfiguration().get(ITEM_NAME);
         String command = (String) module.getConfiguration().get(COMMAND);
 

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateUpdateActionHandler.java
@@ -55,7 +55,7 @@ public class ItemStateUpdateActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> inputs) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> inputs) {
         Configuration config = module.getConfiguration();
         String itemName = (String) config.get(ITEM_NAME);
         String state = (String) config.get(STATE);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RuleEnablementActionHandler.java
@@ -94,7 +94,7 @@ public class RuleEnablementActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
         for (String uid : uids) {
             if (callback != null) {
                 callback.setEnabled(uid, enable);

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/RunRuleActionHandler.java
@@ -94,7 +94,7 @@ public class RunRuleActionHandler extends BaseActionModuleHandler {
     }
 
     @Override
-    public @Nullable Map<String, Object> execute(Map<String, Object> context) {
+    public @Nullable Map<String, @Nullable Object> execute(Map<String, Object> context) {
         // execute each rule after the other; at the moment synchronously
         Object previousEvent = context.get("event");
         Event event = AutomationEventFactory.createExecutionEvent(moduleId,


### PR DESCRIPTION
This started with https://github.com/openhab/openhab-core/pull/4922#discussion_r2294580913 while I was looking for the cause for #4965.

In short, results are inserted into the "result map" of `ScriptActionHandler.execute()` even if the result in `null`. This conflicts with the null annotation in the method signature, which is inherited from `ActionHandler.execute()`. @florian-h05 claimed that the `null` value mean to be inserted, and after some "investigation" I agree. The map stores the "outputs" from the `Action`, and the output should be included even if the value is `null`. This means that the nullness annotations are wrong.

This leads to incorrect warnings for nullness, but that's not the main reason I think it's worth fixing. `null`s in `Map`s in Java is "problematic" because it's not supported by all `Map` implementations. Popular implementations like `ConcurrentHashMap` doesn't support it, moreover it can easily be misinterpreted because `map.get()` returns `null` for these entries, just like it does for non-existing keys. "Popular functions" like `computeIfAbsent()` can't handle it either, and `Map`s with `null`s are probably generally difficult to use with streams. More details about this can be found [here](https://www.javaspecialists.eu/archive/Issue303-Null-Keys-and-Values-in-Maps.html).

As a consequence, we rarely see `null` in `Map`s in Java these days. It's just too many pitfalls, so it is usually avoided. This is a legitimate case for storing `null`s in `Map`s, but the combination of the wrong annotation and the fact that we rarely see it, means that chances are great that a developer will assume that `null`s won't be encountered when dealing with these `Map`s. I think not correcting the annotation is "a bug waiting to happen".

Unfortunately, correcting the annotation leads to changes in quite a few files, but fortunately, not a lot of code actually interacts with these `Map`s.

I have built all add-ons against a core with the modified annotations, and two add-ons must also have their annotations updated. I will create a separate PR with these changes.