### PR TITLE
Make REST endpoints accept more logger name characters

### DIFF
--- a/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
+++ b/bundles/org.openhab.core.karaf/src/main/java/org/openhab/core/karaf/internal/LoggerResource.java
@@ -71,7 +71,7 @@ public class LoggerResource implements RESTResource {
     public static final String PATH_LOGGING = "logging";
 
     private static final Set<String> LOG_LEVELS = Set.of(Level.strings());
-    private static final Pattern BUNDLE_REGEX = Pattern.compile("[\\w.]+");
+    private static final Pattern BUNDLE_REGEX = Pattern.compile("\\w[\\w. -]*");
 
     private final LogService logService;
 
@@ -91,7 +91,7 @@ public class LoggerResource implements RESTResource {
     }
 
     @PUT
-    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Path("/{loggerName: \\w(%20|[\\w.-])*}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(operationId = "putLogger", summary = "Modify or add logger", responses = {
             @ApiResponse(responseCode = "200", description = "OK"),
@@ -108,7 +108,7 @@ public class LoggerResource implements RESTResource {
     }
 
     @GET
-    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Path("/{loggerName: \\w(%20|[\\w.-])*}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getLogger", summary = "Get a single logger.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = LoggerBean.LoggerInfo.class))) })
@@ -119,7 +119,7 @@ public class LoggerResource implements RESTResource {
     }
 
     @DELETE
-    @Path("/{loggerName: [a-zA-Z0-9.]+}")
+    @Path("/{loggerName: \\w(%20|[\\w.-])*}")
     @Operation(operationId = "removeLogger", summary = "Remove a single logger.", responses = {
             @ApiResponse(responseCode = "200", description = "OK") })
     public Response removeLogger(@PathParam("loggerName") @Parameter(description = "logger name") String loggerName,


### PR DESCRIPTION
This fixes #4946.

Given that both `_` and `-` are otherwise in use as logger names in various places in the system, they should be allowed in the REST endpoints so that all loggers can be accessed via the REST API. This PR makes the necessary changes.