### PR TITLE
Upgrade Mockito to 5.19

### DIFF
--- a/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoRegistryMergeTest.java
+++ b/bundles/org.openhab.core.addon/src/test/java/org/openhab/core/addon/AddonInfoRegistryMergeTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.addon;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioConsoleTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.audio.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;

--- a/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
+++ b/bundles/org.openhab.core.audio/src/test/java/org/openhab/core/audio/internal/AudioManagerTest.java
@@ -16,7 +16,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;

--- a/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthRFC8628ClientTest.java
+++ b/bundles/org.openhab.core.auth.oauth2client/src/test/java/org/openhab/core/auth/oauth2client/internal/OAuthRFC8628ClientTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.auth.oauth2client.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/test/java/org/openhab/core/automation/module/script/rulesupport/loader/AbstractScriptFileWatcherTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.automation.module.script.rulesupport.loader;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.OpenHAB.CONFIG_DIR_PROG_ARGUMENT;
 import static org.openhab.core.service.WatchService.Kind.*;

--- a/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
+++ b/bundles/org.openhab.core.automation.module.script/src/test/java/org/openhab/core/automation/module/script/ScriptTransformationServiceTest.java
@@ -15,7 +15,7 @@ package org.openhab.core.automation.module.script;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactoryTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/factory/EphemerisModuleHandlerFactoryTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.automation.internal.module.factory;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/DateTimeTriggerHandlerTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.automation.internal.module.handler;
 
 import static java.util.Map.entry;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.config.core.internal.metadata;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.openhab.core.config.core.internal.metadata.MetadataConfigDescriptionProviderImpl.*;
 

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/internal/validation/ConfigDescriptionValidatorTest.java
@@ -16,7 +16,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;

--- a/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
+++ b/bundles/org.openhab.core.config.core/src/test/java/org/openhab/core/config/core/status/ConfigStatusServiceTest.java
@@ -14,7 +14,7 @@ package org.openhab.core.config.core.status;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/bundles/org.openhab.core.config.discovery.addon.mdns/src/test/java/org/openhab/core/config/discovery/addon/mdns/tests/MDNSAddonFinderTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon.mdns/src/test/java/org/openhab/core/config/discovery/addon/mdns/tests/MDNSAddonFinderTests.java
@@ -13,7 +13,6 @@
 package org.openhab.core.config.discovery.addon.mdns.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.config.discovery.addon.mdns.MDNSAddonFinder.MDNS_SERVICE_TYPE;
 

--- a/bundles/org.openhab.core.config.discovery.addon/src/test/java/org/openhab/core/config/discovery/addon/tests/AddonSuggestionServiceTests.java
+++ b/bundles/org.openhab.core.config.discovery.addon/src/test/java/org/openhab/core/config/discovery/addon/tests/AddonSuggestionServiceTests.java
@@ -14,7 +14,8 @@ package org.openhab.core.config.discovery.addon.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openhab.core.config.discovery.addon.AddonFinderConstants.*;
 
 import java.io.IOException;

--- a/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.ser2net/src/test/java/org/openhab/core/config/discovery/usbserial/ser2net/internal/Ser2NetUsbSerialDiscoveryTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.core.config.discovery.usbserial.ser2net.internal;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.config.discovery.usbserial.ser2net.internal.Ser2NetUsbSerialDiscovery.*;
 

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -14,7 +14,7 @@ package org.openhab.core.config.discovery.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.config.discovery.inbox.InboxPredicates.withFlag;

--- a/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
+++ b/bundles/org.openhab.core.config.discovery/src/test/java/org/openhab/core/config/discovery/internal/PersistentInboxTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.config.discovery.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;

--- a/bundles/org.openhab.core.io.console.karaf/src/test/java/org/openhab/core/io/console/karaf/internal/CompleterWrapperTest.java
+++ b/bundles/org.openhab.core.io.console.karaf/src/test/java/org/openhab/core/io/console/karaf/internal/CompleterWrapperTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.io.console.karaf.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.ArrayList;
 

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleterTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandCompleterTest.java
@@ -14,7 +14,7 @@ package org.openhab.core.io.console.internal.extension;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtensionTest.java
+++ b/bundles/org.openhab.core.io.console/src/test/java/org/openhab/core/io/console/internal/extension/ItemConsoleCommandExtensionTest.java
@@ -14,7 +14,7 @@ package org.openhab.core.io.console.internal.extension;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bundles/org.openhab.core.io.http/src/test/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImplTest.java
+++ b/bundles/org.openhab.core.io.http/src/test/java/org/openhab/core/io/http/internal/HttpContextFactoryServiceImplTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.io.http.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/BaseHttpUtilTest.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.core.io.net.http;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;

--- a/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
+++ b/bundles/org.openhab.core.io.net/src/test/java/org/openhab/core/io/net/http/HttpUtilTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.io.net.http;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.concurrent.TimeUnit;

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/config/ConfigDescriptionResourceTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.io.rest.core.internal.config;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;

--- a/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/org.openhab.core.io.rest.core/src/test/java/org/openhab/core/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;

--- a/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
+++ b/bundles/org.openhab.core.io.rest.sse/src/test/java/org/openhab/core/io/rest/sse/internal/SseItemStatesEventBuilderTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.io.rest.sse.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.util.Locale;
 

--- a/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
+++ b/bundles/org.openhab.core.io.rest/src/test/java/org/openhab/core/io/rest/internal/filter/ProxyFilterTest.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.io.rest.internal.filter;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.io.rest.internal.filter.ProxyFilter.*;
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.io.transport.mqtt;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionTests.java
@@ -15,7 +15,7 @@ package org.openhab.core.io.transport.mqtt;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/bundles/org.openhab.core.io.transport.upnp/src/test/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceTest.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/test/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.io.transport.upnp.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
+++ b/bundles/org.openhab.core.model.thing/src.moved/test/java/org/openhab/core/model/thing/internal/GenericThingProviderMultipleBundlesTest.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.model.thing.internal;
 
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.emf.common.util.BasicEList;

--- a/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
+++ b/bundles/org.openhab.core.model.yaml/src/test/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImplTest.java
@@ -15,7 +15,7 @@ package org.openhab.core.model.yaml.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
+++ b/bundles/org.openhab.core.persistence/src/test/java/org/openhab/core/persistence/internal/PersistenceManagerTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.persistence.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticTagsTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.semantics;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.FileReader;

--- a/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
+++ b/bundles/org.openhab.core.semantics/src/test/java/org/openhab/core/semantics/SemanticsPredicatesTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.semantics;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Objects;

--- a/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
+++ b/bundles/org.openhab.core.test.magic/src/test/java/org/openhab/core/magic/binding/internal/MagicHandlerFactoryTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.magic.binding.internal;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.BeforeEach;

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/ThingManagerImplTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.thing.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemDefaultProfileTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.thing.internal.profiles;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;

--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemFollowProfileTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/internal/profiles/SystemFollowProfileTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.thing.internal.profiles;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verify;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;

--- a/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
+++ b/bundles/org.openhab.core.ui.icon/src/test/java/org/openhab/core/ui/icon/internal/IconServletTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.ui.icon.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.ui.icon.internal.IconServlet.*;
 

--- a/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
+++ b/bundles/org.openhab.core.ui/src/test/java/org/openhab/core/ui/internal/proxy/ProxyServletServiceTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.ui.internal.proxy;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.net.URI;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/common/osgi/ResourceBundleClassLoaderTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.common.osgi;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/events/TopicGlobEventFilterTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/events/TopicGlobEventFilterTest.java
@@ -13,7 +13,8 @@
 package org.openhab.core.events;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.junit.jupiter.api.Test;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/auth/UserRegistryImplTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.auth;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ExpireManagerTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.items;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Duration;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/ItemBuilderTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.items;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.List;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataCommandDescriptionProviderTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.items;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Iterator;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataRegistryImplTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.items;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/items/MetadataStateDescriptionFragmentProviderTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.internal.items;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/DelegatedSchedulerTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/scheduler/DelegatedSchedulerTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.internal.scheduler;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/internal/service/StateDescriptionServiceImplTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.internal.service;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/items/GenericItemTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.ZonedDateTime;

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/net/HttpServiceUtilTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/net/HttpServiceUtilTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.net;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.stream.Stream;

--- a/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/cipher/CipherTest.java
+++ b/itests/org.openhab.core.auth.oauth2client.tests/src/main/java/org/openhab/core/auth/oauth2client/test/internal/cipher/CipherTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.auth.oauth2client.test.internal.cipher;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/RuleSimulationTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.automation.integration.test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.automation.internal.module;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.LinkedList;

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
@@ -14,7 +14,8 @@ package org.openhab.core.automation.internal.module;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/IntervalConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/IntervalConditionHandlerTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
 import java.util.HashMap;

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.automation.module.timer.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
@@ -16,7 +16,8 @@ import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/DiscoveryServiceRegistryOSGiTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.config.discovery;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.time.Instant;

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/inbox/DynamicThingUpdateOSGiTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.config.discovery.inbox;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;

--- a/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
+++ b/itests/org.openhab.core.config.discovery.tests/src/main/java/org/openhab/core/config/discovery/internal/InboxOSGiTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.config.discovery.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.openhab.core.config.discovery.inbox.InboxPredicates.*;
 
 import java.math.BigDecimal;

--- a/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
+++ b/itests/org.openhab.core.config.discovery.usbserial.tests/src/main/java/org/openhab/core/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.config.discovery.DiscoveryService.CONFIG_PROPERTY_BACKGROUND_DISCOVERY;
 

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -17,7 +17,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;

--- a/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceOSGiTest.java
+++ b/itests/org.openhab.core.io.rest.core.tests/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResourceOSGiTest.java
@@ -16,7 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/GenericItemChannelLinkProviderJavaTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.model.thing.test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest2.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest2.java
@@ -14,7 +14,8 @@ package org.openhab.core.model.thing.test.hue;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collection;

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest3.java
@@ -16,7 +16,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;

--- a/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
+++ b/itests/org.openhab.core.model.thing.tests/src/main/java/org/openhab/core/model/thing/test/hue/GenericThingProviderTest4.java
@@ -14,7 +14,8 @@ package org.openhab.core.model.thing.test.hue;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.util.stream.Stream;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -16,7 +16,8 @@ import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/binding/ThingFactoryTest.java
@@ -17,7 +17,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.net.URI;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServiceFirmwareRestrictionTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.thing.firmware;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
@@ -16,7 +16,8 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Locale;
 import java.util.Map;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.java
@@ -15,7 +15,6 @@ package org.openhab.core.thing.i18n;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifierOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/ChannelLinkNotifierOSGiTest.java
@@ -15,7 +15,7 @@ package org.openhab.core.thing.internal;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -13,7 +13,6 @@
 package org.openhab.core.thing.internal;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Collection;

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/update/ThingUpdateOSGiTest.java
@@ -14,7 +14,6 @@ package org.openhab.core.thing.internal.update;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.thing.internal.ThingManagerImpl.PROPERTY_THING_TYPE_VERSION;
 

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/link/ItemChannelLinkOSGiTest.java
@@ -15,7 +15,8 @@ package org.openhab.core.thing.link;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Hashtable;

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <!-- junit 5.12.0 to 5.13.0-M3 fails silently with bnd 7.1.0, not executing itests;
          not sure if this is a bnd/junit issue or due to wrong configuration -->
     <junit.version>5.11.4</junit.version>
-    <mockito.version>4.11.0</mockito.version>
+    <mockito.version>5.19.0</mockito.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
* Upgrade Mockito from 4.11 to 5.19.
  Changelog: https://github.com/mockito/mockito/releases
