### PR TITLE
Pass event source to profiles

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfile.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/profiles/StateProfile.java
@@ -13,6 +13,7 @@
 package org.openhab.core.thing.profiles;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 
@@ -30,6 +31,16 @@ public interface StateProfile extends Profile {
      * @param command
      */
     void onCommandFromItem(Command command);
+
+    /**
+     * Will be called if a command should be forwarded to the binding.
+     *
+     * @param command
+     * @param source the source of the command event
+     */
+    default void onCommandFromItem(Command command, @Nullable String source) {
+        onCommandFromItem(command);
+    }
 
     /**
      * If a binding issued a command to a channel, this method will be called for each linked item.

--- a/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
+++ b/itests/org.openhab.core.thing.tests/src/main/java/org/openhab/core/thing/internal/CommunicationManagerOSGiTest.java
@@ -301,9 +301,9 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
     @Test
     public void testItemCommandEventSingleLink() {
-        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_2, OnOffType.ON));
+        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_2, OnOffType.ON, "mysource"));
         waitForAssert(() -> {
-            verify(stateProfileMock).onCommandFromItem(eq(OnOffType.ON));
+            verify(stateProfileMock).onCommandFromItem(eq(OnOffType.ON), eq("mysource"));
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);
@@ -315,7 +315,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         // Take unit from accepted item type (see channel built from STATE_CHANNEL_UID_3)
         manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_5, DecimalType.valueOf("20")));
         waitForAssert(() -> {
-            verify(stateProfileMock).onCommandFromItem(eq(QuantityType.valueOf("20 °C")));
+            verify(stateProfileMock).onCommandFromItem(eq(QuantityType.valueOf("20 °C")), isNull());
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);
@@ -329,7 +329,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
 
         manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_5, DecimalType.valueOf("20")));
         waitForAssert(() -> {
-            verify(stateProfileMock).onCommandFromItem(eq(QuantityType.valueOf("20 °F")));
+            verify(stateProfileMock).onCommandFromItem(eq(QuantityType.valueOf("20 °F")), isNull());
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);
@@ -339,7 +339,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
     public void testItemCommandEventMultiLink() {
         manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_1, OnOffType.ON));
         waitForAssert(() -> {
-            verify(stateProfileMock, times(2)).onCommandFromItem(eq(OnOffType.ON));
+            verify(stateProfileMock, times(2)).onCommandFromItem(eq(OnOffType.ON), isNull());
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);
@@ -351,7 +351,7 @@ public class CommunicationManagerOSGiTest extends JavaOSGiTest {
         manager.receive(
                 ItemEventFactory.createCommandEvent(ITEM_NAME_1, OnOffType.ON, STATE_CHANNEL_UID_2.getAsString()));
         waitForAssert(() -> {
-            verify(stateProfileMock).onCommandFromItem(eq(OnOffType.ON));
+            verify(stateProfileMock).onCommandFromItem(eq(OnOffType.ON), eq(STATE_CHANNEL_UID_2.getAsString()));
         });
         verifyNoMoreInteractions(stateProfileMock);
         verifyNoMoreInteractions(triggerProfileMock);


### PR DESCRIPTION
So that a user can define a profile that takes different actions depending on what's generating the command.

