### PR TITLE
Fix network interface configuration option enumeration

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/internal/net/NetworkConfigOptionProvider.java
@@ -94,7 +94,7 @@ public class NetworkConfigOptionProvider implements ConfigOptionProvider {
         }).toList();
 
         if (!addresses.isEmpty()) {
-            result.append(" (").append(addresses.get(0).getHostAddress()).append(')');
+            result.append(" (").append(addresses.getFirst().getHostAddress()).append(')');
         }
 
         return result.toString();


### PR DESCRIPTION
After a lot of troubleshooting of the network binding, I've found that one of the reasons for its extreme slowness is right here in core, and stems from #3981.

This relates to https://github.com/openhab/openhab-addons/issues/17956#issuecomment-3251334285

In short, when `network-interface` context was added, it was implemented by enumerating all the network interfaces on the host. As a part of trying to find a suitable label for a network interface label, `InetAddress.getHostName()` was used. This method tries to reverse lookup a hostname from an IP address, which can mean all kind of network activity. This is done for each IP address that is attached to a network interface, which makes it quite slow. On my computer, doing this enumeration once takes 4.27 seconds, but the actual time it takes will depend on many things, like the number of network interfaces and the local network, what name resolution service is configured etc.

The thing is that in the vast majority of cases, a hostname isn't resolved - and it isn't necessary either in my view, since these IPs all belong to the host running OH.

I've removed the use of `InetAddress.getHostName()`, and instead use the JVM provided "interface name", convert `_` into space and then converts it to Title Case, to try to make it more similar to the label convention.

In addition, there's a quirk between the JVM and Windows. Windows keeps all network interfaces, physical or virtual, that has ever been on the computer in the list of network interfaces, but those that are no longer in use are "hidden". The JVM however, doesn't respect/understand this, so it will return all of them. This means that on Windows computers, you will usually have a huge list of network interfaces returned by the JVM. To try to mitigate this a bit, I've added a check that requires the network interface to be "up" to be included in the configuration options.