### PR TITLE
Add HLI bundle with EnhancedHLIInterpreter and shared Card/Component model

### DIFF
--- a/bom/openhab-core/pom.xml
+++ b/bom/openhab-core/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.hli</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.io.bin2json</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>

--- a/bundles/org.openhab.core.hli/.classpath
+++ b/bundles/org.openhab.core.hli/.classpath
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21">
+		<attributes>
+			<attribute name="annotationpath" value="target/dependency"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="annotationpath" value="target/dependency"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/org.openhab.core.hli/.project
+++ b/bundles/org.openhab.core.hli/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.core.hli</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/org.openhab.core.hli/NOTICE
+++ b/bundles/org.openhab.core.hli/NOTICE
@@ -1,0 +1,14 @@
+This content is produced and maintained by the openHAB project.
+
+* Project home: https://www.openhab.org
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/openhab/openhab-core
+

--- a/bundles/org.openhab.core.hli/pom.xml
+++ b/bundles/org.openhab.core.hli/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.core.bundles</groupId>
+    <artifactId>org.openhab.core.reactor.bundles</artifactId>
+    <version>5.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.core.hli</artifactId>
+
+  <name>openHAB Core :: Bundles :: HLI</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.voice</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
@@ -374,7 +374,7 @@ public class Card extends Component implements Identifiable<String> {
     /**
      * Returns whether the card has the specified location attribute
      *
-     * @param location
+     * @param location the location to check
      */
     public boolean hasLocationAttribute(@Nullable String location) {
         if (this.locations == null || location == null || location.isEmpty()) {

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
@@ -228,7 +228,7 @@ public class Card extends Component implements Identifiable<String> {
     }
 
     /**
-     * Updates the timestamp of the card to the current date & time.
+     * Updates the timestamp of the card to the current date &amp; time.
      */
     public void updateTimestamp() {
         this.timestamp = new Date();

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
@@ -130,7 +130,7 @@ public class Card extends Component implements Identifiable<String> {
      * @return the card location attributes
      */
     public Set<String> getLocationAttributes() {
-        return tags;
+        return locations;
     }
 
     /**

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.registry.Identifiable;
+
+/**
+ * A card is a special type of {@link Component} at the root of the hierarchy.
+ * It has a number of specific parameters, a set of tags, a timestamp, and is
+ * identifiable by its UID (generally a GUID).
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+@NonNullByDefault
+public class Card extends Component implements Identifiable<String> {
+    private final String uid;
+    private @Nullable String title;
+    private @Nullable String subtitle;
+    private Set<String> tags = new HashSet<String>();
+    private Set<String> objects = new HashSet<String>();
+    private Set<String> locations = new HashSet<String>();
+    private boolean ephemeral;
+    private @Nullable Date timestamp;
+    private boolean bookmarked;
+    private boolean notReuseableInChat;
+    private boolean addToDeckDenied;
+
+    /**
+     * Constructs a card.
+     *
+     * @param name the name of the UI component to render the card on client frontends, ie. "HbCard"
+     */
+    public Card(String name) {
+        super(name);
+        this.uid = UUID.randomUUID().toString();
+    }
+
+    /**
+     * Constructs a Card with a specific UID.
+     *
+     * @param uid the UID of the new card
+     * @param name the name of the UI component to render the card on client frontends, ie. "HbCard"
+     */
+    public Card(String uid, String name) {
+        super(name);
+        this.uid = uid;
+    }
+
+    @Override
+    public String getUID() {
+        return uid;
+    }
+
+    /**
+     * Gets the card's title
+     *
+     * @return the card title
+     */
+    public @Nullable String getTitle() {
+        return title;
+    }
+
+    /**
+     * Sets the card's title
+     *
+     * @param title the card title
+     */
+    public void setTitle(@Nullable String title) {
+        this.title = title;
+    }
+
+    /**
+     * Gets the card's subtitle
+     *
+     * @return the card subtitle
+     */
+    public @Nullable String getSubtitle() {
+        return subtitle;
+    }
+
+    /**
+     * Sets the card's subtitle
+     *
+     * @param subtitle the card subtitle
+     */
+    public void setSubtitle(@Nullable String subtitle) {
+        this.subtitle = subtitle;
+    }
+
+    /**
+     * Gets the set of tags attached to the card
+     *
+     * @return the card tags
+     */
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Gets the set of object attributes attached to the card
+     *
+     * @return the card object attributes
+     */
+    public Set<String> getObjectAttributes() {
+        return objects;
+    }
+
+    /**
+     * Gets the set of location attributes attached to the card
+     *
+     * @return the card location attributes
+     */
+    public Set<String> getLocationAttributes() {
+        return tags;
+    }
+
+    /**
+     * Returns whether the card is bookmarked (appears on a dedicated "bookmarks" page)
+     *
+     * @return the card bookmark status
+     */
+    public boolean isBookmarked() {
+        return bookmarked;
+    }
+
+    /**
+     * Specifies whether the card is bookmarked or not (appears on a dedicated "bookmarks" page)
+     *
+     * @param bookmarked the card bookmark status
+     */
+    public void setBookmark(boolean bookmarked) {
+        this.bookmarked = bookmarked;
+    }
+
+    /**
+     * Returns whether the card should be ignored during the chat sessions, even if its attributes match an @link
+     * {@link Intent}'s extracted entities.
+     *
+     * @return true if the card is not be considered during chat sessions, false (default) otherwise
+     */
+    public boolean isNotReuseableInChat() {
+        return notReuseableInChat;
+    }
+
+    /**
+     * Specifies whether the card should be ignored during the chat sessions, even if its attributes match an @link
+     * {@link Intent}'s extracted entities.
+     *
+     * @param notReuseableInChat true if the card is not be considered during chat sessions, false (default) otherwise
+     */
+    public void setNotReuseableInChat(boolean notReuseableInChat) {
+        this.notReuseableInChat = notReuseableInChat;
+    }
+
+    /**
+     * Returns whether the card can be added to the "card deck" permanently
+     *
+     * @return true if the card cannot be saved permanently, false (default) if it can
+     */
+    public boolean isAddToDeckDenied() {
+        return addToDeckDenied;
+    }
+
+    /**
+     * Returns whether the card can be added to the "card deck" permanently
+     *
+     * @param addToDeckDenied true if the card cannot be saved permanently, false (default) if it can
+     */
+    public void setAddToDeckDenied(boolean addToDeckDenied) {
+        this.addToDeckDenied = addToDeckDenied;
+    }
+
+    /**
+     * Returns whether the card is ephemeral, meaning it is not saved permanently to the @link {@link CardRegistry} and
+     * will be purged after a number of newer ephemeral cards are added
+     *
+     * @return true if the card is ephemeral, false (default) otherwise
+     */
+    public boolean isEphemeral() {
+        return ephemeral;
+    }
+
+    /**
+     * Specifies whether the card is ephemeral, meaning it is not saved permanently to the @link {@link CardRegistry}
+     * and will be purged once a number of newer ephemeral cards are added
+     *
+     * @param ephemeral true if the card is ephemeral, false (default) otherwise
+     */
+    public void setEphemeral(boolean ephemeral) {
+        this.ephemeral = ephemeral;
+    }
+
+    /**
+     * Gets the timestamp of the card
+     *
+     * @return the timestamp
+     */
+    public @Nullable Date getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the specified timestamp of the card
+     *
+     * @param date the timestamp
+     */
+    public void setTimestamp(Date date) {
+        this.timestamp = date;
+    }
+
+    /**
+     * Updates the timestamp of the card to the current date & time.
+     */
+    public void updateTimestamp() {
+        this.timestamp = new Date();
+    }
+
+    /**
+     * Returns whether the card has a certain tag
+     *
+     * @param tag the tag to check
+     * @return true if the card is tagged with the specified tag
+     */
+    public boolean hasTag(String tag) {
+        return (tags != null && tags.contains(tag));
+    }
+
+    /**
+     * Adds a tag to the card
+     *
+     * @param tag the tag to add
+     */
+    public void addTag(String tag) {
+        this.tags.add(tag);
+    }
+
+    /**
+     * Adds several tags to the card
+     *
+     * @param tags the tags to add
+     */
+    public void addTags(Collection<String> tags) {
+        this.tags.addAll(tags);
+    }
+
+    /**
+     * Adds several tags to the card
+     *
+     * @param tags the tags to add
+     */
+    public void addTags(String... tags) {
+        this.tags.addAll(Arrays.asList(tags));
+    }
+
+    /**
+     * Removes a tag on a card
+     *
+     * @param tag the tag to remove
+     */
+    public void removeTag(String tag) {
+        this.tags.remove(tag);
+    }
+
+    /**
+     * Removes all tags on the card
+     */
+    public void removeAllTags() {
+        this.tags.clear();
+    }
+
+    /**
+     * Adds an object attribute to the card
+     *
+     * @param object the object to add
+     */
+    public void addObjectAttribute(String object) {
+        this.objects.add(object);
+    }
+
+    /**
+     * Adds several object attributes to the card
+     *
+     * @param objects the objects to add
+     */
+    public void addObjectAttributes(Collection<String> objects) {
+        this.objects.addAll(objects);
+    }
+
+    /**
+     * Adds several object attributes to the card
+     *
+     * @param objects the objects to add
+     */
+    public void addObjectAttributes(String... objects) {
+        this.objects.addAll(Arrays.asList(objects));
+    }
+
+    /**
+     * Removes an object attribute on a card
+     *
+     * @param object the object to remove
+     */
+    public void removeObjectAttribute(String object) {
+        this.objects.remove(object);
+    }
+
+    /**
+     * Returns whether the card has the specified object attribute (case insensitive)
+     *
+     * @param object
+     */
+    public boolean hasObjectAttribute(@Nullable String object) {
+        if (this.objects == null || object == null || object.isEmpty()) {
+            return false;
+        }
+        return this.objects.stream().anyMatch(o -> o.equalsIgnoreCase(object));
+    }
+
+    /**
+     * Adds an location attribute to the card
+     *
+     * @param location the location to add
+     */
+    public void addLocationAttribute(String location) {
+        this.locations.add(location);
+    }
+
+    /**
+     * Adds several object attributes to the card
+     *
+     * @param locations the locations to add
+     */
+    public void addLocationAttributes(Collection<String> locations) {
+        this.locations.addAll(locations);
+    }
+
+    /**
+     * Adds several object attributes to the card
+     *
+     * @param locations the locations to add
+     */
+    public void addLocationAttributes(String... locations) {
+        this.locations.addAll(Arrays.asList(locations));
+    }
+
+    /**
+     * Removes an object attribute on a card
+     *
+     * @param location the location to remove
+     */
+    public void removeLocationAttribute(String location) {
+        this.locations.remove(location);
+    }
+
+    /**
+     * Returns whether the card has the specified location attribute
+     *
+     * @param location
+     */
+    public boolean hasLocationAttribute(@Nullable String location) {
+        if (this.locations == null || location == null || location.isEmpty()) {
+            return false;
+        }
+        return this.locations.stream().anyMatch(o -> o.equalsIgnoreCase(location));
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Card other = (Card) obj;
+        if (!this.getUID().equals(other.getUID())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Card.java
@@ -326,7 +326,7 @@ public class Card extends Component implements Identifiable<String> {
     /**
      * Returns whether the card has the specified object attribute (case insensitive)
      *
-     * @param object
+     * @param object the object to check
      */
     public boolean hasObjectAttribute(@Nullable String object) {
         if (this.objects == null || object == null || object.isEmpty()) {

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/CardProvider.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/CardProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.DefaultAbstractManagedProvider;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.storage.StorageService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The @link {@link ManagedProvider} for {@link Card} elements
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = CardProvider.class, immediate = true)
+public class CardProvider extends DefaultAbstractManagedProvider<Card, String> {
+
+    @Activate
+    public CardProvider(final @Reference StorageService storageService) {
+        super(storageService);
+    }
+
+    @Override
+    protected String getStorageName() {
+        return "habot_cards";
+    }
+
+    @Override
+    protected String keyToString(String key) {
+        return key;
+    }
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/CardRegistry.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/CardRegistry.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.registry.AbstractRegistry;
+import org.openhab.core.common.registry.Registry;
+import org.openhab.core.events.EventPublisher;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The @link {@link Registry} tracking for {@link Card} elements provided by the @link {@link CardProvider}
+ *
+ * @author Yannick Schaus - Initial contribution
+ * @author Artur Fedjukevits - Refactored code
+ */
+@NonNullByDefault
+@Component(service = CardRegistry.class, immediate = true)
+public class CardRegistry extends AbstractRegistry<Card, String, CardProvider> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CardRegistry.class);
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MAX_EPHEMERAL_CARDS = 10;
+
+    /**
+     * Comparator for sorting cards by timestamp in descending order (newest first).
+     * Cards without timestamps are considered oldest.
+     */
+    private static final Comparator<Card> BY_TIMESTAMP_DESC = Comparator.<Card, Instant> comparing(
+            card -> card.getTimestamp() != null ? card.getTimestamp().toInstant() : Instant.MIN).reversed();
+
+    public CardRegistry() {
+        super(CardProvider.class);
+    }
+
+    /**
+     * Returns cards having ALL the specified tags
+     *
+     * @param tags the tags to lookup
+     * @return matching cards
+     */
+    public Collection<Card> getCardByTags(Set<String> tags) {
+        return filterCards(card -> cardHasTags(card, tags));
+    }
+
+    /**
+     * Returns cards matching the specified object and/or location attribute(s)
+     *
+     * @param object optional object attribute
+     * @param location optional location attribute
+     * @return matching cards - if one of the 2 arguments is null or empty, matching cards do NOT have the attribute.
+     *         If both are provided, matching cards have both.
+     */
+    public Collection<Card> getCardMatchingAttributes(@Nullable String object, @Nullable String location) {
+        return filterCards(card -> cardMatchesAttributes(card, object, location));
+    }
+
+    @Override
+    public Card add(Card element) {
+        cleanupOldEphemeralCards();
+        return super.add(element);
+    }
+
+    /**
+     * Returns the most recent cards according to their timestamp
+     *
+     * @param skip number of elements to skip, for paging
+     * @param count number of elements to retrieve, for paging (default 10)
+     * @return the recent cards, in decreasing order of age
+     */
+    public Collection<Card> getRecent(int skip, int count) {
+        int limit = count < 1 ? DEFAULT_PAGE_SIZE : count;
+
+        return getAll().stream().sorted(BY_TIMESTAMP_DESC).skip(skip).limit(limit).toList();
+    }
+
+    /**
+     * Returns all the cards that are not ephemeral
+     *
+     * @return the non-ephemeral cards
+     */
+    public Collection<Card> getNonEphemeral() {
+        return filterCards(card -> !card.isEphemeral());
+    }
+
+    /**
+     * Returns all ephemeral cards
+     *
+     * @return the ephemeral cards
+     */
+    public Collection<Card> getEphemeral() {
+        return filterCards(Card::isEphemeral);
+    }
+
+    /**
+     * Returns the count of cards matching the given predicate
+     *
+     * @param predicate the filter condition
+     * @return the count of matching cards
+     */
+    public long countCards(Predicate<Card> predicate) {
+        return getAll().stream().filter(predicate).count();
+    }
+
+    /**
+     * Returns the count of all cards
+     *
+     * @return the total count of cards
+     */
+    public long getCardCount() {
+        return getAll().size();
+    }
+
+    /**
+     * Checks if any card exists matching the given predicate
+     *
+     * @param predicate the filter condition
+     * @return true if at least one card matches the predicate
+     */
+    public boolean hasCards(Predicate<Card> predicate) {
+        return getAll().stream().anyMatch(predicate);
+    }
+
+    /**
+     * Generic filter method for cards
+     *
+     * @param predicate the filter condition
+     * @return filtered collection of cards
+     */
+    private Collection<Card> filterCards(Predicate<Card> predicate) {
+        return getAll().stream().filter(predicate).toList();
+    }
+
+    /**
+     * Removes old ephemeral cards to keep only the most recent ones
+     */
+    private void cleanupOldEphemeralCards() {
+        var oldEphemeralCards = getAll().stream().filter(Card::isEphemeral).sorted(BY_TIMESTAMP_DESC)
+                .skip(MAX_EPHEMERAL_CARDS).toList();
+
+        oldEphemeralCards.forEach(card -> {
+            logger.debug("Removing old ephemeral card {}", card.getUID());
+            remove(card.getUID());
+        });
+    }
+
+    /**
+     * NOTE: unlike the ItemRegistry this method returns true only if the card has ALL the provided tags!
+     */
+    private boolean cardHasTags(Card card, @Nullable Set<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return true; // No tags specified means match all cards
+        }
+
+        var cardTags = card.getTags();
+        return cardTags != null && cardTags.containsAll(tags);
+    }
+
+    /**
+     * Checks if a card matches the specified object and location attributes.
+     * Uses XOR logic: if attribute is null/empty, card should NOT have it; if provided, card should have it.
+     */
+    private boolean cardMatchesAttributes(Card card, @Nullable String object, @Nullable String location) {
+        boolean objectMatches = isNullOrEmpty(object) != card.hasObjectAttribute(object);
+        boolean locationMatches = isNullOrEmpty(location) != card.hasLocationAttribute(location);
+
+        return objectMatches && locationMatches;
+    }
+
+    /**
+     * Utility method to check if a string is null or empty
+     */
+    private boolean isNullOrEmpty(@Nullable String value) {
+        return value == null || value.isEmpty();
+    }
+
+    // OSGi Component References - Maintaining backward compatibility
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    protected void setManagedProvider(CardProvider provider) {
+        super.setManagedProvider(provider);
+    }
+
+    protected void unsetManagedProvider(CardProvider provider) {
+        super.unsetManagedProvider(provider);
+    }
+
+    @Override
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    protected void setEventPublisher(EventPublisher eventPublisher) {
+        super.setEventPublisher(eventPublisher);
+    }
+
+    @Override
+    protected void unsetEventPublisher(EventPublisher eventPublisher) {
+        super.unsetEventPublisher(eventPublisher);
+    }
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
@@ -161,8 +161,7 @@ public class ChatReply {
 
     /**
      * Sets the {@link Card} to present with the answer
-     *
-     * @return the card
+     * @param card the card
      */
     public void setCard(Card card) {
         this.card = card;

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.util.Locale;
+
+/**
+ * The complete DTO object representing an HABot chat reply, returned by the REST API.
+ * It includes the original query, language, natural language answer and hint, recognized intent (name and entities),
+ * matched items and card.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+public class ChatReply {
+
+    private String language;
+    private String query;
+    private String answer;
+    private String hint;
+    private Intent intent;
+    private String[] matchedItemNames;
+    private Card card;
+
+    /**
+     * Constructs a ChatReply for the specified {@link Locale}
+     *
+     * @param locale the locale
+     */
+    public ChatReply(Locale locale) {
+        this.language = locale.getLanguage();
+    }
+
+    /**
+     * Constructs a ChatReply for the specified {@link Locale} and query
+     *
+     * @param locale
+     * @param query
+     */
+    public ChatReply(Locale locale, String query) {
+        this.language = locale.getLanguage();
+        this.query = query;
+    }
+
+    /**
+     * Gets the language of the reply
+     *
+     * @return the ISO-639 code of the language
+     */
+    public String getLanguage() {
+        return language;
+    }
+
+    /**
+     * Gets the user's original query
+     *
+     * @return the user query
+     */
+    public String getQuery() {
+        return query;
+    }
+
+    /**
+     * Sets the user's original query
+     *
+     * @param query the user query
+     */
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    /**
+     * Gets the natural language answer
+     *
+     * @return the answer
+     */
+    public String getAnswer() {
+        return answer;
+    }
+
+    /**
+     * Sets the natural language answer
+     *
+     * @param answer the answer
+     */
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    /**
+     * Gets the hint - usually an indication why the interpretation failed.
+     *
+     * @return the hint
+     */
+    public String getHint() {
+        return hint;
+    }
+
+    /**
+     * Sets the hint - usually an indication why the interpretation failed.
+     *
+     * @param hint the hint
+     */
+    public void setHint(String hint) {
+        this.hint = hint;
+    }
+
+    /**
+     * Gets the recognized intent
+     *
+     * @return the intent
+     */
+    public Intent getIntent() {
+        return intent;
+    }
+
+    /**
+     * Sets the recognized intent
+     *
+     * @param intent the intent
+     */
+    public void setIntent(Intent intent) {
+        this.intent = intent;
+    }
+
+    /**
+     * Gets the item names matched by the intent entities
+     *
+     * @return the matched item names
+     */
+    public String[] getMatchedItemNames() {
+        return matchedItemNames;
+    }
+
+    /**
+     * Sets the item names matched by the intent entities
+     *
+     * @param matchedItemNames the matched item names
+     */
+    public void setMatchedItems(String[] matchedItemNames) {
+        this.matchedItemNames = matchedItemNames;
+    }
+
+    /**
+     * Gets the {@link Card} to present with the answer
+     *
+     * @return the card
+     */
+    public Card getCard() {
+        return card;
+    }
+
+    /**
+     * Sets the {@link Card} to present with the answer
+     *
+     * @return the card
+     */
+    public void setCard(Card card) {
+        this.card = card;
+    }
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
@@ -161,6 +161,7 @@ public class ChatReply {
 
     /**
      * Sets the {@link Card} to present with the answer
+     * 
      * @param card the card
      */
     public void setCard(Card card) {

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/ChatReply.java
@@ -43,8 +43,8 @@ public class ChatReply {
     /**
      * Constructs a ChatReply for the specified {@link Locale} and query
      *
-     * @param locale
-     * @param query
+     * @param locale the locale
+     * @param query the user query
      */
     public ChatReply(Locale locale, String query) {
         this.language = locale.getLanguage();

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Component.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Component.java
@@ -44,7 +44,6 @@ public class Component {
      * @param componentName name of the component as known to the frontend
      */
     public Component(String componentName) {
-        super();
         this.component = componentName;
         this.config = new HashMap<>();
     }

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Component.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Component.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Component represents a piece of UI element that will be passed as part of a @link {@link Card} via the REST API to
+ * a client frontend to render; it is kept very simple and delegates the actual rendering and behavior to the frontend.
+ *
+ * It has a reference to a component's name as defined by the frontend, a map of configuration parameters, and several
+ * named "slots", or placeholders, which may contain other sub-components, thus defining a tree.
+ *
+ * No checks are performed on the actual validity of configuration parameters and their values, the validity of a
+ * particular slot for a certain component or the validity of certain types of sub-components within a particular slot:
+ * that is the frontend's responsibility.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+public class Component {
+    String component;
+
+    Map<String, Object> config;
+
+    Map<String, List<Component>> slots = null;
+
+    /**
+     * Constructs a component by its type name - component names are not arbitrary, they are defined by the target
+     * frontend.
+     *
+     * @param componentName name of the component as known to the frontend
+     */
+    public Component(String componentName) {
+        super();
+        this.component = componentName;
+        this.config = new HashMap<>();
+    }
+
+    /**
+     * Retrieves the name of the component.
+     *
+     * @return the component name
+     */
+    public String getName() {
+        return component;
+    }
+
+    /**
+     * Gets all the configuration parameters of the component
+     *
+     * @return the map of configuration parameters
+     */
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    /**
+     * Adds a new configuration parameter to the component
+     *
+     * @param key the parameter key
+     * @param value the parameter value
+     */
+    public void addConfig(String key, Object value) {
+        this.config.put(key, value);
+    }
+
+    /**
+     * Returns all the slots of the components including their sub-components
+     *
+     * @return the slots and their sub-components
+     */
+    public Map<String, List<Component>> getSlots() {
+        return slots;
+    }
+
+    /**
+     * Adds a new empty slot to the component
+     *
+     * @param slotName the name of the slot
+     * @return the empty list of components in the newly created slot
+     */
+    public List<Component> addSlot(String slotName) {
+        if (slots == null) {
+            slots = new HashMap<>();
+        }
+        List<Component> newSlot = new ArrayList<>();
+        this.slots.put(slotName, newSlot);
+
+        return newSlot;
+    }
+
+    /**
+     * Gets the list of sub-components in a slot
+     *
+     * @param slotName the name of the slot
+     * @return the list of sub-components in the slot
+     */
+    public List<Component> getSlot(String slotName) {
+        return this.slots.get(slotName);
+    }
+
+    /**
+     * Add a new sub-component to the specified slot. Creates the slot if necessary.
+     *
+     * @param slotName the slot to add the component to
+     * @param subComponent the sub-component to add
+     */
+    public void addComponent(String slotName, Component subComponent) {
+        List<Component> slot;
+        if (slots == null || !slots.containsKey(slotName)) {
+            slot = addSlot(slotName);
+        } else {
+            slot = getSlot(slotName);
+        }
+
+        slot.add(subComponent);
+    }
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/EnhancedHLIInterpreter.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/EnhancedHLIInterpreter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.voice.text.HumanLanguageInterpreter;
+import org.openhab.core.voice.text.InterpretationException;
+
+/**
+ * @author Artur Fedjukevits - Initial contribution
+ */
+@NonNullByDefault
+public interface EnhancedHLIInterpreter extends HumanLanguageInterpreter {
+    ChatReply reply(Locale locale, String query) throws InterpretationException;
+}

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Intent.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Intent.java
@@ -30,7 +30,7 @@ public class Intent {
     /**
      * Gets the intent's name (identifier of the type of intent)
      *
-     * @return
+     * @return the intent's name
      */
     public String getName() {
         return name;

--- a/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Intent.java
+++ b/bundles/org.openhab.core.hli/src/main/java/org/openhab/core/hli/Intent.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.hli;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An Intent consists of an identifier of the type of intent, and one or several entities.
+ * It is the result of the categorization (for the intent name) and token extraction (for the entities) performed by
+ * the OpenNLP interpreter.
+ *
+ * @author Yannick Schaus - Initial contribution
+ */
+public class Intent {
+    private String name;
+
+    private Map<String, String> entities;
+
+    /**
+     * Gets the intent's name (identifier of the type of intent)
+     *
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the intent's entities
+     *
+     * @return the map of entities
+     */
+    public Map<String, String> getEntities() {
+        return entities;
+    }
+
+    /**
+     * Sets the intent's entities
+     *
+     * @param entities the map of entities
+     */
+    public void setEntities(Map<String, String> entities) {
+        this.entities = entities;
+    }
+
+    @Override
+    public String toString() {
+        return "Intent [name=" + name + ", entities=" + entities + "]";
+    }
+
+    /**
+     * Constructs an intent with the specified name
+     *
+     * @param name the name (ie. type identifier) of the intent
+     */
+    public Intent(String name) {
+        this.name = name;
+        this.entities = new HashMap<>();
+    }
+}

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -50,6 +50,7 @@
     <module>org.openhab.core</module>
     <module>org.openhab.core.audio</module>
     <module>org.openhab.core.ephemeris</module>
+    <module>org.openhab.core.hli</module>
     <module>org.openhab.core.id</module>
     <module>org.openhab.core.persistence</module>
     <module>org.openhab.core.semantics</module>

--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -58,6 +58,7 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.transform/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.audio/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.voice/${project.version}</bundle>
+		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.hli/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.console/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.monitor/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.net/${project.version}</bundle>


### PR DESCRIPTION
As discussed in the [ChatGPT PR](https://github.com/openhab/openhab-addons/pull/19267) this PR introduces a new bundle **org.openhab.core.hli** for Human Language Interpreters. It defines the new EnhancedHLIInterpreter interface, extending the existing HumanLanguageInterpreter with support for structured replies (ChatReply and Card).

Additionally, the following classes have been moved from HABot into this new bundle as plain model classes so they can be reused across add-ons:

- Card
- Component
- Intent
- CardProvider
- CardRegistry

This allows add-ons like HABot and ChatGPT HLI to share the same core definitions without creating cross-dependencies.

