### PR TITLE
Details error message in log when, in an UI transformation, a script is the error cause.

### DIFF
--- a/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/org.openhab.core.ui/src/main/java/org/openhab/core/ui/internal/items/ItemUIRegistryImpl.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import javax.measure.Unit;
+import javax.script.ScriptException;
 
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
@@ -672,8 +673,9 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                                 "Transformation service of type '" + type + "' is not available.");
                     }
                 } catch (TransformationException e) {
+                    Throwable cause = e.getCause();
                     logger.warn("Failed transforming the value '{}' with pattern '{}': {}", value, formatPattern,
-                            e.getMessage());
+                            cause instanceof ScriptException ? cause.getMessage() : e.getMessage());
                     ret = insertInLabel(label, failbackValue);
                 }
             } else if (labelMappedOption != null) {


### PR DESCRIPTION
Adding log details when having an error in a a script transformation in UI (sitemap).

Before this PR, when using a script transformation in a sitemap, the message doesn't show any hint about the root script issue.
We only have "Failed to execute script".
On the other hand, for the same script and error, in a transformation profile, the message is fully detailed.

This PR use the script cause as log message, if available.
The behaviour is modeled after "ScriptProfile.java" (executeScript method) as a reference.

First seen [in a discussion about a community jsr223 bundle here](https://community.openhab.org/t/java223-scripting-script-with-java-on-openhab-5-0-1-0-6-0-0-0/159853/16)
