### PR TITLE
MQTT transport: add cleanSession/cleanStart parameter

### DIFF
--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -91,7 +91,7 @@ public class MqttBrokerConnection {
     protected final boolean secure;
     protected final boolean hostnameValidated;
     protected final MqttVersion mqttVersion;
-    private boolean cleanSessionStart;
+    private boolean cleanSessionStart = true;
 
     private @Nullable TrustManagerFactory trustManagerFactory = InsecureTrustManagerFactory.INSTANCE;
     protected final String clientId;
@@ -517,7 +517,7 @@ public class MqttBrokerConnection {
     }
 
     /**
-     * Return MQTT3 cleanSession or MQTT5 cleanStart parameter, null if not set and default is used
+     * Return MQTT3 cleanSession or MQTT5 cleanStart parameter
      */
     public boolean getCleanSessionStart() {
         return cleanSessionStart;

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnection.java
@@ -58,6 +58,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
  * @author Markus Rathgeb - added connection state callback
  * @author Jan N. Klug - changed from PAHO to HiveMQ client
  * @author Mark Herwege - Added flag for hostname validation
+ * @author Mark Herwege - Added parameter for cleanSession/cleanStart
  */
 @NonNullByDefault
 public class MqttBrokerConnection {
@@ -90,6 +91,7 @@ public class MqttBrokerConnection {
     protected final boolean secure;
     protected final boolean hostnameValidated;
     protected final MqttVersion mqttVersion;
+    private boolean cleanSessionStart;
 
     private @Nullable TrustManagerFactory trustManagerFactory = InsecureTrustManagerFactory.INSTANCE;
     protected final String clientId;
@@ -506,6 +508,22 @@ public class MqttBrokerConnection {
     }
 
     /**
+     * Sets the MQTT3 cleanSession or MQTT5 cleanStart configuration.
+     *
+     * @param cleanSessionStart
+     */
+    public void setCleanSessionStart(boolean cleanSessionStart) {
+        this.cleanSessionStart = cleanSessionStart;
+    }
+
+    /**
+     * Return MQTT3 cleanSession or MQTT5 cleanStart parameter, null if not set and default is used
+     */
+    public boolean getCleanSessionStart() {
+        return cleanSessionStart;
+    }
+
+    /**
      * Return true if there are subscribers registered via {@link #subscribe(String, MqttMessageSubscriber)}.
      * Call {@link #unsubscribe(String, MqttMessageSubscriber)} or {@link #unsubscribeAll()} if necessary.
      */
@@ -695,7 +713,7 @@ public class MqttBrokerConnection {
         this.client = client;
 
         // connect
-        client.connect(lastWill, keepAliveInterval, user, password);
+        client.connect(lastWill, keepAliveInterval, user, password, cleanSessionStart);
 
         logger.info("Starting MQTT broker connection to '{}' with clientid {}", host, getClientId());
 

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionConfig.java
@@ -22,6 +22,7 @@ import org.openhab.core.io.transport.mqtt.MqttBrokerConnection.Protocol;
  *
  * @author David Graeff - Initial contribution
  * @author Mark Herwege - Added flag for hostname validation
+ * @author Mark Herwege - Added parameter for cleanSession/cleanStart
  */
 @NonNullByDefault
 public class MqttBrokerConnectionConfig {
@@ -32,6 +33,7 @@ public class MqttBrokerConnectionConfig {
     public @Nullable Integer port;
     public boolean secure = true;
     public boolean hostnameValidated = true;
+    public boolean cleanSessionStart = true;
     // Protocol parameters
     public Protocol protocol = MqttBrokerConnection.DEFAULT_PROTOCOL;
     public MqttVersion mqttVersion = MqttBrokerConnection.DEFAULT_MQTT_VERSION;

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt3AsyncClientWrapper.java
@@ -38,6 +38,7 @@ import com.hivemq.client.mqtt.mqtt3.message.unsubscribe.Mqtt3Unsubscribe;
  *
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Added flag for hostname validation
+ * @author Mark Herwege - Added parameter for cleanSession
  */
 @NonNullByDefault
 public class Mqtt3AsyncClientWrapper extends MqttAsyncClientWrapper {
@@ -92,12 +93,15 @@ public class Mqtt3AsyncClientWrapper extends MqttAsyncClientWrapper {
 
     @Override
     public CompletableFuture<?> connect(@Nullable MqttWillAndTestament lwt, int keepAliveInterval,
-            @Nullable String username, @Nullable String password) {
+            @Nullable String username, @Nullable String password, @Nullable Boolean cleanSession) {
         Mqtt3ConnectBuilder connectMessageBuilder = Mqtt3Connect.builder().keepAlive(keepAliveInterval);
         if (lwt != null) {
             Mqtt3Publish willPublish = Mqtt3Publish.builder().topic(lwt.getTopic()).payload(lwt.getPayload())
                     .retain(lwt.isRetain()).qos(getMqttQosFromInt(lwt.getQos())).build();
             connectMessageBuilder.willPublish(willPublish);
+        }
+        if (cleanSession != null) {
+            connectMessageBuilder.cleanSession(cleanSession);
         }
 
         if (username != null && !username.isBlank() && password != null && !password.isBlank()) {

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/Mqtt5AsyncClientWrapper.java
@@ -39,6 +39,7 @@ import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.Mqtt5Unsubscribe;
  *
  * @author Jan N. Klug - Initial contribution
  * @author Mark Herwege - Added flag for hostname validation
+ * @author Mark Herwege - Added parameter for cleanStart
  */
 @NonNullByDefault
 public class Mqtt5AsyncClientWrapper extends MqttAsyncClientWrapper {
@@ -93,12 +94,15 @@ public class Mqtt5AsyncClientWrapper extends MqttAsyncClientWrapper {
 
     @Override
     public CompletableFuture<?> connect(@Nullable MqttWillAndTestament lwt, int keepAliveInterval,
-            @Nullable String username, @Nullable String password) {
+            @Nullable String username, @Nullable String password, @Nullable Boolean cleanStart) {
         Mqtt5ConnectBuilder connectMessageBuilder = Mqtt5Connect.builder().keepAlive(keepAliveInterval);
         if (lwt != null) {
             Mqtt5Publish willPublish = Mqtt5Publish.builder().topic(lwt.getTopic()).payload(lwt.getPayload())
                     .retain(lwt.isRetain()).qos(getMqttQosFromInt(lwt.getQos())).build();
             connectMessageBuilder.willPublish(willPublish);
+        }
+        if (cleanStart != null) {
+            connectMessageBuilder.cleanStart(cleanStart);
         }
 
         if (username != null && !username.isBlank() && password != null && !password.isBlank()) {

--- a/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/main/java/org/openhab/core/io/transport/mqtt/internal/client/MqttAsyncClientWrapper.java
@@ -29,6 +29,7 @@ import com.hivemq.client.mqtt.datatypes.MqttQos;
  * The {@link MqttAsyncClientWrapper} is the base class for async client wrappers
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Mark Herwege - Added parameter for cleanSession/cleanStart
  */
 
 @NonNullByDefault
@@ -40,10 +41,11 @@ public abstract class MqttAsyncClientWrapper implements HostnameVerifier {
      * @param keepAliveInterval keep-alive interval in ms
      * @param username username (optional)
      * @param password password (optional)
+     * @param cleanSessionStart cleanSession (MQTT3) or cleanStart (MQTT5)
      * @return a CompletableFuture (exceptionally on fail)
      */
     public abstract CompletableFuture<?> connect(@Nullable MqttWillAndTestament lwt, int keepAliveInterval,
-            @Nullable String username, @Nullable String password);
+            @Nullable String username, @Nullable String password, @Nullable Boolean cleanSessionStart);
 
     /**
      * disconnect this client

--- a/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
+++ b/bundles/org.openhab.core.io.transport.mqtt/src/test/java/org/openhab/core/io/transport/mqtt/MqttBrokerConnectionEx.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.core.io.transport.mqtt;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Map;
@@ -68,7 +69,7 @@ public class MqttBrokerConnectionEx extends MqttBrokerConnection {
                 return CompletableFuture.completedFuture(null);
             }
             return new CompletableFuture<Boolean>();
-        }).when(mockedClient).connect(any(), anyInt(), any(), any());
+        }).when(mockedClient).connect(any(), anyInt(), any(), any(), any());
         doAnswer(i -> {
             if (disconnectSuccess) {
                 connectionCallback.onDisconnected(new Throwable("disconnect"));


### PR DESCRIPTION
Some MQTT broker connections should be configured with cleanSession (MQTTv3) or cleanStart (MQTTv5) set to false. The default is true.
This was not possible so far as the MQTT transport does not expose this as an option, and therefore always starts with a clean session on every reconnect.

This PR adds support for setting it.

This is relevant for https://github.com/openhab/openhab-addons/pull/19322. That addon PR removes the code directly using hivemq and replaces it by the transport. And this parameter is not accessible. While I did not see a major impact in my testing so far, it would most likely reduce the risk of being banned from the cloud service if it is possible to set it right.