### PR TITLE
Isolate discovery result registrations from binding threads

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractDiscoveryService.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -61,20 +62,26 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(DISCOVERY_THREADPOOL_NAME);
 
     private final Set<DiscoveryListener> discoveryListeners = new CopyOnWriteArraySet<>();
-    protected @Nullable ScanListener scanListener = null;
 
-    private boolean backgroundDiscoveryEnabled;
+    // All access must be guarded by "this"
+    protected @Nullable ScanListener scanListener;
 
-    private @Nullable String scanInputLabel;
-    private @Nullable String scanInputDescription;
+    private volatile boolean backgroundDiscoveryEnabled;
 
+    private final @Nullable String scanInputLabel;
+    private final @Nullable String scanInputDescription;
+
+    // All access must be guarded by "cachedResults"
     private final Map<ThingUID, DiscoveryResult> cachedResults = new HashMap<>();
 
+    // This set is immutable and can safely be shared between threads
     private final Set<ThingTypeUID> supportedThingTypes;
     private final int timeout;
 
+    // All access must be guarded by "this"
     private Instant timestampOfLastScan = Instant.MIN;
 
+    // All access must be guarded by "this"
     private @Nullable ScheduledFuture<?> scheduledStop;
 
     protected @NonNullByDefault({}) TranslationProvider i18nProvider;
@@ -198,12 +205,14 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
         if (listener == null) {
             return;
         }
-        synchronized (cachedResults) {
-            for (DiscoveryResult cachedResult : cachedResults.values()) {
-                listener.thingDiscovered(this, cachedResult);
-            }
-        }
         discoveryListeners.add(listener);
+        Map<ThingUID, DiscoveryResult> existingResults;
+        synchronized (cachedResults) {
+            existingResults = Map.copyOf(cachedResults);
+        }
+        for (DiscoveryResult existingResult : existingResults.values()) {
+            listener.thingDiscovered(this, existingResult);
+        }
     }
 
     @Override
@@ -221,11 +230,10 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
         startScanInternal(input, listener);
     }
 
-    private synchronized void startScanInternal(@Nullable String input, @Nullable ScanListener listener) {
+    private void startScanInternal(@Nullable String input, @Nullable ScanListener listener) {
+        // we first stop any currently running scan and its scheduled stop call
+        stopScan();
         synchronized (this) {
-            // we first stop any currently running scan and its scheduled stop
-            // call
-            stopScan();
             ScheduledFuture<?> scheduledStop = this.scheduledStop;
             if (scheduledStop != null) {
                 scheduledStop.cancel(false);
@@ -245,39 +253,41 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
                 }, getScanTimeout(), TimeUnit.SECONDS);
             }
             timestampOfLastScan = Instant.now();
-
-            try {
-                if (isScanInputSupported() && input != null) {
-                    startScan(input);
-                } else {
-                    startScan();
-                }
-            } catch (Exception ex) {
-                scheduledStop = this.scheduledStop;
+        }
+        try {
+            if (isScanInputSupported() && input != null) {
+                startScan(input);
+            } else {
+                startScan();
+            }
+        } catch (Exception ex) {
+            synchronized (this) {
+                ScheduledFuture<?> scheduledStop = this.scheduledStop;
                 if (scheduledStop != null) {
                     scheduledStop.cancel(false);
                     this.scheduledStop = null;
                 }
                 scanListener = null;
-                throw ex;
             }
+            throw ex;
         }
     }
 
     @Override
-    public synchronized void abortScan() {
+    public void abortScan() {
+        ScanListener scanListener = null;
         synchronized (this) {
             ScheduledFuture<?> scheduledStop = this.scheduledStop;
             if (scheduledStop != null) {
-                scheduledStop.cancel(false);
+                scheduledStop.cancel(true);
                 this.scheduledStop = null;
             }
-            final ScanListener scanListener = this.scanListener;
-            if (scanListener != null) {
-                Exception e = new CancellationException("Scan has been aborted.");
-                scanListener.onErrorOccurred(e);
-                this.scanListener = null;
-            }
+            scanListener = this.scanListener;
+            this.scanListener = null;
+        }
+        if (scanListener != null) {
+            Exception e = new CancellationException("Scan has been aborted.");
+            scanListener.onErrorOccurred(e);
         }
     }
 
@@ -297,11 +307,14 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     /**
      * This method cleans up after a scan, i.e. it removes listeners and other required operations.
      */
-    protected synchronized void stopScan() {
-        ScanListener scanListener = this.scanListener;
+    protected void stopScan() {
+        ScanListener scanListener = null;
+        synchronized (this) {
+            scanListener = this.scanListener;
+            this.scanListener = null;
+        }
         if (scanListener != null) {
             scanListener.onFinished();
-            this.scanListener = null;
         }
     }
 
@@ -314,12 +327,14 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
         final DiscoveryResult discoveryResultNew = getLocalizedDiscoveryResult(discoveryResult,
                 FrameworkUtil.getBundle(this.getClass()));
         for (DiscoveryListener discoveryListener : discoveryListeners) {
-            try {
-                discoveryListener.thingDiscovered(this, discoveryResultNew);
-            } catch (Exception e) {
-                logger.error("An error occurred while calling the discovery listener {}.",
-                        discoveryListener.getClass().getName(), e);
-            }
+            scheduler.execute(() -> {
+                try {
+                    discoveryListener.thingDiscovered(this, discoveryResultNew);
+                } catch (Exception e) {
+                    logger.error("An error occurred while calling the discovery listener {}.",
+                            discoveryListener.getClass().getName(), e);
+                }
+            });
         }
         synchronized (cachedResults) {
             cachedResults.put(discoveryResultNew.getThingUID(), discoveryResultNew);
@@ -384,18 +399,22 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      */
     protected void removeOlderResults(Instant timestamp, @Nullable Collection<ThingTypeUID> thingTypeUIDs,
             @Nullable ThingUID bridgeUID) {
-        Collection<ThingUID> removedThings = null;
+        Set<ThingUID> removedThings = new HashSet<>();
 
+        Collection<ThingUID> removed;
         Collection<ThingTypeUID> toBeRemoved = thingTypeUIDs != null ? thingTypeUIDs : getSupportedThingTypes();
         for (DiscoveryListener discoveryListener : discoveryListeners) {
             try {
-                removedThings = discoveryListener.removeOlderResults(this, timestamp, toBeRemoved, bridgeUID);
+                removed = discoveryListener.removeOlderResults(this, timestamp, toBeRemoved, bridgeUID);
+                if (removed != null) {
+                    removedThings.addAll(removed);
+                }
             } catch (Exception e) {
                 logger.error("An error occurred while calling the discovery listener {}.",
                         discoveryListener.getClass().getName(), e);
             }
         }
-        if (removedThings != null) {
+        if (!removedThings.isEmpty()) {
             synchronized (cachedResults) {
                 for (ThingUID uid : removedThings) {
                     cachedResults.remove(uid);
@@ -486,7 +505,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *
      * @return timestamp as {@link Instant}
      */
-    protected Instant getTimestampOfLastScan() {
+    protected synchronized Instant getTimestampOfLastScan() {
         return timestampOfLastScan;
     }
 
@@ -496,6 +515,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     protected DiscoveryResult getLocalizedDiscoveryResult(final DiscoveryResult discoveryResult,
             @Nullable Bundle bundle) {
+        TranslationProvider i18nProvider = this.i18nProvider;
+        LocaleProvider localeProvider = this.localeProvider;
         if (i18nProvider != null && localeProvider != null) {
             String currentLabel = discoveryResult.getLabel();
 


### PR DESCRIPTION
By using the discovery thread pool to do the actual registrations in `AbstractDiscoveryService`, binding threads won't have to wait for the registration to complete, which can be slow.

In addition, some thread-safety fixes have been done in `AbstractDiscoveryService` and `DiscoveryServiceRegistryImpl`, both to avoid contention and to ensure isolation of mutable objects.

This has emerged as an idea of mine after "investigating" several cases where OH gets very slow, stops working all together or crashes. Blocked threads with ever-increasing memory consumption as the thread pool queues are never processed seems to be a common theme.

There are many reasons for the situation, this PR only addresses a little piece of the puzzle. But, I think it can make a real difference, because by using an executor to do the actual registration, we "break" the chain of locks/monitors being held. It no longer matters what locks the binding holds when `thingDiscovered()` is called, when the registration is done by the thread pool, it won't "inherit" any of the locks, and the rest of the system is free to move forward.

As everybody know, I assume, one of the "classic traps" in concurrency is to lock two locks/monitors in different order in different places of the code. Doing that practically ensures that you will have a deadlock, but it can be hard to avoid when parts of the system invokes other parts of the system in a complex way. The best way I've found to avoid this is to hold the locks as short as possible, and don't make calls into "unknown code" while holding locks, if at all avoidable. Invoking a listener method while holding a lock is a typical situation that has a high risk of causing a deadlock.

Even without a deadlock, the extreme slowness of the registration of discovery results can have cascading effects throughout the system. It would be interesting to find the reason for the slowness, and I hope that some of the "contention fixes" in this PR will help mitigate the problem. Regardless, an added bonus of isolating the locks by using the thread pool to do the registrations, is that this cascading effect is prevented.

Recently, when we worked on https://github.com/openhab/openhab-addons/pull/17972, we had to make the Network binding spawn separate threads for registering the results to make the discovery operation smooth/fast. This PR will make that unnecessary, and it will benefit all bindings.

When I created https://github.com/openhab/openhab-addons/issues/19351 a couple of days ago, it dawned on me that trying to chase this down on a binding-by-binding basis was the wrong approach.

Here is an excerpt from the thread dump from [the associated forum thread](https://community.openhab.org/t/jmdns-memory-leak/166318) (pay attention to lock `0x00000000814f9128`):
```log
"JmDNS pool-26-thread-1" #870 [2819882] prio=5 os_prio=0 cpu=2310,95ms elapsed=21361,57s tid=0x00007fbb35623170 nid=2819882 runnable  [0x00007fba20efc000]
   java.lang.Thread.State: RUNNABLE
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.write(ReflectiveTypeAdapterFactory.java:493)
	at com.google.gson.Gson.toJson(Gson.java:944)
	at com.google.gson.Gson.toJsonTree(Gson.java:802)
	at com.google.gson.Gson.toJsonTree(Gson.java:779)
	at com.google.gson.internal.bind.TreeTypeAdapter$GsonContextImpl.serialize(TreeTypeAdapter.java:189)
	at org.openhab.core.config.core.OrderingMapSerializer.lambda$0(OrderingMapSerializer.java:52)
	at org.openhab.core.config.core.OrderingMapSerializer$$Lambda/0x0000000100cf61e8.accept(Unknown Source)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(java.base@21.0.8/ForEachOps.java:184)
	at java.util.stream.SortedOps$RefSortingSink$$Lambda/0x00000001006ee168.accept(java.base@21.0.8/Unknown Source)
	at java.util.ArrayList.forEach(java.base@21.0.8/ArrayList.java:1596)
	at java.util.stream.SortedOps$RefSortingSink.end(java.base@21.0.8/SortedOps.java:395)
	at java.util.stream.AbstractPipeline.copyInto(java.base@21.0.8/AbstractPipeline.java:510)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@21.0.8/AbstractPipeline.java:499)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(java.base@21.0.8/ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(java.base@21.0.8/ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(java.base@21.0.8/AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEachOrdered(java.base@21.0.8/ReferencePipeline.java:601)
	at org.openhab.core.config.core.OrderingMapSerializer.serialize(OrderingMapSerializer.java:49)
	at org.openhab.core.config.core.OrderingMapSerializer.serialize(OrderingMapSerializer.java:1)
	at com.google.gson.internal.bind.TreeTypeAdapter.write(TreeTypeAdapter.java:108)
	at com.google.gson.internal.bind.TreeTypeAdapter.write(TreeTypeAdapter.java:101)
	at com.google.gson.Gson.toJson(Gson.java:944)
	at com.google.gson.Gson.toJson(Gson.java:899)
	at com.google.gson.Gson.toJson(Gson.java:848)
	at com.google.gson.Gson.toJson(Gson.java:825)
	at org.openhab.core.storage.json.internal.JsonStorage.flush(JsonStorage.java:352)
	- locked <0x00000000810e8820> (a org.openhab.core.storage.json.internal.JsonStorage)
	at org.openhab.core.storage.json.internal.JsonStorage.deferredCommit(JsonStorage.java:400)
	- locked <0x00000000810e8820> (a org.openhab.core.storage.json.internal.JsonStorage)
	at org.openhab.core.storage.json.internal.JsonStorage.put(JsonStorage.java:168)
	at org.openhab.core.common.registry.AbstractManagedProvider.update(AbstractManagedProvider.java:109)
	at org.openhab.core.config.discovery.internal.PersistentInbox.internalAdd(PersistentInbox.java:305)
	at org.openhab.core.config.discovery.internal.PersistentInbox.add(PersistentInbox.java:237)
	- locked <0x000000008514ce30> (a org.openhab.core.config.discovery.internal.PersistentInbox)
	at org.openhab.core.config.discovery.internal.PersistentInbox.thingDiscovered(PersistentInbox.java:402)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:262)
	- locked <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.createDiscoveryResult(MDNSDiscoveryService.java:227)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.considerService(MDNSDiscoveryService.java:214)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.serviceResolved(MDNSDiscoveryService.java:207)
	at javax.jmdns.impl.ListenerStatus$ServiceListenerStatus.serviceResolved(ListenerStatus.java:117)
	- locked <0x00000000e096ed10> (a javax.jmdns.impl.ListenerStatus$ServiceListenerStatus)
	at javax.jmdns.impl.JmDNSImpl$1.run(JmDNSImpl.java:923)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

"JmDNS pool-27-thread-1" #871 [2819883] prio=5 os_prio=0 cpu=2478,52ms elapsed=21361,56s tid=0x00007fbb35624bf0 nid=2819883 waiting for monitor entry  [0x00007fba205fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:257)
	- waiting to lock <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.createDiscoveryResult(MDNSDiscoveryService.java:227)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.considerService(MDNSDiscoveryService.java:214)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.serviceResolved(MDNSDiscoveryService.java:207)
	at javax.jmdns.impl.ListenerStatus$ServiceListenerStatus.serviceResolved(ListenerStatus.java:117)
	- locked <0x00000000911c3db0> (a javax.jmdns.impl.ListenerStatus$ServiceListenerStatus)
	at javax.jmdns.impl.JmDNSImpl$1.run(JmDNSImpl.java:923)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

"JmDNS pool-28-thread-1" #872 [2819884] prio=5 os_prio=0 cpu=2226,44ms elapsed=21361,56s tid=0x00007fbb356244a0 nid=2819884 waiting for monitor entry  [0x00007fba204fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:257)
	- waiting to lock <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.createDiscoveryResult(MDNSDiscoveryService.java:227)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.considerService(MDNSDiscoveryService.java:214)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.serviceResolved(MDNSDiscoveryService.java:207)
	at javax.jmdns.impl.ListenerStatus$ServiceListenerStatus.serviceResolved(ListenerStatus.java:117)
	- locked <0x000000009119c2e0> (a javax.jmdns.impl.ListenerStatus$ServiceListenerStatus)
	at javax.jmdns.impl.JmDNSImpl$1.run(JmDNSImpl.java:923)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

"JmDNS pool-30-thread-1" #874 [2819886] prio=5 os_prio=0 cpu=2401,91ms elapsed=21361,54s tid=0x00007fbb35626f10 nid=2819886 waiting for monitor entry  [0x00007fba202fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:257)
	- waiting to lock <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.createDiscoveryResult(MDNSDiscoveryService.java:227)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.considerService(MDNSDiscoveryService.java:214)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.serviceResolved(MDNSDiscoveryService.java:207)
	at javax.jmdns.impl.ListenerStatus$ServiceListenerStatus.serviceResolved(ListenerStatus.java:117)
	- locked <0x000000008d346d28> (a javax.jmdns.impl.ListenerStatus$ServiceListenerStatus)
	at javax.jmdns.impl.JmDNSImpl$1.run(JmDNSImpl.java:923)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

"JmDNS pool-32-thread-1" #876 [2819889] prio=5 os_prio=0 cpu=2249,22ms elapsed=21361,53s tid=0x00007fbb35629990 nid=2819889 waiting for monitor entry  [0x00007fba200fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:257)
	- waiting to lock <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.createDiscoveryResult(MDNSDiscoveryService.java:227)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.considerService(MDNSDiscoveryService.java:214)
	at org.openhab.core.config.discovery.mdns.internal.MDNSDiscoveryService.serviceResolved(MDNSDiscoveryService.java:207)
	at javax.jmdns.impl.ListenerStatus$ServiceListenerStatus.serviceResolved(ListenerStatus.java:117)
	- locked <0x000000008d7afcd0> (a javax.jmdns.impl.ListenerStatus$ServiceListenerStatus)
	at javax.jmdns.impl.JmDNSImpl$1.run(JmDNSImpl.java:923)
	at java.util.concurrent.Executors$RunnableAdapter.call(java.base@21.0.8/Executors.java:572)
	at java.util.concurrent.FutureTask.run(java.base@21.0.8/FutureTask.java:317)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@21.0.8/ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@21.0.8/ThreadPoolExecutor.java:642)
	at java.lang.Thread.runWith(java.base@21.0.8/Thread.java:1596)
	at java.lang.Thread.run(java.base@21.0.8/Thread.java:1583)

"OH-binding-teleinfo:serialcontroller:teleinfoserial" #1165 [2820248] daemon prio=5 os_prio=0 cpu=9998,65ms elapsed=21349,28s tid=0x00007fbb0c114430 nid=2820248 waiting for monitor entry  [0x00007fba1b8fe000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl.thingDiscovered(DiscoveryServiceRegistryImpl.java:257)
	- waiting to lock <0x00000000814f9128> (a org.openhab.core.config.discovery.internal.DiscoveryServiceRegistryImpl)
	at org.openhab.core.config.discovery.AbstractDiscoveryService.thingDiscovered(AbstractDiscoveryService.java:318)
	at org.openhab.binding.teleinfo.internal.TeleinfoDiscoveryService.detectNewElectricityMeterFromReceivedFrame(TeleinfoDiscoveryService.java:132)
	at org.openhab.binding.teleinfo.internal.TeleinfoDiscoveryService.onFrameReceived(TeleinfoDiscoveryService.java:111)
	at org.openhab.binding.teleinfo.internal.handler.TeleinfoAbstractControllerHandler.lambda$0(TeleinfoAbstractControllerHandler.java:49)
	at org.openhab.binding.teleinfo.internal.handler.TeleinfoAbstractControllerHandler$$Lambda/0x0000000101341188.accept(Unknown Source)
	at java.util.concurrent.CopyOnWriteArrayList.forEach(java.base@21.0.8/CopyOnWriteArrayList.java:891)
	at java.util.concurrent.CopyOnWriteArraySet.forEach(java.base@21.0.8/CopyOnWriteArraySet.java:425)
	at org.openhab.binding.teleinfo.internal.handler.TeleinfoAbstractControllerHandler.fireOnFrameReceivedEvent(TeleinfoAbstractControllerHandler.java:49)
	at org.openhab.binding.teleinfo.internal.serial.TeleinfoSerialControllerHandler.onFrameReceived(TeleinfoSerialControllerHandler.java:108)
	at org.openhab.binding.teleinfo.internal.serial.TeleinfoReceiveThread.run(TeleinfoReceiveThread.java:63)
```

For all mDNS discoveries, the `JmDNS` threads will be he ones performing the actual "discovery process", because they are the ones the executes the listener methods. In the above case, `JmDNS pool-26-thread-1` are busy deep inside Gson doing something that I assume takes a long time. In the meanwhile, 4 other JmDNS threads and the Teleinfo binding discovery thread are blocked waiting for `JmDNS pool-26-thread-1` to finish. I don't know how big the JmDNS thread pool is, but this could potentially exchaust the thread pool. For Teleinfo, the thread name `OH-binding-teleinfo:serialcontroller:teleinfoserial` hints that this is the sole thread responsible for communication with the serial controller that is being blocked.

By isolating the discovery result registration from the rest of the system, we will no longer have situations like this.