### PR TITLE
Fix flaky test ThingEventFactoryTest.testCreateTriggerPressedEvent

### DIFF
--- a/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
+++ b/bundles/org.openhab.core.thing/src/test/java/org/openhab/core/thing/events/ThingEventFactoryTest.java
@@ -371,7 +371,9 @@ public class ThingEventFactoryTest {
 
         assertEquals(ChannelTriggeredEvent.TYPE, event.getType());
         assertEquals(CHANNEL_TRIGGERED_EVENT_TOPIC, event.getTopic());
-        assertEquals(CHANNEL_TRIGGERED_PRESSED_EVENT_PAYLOAD, event.getPayload());
+        Gson gson = new Gson();
+        assertEquals(gson.fromJson(CHANNEL_TRIGGERED_PRESSED_EVENT_PAYLOAD, Object.class),
+                gson.fromJson(event.getPayload(), Object.class));
         assertNotNull(event.getEvent());
         assertEquals(CommonTriggerEvents.PRESSED, event.getEvent());
         assertEquals(CHANNEL_UID, event.getChannel());


### PR DESCRIPTION
## Summary
Fixes a flaky test in `ThingEventFactoryTest.testCreateTriggerPressedEvent`.

## Root Cause
The test compared a JSON string generated from a `Map` against a hardcoded string. 
Because `Map` does not guarantee key ordering, the JSON varied nondeterministically, 
causing flakes under NonDex and different JVM orders.

## Fix
- Replace brittle string comparison with structural JSON comparison.
- Both expected and actual payloads are deserialized via Gson and compared as objects.
- This ensures the comparison is order-independent while preserving test intent.

## Validation
- Verified stable behavior with repeated NonDex runs.
- Test-only change, no production code modified.
