### PR TITLE
Add item overloads for providing source

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -211,10 +211,10 @@ public abstract class GenericItem implements ActiveItem {
         this.itemStateConverter = itemStateConverter;
     }
 
-    protected void internalSend(Command command) {
+    protected void internalSend(Command command, @Nullable String source) {
         // try to send the command to the bus
         if (eventPublisher instanceof EventPublisher publisher) {
-            publisher.post(ItemEventFactory.createCommandEvent(this.getName(), command));
+            publisher.post(ItemEventFactory.createCommandEvent(this.getName(), command, source));
         }
     }
 
@@ -339,7 +339,11 @@ public abstract class GenericItem implements ActiveItem {
     }
 
     public void send(RefreshType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(RefreshType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     protected void notifyListeners(final State oldState, final State newState) {

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GenericItem.java
@@ -338,10 +338,20 @@ public abstract class GenericItem implements ActiveItem {
         }
     }
 
+    /**
+     * Send a REFRESH command to the item.
+     */
     public void send(RefreshType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a REFRESH command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(RefreshType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -278,10 +278,22 @@ public class GroupItem extends GenericItem implements StateChangeListener, Metad
         }
     }
 
+    /**
+     * Send a command to the each member of the group.
+     *
+     * @param command the command to be sent
+     */
     public void send(Command command) {
         send(command, null);
     }
 
+    /**
+     * Send a command to the each member of the group.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(Command command, @Nullable String source) {
         if (getAcceptedCommandTypes().contains(command.getClass())) {
             internalSend(command, source);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/GroupItem.java
@@ -279,20 +279,24 @@ public class GroupItem extends GenericItem implements StateChangeListener, Metad
     }
 
     public void send(Command command) {
+        send(command, null);
+    }
+
+    public void send(Command command, @Nullable String source) {
         if (getAcceptedCommandTypes().contains(command.getClass())) {
-            internalSend(command);
+            internalSend(command, source);
         } else {
             logger.warn("Command '{}' has been ignored for group '{}' as it is not accepted.", command, getName());
         }
     }
 
     @Override
-    protected void internalSend(Command command) {
+    protected void internalSend(Command command, @Nullable String source) {
         EventPublisher eventPublisher = this.eventPublisher;
         if (eventPublisher != null) {
             for (Item member : members) {
                 // try to send the command to the bus
-                eventPublisher.post(ItemEventFactory.createCommandEvent(member.getName(), command));
+                eventPublisher.post(ItemEventFactory.createCommandEvent(member.getName(), command, source));
             }
         }
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.HSBType;
@@ -46,7 +47,11 @@ public class ColorItem extends DimmerItem {
     }
 
     public void send(HSBType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(HSBType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/ColorItem.java
@@ -46,10 +46,22 @@ public class ColorItem extends DimmerItem {
         super(CoreItemFactory.COLOR, name);
     }
 
+    /**
+     * Send an HSBType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(HSBType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send an HSBType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(HSBType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -15,6 +15,7 @@ package org.openhab.core.library.items;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.DateTimeType;
@@ -53,7 +54,11 @@ public class DateTimeItem extends GenericItem {
     }
 
     public void send(DateTimeType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(DateTimeType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DateTimeItem.java
@@ -53,10 +53,22 @@ public class DateTimeItem extends GenericItem {
         return ACCEPTED_COMMAND_TYPES;
     }
 
+    /**
+     * Send a DateTimeType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(DateTimeType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a DateTimeType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(DateTimeType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
@@ -15,6 +15,7 @@ package org.openhab.core.library.items;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.IncreaseDecreaseType;
 import org.openhab.core.library.types.OnOffType;
@@ -49,11 +50,19 @@ public class DimmerItem extends SwitchItem {
     }
 
     public void send(PercentType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(PercentType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(IncreaseDecreaseType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(IncreaseDecreaseType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/DimmerItem.java
@@ -49,18 +49,42 @@ public class DimmerItem extends SwitchItem {
         super(type, name);
     }
 
+    /**
+     * Send a PercentType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(PercentType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a PercentType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(PercentType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send an INCREASE/DECREASE command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(IncreaseDecreaseType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send an INCREASE/DECREASE command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(IncreaseDecreaseType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -44,7 +44,11 @@ public class LocationItem extends GenericItem {
     }
 
     public void send(PointType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(PointType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/LocationItem.java
@@ -43,10 +43,22 @@ public class LocationItem extends GenericItem {
         super(CoreItemFactory.LOCATION, name);
     }
 
+    /**
+     * Send a PointType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(PointType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a PointType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(PointType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -98,18 +98,42 @@ public class NumberItem extends GenericItem implements MetadataAwareItem {
         return ACCEPTED_COMMAND_TYPES;
     }
 
+    /**
+     * Send a DecimalType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(DecimalType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a DecimalType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(DecimalType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send a QuantityType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(QuantityType<?> command) {
         send(command, null);
     }
 
+    /**
+     * Send a QuantityType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(QuantityType<?> command, @Nullable String source) {
         if (dimension == null) {
             DecimalType strippedCommand = new DecimalType(command);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/NumberItem.java
@@ -99,15 +99,23 @@ public class NumberItem extends GenericItem implements MetadataAwareItem {
     }
 
     public void send(DecimalType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(DecimalType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(QuantityType<?> command) {
+        send(command, null);
+    }
+
+    public void send(QuantityType<?> command, @Nullable String source) {
         if (dimension == null) {
             DecimalType strippedCommand = new DecimalType(command);
-            internalSend(strippedCommand);
+            internalSend(strippedCommand, source);
         } else if (command.getUnit().isCompatible(unit) || command.getUnit().inverse().isCompatible(unit)) {
-            internalSend(command);
+            internalSend(command, source);
         } else {
             logger.warn("Command '{}' to item '{}' was rejected because it is incompatible with the item unit '{}'",
                     command, name, unit);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
@@ -58,26 +58,62 @@ public class PlayerItem extends GenericItem {
         return ACCEPTED_COMMAND_TYPES;
     }
 
+    /**
+     * Send a PLAY/PAUSE command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(PlayPauseType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a PLAY/PAUSE command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(PlayPauseType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send a REWIND/FASTFORWARD command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(RewindFastforwardType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a REWIND/FASTFORWARD command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(RewindFastforwardType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send a NEXT/PREVIOUS command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(NextPreviousType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a NEXT/PREVIOUS command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(NextPreviousType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/PlayerItem.java
@@ -15,6 +15,7 @@ package org.openhab.core.library.items;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.NextPreviousType;
@@ -58,15 +59,27 @@ public class PlayerItem extends GenericItem {
     }
 
     public void send(PlayPauseType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(PlayPauseType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(RewindFastforwardType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(RewindFastforwardType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(NextPreviousType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(NextPreviousType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
@@ -15,6 +15,7 @@ package org.openhab.core.library.items;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.PercentType;
@@ -56,15 +57,27 @@ public class RollershutterItem extends GenericItem {
     }
 
     public void send(UpDownType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(UpDownType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(StopMoveType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(StopMoveType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     public void send(PercentType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(PercentType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/RollershutterItem.java
@@ -56,26 +56,62 @@ public class RollershutterItem extends GenericItem {
         return ACCEPTED_COMMAND_TYPES;
     }
 
+    /**
+     * Send an UP/DOWN command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(UpDownType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send an UP/DOWN command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(UpDownType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send a STOP/MOVE command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(StopMoveType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a STOP/MOVE command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(StopMoveType command, @Nullable String source) {
         internalSend(command, source);
     }
 
+    /**
+     * Send a PercentType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(PercentType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a PercentType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(PercentType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -48,10 +48,22 @@ public class StringItem extends GenericItem {
         super(CoreItemFactory.STRING, name);
     }
 
+    /**
+     * Send a StringType command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(StringType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send a StringType command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(StringType command, @Nullable String source) {
         internalSend(command, source);
     }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/StringItem.java
@@ -49,7 +49,11 @@ public class StringItem extends GenericItem {
     }
 
     public void send(StringType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(StringType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
@@ -15,6 +15,7 @@ package org.openhab.core.library.items;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.items.GenericItem;
 import org.openhab.core.library.CoreItemFactory;
 import org.openhab.core.library.types.OnOffType;
@@ -46,7 +47,11 @@ public class SwitchItem extends GenericItem {
     }
 
     public void send(OnOffType command) {
-        internalSend(command);
+        internalSend(command, null);
+    }
+
+    public void send(OnOffType command, @Nullable String source) {
+        internalSend(command, source);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/items/SwitchItem.java
@@ -46,10 +46,22 @@ public class SwitchItem extends GenericItem {
         super(type, name);
     }
 
+    /**
+     * Send an ON/OFF command to the item.
+     *
+     * @param command the command to be sent
+     */
     public void send(OnOffType command) {
         internalSend(command, null);
     }
 
+    /**
+     * Send an ON/OFF command to the item.
+     *
+     * @param command the command to be sent
+     * @param source the source of the command. See
+     *            https://www.openhab.org/docs/developer/utils/events.html#the-core-events
+     */
     public void send(OnOffType command, @Nullable String source) {
         internalSend(command, source);
     }


### PR DESCRIPTION
Providing a source with a command can allow rules (or profiles) to react differently depending on what's sending the command. For example, if it's from a user interaction in BasicUI or MainUI, or from HomeKit, or if it's an automated action such as another rule. These overloads are helpful for those sources to easily declare they are who is sending the command.