### PR TITLE
ChannelTransformation: log exact syntax errors in transformations

### DIFF
--- a/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
+++ b/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/generic/ChannelTransformation.java
@@ -19,6 +19,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import javax.script.ScriptException;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.transform.TransformationException;
@@ -167,7 +169,10 @@ public class ChannelTransformation {
                 try {
                     return Optional.ofNullable(service.transform(function, value));
                 } catch (TransformationException e) {
-                    logger.debug("Applying {} failed: {}", this, e.getMessage());
+                    if (e.getCause() instanceof ScriptException ex) {
+                        logger.error("Applying {} failed: {}", this, ex.getMessage());
+                    } else
+                        logger.debug("Applying {} failed: {}", this, e.getMessage());
                 }
             } else {
                 logger.warn("Failed to use {}, service not found", this);


### PR DESCRIPTION
For:
```
Thing mqtt:topic:r (mqtt:broker:b) {
  Channels:
    Type string : a [stateTopic="a/b", transformationPattern="DSL:|O_N.toString()"]
}
```
before this change:
```    
2025-09-25 04:57:05.588 [DEBUG] [nelTransformation$TransformationStep] - Applying TransformationStep{serviceName='DSL', function='|O_N.toString()'} failed: Failed to execute script.
```
after:
```    
2025-09-25 05:03:48.524 [ERROR] [nelTransformation$TransformationStep] - Applying TransformationStep{serviceName='DSL', function='|O_N.toString()'} failed:  ___ O_N.toString()
   The method or field O_N is undefined; line 1, column 0, length 3
```
This changes the logging level to Error, so that syntax errors are logged.  `ScriptException` is logged on other places with level ERROR .  Disadvantage of this change is that the same syntax error will be logged many, many times, in fact each minute, until it is fixed for the channel.

If you ask me, similar change must be done on all places with `catch (org.openhab.core.transform.TransformationException)`, but I do not know how to trigger execution over these places.