### PR TITLE
Make TimerImpl thread-safe

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/action/TimerImpl.java
@@ -29,9 +29,12 @@ import org.openhab.core.scheduler.SchedulerRunnable;
 @NonNullByDefault
 public class TimerImpl implements Timer {
 
+    // All access must be guarded by "this"
     private final Scheduler scheduler;
     private final SchedulerRunnable runnable;
     private final @Nullable String identifier;
+
+    // All access must be guarded by "this"
     private ScheduledCompletableFuture<?> future;
 
     public TimerImpl(Scheduler scheduler, ZonedDateTime startTime, SchedulerRunnable runnable) {
@@ -48,7 +51,7 @@ public class TimerImpl implements Timer {
     }
 
     @Override
-    public boolean cancel() {
+    public synchronized boolean cancel() {
         return future.cancel(true);
     }
 
@@ -60,27 +63,27 @@ public class TimerImpl implements Timer {
     }
 
     @Override
-    public @Nullable ZonedDateTime getExecutionTime() {
+    public synchronized @Nullable ZonedDateTime getExecutionTime() {
         return future.isCancelled() ? null : future.getScheduledTime();
     }
 
     @Override
-    public boolean isActive() {
+    public synchronized boolean isActive() {
         return !future.isDone();
     }
 
     @Override
-    public boolean isCancelled() {
+    public synchronized boolean isCancelled() {
         return future.isCancelled();
     }
 
     @Override
-    public boolean isRunning() {
+    public synchronized boolean isRunning() {
         return isActive() && ZonedDateTime.now().isAfter(future.getScheduledTime());
     }
 
     @Override
-    public boolean hasTerminated() {
+    public synchronized boolean hasTerminated() {
         return future.isDone();
     }
 }


### PR DESCRIPTION
We were [discussing timers in scripts and sharing of them with other scripts](https://community.openhab.org/t/rules-and-concurrency/166577/20), and whether the `Timer` implementation itself was thread-safe. I checked the source, and found that it had some locking, but not everywhere where it was needed.

This is my take a fixing that.

It might look like I've just slapped a lot of `synchronized` everywhere, because it so happened that this was the end result, but that's not what I did. I analyzed which fields need protection, and added locks to achieve that. In addition, I added comments above the fields that need it.

Even though `scheduler` is final and the instance itself thus can't change, I couldn't find any proof that the `Scheduler` implementations are thread-safe, or are required to be so. That's why it needs protection for all calls/use. `future` should be obvious.

I've not made any protection for `runnable`, because it isn't directly retrievable. Execution of the runnable isn't protected, that must be up to the code that is being run (in the `SchedulerRunnable`) to handle if necessary.

