### PR TITLE
[automation] AbstractScriptModuleHandler: Inject module type ID into context

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -51,10 +51,15 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     private final Logger logger = LoggerFactory.getLogger(AbstractScriptModuleHandler.class);
 
     /** Constant defining the configuration parameter of modules that specifies the mime type of a script */
-    public static final String SCRIPT_TYPE = "type";
+    public static final String CONFIG_SCRIPT_TYPE = "type";
 
     /** Constant defining the configuration parameter of modules that specifies the script itself */
-    public static final String SCRIPT = "script";
+    public static final String CONFIG_SCRIPT = "script";
+
+    /**
+     * Constant defining the context key of the module type id.
+     */
+    public static final String CONTEXT_KEY_MODULE_TYPE_ID = "oh.module-type-id";
 
     protected final ScriptEngineManager scriptEngineManager;
 
@@ -73,8 +78,8 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
         this.ruleUID = ruleUID;
         this.engineIdentifier = UUID.randomUUID().toString();
 
-        this.type = getValidConfigParameter(SCRIPT_TYPE, module.getConfiguration(), module.getId(), false);
-        this.script = getValidConfigParameter(SCRIPT, module.getConfiguration(), module.getId(), true);
+        this.type = getValidConfigParameter(CONFIG_SCRIPT_TYPE, module.getConfiguration(), module.getId(), false);
+        this.script = getValidConfigParameter(CONFIG_SCRIPT, module.getConfiguration(), module.getId(), true);
     }
 
     private static String getValidConfigParameter(String parameter, Configuration config, String moduleId,
@@ -136,6 +141,13 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
     }
 
     /**
+     * Gets the type identifier of this module handler
+     * 
+     * @return the type identifier
+     */
+    abstract public String getTypeId();
+
+    /**
      * Gets the script engine identifier for this module
      *
      * @return the engine identifier string
@@ -194,6 +206,7 @@ public abstract class AbstractScriptModuleHandler<T extends Module> extends Base
             contextNew.put(key, value);
         }
         contextNew.put("ruleUID", this.ruleUID);
+        contextNew.put(CONTEXT_KEY_MODULE_TYPE_ID, this.getTypeId());
         executionContext.setAttribute("ctx", contextNew, ScriptContext.ENGINE_SCOPE);
 
         // add the single contextNew entries to the scope

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -66,6 +66,11 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action> imp
     }
 
     @Override
+    public String getTypeId() {
+        return TYPE_ID;
+    }
+
+    @Override
     public void compile() throws ScriptException {
         super.compileScript();
     }

--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -47,6 +47,11 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
     }
 
     @Override
+    public String getTypeId() {
+        return TYPE_ID;
+    }
+
+    @Override
     public void compile() throws ScriptException {
         super.compileScript();
     }

--- a/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
+++ b/itests/org.openhab.core.model.rule.tests/src/main/java/org/openhab/core/model/rule/runtime/DSLRuleProviderTest.java
@@ -119,7 +119,7 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
         assertThat(firstRule.getName(), is("RuleNumberOne"));
         assertThat(firstRule.getTriggers().getFirst().getTypeUID(), is(SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID));
         assertThat(firstRule.getActions().getFirst().getTypeUID(), is(ScriptActionHandler.TYPE_ID));
-        assertThat(firstRule.getActions().getFirst().getConfiguration().get(AbstractScriptModuleHandler.SCRIPT_TYPE),
+        assertThat(firstRule.getActions().getFirst().getConfiguration().get(AbstractScriptModuleHandler.CONFIG_SCRIPT_TYPE),
                 is(DSLScriptEngine.MIMETYPE_OPENHAB_DSL_RULE));
 
         Rule secondRule = it.next();
@@ -130,7 +130,7 @@ public class DSLRuleProviderTest extends JavaOSGiTest {
         assertThat(secondRule.getTriggers().getFirst().getConfiguration().get(ItemStateTriggerHandler.CFG_ITEMNAME),
                 is("X"));
         assertThat(secondRule.getActions().getFirst().getTypeUID(), is(ScriptActionHandler.TYPE_ID));
-        assertThat(secondRule.getActions().getFirst().getConfiguration().get(AbstractScriptModuleHandler.SCRIPT_TYPE),
+        assertThat(secondRule.getActions().getFirst().getConfiguration().get(AbstractScriptModuleHandler.CONFIG_SCRIPT_TYPE),
                 is(DSLScriptEngine.MIMETYPE_OPENHAB_DSL_RULE));
     }
 


### PR DESCRIPTION
This allows scripts to know whether they are a script action or a script condition.