### PR TITLE
Script cache experimentation

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/LockingCache.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/LockingCache.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared;
+
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link LockingCache} can be used by scripts to share information between subsequent runs of the same script or
+ * between scripts (depending on implementation).
+ *
+ * @author Ravi Nadahar - Initial contribution
+ *
+ * @apiNote Implementations must be thread-safe.
+ */
+@NonNullByDefault
+public interface LockingCache {// TODO: (Nad) Redo JavaDocs
+
+    /**
+     * Add a new key-value-pair to the cache. If the key is already present, the old value is replaces by the new value.
+     *
+     * @param key a {@link String} used as key
+     * @param object the {@code Object} to store with the key
+     * @return the old object associated with this key or {@code null} if the key didn't exist
+     */
+    @Nullable
+    Object put(String key, Object object);
+
+    @Nullable
+    Object lockAndPut(String key, Object object);
+
+    /**
+     * Remove a key (and its associated object) from the cache
+     *
+     * @param key the key to remove.
+     * @return the object previously associated to this key or {@code null}.
+     */
+    @Nullable
+    Object remove(String key);
+
+    /**
+     * Get a object from the cache
+     *
+     * @param key the key of the requested object
+     * @return the object associated with the key or {@code null}.
+     */
+    @Nullable
+    Object lockAndGet(String key);
+
+    /**
+     * Get a serialized object from the cache or create a new key-value-pair from the given supplier
+     *
+     * @param key the key of the requested serialized object
+     * @param supplier a supplier that returns a non-null serialized object to be used if the key isn't present
+     * @return the serialized object associated with the key
+     */
+    Object lockAndGet(String key, Supplier<Object> supplier);
+
+    void unlock(String key);
+}

--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ObjectCache.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/shared/ObjectCache.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.module.script.rulesupport.shared;
+
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * The {@link ObjectCache} can be used by scripts to share information between subsequent runs of the same script or
+ * between scripts (depending on implementation).
+ *
+ * @author Ravi Nadahar - Initial contribution
+ *
+ * @apiNote Implementations must be thread-safe.
+ */
+@NonNullByDefault
+public interface ObjectCache {// TODO: (Nad) Redo JavaDocs
+
+    /**
+     * Add a new key-value-pair to the cache. If the key is already present, the old value is replaces by the new value.
+     *
+     * @param key a {@link String} used as key
+     * @param serializedObject the {@code String} to store with the key
+     * @return the old serialized object associated with this key or {@code null} if key didn't exist
+     */
+    @Nullable
+    String put(String key, String serializedObject);
+
+    /**
+     * Remove a key (and its associated serialized object) from the cache
+     *
+     * @param key the key to remove.
+     * @return the serialized object previously associated to this key or {@code null} if key not present.
+     */
+    @Nullable
+    String remove(String key);
+
+    /**
+     * Get a serialized object from the cache
+     *
+     * @param key the key of the requested serialized object
+     * @return the serialized object associated with the key or {@code null}.
+     */
+    @Nullable
+    String get(String key);
+
+    /**
+     * Get a serialized object from the cache or create a new key-value-pair from the given supplier
+     *
+     * @param key the key of the requested serialized object
+     * @param supplier a supplier that returns a non-null serialized object to be used if the key isn't present
+     * @return the serialized object associated with the key
+     */
+    String get(String key, Supplier<String> supplier);
+
+    /**
+     * Attempts to compute a mapping for the specified key and its current mapped serialized object
+     * (or {@code null} if there is no current mapping).
+     *
+     * See {@code java.util.Map.compute()} for details.
+     *
+     * @param key the key of the requested serialized object.
+     * @param remappingFunction the remapping function to compute a serialized object.
+     * @return the new serialized object associated with the specified key or {@code null}.
+     */
+    @Nullable
+    String compute(String key, BiFunction<String, @Nullable String, @Nullable String> remappingFunction);
+}


### PR DESCRIPTION
This isn't a traditional PR and might never become one. It's a way to illustrate some ideas so that others can judge if they might be useful. The code isn't tested, and isn't intended to be complete in any way. It's closer to "compilable pseudocode".

It's somewhat tricky to get the logic in the `LockingCache` right. I've made an attempt, but haven't tested or debugged it, so it might be flawed and need further refactoring if the idea is accepted as worthwhile.

This contains two potential implementations for shared caches:
* `ObjectCache` is meant to store serialized objects. Objects would have to be serialized and deserialized on storage and retrieval. This would have to be done by the individual scripting language add-on, and objects are unlikely to be valid across different scripting languages. The deserialization procedure would have to have some way to implement that deserialization failed/that the object is invalid, preferably a way that differs from if the object simply doesn't exist in the cache.
* `LockingCache` is meant to store (mutable) objects that can be locked, processed and then unlocked. This could be used to "coordinate" several scripts, for example with counters. Cache entries are locked on an individual basis, so one entry can remain locked while other entries can be processed normally. While locked, exclusive access to the object is obtained, so that decisions can be made based on the current value without the possibility that the value changes in the meanwhile, thus avoiding [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use). What is especially tricky here is preventing potential deadlocks if the entry is removed from the cache while scripts still potentially have references to it. Once it has been removed from the cache, it's no longer possible to get the `Lock` instance, and thus it can't be unlocked. Therefore, I've tried to make logic that tries to make that impossible, but I'm not sure if it's actually "waterproof".
* 