### PR TITLE
ScriptTransformationService: Handle engine removal through ScriptEngineManager

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptTransformationService.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -134,7 +135,8 @@ public class ScriptTransformationService implements TransformationService, Confi
             params = configMatcher.group("params");
         }
 
-        ScriptRecord scriptRecord = scriptCache.computeIfAbsent(scriptUid, k -> new ScriptRecord());
+        ScriptRecord scriptRecord = Objects
+                .requireNonNull(scriptCache.computeIfAbsent(scriptUid, k -> new ScriptRecord()));
         scriptRecord.lock.lock();
         try {
             if (scriptRecord.script.isBlank()) {


### PR DESCRIPTION
Currently, there are two issues:

When a ScriptRecord is cleared from the cache,
the ScriptTransformationService currently closes the ScriptEngine itself, without involving the ScriptEngineManager. If a transformation script is invoked again after it has been cleared from the scriptCache, the ScriptEngineManager::createScriptEngine call makes the ScriptEngineManager first remove the old engine from its internal "store", which includes invoking the scriptUnloaded hook. This invocation can cause an exception because the engine is already closed (by ScriptTransformationService) and hence function/method invocations inside the engine are not possible anymore.

Ff the engine implement Compilable, it is even closed two times by ScriptTransformationService, possibly causing an exception if the ScriptEngine doesn't handle multiple close() calls gracefully.

These issues are fixed by properly notifying the ScriptEngineManager when an engine should be removed and leaving the removal handling to the ScriptEngineManager.

The issues were discovered while working on #5062.