### PR TITLE
ScriptEngineFactory.createScriptEngine() - describe purpose of parameter

### DIFF
--- a/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
+++ b/bundles/org.openhab.core.automation.module.script/src/main/java/org/openhab/core/automation/module/script/ScriptEngineFactory.java
@@ -68,6 +68,9 @@ public interface ScriptEngineFactory {
 
     /**
      * This method creates a new ScriptEngine based on the supplied file extension or MimeType.
+     * openHAB-core always passes as parameter one of the values, returned by getScriptTypes().
+     * The parameter serves for a ScriptEngineFactory, which announces support for several
+     * distinct languages, to create a ScriptEngine for the requested language.
      *
      * @param scriptType a file extension (script) or MimeType (ScriptAction or ScriptCondition)
      * @return ScriptEngine or null


### PR DESCRIPTION
I reached this conclusion after looking at all .createScriptEngine() calls in openhab-core.