### PR TITLE
Very minor rulesupport fixes

### DIFF
--- a/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
+++ b/bundles/org.openhab.core.automation.module.script.rulesupport/src/main/java/org/openhab/core/automation/module/script/rulesupport/internal/loader/ScriptFileReference.java
@@ -18,8 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Script File wrapper offering various methods to inspect the script
@@ -28,8 +26,6 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class ScriptFileReference implements Comparable<ScriptFileReference> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ScriptFileReference.class);
-
     private final AtomicBoolean queued = new AtomicBoolean();
     private final AtomicBoolean loaded = new AtomicBoolean();
 
@@ -82,10 +78,7 @@ public class ScriptFileReference implements Comparable<ScriptFileReference> {
         }
 
         String name1 = scriptFilePath.getFileName().toString();
-        LOGGER.trace("o1 [{}], name1 [{}]", scriptFilePath, name1);
-
         String name2 = other.scriptFilePath.getFileName().toString();
-        LOGGER.trace("o2 [{}], name2 [{}]", other.scriptFilePath, name2);
 
         int nameCompare = name1.compareToIgnoreCase(name2);
         if (nameCompare != 0) {
@@ -101,11 +94,11 @@ public class ScriptFileReference implements Comparable<ScriptFileReference> {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ScriptFileReference other)) {
             return false;
         }
-        ScriptFileReference that = (ScriptFileReference) o;
-        return scriptFilePath.equals(that.scriptFilePath);
+        return Objects.equals(scriptFilePath, other.scriptFilePath) && Objects.equals(scriptType, other.scriptType)
+                && startLevel == other.startLevel;
     }
 
     @Override


### PR DESCRIPTION
While looking for other problems, I studied some of these classes and did some minor adjustments along the way. I actually don't remember what my goal was when I did it, but it was abandoned. I'm left with these minor fixes that I either have to throw away or submit. So, I'm submitting them, since I've made them anyway.

There is no goal here, this is just minor issues that appeared "problematic" and in need of some attention. Since there is no goal, and the changes are so few, I'll describe the details.

### `ScriptFileReference`

* Logging in `compareTo()`, `equals()` or `hashCode()` is bad. These methods will be called a lot, "behind the scenes", from various `Collection`s or other components. They must perform. The logging also seems more like some debugging that has been left behind. Thus, logging in `compareTo()` has been removed.
* Once the logging was removed, the `Logger` wasn't in use, and was removed.
* `equals()` didn't have parity with `hashCode()`. `equals()` only considered one field, while `hashCode()` considered three. I modified `equals()` to match `hashCode()`.

### `AbstractScriptFileWatcher`

* `scheduler` wasn't `final`, but could be (making the field thread-safe, since `ScheduledExecutorService` implementations must be thread-safe).
* Addressed a couple of `computeIfAbsent()`s that gave null warnings.
* Removed `synchronized` from `getLockForScript()` because it served no purpose (`scriptLockMap` is a `ConcurrentHashMap`).
* `onReadyMarkerAdded()`: Slight redesign to improve performance and consistency. `currentStartLevel` is `volatile` and can change at any time, so one can't assume that the value will remain the same during execution of the method. Also, it has some "penalties" associated with it as a `volatile` field (memory barrier, CPU cache flush), so using it like it were a local variable isn't ideal. I changed the method to use a local variable internally, and only access `currentStartLevel` the two times that were required: once to read and once to write.
