### PR TITLE
Script DSL: accept Collection Literals

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/Script.xtext
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/Script.xtext
@@ -13,12 +13,7 @@ Script returns XBlockExpression:
 
 @Override
 XLiteral returns XExpression:
-  XClosure |
-  XBooleanLiteral |
-  XNullLiteral |
-  XStringLiteral |
-  XNumberLiteral |
-  XTypeLiteral |
+  super |
   QuantityLiteral
 ;
 


### PR DESCRIPTION
https://github.com/eclipse-xtext/xtext/commit/96db5a594c3a24e72b02f3fddfb23950e3959375#diff-ce486852f7e6fc1d4b4c658a87682c5e1053ae43c6e678fbb914ff796c5c93a1 added in 2013 to Xbase.xtext / `XLiteral` [Collection Literals](https://eclipse.dev/Xtext/xtend/documentation/203_xtend_expressions.html#collection-literals):

* lists - `#['Hello','World']` , and
* sets - `#{'Hello','World'}`

The collection literals are added now also to Scripts/Rules DSL in openHAB.

Before this change
```
rule "A"
when Item r3  changed
then
  logError("Closure literal", [ 12 ].toString)
  logError("Boolean literal", true.toString)
  logError("Number Literal", 7.toString)
  logError("Number Literal", 7.12.toString)
  logError("XType Literal", typeof (Number).toString)
  logError("Quantity Literal", 1|Ω.toStrig);
  logError("Quantity Literal", 2|A.toString);
  logError("Quantity Literal", 3|m³.toString);
//  for(l: #["1", "2"]) logError("A", l) // list literal
//  logError("List Literal", #["3", "4"].toString)
//  for(s: #{'1|A', '2|A'}) logError("B", s) // set literal
//  for(s: #{1|Ω, 2|Ω}) logError("C", s.toString) // set literal with Quantity Type
//  logError("Set Literal", #{12, 17, 4}.toString)
//  logError("Set Literal with Quantitity Type to String", #{1|Ω, 2|A, 3|m³}.toString)
end
```
prints
```
2025-10-17 16:27:01.908 [ERROR] [ab.core.model.script.Closure literal] - Proxy for org.eclipse.xtext.xbase.lib.Functions$Function1: [ {
  org.eclipse.xtext.xbase.impl.XNumberLiteralImpl@58a84212 (value: 12)
} ]
2025-10-17 16:27:01.911 [ERROR] [ab.core.model.script.Boolean literal] - true
2025-10-17 16:27:01.913 [ERROR] [hab.core.model.script.Number Literal] - 7
2025-10-17 16:27:01.917 [ERROR] [hab.core.model.script.Number Literal] - 7.12
2025-10-17 16:27:01.920 [ERROR] [nhab.core.model.script.XType Literal] - class java.lang.Number
2025-10-17 16:27:01.924 [ERROR] [b.core.model.script.Quantity Literal] - 1 Ω
2025-10-17 16:27:01.929 [ERROR] [b.core.model.script.Quantity Literal] - 2 A
2025-10-17 16:27:01.933 [ERROR] [b.core.model.script.Quantity Literal] - 3 m³
```
and the commented lines are syntax errors.

With the current change, the same code as above but without the comments:
```
rule "A"
when Item r3  changed
then
  logError("Closure literal", [ 12 ].toString)
  logError("Boolean literal", true.toString)
  logError("Number Literal", 7.toString)
  logError("Number Literal", 7.12.toString)
  logError("XType Literal", typeof (Number).toString)
  logError("Quantity Literal", 1|Ω.toString);
  logError("Quantity Literal", 2|A.toString);
  logError("Quantity Literal", 3|m³.toString);

  for(l: #["1", "2"]) logError("A", l) // list literal
  logError("List Literal", #["3", "4"].toString)
  for(s: #{'1|A', '2|A'}) logError("B", s) // set literal
  for(s: #{1|Ω, 2|Ω}) logError("C", s.toString) // set literal with Quantity Type
  logError("Set Literal", #{12, 17, 4}.toString)
  logError("Set Literal with Quantitity Type to String", #{1|Ω, 2|A, 3|m³}.toString)
end

```
emits
```
2025-10-17 17:38:08.105 [ERROR] [ab.core.model.script.Closure literal] - Proxy for org.eclipse.xtext.xbase.lib.Functions$Function1: [ {
  org.eclipse.xtext.xbase.impl.XNumberLiteralImpl@2448f2e4 (value: 12)
} ]
2025-10-17 17:38:08.112 [ERROR] [ab.core.model.script.Boolean literal] - true
2025-10-17 17:38:08.118 [ERROR] [hab.core.model.script.Number Literal] - 7
2025-10-17 17:38:08.124 [ERROR] [hab.core.model.script.Number Literal] - 7.12
2025-10-17 17:38:08.130 [ERROR] [nhab.core.model.script.XType Literal] - class java.lang.Number
2025-10-17 17:38:08.137 [ERROR] [b.core.model.script.Quantity Literal] - 1 Ω
2025-10-17 17:38:08.143 [ERROR] [b.core.model.script.Quantity Literal] - 2 A
2025-10-17 17:38:08.148 [ERROR] [b.core.model.script.Quantity Literal] - 3 m³
2025-10-17 17:38:08.151 [ERROR] [org.openhab.core.model.script.A     ] - 1
2025-10-17 17:38:08.153 [ERROR] [org.openhab.core.model.script.A     ] - 2
2025-10-17 17:38:08.156 [ERROR] [enhab.core.model.script.List Literal] - [3, 4]
2025-10-17 17:38:08.158 [ERROR] [org.openhab.core.model.script.B     ] - 1|A
2025-10-17 17:38:08.160 [ERROR] [org.openhab.core.model.script.B     ] - 2|A
2025-10-17 17:38:08.163 [ERROR] [org.openhab.core.model.script.C     ] - 1 Ω
2025-10-17 17:38:08.165 [ERROR] [org.openhab.core.model.script.C     ] - 2 Ω
2025-10-17 17:38:08.168 [ERROR] [penhab.core.model.script.Set Literal] - [17, 4, 12]
2025-10-17 17:38:08.173 [ERROR] [teral with Quantitity Type to String] - [1 Ω, 2 A, 3 m³]

```
so it works.