### PR TITLE
Include source with item event descriptions when present

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupItemStateChangedEvent.java
@@ -57,6 +57,11 @@ public class GroupItemStateChangedEvent extends ItemStateChangedEvent {
 
     @Override
     public String toString() {
-        return String.format("%s through %s", super.toString(), memberName);
+        String result = String.format("%s through %s", super.toString(), memberName);
+        String source = getSource();
+        if (source != null) {
+            result = String.format("%s (source: %s)", result, source);
+        }
+        return result;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemCommandEvent.java
@@ -63,6 +63,11 @@ public class ItemCommandEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' received command %s", itemName, command);
+        String result = String.format("Item '%s' received command %s", itemName, command);
+        String source = getSource();
+        if (source != null) {
+            result = String.format("%s (source: %s)", result, source);
+        }
+        return result;
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemStateChangedEvent.java
@@ -104,6 +104,11 @@ public class ItemStateChangedEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' changed from %s to %s", itemName, oldItemState, itemState);
+        String result = String.format("Item '%s' changed from %s to %s", itemName, oldItemState, itemState);
+        String source = getSource();
+        if (source != null) {
+            result = String.format("%s (source: %s)", result, source);
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Example log lines in events.log:

```
2025-10-17 11:20:41.052 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'TestSwitch1' received command ON (source: org.openhab.core.io.console$openhab)
2025-10-17 11:28:59.527 [INFO ] [openhab.event.ItemCommandEvent      ] - Item 'TestSwitch1' received command OFF (source: org.openhab.io.homekit$15680270-F69A-C8A8-863A-2B6697D83A35)
```