### PR TITLE
Textual Rules: evaluate global variables in the context of previous variables

### DIFF
--- a/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleContextHelper.java
+++ b/bundles/org.openhab.core.model.rule.runtime/src/org/openhab/core/model/rule/runtime/internal/RuleContextHelper.java
@@ -16,7 +16,6 @@ import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.ecore.util.EContentAdapter;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.xtext.naming.QualifiedName;
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.xbase.interpreter.IEvaluationContext;
 import org.openhab.core.model.rule.RulesStandaloneSetup;
 import org.openhab.core.model.rule.rules.RuleModel;
@@ -61,7 +60,7 @@ public class RuleContextHelper {
         for (VariableDeclaration var : ruleModel.getVariables()) {
             try {
                 Object initialValue = var.getRight() == null ? null
-                        : scriptEngine.newScriptFromXExpression(var.getRight()).execute();
+                        : scriptEngine.newScriptFromXExpression(var.getRight()).execute(evaluationContext);
                 evaluationContext.newValue(QualifiedName.create(var.getName()), initialValue);
             } catch (ScriptExecutionException e) {
                 logger.warn("Variable '{}' on rule file '{}' cannot be initialized with value '{}': {}", var.getName(),
@@ -70,14 +69,6 @@ public class RuleContextHelper {
         }
         ruleModel.eAdapters().add(new RuleContextAdapter(evaluationContext));
         return evaluationContext;
-    }
-
-    public static synchronized String getVariableDeclaration(RuleModel ruleModel) {
-        StringBuilder vars = new StringBuilder();
-        for (VariableDeclaration var : ruleModel.getVariables()) {
-            vars.append(NodeModelUtils.findActualNodeFor(var).getText());
-        }
-        return vars.toString();
     }
 
     /**


### PR DESCRIPTION
Before this change `openhab/rules/b.rules`:
```
val a = 1
val b = a + 2

rule "B"
when Item b changed
then 
  logError("B", Integer.toString(b))
end
```
emitted
```
[INFO ] [el.core.internal.ModelRepositoryImpl] - Loading DSL model 'b.rules'
[WARN ] [e.runtime.internal.RuleContextHelper] - Variable 'b' on rule file 'b.rules' cannot be initialized with value '<XFeatureCallImplCustom> + <XNumberLiteralImpl>': An error occurred during the script execution: Could not invoke method: org.eclipse.xtext.xbase.lib.IntegerExtensions.operator_plus(int,int) on instance: null
```
and during execution
```
[ERROR] [.handler.AbstractScriptModuleHandler] - Script execution of rule with UID 'b-1' failed: An error occurred during the script execution: Could not invoke method: java.lang.Integer.toString(int) on instance: null in b
```
With the current change the above produces:
```
[INFO ] [el.core.internal.ModelRepositoryImpl] - Loading DSL model 'b.rules'
[ERROR] [org.openhab.core.model.script.B     ] - 3
```
Closes: https://github.com/openhab/openhab-core/issues/3696
Closes: https://github.com/openhab/openhab-core/issues/4493.