### PR TITLE
IP add-on finder: resolve source IP before broadcast scan

### DIFF
--- a/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
+++ b/bundles/org.openhab.core.config.discovery.addon.ip/src/main/java/org/openhab/core/config/discovery/addon/ip/IpAddonFinder.java
@@ -406,20 +406,20 @@ public class IpAddonFinder extends BaseAddonFinder implements NetworkAddressChan
             return;
         }
         String broadcastAddress = networkAddressService.getConfiguredBroadcastAddress();
+        if (broadcastAddress == null || broadcastAddress.isBlank()) {
+            logger.debug("Unable to resolve broadcast address");
+            return;
+        }
         InetAddress bAddr;
         try {
             bAddr = InetAddress.getByName(broadcastAddress);
         } catch (UnknownHostException e) {
-            logger.warn("Unable to resolve broadcast address: {}", e.getMessage());
-            return;
-        }
-        if (broadcastAddress == null || broadcastAddress.isBlank()) {
-            logger.warn("Unable to resolve broadcast address");
+            logger.debug("Unable to resolve broadcast address: {}", e.getMessage());
             return;
         }
         InterfaceAddress sourceAddress = NetUtil.getSameSubnetInterfaceAddress(bAddr);
         if (sourceAddress == null) {
-            logger.warn("Unable to find a suitable interface address for broadcast address \"{}\"", broadcastAddress);
+            logger.debug("Unable to find a suitable interface address for broadcast address \"{}\"", broadcastAddress);
             return;
         }
         logger.debug("Starting broadcast scan with address {}", broadcastAddress);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/net/NetUtil.java
@@ -272,7 +272,7 @@ public class NetUtil implements NetworkAddressService {
     }
 
     /**
-     * Finds the local interface address that is on the same subnet as the specific IP address, if one exists.
+     * Finds the local interface address that is on the same subnet as the specified IP address, if one exists.
      *
      * @param address the IP address for which to find an interface address on the same subnet.
      * @return The matching {@link InterfaceAddress} or {@code null} if no such local interface address exists.


### PR DESCRIPTION
I've noticed in the past that `IpAddonFinder` crashes every time the WiZ binding search is being performed: https://github.com/openhab/openhab-addons/issues/19385

I did some debugging, and found that the reason seemed to be that the WiZ binding was the only one that did a broadcast scan using a "plain" request. When doing a "plain" request, the source MAC address needs to be resolved, but what happens is that the IP address used to resolve the MAC address is actually the "any IP" address (`0.0.0.0`/`::/0`). Since it's not bound to a concrete network interface, it doesn't have a MAC address, and the process fails with a socket exception.

To solve this, I've created a new method in `NetUtil` that will try to find a network interface address that is on the same subnet as a query IP, and then use that in `IpAddonFinder` to find the source network interface address before trying to resolve the MAC address.

It seems to resolve the problem when I test, but my testing is limited: I don't have any of these devices, so I can't actually test that the IP discovery works. Furthermore, I don't use IPv6 addresses, so I can't test that the source address resolution works on IPv6. The intention is that it should work for both IPv4 and IPv6, but IPv6 is completely untested.

Since you @holgerfriedrich and @jlaur are the authors of `IpAddonFinder`, I'm hoping that you can evaluate, and ideally test, this broader than what I've been able to.