### PR TITLE
Do not require `Strategies{}` in `persistence/` files

### DIFF
--- a/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
+++ b/bundles/org.openhab.core.model.persistence/src/org/openhab/core/model/persistence/Persistence.xtext
@@ -6,9 +6,9 @@ generate persistence "https://openhab.org/model/Persistence"
 
 PersistenceModel:
 	{PersistenceModel}
-	'Strategies' '{' strategies+=Strategy* 
+	('Strategies' '{' strategies+=Strategy*
 		('default' '=' defaults+=[Strategy|ID] (',' defaults+=[Strategy|ID])*)?
-	'}'
+	'}')?
 	('Filters' '{' filters+=Filter* '}')?
 	('Items' '{' configs+=PersistenceConfiguration* '}')?
 	('Aliases' '{' aliases+=AliasConfiguration* '}')?


### PR DESCRIPTION
To define how an item has to be persisted in an `openhab/persistence/….persist` file, using one of the predefined strategies (`everyChange`, `forecast`), the file has to start with `Strategies{}`.  Here this requirement is lifted: `Strategies { … }` is now optional. It is possible to write just
```
Items { 
  i: strategy=forecast
}
```

An empty `.persist` file, or one containing only spaces, is also valid, it prevents creating configuration with the same name in the UI.  That is, if the file `openhab/persistence/jdbc.persist` is empty, the JDBC persistence is shown in `/settings/persistence/jdbc` as “Note: This persistence configuration is not editable because it has been provisioned from a file. ”, is empty in the UI and cannot be configured over the UI.