### PR TITLE
Script DSL: do implicit `import java.time.temporal.ChronoUnit;`

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImportSectionNamespaceScopeProvider.java
@@ -35,6 +35,7 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
     public static final QualifiedName MODEL_SCRIPT_ACTIONS_PACKAGE = QualifiedName.create("org", "openhab", "core",
             "model", "script", "actions");
     public static final QualifiedName TIME_PACKAGE = QualifiedName.create("java", "time");
+    public static final QualifiedName CHRONOUNIT_CLASS = QualifiedName.create("java", "time", "temporal", "ChronoUnit");
     public static final QualifiedName QUANTITY_PACKAGE = QualifiedName.create("javax", "measure", "quantity");
 
     @Override
@@ -47,6 +48,7 @@ public class ScriptImportSectionNamespaceScopeProvider extends XImportSectionNam
         implicitImports.add(doCreateImportNormalizer(CORE_PERSISTENCE_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(MODEL_SCRIPT_ACTIONS_PACKAGE, true, false));
         implicitImports.add(doCreateImportNormalizer(TIME_PACKAGE, true, false));
+        implicitImports.add(doCreateImportNormalizer(CHRONOUNIT_CLASS, false, false));
         implicitImports.add(doCreateImportNormalizer(QUANTITY_PACKAGE, true, false));
         return implicitImports;
     }


### PR DESCRIPTION
The current addition:
```java
imlicitImports.add(doCreateImportNormalizer(
    QualifiedName.create("java", "time", "temporal", "ChronoUnit"), false, false);
```
corresponds to having in DSL scripts/rules implicit: `import java.time.temporal.ChronoUnit;`, whereas
```java
imlicitImports.add(doCreateImportNormalizer(
    QualifiedName.create("java", "time", "temporal"), true, false);
```
(cutting `, "ChronoUnit"` and toggling the middle parameter), would correspond to `import java.time.temporal.*;`.

The reason why `DayOfWeek.MONDAY` and `logError("A", MonthDay.now.toString)` (⇔ `MonthDay.now()`) work is, because `ScriptImportSectionNamespaceScopeProvider.java:getImplicitImports()` contains `implicitImports.add(doCreateImportNormalizer(QualifiedName.create("java", "time"), true, false));` corresponding to implicit `import java.time.*;` in DSL scripts.

N.B. As the result of ScriptImplicitlyImportedTypes.java:getStaticImportClasses() includes `ChronoUnit.class` and `DayOfWeek.class`, DSL Scripts have implicit `import static java.time.temporal.ChronoUnit.*; import static java.time.DayOfWeek.*;`.  For this reason just `TUESDAY` and `DAYS` in Script DSL are recognized.

Closes https://github.com/openhab/openhab-core/issues/4791.