### PR TITLE
model.script.ScriptImplicitlyImportedTypes: remove dead code

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -12,8 +12,6 @@
  */
 package org.openhab.core.model.script.scoping;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.net.URLEncoder;
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -69,12 +67,6 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
     @Override
     protected List<Class<?>> getExtensionClasses() {
         List<Class<?>> result = super.getExtensionClasses();
-        result.remove(Comparable.class);
-        result.remove(Double.class);
-        result.remove(Integer.class);
-        result.remove(BigInteger.class);
-        result.remove(BigDecimal.class);
-        result.remove(double.class);
 
         result.add(NumberExtensions.class);
 


### PR DESCRIPTION
`super.getExtensionClasses()` returns `org.eclipse.xtext.xbase.lib.ArrayExtensions`, `org.eclipse.xtext.xbase.lib.BigDecimalExtensions`, `org.eclipse.xtext.xbase.lib.BigIntegerExtensions`, `org.eclipse.xtext.xbase.lib.BooleanExtensions`, `org.eclipse.xtext.xbase.lib.ByteExtensions`, `org.eclipse.xtext.xbase.lib.CharacterExtensions`, `org.eclipse.xtext.xbase.lib.CollectionExtensions`, `org.eclipse.xtext.xbase.lib.ComparableExtensions`, `org.eclipse.xtext.xbase.lib.DoubleExtensions`, `org.eclipse.xtext.xbase.lib.FloatExtensions`, `org.eclipse.xtext.xbase.lib.FunctionExtensions`, `org.eclipse.xtext.xbase.lib.IntegerExtensions`, `org.eclipse.xtext.xbase.lib.IterableExtensions`, `org.eclipse.xtext.xbase.lib.IteratorExtensions`, `org.eclipse.xtext.xbase.lib.ListExtensions`, `org.eclipse.xtext.xbase.lib.LongExtensions`, `org.eclipse.xtext.xbase.lib.MapExtensions`, `org.eclipse.xtext.xbase.lib.ObjectExtensions`, `org.eclipse.xtext.xbase.lib.ProcedureExtensions`, `org.eclipse.xtext.xbase.lib.ShortExtensions` and `org.eclipse.xtext.xbase.lib.StringExtensions`.