### PR TITLE
Add AbstractThingHandlerDiscoveryService constructor for tests to use

### DIFF
--- a/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery/src/main/java/org/openhab/core/config/discovery/AbstractThingHandlerDiscoveryService.java
@@ -14,6 +14,7 @@ package org.openhab.core.config.discovery;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -45,6 +46,21 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
     // initialized when the type is generic, so we have to initialize it with "something"
     protected @NonNullByDefault({}) T thingHandler = (@NonNull T) null;
 
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @param thingClazz the {@link ThingHandler} class.
+     * @param supportedThingTypes the list of Thing types which are supported (can be {@code null}).
+     * @param timeout the discovery timeout in seconds after which the discovery
+     *            service automatically stops its forced discovery process (>= 0).
+     * @param backgroundDiscoveryEnabledByDefault defines, whether the default for this discovery service is to
+     *            enable background discovery or not.
+     * @param scanInputLabel the label of the optional input parameter to start the discovery or null if no input
+     *            parameter supported.
+     * @param scanInputDescription the description of the optional input parameter to start the discovery or null if no
+     *            input parameter supported.
+     * @throws IllegalArgumentException if {@code timeout < 0}.
+     */
     protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
             int timeout, boolean backgroundDiscoveryEnabledByDefault, @Nullable String scanInputLabel,
             @Nullable String scanInputDescription) throws IllegalArgumentException {
@@ -53,18 +69,77 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
         this.backgroundDiscoveryEnabled = backgroundDiscoveryEnabledByDefault;
     }
 
+    /**
+     * Creates a new instance of this class with the specified parameters and with {@code scanInputLabel} and
+     * {@code scanInputDescription} set to {@code null}.
+     *
+     * @param thingClazz the {@link ThingHandler} class.
+     * @param supportedThingTypes the list of Thing types which are supported (can be {@code null}).
+     * @param timeout the discovery timeout in seconds after which the discovery
+     *            service automatically stops its forced discovery process (>= 0).
+     * @param backgroundDiscoveryEnabledByDefault defines, whether the default for this discovery service is to
+     *            enable background discovery or not.
+     * @throws IllegalArgumentException if {@code timeout < 0}.
+     */
     protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
             int timeout, boolean backgroundDiscoveryEnabledByDefault) throws IllegalArgumentException {
         this(thingClazz, supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault, null, null);
     }
 
+    /**
+     * Creates a new instance of this class with the specified parameters and with {@code scanInputLabel} and
+     * {@code scanInputDescription} set to {@code null}, and {@code backgroundDiscoveryEnabledByDefault} enabled.
+     *
+     * @param thingClazz the {@link ThingHandler} class.
+     * @param supportedThingTypes the list of Thing types which are supported (can be {@code null}).
+     * @param timeout the discovery timeout in seconds after which the discovery
+     *            service automatically stops its forced discovery process (>= 0).
+     * @throws IllegalArgumentException if {@code timeout < 0}.
+     */
     protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, @Nullable Set<ThingTypeUID> supportedThingTypes,
             int timeout) throws IllegalArgumentException {
         this(thingClazz, supportedThingTypes, timeout, true);
     }
 
+    /**
+     * Creates a new instance of this class with the specified parameters and with {@code scanInputLabel} and
+     * {@code scanInputDescription} set to {@code null}, without any {@code supportedThingTypes}, and
+     * {@code backgroundDiscoveryEnabledByDefault} enabled.
+     *
+     * @param thingClazz the {@link ThingHandler} class.
+     * @param timeout the discovery timeout in seconds after which the discovery
+     *            service automatically stops its forced discovery process (>= 0).
+     * @throws IllegalArgumentException if {@code timeout < 0}.
+     */
     protected AbstractThingHandlerDiscoveryService(Class<T> thingClazz, int timeout) throws IllegalArgumentException {
         this(thingClazz, null, timeout);
+    }
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     * <p>
+     * <b>For use by tests only</b>, allows setting a different {@link ScheduledExecutorService} like
+     * {@link org.openhab.core.util.SameThreadExecutorService} for synchronous behavior during testing.
+     *
+     * @param thingClazz the {@link ThingHandler} class.
+     * @param supportedThingTypes the list of Thing types which are supported (can be {@code null}).
+     * @param timeout the discovery timeout in seconds after which the discovery
+     *            service automatically stops its forced discovery process (>= 0).
+     * @param backgroundDiscoveryEnabledByDefault defines, whether the default for this discovery service is to
+     *            enable background discovery or not.
+     * @param scanInputLabel the label of the optional input parameter to start the discovery or null if no input
+     *            parameter supported.
+     * @param scanInputDescription the description of the optional input parameter to start the discovery or null if no
+     *            input parameter supported.
+     * @throws IllegalArgumentException if {@code timeout < 0}.
+     */
+    protected AbstractThingHandlerDiscoveryService(ScheduledExecutorService scheduler, Class<T> thingClazz,
+            @Nullable Set<ThingTypeUID> supportedThingTypes, int timeout, boolean backgroundDiscoveryEnabledByDefault,
+            @Nullable String scanInputLabel, @Nullable String scanInputDescription) throws IllegalArgumentException {
+        super(scheduler, supportedThingTypes, timeout, backgroundDiscoveryEnabledByDefault, scanInputLabel,
+                scanInputDescription);
+        this.thingClazz = thingClazz;
+        this.backgroundDiscoveryEnabled = backgroundDiscoveryEnabledByDefault;
     }
 
     @Override
@@ -82,7 +157,7 @@ public abstract class AbstractThingHandlerDiscoveryService<T extends ThingHandle
     }
 
     @Override
-    public @Nullable ThingHandler getThingHandler() {
+    public @Nullable T getThingHandler() {
         return thingHandler;
     }
 


### PR DESCRIPTION
@holgerfriedrich Immediately when starting to try to fix the tests, I met one of the situations where I needed the ability to override `thingDiscovered()`. This is the alternative I've been able to come up with for this particular problem, we need a corresponding "test constructor" in `AbstractThingHandlerDiscoveryService` as we have in `AbstractDiscoveryService`.

As usual, I can't keep my fingers off other things I bump into, so I've added some JavaDoc to the constructors, and changed the return type of `getThingHandler()`. If that's controversial, I can just revert it, but the reason I did it was that when trying to research how to document the parameter in the JavaDoc, I realized that it wasn't actually used for anything (except to enforce the type in `setThingHandler()` - which serves no purpose alone).

As far as I can understand, this change will only trigger warnings for "unnecessary casts", so it shouldn't break anything. Not having to cast the result should at least make having the parameter there do something useful.