### PR TITLE
[rest-api]: Change error code 500 to 400

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/JSONResponseExceptionMapper.java
@@ -13,7 +13,6 @@
 package org.openhab.core.io.rest.core.internal;
 
 import java.io.IOException;
-import java.lang.IllegalArgumentException;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
@@ -57,7 +56,7 @@ public class JSONResponseExceptionMapper implements ExceptionMapper<Exception> {
             // see https://github.com/openhab/openhab-distro/issues/1616
             logger.debug("Requested resource not (yet) found", cee);
             return cee.getResponse();
-        } else if (e instanceof IllegalArgumentException){
+        } else if (e instanceof IllegalArgumentException) {
             logger.debug("Invalid argument submitted for REST request", e);
             return JSONResponse.createErrorResponse(Response.Status.BAD_REQUEST, e.getMessage());
         } else {


### PR DESCRIPTION
# Description

Submitting invalid parameters to the rest API - like invalid date-time (`starttime=2025-10-26T07:34:71.502Z`), leads to a server error - `500 - Internal Server Error`.

I think it would be better to return `400 - Bad Request` and not record the full backtrace in the logs of the server for submitting an invalid parameter. But there is something to consider, that this change may have an impact on other services like:

- `openhab-ios` - [1](https://github.com/openhab/openhab-ios/blob/c5754e2285037fbc89831dc7bbb05f91510827a2/openHAB/openapi/openapitest/openapiCorrected.json#L1109), [2](https://github.com/openhab/openhab-ios/blob/c5754e2285037fbc89831dc7bbb05f91510827a2/OpenHABCore/Sources/OpenHABCore/openapi/openapi.json#L1108)
- `openhab-android` - [1](https://github.com/openhab/openhab-android/blob/3b6fa1efadbdb1e8be46cebc6983b667d5692a21/mobile/src/test/java/org/openhab/habdroid/util/SyncHttpClientTest.kt#L46)
- `openhab-webui` - [1](https://github.com/openhab/openhab-webui/blob/1ac744b29878313f97b3b7860014a34e57a1a6b7/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/rest/internal/HABotResource.java#L124), [2](https://github.com/openhab/openhab-webui/blob/1ac744b29878313f97b3b7860014a34e57a1a6b7/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ConfigResource.java#L219), [3](https://github.com/openhab/openhab-webui/blob/1ac744b29878313f97b3b7860014a34e57a1a6b7/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ProxyResource.java#L87)(this looks ok, because it has a 400 option), [5](https://github.com/openhab/openhab-webui/blob/1ac744b29878313f97b3b7860014a34e57a1a6b7/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ConfigResource.java#L239)

I can also make PR to handle also `400` response code.

If you decide that this PR doesn't make enough sense compared to the risk of problems if could cause, please discard it.