### PR TITLE
make FilterCriteria.Operator.getSymbol public

### DIFF
--- a/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
+++ b/bundles/org.openhab.core.persistence/src/main/java/org/openhab/core/persistence/FilterCriteria.java
@@ -56,7 +56,7 @@ public class FilterCriteria {
             this.symbol = symbol;
         }
 
-        String getSymbol() {
+        public String getSymbol() {
             return symbol;
         }
     }


### PR DESCRIPTION
Several persistence services already have their own helper methods to do this conversion, when we could just expose this method to make it easy
