### PR TITLE
Revert "[upnp] Fix event handling for embeded devices"

### DIFF
--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -149,13 +149,13 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
         @Override
         protected void eventReceived(GENASubscription sub) {
             Map<String, StateVariableValue> values = sub.getCurrentValues();
-            Device device = sub.getService().getDevice();
+            Device deviceRoot = sub.getService().getDevice().getRoot();
             String serviceId = sub.getService().getServiceId().getId();
 
             logger.trace("Receiving a GENA subscription '{}' response for device '{}'", serviceId,
-                    device.getIdentity().getUdn());
+                    deviceRoot.getIdentity().getUdn());
             for (UpnpIOParticipant participant : participants) {
-                if (Objects.equals(getDevice(participant), device)) {
+                if (Objects.equals(getDevice(participant), deviceRoot)) {
                     for (Entry<String, StateVariableValue> entry : values.entrySet()) {
                         Object value = entry.getValue().getValue();
                         if (value != null) {


### PR DESCRIPTION
Reverts openhab/openhab-core#5076

This PR broke the receiving of events in the Sonos binding (and I guess few other bindings relying on UPnP to receive events).

Closes openhab/openhab-addons#19600

Signed-off-by: Laurent Garnier <lg.hc@free.fr>