### PR TITLE
Added dimension for price per volume and related currency units

### DIFF
--- a/bundles/org.openhab.core.thing/schema/thing/thing-description-1.0.0.xsd
+++ b/bundles/org.openhab.core.thing/schema/thing/thing-description-1.0.0.xsd
@@ -198,6 +198,7 @@
 			<xs:enumeration value="Number:Temperature"/>
 			<xs:enumeration value="Number:Time"/>
 			<xs:enumeration value="Number:Volume"/>
+			<xs:enumeration value="Number:VolumePrice"/>
 			<xs:enumeration value="Number:VolumetricFlowRate"/>
 			<xs:enumeration value="Player"/>
 			<xs:enumeration value="Rollershutter"/>

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/internal/i18n/I18nProviderImpl.java
@@ -79,6 +79,7 @@ import org.openhab.core.library.dimension.EnergyPrice;
 import org.openhab.core.library.dimension.Intensity;
 import org.openhab.core.library.dimension.RadiantExposure;
 import org.openhab.core.library.dimension.RadiationSpecificActivity;
+import org.openhab.core.library.dimension.VolumePrice;
 import org.openhab.core.library.dimension.VolumetricFlowRate;
 import org.openhab.core.library.types.PointType;
 import org.openhab.core.library.unit.CurrencyUnits;
@@ -115,6 +116,7 @@ import org.slf4j.LoggerFactory;
  * @author Markus Rathgeb - Initial contribution
  * @author Stefan Triller - Initial contribution
  * @author Erdoan Hadzhiyusein - Added time zone
+ * @author Christoph Weitkamp - Added price per volume
  */
 @Component(immediate = true, configurationPid = I18nProviderImpl.CONFIGURATION_PID, property = {
         Constants.SERVICE_PID + "=org.openhab.i18n", //
@@ -437,6 +439,9 @@ public class I18nProviderImpl
         addDefaultUnit(dimensionMap, Temperature.class, SIUnits.CELSIUS, ImperialUnits.FAHRENHEIT);
         addDefaultUnit(dimensionMap, Time.class, Units.SECOND);
         addDefaultUnit(dimensionMap, Volume.class, SIUnits.CUBIC_METRE, ImperialUnits.GALLON_LIQUID_US);
+        addDefaultUnit(dimensionMap, VolumePrice.class, CurrencyUnits.PRICE_PER_LITRE);
+        addDefaultUnit(dimensionMap, VolumePrice.class, CurrencyUnits.PRICE_PER_CUBIC_METRE);
+        addDefaultUnit(dimensionMap, VolumePrice.class, CurrencyUnits.PRICE_PER_GALLON_LIQUID_US);
         addDefaultUnit(dimensionMap, VolumetricFlowRate.class, Units.LITRE_PER_MINUTE, ImperialUnits.GALLON_PER_MINUTE);
 
         return dimensionMap;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/VolumePrice.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/dimension/VolumePrice.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.library.dimension;
+
+import javax.measure.Quantity;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * The {@link VolumePrice} defines the dimension for prices
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public interface VolumePrice extends Quantity<VolumePrice> {
+}

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnits.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/library/unit/CurrencyUnits.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.internal.library.unit.CurrencyService;
 import org.openhab.core.library.dimension.Currency;
 import org.openhab.core.library.dimension.EnergyPrice;
+import org.openhab.core.library.dimension.VolumePrice;
 
 import tech.units.indriya.AbstractSystemOfUnits;
 import tech.units.indriya.format.SimpleUnitFormat;
@@ -32,6 +33,7 @@ import tech.units.indriya.unit.ProductUnit;
  * The {@link CurrencyUnits} defines the UoM system for handling currencies
  *
  * @author Jan N. Klug - Initial contribution
+ * @author Christoph Weitkamp - Added price per volume
  */
 @NonNullByDefault
 public final class CurrencyUnits extends AbstractSystemOfUnits {
@@ -41,10 +43,18 @@ public final class CurrencyUnits extends AbstractSystemOfUnits {
     public static final Unit<Currency> BASE_CURRENCY = new CurrencyUnit("DEF", null);
     public static final Unit<EnergyPrice> BASE_ENERGY_PRICE = new ProductUnit<>(
             BASE_CURRENCY.divide(Units.KILOWATT_HOUR));
+    public static final Unit<VolumePrice> PRICE_PER_LITRE = new ProductUnit<>(BASE_CURRENCY.divide(Units.LITRE));
+    public static final Unit<VolumePrice> PRICE_PER_CUBIC_METRE = new ProductUnit<>(
+            BASE_CURRENCY.divide(SIUnits.CUBIC_METRE));
+    public static final Unit<VolumePrice> PRICE_PER_GALLON_LIQUID_US = new ProductUnit<>(
+            BASE_CURRENCY.divide(ImperialUnits.GALLON_LIQUID_US));
 
     static {
         addUnit(BASE_CURRENCY);
         INSTANCE.units.add(BASE_ENERGY_PRICE);
+        INSTANCE.units.add(PRICE_PER_LITRE);
+        INSTANCE.units.add(PRICE_PER_CUBIC_METRE);
+        INSTANCE.units.add(PRICE_PER_GALLON_LIQUID_US);
     }
 
     @Override

--- a/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
+++ b/bundles/org.openhab.core/src/test/java/org/openhab/core/library/unit/UnitsTest.java
@@ -12,8 +12,9 @@
  */
 package org.openhab.core.library.unit;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,6 +29,7 @@ import javax.measure.quantity.Power;
 import javax.measure.quantity.Pressure;
 import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
+import javax.measure.quantity.Volume;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -282,6 +284,70 @@ public class UnitsTest {
         Quantity<Length> mile = km.to(ImperialUnits.MILE);
         assertThat(mile.getUnit(), is(ImperialUnits.MILE));
         assertThat(mile.getValue().doubleValue(), is(closeTo(6.2137119223733395d, DEFAULT_ERROR)));
+    }
+
+    @Test
+    public void testLitre2CubicMetre() {
+        Quantity<Volume> l = Quantities.getQuantity(BigDecimal.ONE, Units.LITRE);
+
+        Quantity<Volume> m3 = l.to(SIUnits.CUBIC_METRE);
+        assertThat(m3.getUnit(), is(SIUnits.CUBIC_METRE));
+        assertThat(m3.getValue().doubleValue(), closeTo(0.001, DEFAULT_ERROR));
+
+        QuantityType<Volume> litre = new QuantityType<>("5 l");
+
+        QuantityType<?> cubicMetre = litre.toUnit(SIUnits.CUBIC_METRE);
+        assertThat(cubicMetre, is(notNullValue()));
+        assertThat(cubicMetre.getUnit(), is(SIUnits.CUBIC_METRE));
+        assertThat(cubicMetre.doubleValue(), closeTo(0.005, DEFAULT_ERROR));
+    }
+
+    @Test
+    public void testCubicMetre2Litre() {
+        Quantity<Volume> m3 = Quantities.getQuantity(BigDecimal.ONE, SIUnits.CUBIC_METRE);
+
+        Quantity<Volume> l = m3.to(Units.LITRE);
+        assertThat(l.getUnit(), is(Units.LITRE));
+        assertThat(l.getValue().doubleValue(), closeTo(1000, DEFAULT_ERROR));
+
+        QuantityType<Volume> cubicMetre = new QuantityType<>("5 m³");
+
+        QuantityType<?> litre = cubicMetre.toUnit(Units.LITRE);
+        assertThat(litre, is(notNullValue()));
+        assertThat(litre.getUnit(), is(Units.LITRE));
+        assertThat(litre.doubleValue(), closeTo(5000, DEFAULT_ERROR));
+    }
+
+    @Test
+    public void testLitre2Gallon() {
+        Quantity<Volume> l = Quantities.getQuantity(BigDecimal.ONE, Units.LITRE);
+
+        Quantity<Volume> gal = l.to(ImperialUnits.GALLON_LIQUID_US);
+        assertThat(gal.getUnit(), is(ImperialUnits.GALLON_LIQUID_US));
+        assertThat(gal.getValue().doubleValue(), closeTo(0.2641, 1e-4));
+
+        QuantityType<Volume> litre = new QuantityType<>("5 l");
+
+        QuantityType<?> gallon = litre.toUnit(ImperialUnits.GALLON_LIQUID_US);
+        assertThat(gallon, is(notNullValue()));
+        assertThat(gallon.getUnit(), is(ImperialUnits.GALLON_LIQUID_US));
+        assertThat(gallon.doubleValue(), closeTo(1.3208, 1e-4));
+    }
+
+    @Test
+    public void testGallon2Litre() {
+        Quantity<Volume> gal = Quantities.getQuantity(BigDecimal.ONE, ImperialUnits.GALLON_LIQUID_US);
+
+        Quantity<Volume> l = gal.to(Units.LITRE);
+        assertThat(l.getUnit(), is(Units.LITRE));
+        assertThat(l.getValue().doubleValue(), closeTo(3.7854, 1e-4));
+
+        QuantityType<Volume> gallon = new QuantityType<>("5 gal");
+
+        QuantityType<?> litre = gallon.toUnit(Units.LITRE);
+        assertThat(litre, is(notNullValue()));
+        assertThat(litre.getUnit(), is(Units.LITRE));
+        assertThat(litre.doubleValue(), closeTo(18.9270, 1e-4));
     }
 
     @Test


### PR DESCRIPTION
- Added dimension for price per volume and related currency units

This allows UoM price calculations for more volume based assets like gas or water.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>