### PR TITLE
Fixed flaky test in JsonStorageTest

### DIFF
--- a/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
+++ b/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java
@@ -156,6 +156,7 @@ public class JsonStorageTest extends JavaTest {
     @SuppressWarnings({ "null", "unchecked" })
     @Test
     public void testOrdering() throws IOException {
+        Gson gson = new GsonBuilder().setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT).create();
         objectStorage.put("DummyObject", new DummyObject());
         {
             objectStorage.put("a", new DummyObject());
@@ -172,15 +173,16 @@ public class JsonStorageTest extends JavaTest {
             persistAndReadAgain();
         }
         String storageStringBA = Files.readString(tmpFile.toPath());
-        assertEquals(storageStringAB, storageStringBA);
+        assertEquals(gson.fromJson(storageStringAB, JsonObject.class),
+                gson.fromJson(storageStringBA, JsonObject.class));
 
         {
             objectStorage = new JsonStorage<>(tmpFile, this.getClass().getClassLoader(), 0, 0, 0, List.of());
             objectStorage.flush();
         }
         String storageStringReserialized = Files.readString(tmpFile.toPath());
-        assertEquals(storageStringAB, storageStringReserialized);
-        Gson gson = new GsonBuilder().setDateFormat(DateTimeType.DATE_PATTERN_JSON_COMPAT).create();
+        assertEquals(gson.fromJson(storageStringAB, JsonObject.class),
+                gson.fromJson(storageStringReserialized, JsonObject.class));
 
         // Parse json. Gson preserves json object key ordering when we parse only JsonObject
         JsonObject orderedMap = gson.fromJson(storageStringAB, JsonObject.class);


### PR DESCRIPTION
### Description
I noticed that the test [`org.openhab.core.storage.json.internal.JsonStorageTest.testOrdering`](https://github.com/openhab/openhab-core/blob/b1670ec2fae5e523f440f220b582eef8e9d004ff/bundles/org.openhab.core.storage.json/src/test/java/org/openhab/core/storage/json/internal/JsonStorageTest.java#L158) in `JsonStorageTest.java` may fail due to how the `DummyObject` is serialized through the `JsonStorage`. This PR fixes the test by allowing for more flexibility when comparing how the `DummyObject` is serialized. 

### Steps to Reproduce 

To reproduce the errors run the following commands:

```
mvn clean install -pl bundles/org.openhab.core.storage.json -am -DskipTests

# Run using Nondex tool
mvn -pl bundles/org.openhab.core.storage.json edu.illinois:nondex-maven-plugin:2.2.1:nondex -Dtest=org.openhab.core.storage.json.internal.JsonStorageTest#testOrdering
```

This results in the following error:
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.459 s <<< FAILURE! -- in org.openhab.core.storage.json.internal.JsonStorageTest
[ERROR] org.openhab.core.storage.json.internal.JsonStorageTest.testOrdering -- Time elapsed: 0.428 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <{
  "DummyObject": {
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject",
    "value": {
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ],
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      }
    }
  },
  "a": {
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject",
    "value": {
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ],
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      }
    }
  },
  "b": {
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject",
    "value": {
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ],
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      }
    }
  }
}> but was: <{
  "DummyObject": {
    "value": {
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ],
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      }
    },
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject"
  },
  "a": {
    "value": {
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      },
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ]
    },
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject"
  },
  "b": {
    "value": {
      "innerMapWithNonComparableKeys": {
        "http://www.example.com/key2": 1,
        "http://www.example.com/key1": 2,
        "http://www.example.com/key3": 3
      },
      "innerMapWithComparableKeys": {
        "-5": 4,
        "0": 2,
        "3": 1,
        "50": 3
      },
      "configuration": {
        "properties": {
          "multiInt": [
            1,
            2,
            3
          ],
          "testBigDecimal": 12,
          "testBoolean": true,
          "testDouble": 12.12,
          "testFloat": 12.12,
          "testInt": 12,
          "testLong": 12,
          "testShort": 12,
          "testString": "hello world"
        }
      },
      "innerSetWithNonComparableElements": [
        "http://www.example.com/key2",
        "http://www.example.com/key1",
        "http://www.example.com/key3"
      ],
      "channels": [
        {
          "configuration": {
            "properties": {
              "testChildLong": 12
            }
          }
        }
      ],
      "innerSetWithComparableElements": [
        -5,
        0,
        3,
        50
      ]
    },
    "class": "org.openhab.core.storage.json.internal.JsonStorageTest$DummyObject"
  }
}>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.openhab.core.storage.json.internal.JsonStorageTest.testOrdering(JsonStorageTest.java:175)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

### Reason for Failure
Notice how the `class` field in `DummyObject`  in the first JSON is serialized first whereas in the second JSON it is serialized second. Additionally, the ordering of the objects within the `value` field also differ. 

The root of the problem comes from when the `DummyObject` in the test gets put into the `JsonStorage`. The JsonStorage uses a `GsonBuilder`  called `entityMapper` to serialize the `DummyObject` into a `StorageEntry` value [here](https://github.com/openhab/openhab-core/blob/b1670ec2fae5e523f440f220b582eef8e9d004ff/bundles/org.openhab.core.storage.json/src/main/java/org/openhab/core/storage/json/internal/JsonStorage.java#L166). However, the `GsonBuilder` does not guarantee one specific ordering when creating a JSON string for the fields within the `DummyObject`. It is important to note that the `entityMapper` does have custom serializers to enforce the ordering of maps and sets but not for the `DummyObject`. As a result, the fields `innerMapWithNonComparableKeys`, `innerMapWithComparableKeys`, `configuration`, etc. may come in any ordering in the JSON string. Furthermore, the ordering of the `class` and `value` fields in `StorageEntry` may also come in any ordering since that is also not enforced.

### Key Changes in this PR
Instead of comparing the JSON strings created by the `objectStorage` directly, I used a `GsonBuilder` to parse the JSON strings before the comparison. This will allow for some more flexibility in the comparison.
