### PR TITLE
Fix event handling for Genasubscription

### DIFF
--- a/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
+++ b/bundles/org.openhab.core.io.transport.upnp/src/main/java/org/openhab/core/io/transport/upnp/internal/UpnpIOServiceImpl.java
@@ -150,7 +150,6 @@ public class UpnpIOServiceImpl implements UpnpIOService, RegistryListener {
         protected void eventReceived(GENASubscription sub) {
             Map<String, StateVariableValue> values = sub.getCurrentValues();
             Device device = sub.getService().getDevice();
-
             String serviceId = sub.getService().getServiceId().getId();
 
             logger.trace("Receiving a GENA subscription '{}' response for device '{}'", serviceId,


### PR DESCRIPTION
This PR uperseed PR #5076.

It will fix the event handling in eventReceived so we match at the same time the device from the UpnpIoParticipant to:

- The event device.
- The event device.getRoot().

This modification will enable eventReceived to work even we use embededDevice or not, and so will fix the Sonos binding.

Link to issue : https://github.com/openhab/openhab-addons/issues/19600

