### PR TITLE
[WIP] Experimental MPEG-DASH support in core.audio

### DIFF
--- a/bundles/org.openhab.core.audio/pom.xml
+++ b/bundles/org.openhab.core.audio/pom.xml
@@ -44,6 +44,17 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+        <dependency>
+      <groupId>com.fasterxml.woodstox</groupId>
+      <artifactId>woodstox-core</artifactId>
+      <version>6.6.2</version>
+    </dependency>
+    <dependency>
+        <groupId>io.lindstrom</groupId>
+        <artifactId>mpd-parser</artifactId>
+        <version>0.19</version>
+        <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bundles/org.openhab.core.audio/pom.xml
+++ b/bundles/org.openhab.core.audio/pom.xml
@@ -44,16 +44,16 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-        <dependency>
+    <dependency>
       <groupId>com.fasterxml.woodstox</groupId>
       <artifactId>woodstox-core</artifactId>
       <version>6.6.2</version>
     </dependency>
     <dependency>
-        <groupId>io.lindstrom</groupId>
-        <artifactId>mpd-parser</artifactId>
-        <version>0.19</version>
-        <scope>compile</scope>
+      <groupId>io.lindstrom</groupId>
+      <artifactId>mpd-parser</artifactId>
+      <version>0.19</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/LazzyLoadingAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/LazzyLoadingAudioStream.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.audio;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an AudioStream from a URL. Note that some sinks, like Sonos, can directly handle URL
+ * based streams, and therefore can/should call getURL() to get a direct reference to the URL.
+ *
+ * @author Karel Goderis - Initial contribution
+ * @author Kai Kreuzer - Refactored to not require a source
+ * @author Christoph Weitkamp - Refactored use of filename extension
+ */
+@NonNullByDefault
+public class LazzyLoadingAudioStream extends InputStream {
+    private final Logger logger = LoggerFactory.getLogger(LazzyLoadingAudioStream.class);
+
+    private final Iterator<URL> urls;
+    @Nullable
+    private InputStream current;
+
+    public LazzyLoadingAudioStream(List<URL> urls) {
+        this.urls = urls.iterator();
+    }
+
+    private InputStream startDownload(URL url) throws IOException {
+        PipedInputStream in = new PipedInputStream(64 * 1024);
+        PipedOutputStream out = new PipedOutputStream(in);
+
+        new Thread(() -> {
+            try (InputStream src = url.openStream()) {
+                logger.info("Download URL:" + url.toString());
+
+                src.transferTo(out);
+            } catch (IOException ignored) {
+            } finally {
+                try {
+                    out.close();
+                } catch (IOException ignored) {
+                }
+            }
+        }, "preload-" + url).start();
+
+        return in;
+    }
+
+    private void ensureCurrent() throws IOException {
+        if (current == null && urls.hasNext()) {
+            current = startDownload(urls.next());
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        ensureCurrent();
+        if (current == null) {
+            return -1;
+        }
+
+        int b = current.read();
+        if (b == -1) {
+            current.close();
+            current = null;
+            return read();
+        }
+        return b;
+    }
+}

--- a/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
+++ b/bundles/org.openhab.core.audio/src/main/java/org/openhab/core/audio/URLAudioStream.java
@@ -22,6 +22,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Scanner;
 import java.util.regex.Matcher;
@@ -32,6 +34,14 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.audio.utils.AudioStreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.lindstrom.mpd.MPDParser;
+import io.lindstrom.mpd.data.AdaptationSet;
+import io.lindstrom.mpd.data.MPD;
+import io.lindstrom.mpd.data.Period;
+import io.lindstrom.mpd.data.Representation;
+import io.lindstrom.mpd.data.Segment;
+import io.lindstrom.mpd.data.SegmentTemplate;
 
 /**
  * This is an AudioStream from a URL. Note that some sinks, like Sonos, can directly handle URL
@@ -48,6 +58,7 @@ public class URLAudioStream extends AudioStream implements ClonableAudioStream {
 
     public static final String M3U_EXTENSION = "m3u";
     public static final String PLS_EXTENSION = "pls";
+    public static final String MPD_EXTENSION = "mpd";
 
     private final Logger logger = LoggerFactory.getLogger(URLAudioStream.class);
 
@@ -66,6 +77,7 @@ public class URLAudioStream extends AudioStream implements ClonableAudioStream {
     private InputStream createInputStream() throws AudioException {
         final String filename = url.toLowerCase();
         final String extension = AudioStreamUtils.getExtension(filename);
+
         try {
             URL streamUrl = new URI(url).toURL();
             switch (extension) {
@@ -96,6 +108,47 @@ public class URLAudioStream extends AudioStream implements ClonableAudioStream {
                         }
                     } catch (NoSuchElementException e) {
                         // we reached the end of the file, this exception is thus expected
+                    }
+                    break;
+                case MPD_EXTENSION:
+                    logger.info("=============================");
+                    try {
+                        MPDParser parser = new MPDParser();
+                        MPD mpd = parser.parse(streamUrl.openStream());
+
+                        List<Period> periodList = mpd.getPeriods();
+                        if (periodList.size() > 1) {
+                            logger.debug("We only support simple period mpd at this time");
+                            throw new Exception("NIY");
+                        }
+
+                        Period period = periodList.get(0);
+                        List<AdaptationSet> adaptationSetList = period.getAdaptationSets();
+                        AdaptationSet adaptationSet = adaptationSetList.get(0);
+
+                        List<Representation> representationList = adaptationSet.getRepresentations();
+                        Representation representation = representationList.get(0);
+
+                        SegmentTemplate segmentTemplate = representation.getSegmentTemplate();
+                        String initializationUri = segmentTemplate.getInitialization();
+                        String mediaUri = segmentTemplate.getMedia();
+
+                        List<Segment> segmentList = segmentTemplate.getSegmentTimeline();
+                        Segment segment = segmentList.get(0);
+                        long r = segment.getR();
+
+                        List<URL> urls = new ArrayList();
+                        urls.add(new URI(initializationUri).toURL());
+                        for (int i = 0; i < r; i++) {
+                            logger.info("Segment:" + i);
+                            String downloadUri = mediaUri.replace("$Number$", "" + i);
+                            urls.add(new URI(downloadUri).toURL());
+                        }
+
+                        LazzyLoadingAudioStream stream = new LazzyLoadingAudioStream(urls);
+                        return stream;
+                    } catch (Exception ex) {
+                        logger.info("bb");
                     }
                     break;
                 default:


### PR DESCRIPTION
# Add experimental MPEG-DASH support in core.audio

Tidal use Mpeg-dash file format (.mpd) to deliver high loss less audio > 44khz/16bit, up to 192khz/24bit.
This PR is about experimenting to add support for this mpeg-dash inside core.audio so we can play stream directly from a mpd files.

# Description

With this PR you will be able to do something like:

openhab:audio stream http://192.168.254.101:8080/static/test.mpd

Mpd file are xml file that content multiple representation of a media file, and possibly divice this media in multiple chunk that need to be downloads as we stream the media to sink.

The PR consist of two main modifications:

- Modification of URLAudioStream : will detect that we stream a .mpd files, use external io.lindstrom.mpd-parser library to decode the Mpd files, and queue the different URL chunck to LazzyLoadingAudioStream.

- LazzyLoadingAudioStream : a experimental overload of inputStream that will use PipedInputStream/PipedOutputStream to download the chunck URL only when we need them to feed the output Audio sink.

