### PR TITLE
Allow source from header in REST API

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/item/ItemResource.java
@@ -466,10 +466,10 @@ public class ItemResource implements RESTResource {
                     @ApiResponse(responseCode = "400", description = "State cannot be parsed") })
     public Response putItemStatePlain(
             @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Parameter(description = "language") @Nullable String language,
+            @HeaderParam("X-OpenHAB-Source") @Parameter(description = "the source of the event; takes priority over the query parameter or JSON body if multiple are set") @Nullable String headerSource,
             @PathParam("itemname") @Parameter(description = "item name") String itemname,
             @Parameter(description = "valid item state (e.g. ON, OFF)", required = true) String value,
             @QueryParam("source") @Parameter(description = "the source of the event") @Nullable String querySource,
-            @HeaderParam("X-OpenHAB-Source") @Parameter(description = "the source of the event; takes priority over the query parameter or JSON body if both are set") @Nullable String headerSource,
             @Context SecurityContext securityContext) {
         String source = headerSource != null ? headerSource : querySource;
         return sendItemStateInternal(language, itemname, value, source, securityContext);
@@ -480,8 +480,8 @@ public class ItemResource implements RESTResource {
     @Path("/{itemname: [a-zA-Z_0-9]+}/state")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response putItemStateJson(@HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @Nullable String language,
-            @QueryParam("source") @Parameter(description = "the source of the event") @Nullable String querySource,
-            @PathParam("itemname") String itemname, @HeaderParam("X-OpenHAB-Source") @Nullable String headerSource,
+            @HeaderParam("X-OpenHAB-Source") @Nullable String headerSource,
+            @QueryParam("source") @Nullable String querySource, @PathParam("itemname") String itemname,
             @Context SecurityContext securityContext, ValueContainer valueContainer) {
         String source;
         if (headerSource != null) {
@@ -533,10 +533,11 @@ public class ItemResource implements RESTResource {
                     @ApiResponse(responseCode = "200", description = "OK"),
                     @ApiResponse(responseCode = "404", description = "Item not found"),
                     @ApiResponse(responseCode = "400", description = "Command cannot be parsed") })
-    public Response postItemCommandPlain(@PathParam("itemname") @Parameter(description = "item name") String itemname,
+    public Response postItemCommandPlain(
+            @HeaderParam("X-OpenHAB-Source") @Parameter(description = "the source of the command; takes priority over the query parameter or JSON body if multiple are set") @Nullable String headerSource,
+            @PathParam("itemname") @Parameter(description = "item name") String itemname,
             @Parameter(description = "valid item command (e.g. ON, OFF, UP, DOWN, REFRESH)", required = true) String value,
             @QueryParam("source") @Parameter(description = "the source of the command") @Nullable String querySource,
-            @HeaderParam("X-OpenHAB-Source") @Parameter(description = "the source of the command; takes priority over the query parameter or JSON body if multiple are set") @Nullable String headerSource,
             @Context SecurityContext securityContext) {
         String source = headerSource != null ? headerSource : querySource;
         return sendItemCommandInternal(itemname, value, source, securityContext);
@@ -546,10 +547,9 @@ public class ItemResource implements RESTResource {
     @RolesAllowed({ Role.USER, Role.ADMIN })
     @Path("/{itemname: [a-zA-Z_0-9]+}")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response postItemCommandJson(@PathParam("itemname") String itemname,
-            @QueryParam("source") @Parameter(description = "the source of the command") @Nullable String querySource,
-            @HeaderParam("X-OpenHAB-Source") @Nullable String headerSource, @Context SecurityContext securityContext,
-            ValueContainer valueContainer) {
+    public Response postItemCommandJson(@HeaderParam("X-OpenHAB-Source") @Nullable String headerSource,
+            @PathParam("itemname") String itemname, @QueryParam("source") @Nullable String querySource,
+            @Context SecurityContext securityContext, ValueContainer valueContainer) {
         String source;
         if (headerSource != null) {
             source = headerSource;


### PR DESCRIPTION
This makes it easier for Basic UI and mobile apps to inject a source.
