### PR TITLE
Make ConfigDescriptionParameter.stepsize serialize to "step"

### DIFF
--- a/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
+++ b/bundles/org.openhab.core.config.core/src/main/java/org/openhab/core/config/core/dto/ConfigDescriptionParameterDTO.java
@@ -39,6 +39,7 @@ public class ConfigDescriptionParameterDTO {
     public Type type;
     public BigDecimal min;
     public BigDecimal max;
+    @SerializedName(value = "step", alternate = "stepsize")
     public BigDecimal stepsize;
     public String pattern;
     public Boolean readOnly;


### PR DESCRIPTION
This is to be consistent with the XML schema described here: https://www.openhab.org/docs/developer/addons/config-xml.html#xml-structure-for-configuration-descriptions

Using two different names for the same fields is just confusing and leads to unnecessary problems like [here](https://github.com/openhab/openhab-webui/issues/3457#issuecomment-3529430427).

Both are accepted when deserializing to prevent breaking anything, but for serialization, one must be selected. I've not been able to identify anything else than MainUI that consumes this field, and this has already been addressed: https://github.com/openhab/openhab-webui/pull/3471