### PR TITLE
[DSL/YAML] Changes prefix for isolated models

### DIFF
--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelCoreConstants.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/ModelCoreConstants.java
@@ -25,7 +25,7 @@ public class ModelCoreConstants {
     /** The service pid used for the managed service (without the "org.openhab.core" prefix */
     public static final String SERVICE_PID = "folder";
 
-    public static final String PREFIX_TMP_MODEL = "tmp_";
+    public static final String PREFIX_TMP_MODEL = "___tmp_";
 
     /**
      * Indicates if a model is an isolated model

--- a/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.core/src/main/java/org/openhab/core/model/core/internal/ModelRepositoryImpl.java
@@ -102,6 +102,10 @@ public class ModelRepositoryImpl implements ModelRepository {
 
     @Override
     public boolean addOrRefreshModel(String name, final InputStream originalInputStream) {
+        if (isIsolatedModel(name)) {
+            logger.info("Ignoring DSL model '{}'", name);
+            return false;
+        }
         return addOrRefreshModel(name, originalInputStream, null, null);
     }
 
@@ -261,14 +265,14 @@ public class ModelRepositoryImpl implements ModelRepository {
     @Override
     public @Nullable String createIsolatedModel(String modelType, InputStream inputStream, List<String> errors,
             List<String> warnings) {
-        String name = "%sDSL_model_%d.%s".formatted(PREFIX_TMP_MODEL, ++counter, modelType);
+        String name = "%smodel_%d.%s".formatted(PREFIX_TMP_MODEL, ++counter, modelType);
         return addOrRefreshModel(name, inputStream, errors, warnings) ? name : null;
     }
 
     @Override
     public void generateFileFormat(OutputStream out, String modelType, EObject modelContent) {
         synchronized (resourceSet) {
-            String name = "%sgenerated_DSL_%d.%s".formatted(PREFIX_TMP_MODEL, ++counter, modelType);
+            String name = "%sgenerated_%d.%s".formatted(PREFIX_TMP_MODEL, ++counter, modelType);
             Resource resource = resourceSet.createResource(URI.createURI(name));
             try {
                 resource.getContents().add(modelContent);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelUtils.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/YamlModelUtils.java
@@ -22,7 +22,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class YamlModelUtils {
 
-    public static final String PREFIX_TMP_MODEL = "tmp_";
+    public static final String PREFIX_TMP_MODEL = "___tmp_";
 
     /**
      * Indicates if a model is an isolated model

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -584,7 +584,7 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
     @Override
     public synchronized @Nullable String createIsolatedModel(InputStream inputStream, List<String> errors,
             List<String> warnings) {
-        String modelName = "%sYAML_model_%d.yaml".formatted(PREFIX_TMP_MODEL, ++counter);
+        String modelName = "%smodel_%d.yaml".formatted(PREFIX_TMP_MODEL, ++counter);
         boolean valid;
         try {
             valid = processModelContent(modelName, Kind.CREATE, objectMapper.readTree(inputStream), errors, warnings);


### PR DESCRIPTION
Isolated DSL/YAML models are models that do not fill the things/items/... registries when they are loaded. They are used as temporary models for particular features.

These models have a particular prefix in their names to distinguish them. It was `tmp_` before, it is now `___tmp_`.
The risk that a user names one of his files with such prefix is reduced. If a DSL file with prefix `___tmp_` is by the way used by a user, this file is ignored and a message is now logged to inform the user.

Closed #5134

Change pattern for isolated model name
    
`tmp_DSL_model_<N>.items` => `___tmp_model_<N>.items`

`tmp_YAML_model_<N>.yaml` => `___tmp_model_<N>.yaml
`