### PR TITLE
[DSL/YAML generator] Consider item pattern formatter even without label

### DIFF
--- a/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemFileConverter.java
+++ b/bundles/org.openhab.core.model.item/src/org/openhab/core/model/item/internal/fileconverter/DslItemFileConverter.java
@@ -139,15 +139,15 @@ public class DslItemFileConverter extends AbstractItemFileGenerator implements I
         String label = item.getLabel();
         boolean patternInjected = false;
         String defaultPattern = getDefaultStatePattern(item);
-        String patterToInject = stateFormatter != null && !stateFormatter.equals(defaultPattern) ? stateFormatter
+        String patternToInject = stateFormatter != null && !stateFormatter.equals(defaultPattern) ? stateFormatter
                 : null;
-        if (patterToInject != null) {
+        if (patternToInject != null) {
             // Inject the pattern in the label
             patternInjected = true;
             if (label != null && !label.isEmpty()) {
-                model.setLabel("%s [%s]".formatted(label, patterToInject));
+                model.setLabel("%s [%s]".formatted(label, patternToInject));
             } else {
-                model.setLabel("[%s]".formatted(patterToInject));
+                model.setLabel("[%s]".formatted(patternToInject));
             }
         } else {
             model.setLabel(label);

--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemFileConverter.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/items/fileconverter/YamlItemFileConverter.java
@@ -115,9 +115,9 @@ public class YamlItemFileConverter extends AbstractItemFileGenerator implements 
         if (label != null && !label.isEmpty()) {
             dto.label = item.getLabel();
         }
-        String patterToSet = stateFormatter != null && !stateFormatter.equals(defaultPattern) ? stateFormatter : null;
-        dto.format = patterToSet;
-        patternSet = patterToSet != null;
+        String patternToSet = stateFormatter != null && !stateFormatter.equals(defaultPattern) ? stateFormatter : null;
+        dto.format = patternToSet;
+        patternSet = patternToSet != null;
 
         dto.type = item.getType();
         String mainType = ItemUtil.getMainItemType(item.getType());


### PR DESCRIPTION
Items without label but with a formatter are now properly considered when generating DSL and YAML syntax.
Example: Number SceneItem "[MAP(scene.map):%s]"
Bug was reported on the community forum.
