### PR TITLE
Use dedicated executor for long-running SDDP discovery tasks

### DIFF
--- a/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
+++ b/bundles/org.openhab.core.config.discovery.sddp/src/main/java/org/openhab/core/config/discovery/sddp/SddpDiscoveryService.java
@@ -33,12 +33,15 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadFactoryBuilder;
 import org.openhab.core.config.discovery.AbstractDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResult;
 import org.openhab.core.config.discovery.DiscoveryService;
@@ -106,6 +109,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
 
     private boolean closing = false;
 
+    private ScheduledExecutorService longRunningTaskExecutor;
     private @Nullable Future<?> listenBackgroundMulticastTask = null;
     private @Nullable Future<?> listenActiveScanUnicastTask = null;
     private @Nullable ScheduledFuture<?> purgeExpiredDevicesTask = null;
@@ -116,6 +120,12 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
             final @Reference TranslationProvider i18nProvider, //
             final @Reference LocaleProvider localeProvider) {
         super((int) SEARCH_LISTEN_DURATION.getSeconds());
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(2, ThreadFactoryBuilder.create()
+                .withName("SDDP-discovery").withDaemonThreads(true).withUncaughtExceptionHandler((t, e) -> {
+                    logger.debug("SDDP discovery service encountered an unexpected exception", e);
+                }).build());
+        executor.allowCoreThreadTimeOut(true);
+        this.longRunningTaskExecutor = executor;
 
         this.networkAddressService = networkAddressService;
         this.i18nProvider = i18nProvider;
@@ -202,6 +212,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
 
         cancelTask(purgeExpiredDevicesTask);
         purgeExpiredDevicesTask = null;
+        longRunningTaskExecutor.shutdownNow();
     }
 
     @Override
@@ -339,12 +350,12 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
         Future<?> multicastTask = listenBackgroundMulticastTask;
         if (multicastTask != null && !multicastTask.isDone()) {
             multicastTask.cancel(true);
-            listenBackgroundMulticastTask = scheduler.submit(() -> listenBackGroundMulticast());
+            listenBackgroundMulticastTask = longRunningTaskExecutor.submit(() -> listenBackGroundMulticast());
         }
         Future<?> unicastTask = listenActiveScanUnicastTask;
         if (unicastTask != null && !unicastTask.isDone()) {
             unicastTask.cancel(true);
-            listenActiveScanUnicastTask = scheduler.submit(() -> listenActiveScanUnicast());
+            listenActiveScanUnicastTask = longRunningTaskExecutor.submit(() -> listenActiveScanUnicast());
         }
     }
 
@@ -425,7 +436,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
     protected void startBackgroundDiscovery() {
         Future<?> task = listenBackgroundMulticastTask;
         if (task == null || task.isDone()) {
-            listenBackgroundMulticastTask = scheduler.submit(() -> listenBackGroundMulticast());
+            listenBackgroundMulticastTask = longRunningTaskExecutor.submit(() -> listenBackGroundMulticast());
         }
     }
 
@@ -436,7 +447,7 @@ public class SddpDiscoveryService extends AbstractDiscoveryService
     protected void startScan() {
         Future<?> task = listenActiveScanUnicastTask;
         if (task == null || task.isDone()) {
-            listenActiveScanUnicastTask = scheduler.submit(() -> listenActiveScanUnicast());
+            listenActiveScanUnicastTask = longRunningTaskExecutor.submit(() -> listenActiveScanUnicast());
         }
     }
 


### PR DESCRIPTION
I discovered this while debugging #5165. Basically, #4969 was merged without actually checking that some of the "standard operations" of the system isn't "in violation" of the 5 seconds rule. The result is, when `DEBUG` is enabled, the log is filled with these "warnings" that will confuse those looking for some other problem.

Some of the SDDP tasks are long-running by design, the background scan task in particular runs indefinitely (until interrupted). This clashes with the idea in #4969, and perhaps with the envisioned use of OH's shared thread pools in general, in that pools are small and tasks are expected to be short-lived. When setting logging to DEBUG, the log will be constantly "spammed" with complaints about the SDDP discovery task taking more than 5 seconds, which it is in fact designed to do.

I've solved it here by making a dedicated executor for these long-running tasks that don't use `WrappedScheduledExecutorService`, and thus won't log the fact that it task takes more than 5 seconds. I also think this is a better design in general, because as far as I remember, the thread pool is limited to 5 threads by default, and since SDDP background discovery will constantly consume at least one thread (active scan will consume another for a period), the thread pool available for other tasks is in effect just 4 threads.