### PR TITLE
org.openhab.core.model.*/bnd.bnd: Require-Bundle: remove dependency on org.eclipse.xtend.lib

### DIFF
--- a/bundles/org.openhab.core.model.item/bnd.bnd
+++ b/bundles/org.openhab.core.model.item/bnd.bnd
@@ -40,7 +40,6 @@ Require-Bundle: com.ibm.icu;resolution:=optional,\
  org.eclipse.emf.ecore;visibility:=reexport,\
  org.eclipse.emf.mwe.utils;resolution:=optional,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext,\
  org.eclipse.xtext.common.types,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\

--- a/bundles/org.openhab.core.model.persistence/bnd.bnd
+++ b/bundles/org.openhab.core.model.persistence/bnd.bnd
@@ -38,7 +38,6 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.mwe.utils;resolution:=optional,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
  org.openhab.core.model.item,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext.common.types,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\

--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -45,7 +45,6 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
  org.openhab.core.model.item,\
  org.openhab.core.model.script,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext.common.types,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\

--- a/bundles/org.openhab.core.model.script/bnd.bnd
+++ b/bundles/org.openhab.core.model.script/bnd.bnd
@@ -61,7 +61,6 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.ecore,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
  org.openhab.core.model.item,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext.common.types,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\

--- a/bundles/org.openhab.core.model.sitemap/bnd.bnd
+++ b/bundles/org.openhab.core.model.sitemap/bnd.bnd
@@ -23,7 +23,6 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.common,\
  org.eclipse.emf.ecore,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\

--- a/bundles/org.openhab.core.model.thing/bnd.bnd
+++ b/bundles/org.openhab.core.model.thing/bnd.bnd
@@ -42,7 +42,6 @@ Require-Bundle: org.antlr.runtime,\
  org.eclipse.emf.ecore,\
  org.eclipse.emf.mwe.utils;resolution:=optional,\
  org.eclipse.emf.mwe2.launch;resolution:=optional,\
- org.eclipse.xtend.lib;resolution:=optional,\
  org.eclipse.xtext.common.types,\
  org.eclipse.xtext.xtext.generator;resolution:=optional,\
  org.eclipse.xtext.util,\


### PR DESCRIPTION
My understanding is that XBase is a language, written using XText, and Xtend is another language, which inherits from XBase.

Script/Rules DSL use XBase but not Xtend.  One way to verify this, is to take into account that `new` is a reserved word in both Xtend and Xbase, while `class` is a reserved word only in Xtend.  So it is possible in Script/Rules DSL to create a `val class = 7`, but `val new = 7` does not work.  

Compiling openHAB requires Xtend, however at run-time Xtend is not necessary,  This can be checked after stopping the bundles `Xtend Runtime Library` and `Xtend Macro Interfaces`  in the Karaf’s console and observing that everything works in the same way.

This change removes some dependencies on Xtend.