### PR TITLE
EnrichedSemanticTagDTO members not listed in openapi spec

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/EnrichedSemanticTagDTO.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/tag/EnrichedSemanticTagDTO.java
@@ -23,12 +23,12 @@ import org.openhab.core.semantics.SemanticTag;
  * @author Laurent Garnier - Class renamed and members uid, description and editable added
  */
 public class EnrichedSemanticTagDTO {
-    String uid;
-    String name;
-    String label;
-    String description;
-    List<String> synonyms;
-    boolean editable;
+    public String uid;
+    public String name;
+    public String label;
+    public String description;
+    public List<String> synonyms;
+    public boolean editable;
 
     public EnrichedSemanticTagDTO(SemanticTag tag, boolean editable) {
         this.uid = tag.getUID();


### PR DESCRIPTION
Members of DTO are not listed in the openapi spec because they were not listed as public.
