### PR TITLE
Fix minor copy-pasted text inconsistencies and typos

### DIFF
--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupStateUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/GroupStateUpdatedEvent.java
@@ -29,7 +29,7 @@ import org.openhab.core.types.State;
 public class GroupStateUpdatedEvent extends ItemStateUpdatedEvent {
 
     /**
-     * The group item state changed event type.
+     * The group item state updated event type.
      */
     public static final String TYPE = GroupStateUpdatedEvent.class.getSimpleName();
 
@@ -42,7 +42,7 @@ public class GroupStateUpdatedEvent extends ItemStateUpdatedEvent {
     }
 
     /**
-     * @return the name of the changed group member
+     * @return the name of the updated group member
      */
     public String getMemberName() {
         return this.memberName;

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemEventFactory.java
@@ -61,7 +61,7 @@ public class ItemEventFactory extends AbstractEventFactory {
 
     private static final String ITEM_STATE_CHANGED_EVENT_TOPIC = "openhab/items/{itemName}/statechanged";
 
-    private static final String GROUP_STATE_EVENT_TOPIC = "openhab/items/{itemName}/{memberName}/stateupdated";
+    private static final String GROUPITEM_STATE_UPDATED_EVENT_TOPIC = "openhab/items/{itemName}/{memberName}/stateupdated";
 
     private static final String GROUPITEM_STATE_CHANGED_EVENT_TOPIC = "openhab/items/{itemName}/{memberName}/statechanged";
 
@@ -387,7 +387,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     public static GroupStateUpdatedEvent createGroupStateUpdatedEvent(String groupName, String member, State state,
             @Nullable ZonedDateTime lastStateUpdate, @Nullable String source) {
         assertValidArguments(groupName, member, state, "state");
-        String topic = buildGroupTopic(GROUP_STATE_EVENT_TOPIC, groupName, member);
+        String topic = buildGroupTopic(GROUPITEM_STATE_UPDATED_EVENT_TOPIC, groupName, member);
         ItemStateUpdatedEventPayloadBean bean = new ItemStateUpdatedEventPayloadBean(getStateType(state),
                 state.toFullString(), lastStateUpdate);
         String payload = serializePayload(bean);

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesEvent.java
@@ -60,6 +60,6 @@ public class ItemTimeSeriesEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' shall process timeseries with %d values.", itemName, timeSeries.size());
+        return String.format("Item '%s' shall process time series with %d values.", itemName, timeSeries.size());
     }
 }

--- a/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
+++ b/bundles/org.openhab.core/src/main/java/org/openhab/core/items/events/ItemTimeSeriesUpdatedEvent.java
@@ -60,6 +60,6 @@ public class ItemTimeSeriesUpdatedEvent extends ItemEvent {
 
     @Override
     public String toString() {
-        return String.format("Item '%s' updated timeseries with %d values.", itemName, timeSeries.size());
+        return String.format("Item '%s' updated time series with %d values.", itemName, timeSeries.size());
     }
 }


### PR DESCRIPTION
This fixes a few minor copy'n'pasted texts and typos.

I found them in an old branch I was working on, but since they are unrelated to that work, I might as well reduce the diff in advance. 😉