### PR TITLE
core.model.persistence/bnd.bnd: avoid exporting non-existent package

### DIFF
--- a/bundles/org.openhab.core.model.persistence/bnd.bnd
+++ b/bundles/org.openhab.core.model.persistence/bnd.bnd
@@ -1,6 +1,5 @@
 Bundle-SymbolicName: ${project.artifactId}
 Export-Package: org.openhab.core.model.persistence,\
- org.openhab.core.model.persistence.extensions,\
  org.openhab.core.model.persistence.formatting,\
  org.openhab.core.model.persistence.generator,\
  org.openhab.core.model.persistence.parser.antlr,\


### PR DESCRIPTION
`Export-Package: org.openhab.core.model.persistence.extensions` does nothing.