### PR TITLE
Persistence upgrader: Fix unmanaged config not respected

### DIFF
--- a/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/PersistenceUpgrader.java
+++ b/tools/upgradetool/src/main/java/org/openhab/core/tools/internal/PersistenceUpgrader.java
@@ -78,7 +78,7 @@ public class PersistenceUpgrader implements Upgrader {
             // No managed persistence configurations, so no need to upgrade
             return true;
         }
-        logger.debug("found {} managed persistence configurations: {}", managedConfigs.size(),
+        logger.debug("found {} (missing) managed persistence configurations: {}", managedConfigs.size(),
                 String.join(",", managedConfigs));
         logger.debug("found {} unmanaged persistence configurations: {}", unmanagedConfigs.size(),
                 String.join(",", unmanagedConfigs));


### PR DESCRIPTION
Unmanaged configs were not respected because they were not recognized due to an invalid file extension check.

Looks good to me now:

```
florianh@zephyrus-fh211 /u/s/openhab> ls /etc/openhab/persistence/
inmemory.persist  readme.txt*
florianh@zephyrus-fh211 /u/s/openhab> rm /var/lib/openhab/jsondb/org.openhab.core.persistence.PersistenceServiceConfiguration.json
florianh@zephyrus-fh211 /u/s/openhab> java -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG -jar upgradetool-5.1.0-SNAPSHOT-jar-with-dependencies.jar --command persistenceCopyDefaultStrategy --force 
[main] DEBUG org.openhab.core.common.ThreadPoolManager - Created scheduled thread pool 'JsonStorage' of size 5
[main] DEBUG org.openhab.core.storage.json.internal.JsonStorage - Opened Json storage file at '/var/lib/openhab/jsondb/org.openhab.core.tools.UpgradeTool'.
[main] INFO org.openhab.core.tools.UpgradeTool - Executing persistenceCopyDefaultStrategy: Move persistence default strategy configuration to all persistence configuration without strategy defined
[main] DEBUG org.openhab.core.tools.internal.PersistenceUpgrader - found 2 managed persistence configurations: rrd4j,mapdb
[main] DEBUG org.openhab.core.tools.internal.PersistenceUpgrader - found 1 unmanaged persistence configurations: inmemory
[main] DEBUG org.openhab.core.storage.json.internal.JsonStorage - Opened Json storage file at '/var/lib/openhab/jsondb/org.openhab.core.persistence.PersistenceServiceConfiguration.json'.
[main] INFO org.openhab.core.tools.internal.PersistenceUpgrader - rrd4j: added strategy configurations for persistence service without configuration
[main] INFO org.openhab.core.tools.internal.PersistenceUpgrader - mapdb: added strategy configurations for persistence service without configuration
```