### PR TITLE
[REST] Add missing media type for output of /links/orphans API

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -321,6 +321,7 @@ public class ItemChannelLinkResource implements RESTResource {
 
     @GET
     @Path("/orphans")
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(operationId = "getOrphanLinks", summary = "Get orphan links between items and broken/non-existent thing channels", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = BrokenItemChannelLinkDTO.class)))) })
     public Response getOrphanLinks() {


### PR DESCRIPTION
This is not critical for 5.1 as the API is now working well even without this fix after my fix from yesterday.