### PR TITLE
Fix checkstyle findings in config.discovery.usbserial.windowsregistry

### DIFF
--- a/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/User32Ex.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/User32Ex.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.core.config.discovery.usbserial.windowsregistry.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.NTStatus;
 import com.sun.jna.platform.win32.User32;
@@ -23,6 +25,7 @@ import com.sun.jna.win32.W32APIOptions;
  *
  * @author Ravi Nadahar - Initial contribution.
  */
+@NonNullByDefault
 public interface User32Ex extends User32 {
 
     /** The instance. */
@@ -145,5 +148,5 @@ public interface User32Ex extends User32 {
      *         <li>{@link #WAIT_FAILED}</li>
      *         </ul>
      */
-    int MsgWaitForMultipleObjects(int nCount, HANDLE[] pHandles, boolean fWaitAll, int dwMilliseconds, int dwWakeMask);
+    int msgWaitForMultipleObjects(int nCount, HANDLE[] pHandles, boolean fWaitAll, int dwMilliseconds, int dwWakeMask);
 }

--- a/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowMessageHandler.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowMessageHandler.java
@@ -138,7 +138,7 @@ public class WindowMessageHandler implements Runnable, WindowProc {
             HANDLE[] handles = new HANDLE[] { terminateEvent };
             boolean running = true;
             while (running) {
-                switch (user32.MsgWaitForMultipleObjects(handles.length, handles, false, WinBase.INFINITE,
+                switch (user32.msgWaitForMultipleObjects(handles.length, handles, false, WinBase.INFINITE,
                         User32Ex.QS_ALLINPUT)) {
                     case User32Ex.WAIT_OBJECT_0:
                         // terminateEvent was triggered, terminate

--- a/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowsUsbSerialDiscovery.java
+++ b/bundles/org.openhab.core.config.discovery.usbserial.windowsregistry/src/main/java/org/openhab/core/config/discovery/usbserial/windowsregistry/internal/WindowsUsbSerialDiscovery.java
@@ -90,6 +90,10 @@ public class WindowsUsbSerialDiscovery implements UsbSerialDiscovery, WindowMess
     // registry accessor strings
     private static final String KEY_SERIAL_PORT = "PortName";
 
+    private static final GUID GUID_DEVINTERFACE_USB_DEVICE = new GUID("A5DCBF10-6530-11D2-901F-00C04FB951ED");
+    private static final int SPDRP_FRIENDLYNAME = 0x0000000C;
+    private static final int SPDRP_MFG = 0x0000000B;
+
     private final Logger logger = LoggerFactory.getLogger(WindowsUsbSerialDiscovery.class);
     private final Set<UsbSerialDiscoveryListener> discoveryListeners = new CopyOnWriteArraySet<>();
     private volatile Duration scanInterval = Duration.ofSeconds(DEFAULT_SCAN_INTERVAL_SECONDS);
@@ -230,10 +234,6 @@ public class WindowsUsbSerialDiscovery implements UsbSerialDiscovery, WindowMess
             return Set.of();
         }
 
-        GUID GUID_DEVINTERFACE_USB_DEVICE = new GUID("A5DCBF10-6530-11D2-901F-00C04FB951ED");
-        int SPDRP_FRIENDLYNAME = 0x0000000C;
-        int SPDRP_MFG = 0x0000000B;
-
         SetupApi apiInst = SetupApi.INSTANCE;
 
         Set<UsbSerialDeviceInformation> result = new HashSet<>();
@@ -249,7 +249,6 @@ public class WindowsUsbSerialDiscovery implements UsbSerialDiscovery, WindowMess
                 int devIdx = 0;
                 int intIdx;
                 while (apiInst.SetupDiEnumDeviceInfo(deviceInfoSet, devIdx, deviceInfoData)) {
-
                     String name;
                     String friendlyName;
                     String mfg;


### PR DESCRIPTION
LocalVariableNameCheck
NoEmptyLineSeparatorCheck
NullAnnotationsCheck
MethodNameCheck
