### PR TITLE
Switch to using asynchronous send with Jetty websockets

### DIFF
--- a/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/EventWebSocketTest.java
+++ b/bundles/org.openhab.core.io.websocket/src/test/java/org/openhab/core/io/websocket/EventWebSocketTest.java
@@ -198,7 +198,7 @@ public class EventWebSocketTest {
         eventWebSocket.processEvent(event);
         EventDTO eventDTO = new EventDTO(event);
 
-        verify(remoteEndpoint).sendString(gson.toJson(eventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(eventDTO)), any());
     }
 
     @Test
@@ -208,18 +208,18 @@ public class EventWebSocketTest {
         EventDTO responseEventDTO = new EventDTO(WEBSOCKET_EVENT_TYPE, WEBSOCKET_TOPIC_PREFIX + "filter/type",
                 eventDTO.payload, null, null);
         eventWebSocket.onText(gson.toJson(eventDTO));
-        verify(remoteEndpoint).sendString(gson.toJson(responseEventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(responseEventDTO)), any());
 
         // subscribed type is sent
         Event event = ItemEventFactory.createCommandEvent(TEST_ITEM_NAME, DecimalType.ZERO,
                 REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         // not subscribed event not sent
         event = ItemEventFactory.createStateEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint, times(2)).sendString(any());
+        verify(remoteEndpoint, times(2)).sendString(any(), any());
     }
 
     @Test
@@ -229,17 +229,17 @@ public class EventWebSocketTest {
         EventDTO responseEventDTO = new EventDTO(WEBSOCKET_EVENT_TYPE, WEBSOCKET_TOPIC_PREFIX + "filter/source",
                 eventDTO.payload, null, null);
         eventWebSocket.onText(gson.toJson(eventDTO));
-        verify(remoteEndpoint).sendString(gson.toJson(responseEventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(responseEventDTO)), any());
 
         // non-matching is sent
         Event event = ItemEventFactory.createCommandEvent(TEST_ITEM_NAME, DecimalType.ZERO);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         // matching is not sent
         event = ItemEventFactory.createStateEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint, times(2)).sendString(any());
+        verify(remoteEndpoint, times(2)).sendString(any(), any());
     }
 
     @Test
@@ -249,24 +249,24 @@ public class EventWebSocketTest {
         EventDTO responseEventDTO = new EventDTO(WEBSOCKET_EVENT_TYPE, WEBSOCKET_TOPIC_PREFIX + "filter/topic",
                 eventDTO.payload, null, null);
         eventWebSocket.onText(gson.toJson(eventDTO));
-        verify(remoteEndpoint).sendString(gson.toJson(responseEventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(responseEventDTO)), any());
         clearInvocations(remoteEndpoint);
 
         // subscribed topics are sent
         Event event = ItemEventFactory.createCommandEvent(TEST_ITEM_NAME, DecimalType.ZERO,
                 REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         event = ItemEventFactory.createStateChangedEvent(TEST_ITEM_NAME, DecimalType.ZERO, DecimalType.ZERO, null,
                 null);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         // not subscribed topics are not sent
         event = ItemEventFactory.createStateEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint, times(2)).sendString(any());
+        verify(remoteEndpoint, times(2)).sendString(any(), any());
     }
 
     @Test
@@ -276,7 +276,7 @@ public class EventWebSocketTest {
         EventDTO responseEventDTO = new EventDTO(WEBSOCKET_EVENT_TYPE, WEBSOCKET_TOPIC_PREFIX + "filter/topic",
                 eventDTO.payload, null, null);
         eventWebSocket.onText(gson.toJson(eventDTO));
-        verify(remoteEndpoint).sendString(gson.toJson(responseEventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(responseEventDTO)), any());
         clearInvocations(remoteEndpoint);
 
         // excluded topics are not sent
@@ -289,15 +289,15 @@ public class EventWebSocketTest {
         event = ItemEventFactory.createStateChangedEvent(TEST_ITEM_NAME, DecimalType.ZERO, DecimalType.ZERO, null,
                 null);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         event = ItemEventFactory.createStateEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         event = ItemEventFactory.createStateEvent("anotherItem", DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
     }
 
     @Test
@@ -307,23 +307,23 @@ public class EventWebSocketTest {
         EventDTO responseEventDTO = new EventDTO(WEBSOCKET_EVENT_TYPE, WEBSOCKET_TOPIC_PREFIX + "filter/topic",
                 eventDTO.payload, null, null);
         eventWebSocket.onText(gson.toJson(eventDTO));
-        verify(remoteEndpoint).sendString(gson.toJson(responseEventDTO));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(responseEventDTO)), any());
         clearInvocations(remoteEndpoint);
 
         // included topics are sent
         Event event = ItemEventFactory.createStateChangedEvent(TEST_ITEM_NAME, DecimalType.ZERO, DecimalType.ZERO, null,
                 null);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         event = ItemEventFactory.createStateEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint).sendString(gson.toJson(new EventDTO(event)));
+        verify(remoteEndpoint).sendString(eq(gson.toJson(new EventDTO(event))), any());
 
         // excluded sub-topics are not sent
         event = ItemEventFactory.createCommandEvent(TEST_ITEM_NAME, DecimalType.ZERO, REMOTE_WEBSOCKET_IMPLEMENTATION);
         eventWebSocket.processEvent(event);
-        verify(remoteEndpoint, times(2)).sendString(any());
+        verify(remoteEndpoint, times(2)).sendString(any(), any());
     }
 
     private void assertEventProcessing(EventDTO incoming, @Nullable Event expectedEvent,
@@ -338,7 +338,7 @@ public class EventWebSocketTest {
 
         if (expectedResponse != null) {
             String expectedResponseString = gson.toJson(expectedResponse);
-            verify(remoteEndpoint).sendString(eq(expectedResponseString));
+            verify(remoteEndpoint).sendString(eq(expectedResponseString), any());
         } else {
             verify(remoteEndpoint, never()).sendString(any());
         }


### PR DESCRIPTION
Following the changes made in #5165, HABApp has experienced websocket disconnects, as reported both [here](https://community.openhab.org/t/habapp-25/163853) and in #5224.

I haven't been able to figure out exactly what goes wrong, but as far as I can tell, it happens either in Jetty's code or between Jetty and the remote party. Before #5165, all messages were sent while holding a lock. This led to thread starvation in OH if the remote party didn't receive the message in a timely fashion, because both event dispatcher threads and logger threads would pile up waiting for that lock to be released. Preventing this was the prime motivation behind #5165, but now that messages are no longer sent while holding a lock, a new problem has arisen. It turns out that Jetty has a lock of its own, preventing multiple messages being sent at once, but this lock has a hard-coded 10 seconds timeout, as far as I can understand. If it times out, Jetty will close the websocket.

Finding detailed documentation about exactly how this is supposed to work is hard, but I've found an old reference on a mailing list that says something like "sending from multiple threads to the same endpoint is a bad idea". Whether this still applies is unknown.

Jetty has both synchronous and asynchronous send methods. The synchronous send methods have no queue mechanism, they will block until the message has been sent. The asynchronous methods use a queue instead, and probably a thread/thread pool to process the queue. This PR switches the synchronous methods to asynchronous ones, and according to testing, this solves the disconnect issue.

Even though I can't fully pin down what goes wrong, I think this is a good thing to do anyway. It will mean that logger and event dispatcher threads can return quicker, and Jetty can handle the actual sending. The only downside is that when a transmission fails, we don't know exactly what message that failed. But, this is just logged anyway, so I'm not sure that matters so much. The problem/exception will still be logged, and what remote endpoint that had the problem, we just won't get the actual content of the message logged with it.

I'm having this implementation running as a test to see if there are any stability issues, and plan to let it run for a while. I'll report back what the results are.
