### PR TITLE
Remove outdated import

### DIFF
--- a/bundles/org.openhab.core.model.rule/bnd.bnd
+++ b/bundles/org.openhab.core.model.rule/bnd.bnd
@@ -28,7 +28,6 @@ Import-Package: \
  org.openhab.core.types,\
  org.openhab.core.model.core,\
  org.openhab.core.model.items,\
- org.openhab.core.model.persistence.extensions,\
  org.openhab.core.model.script,\
  org.openhab.core.model.script.engine.action,\
  org.openhab.core.automation.module.script.rulesupport.shared,\


### PR DESCRIPTION
While https://github.com/openhab/openhab-core/pull/5209 removed the export, it missed to also remove the import.
This PR cleans this up.