### PR TITLE
[automation] Support conditions related to the ThingStatus

### DIFF
--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/factory/CoreModuleHandlerFactory.java
@@ -38,11 +38,13 @@ import org.openhab.core.automation.internal.module.handler.ItemStateUpdateAction
 import org.openhab.core.automation.internal.module.handler.RuleEnablementActionHandler;
 import org.openhab.core.automation.internal.module.handler.RunRuleActionHandler;
 import org.openhab.core.automation.internal.module.handler.SystemTriggerHandler;
+import org.openhab.core.automation.internal.module.handler.ThingStatusConditionHandler;
 import org.openhab.core.automation.internal.module.handler.ThingStatusTriggerHandler;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.service.StartLevelService;
+import org.openhab.core.thing.ThingRegistry;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -67,14 +69,15 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
     private static final Collection<String> TYPES = List.of(ItemCommandTriggerHandler.MODULE_TYPE_ID,
             GroupCommandTriggerHandler.MODULE_TYPE_ID, ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID,
             ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID, GroupStateTriggerHandler.UPDATE_MODULE_TYPE_ID,
-            GroupStateTriggerHandler.CHANGE_MODULE_TYPE_ID, ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID,
-            ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID, ItemStateConditionHandler.ITEM_STATE_CONDITION,
-            ItemCommandActionHandler.ITEM_COMMAND_ACTION, ItemStateUpdateActionHandler.ITEM_STATE_UPDATE_ACTION,
-            GenericEventTriggerHandler.MODULE_TYPE_ID, ChannelEventTriggerHandler.MODULE_TYPE_ID,
-            GenericEventConditionHandler.MODULETYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
-            CompareConditionHandler.MODULE_TYPE, SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID,
-            RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
+            GroupStateTriggerHandler.CHANGE_MODULE_TYPE_ID, ThingStatusConditionHandler.THING_STATUS_CONDITION,
+            ThingStatusTriggerHandler.UPDATE_MODULE_TYPE_ID, ThingStatusTriggerHandler.CHANGE_MODULE_TYPE_ID,
+            ItemStateConditionHandler.ITEM_STATE_CONDITION, ItemCommandActionHandler.ITEM_COMMAND_ACTION,
+            ItemStateUpdateActionHandler.ITEM_STATE_UPDATE_ACTION, GenericEventTriggerHandler.MODULE_TYPE_ID,
+            ChannelEventTriggerHandler.MODULE_TYPE_ID, GenericEventConditionHandler.MODULETYPE_ID,
+            GenericEventConditionHandler.MODULETYPE_ID, CompareConditionHandler.MODULE_TYPE,
+            SystemTriggerHandler.STARTLEVEL_MODULE_TYPE_ID, RuleEnablementActionHandler.UID, RunRuleActionHandler.UID);
 
+    private final ThingRegistry thingRegistry;
     private final ItemRegistry itemRegistry;
     private final TimeZoneProvider timeZoneProvider;
     private final EventPublisher eventPublisher;
@@ -83,10 +86,11 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
 
     @Activate
     public CoreModuleHandlerFactory(BundleContext bundleContext, final @Reference EventPublisher eventPublisher,
-            final @Reference ItemRegistry itemRegistry, final @Reference TimeZoneProvider timeZoneProvider,
-            final @Reference StartLevelService startLevelService) {
+            final @Reference ThingRegistry thingRegistry, final @Reference ItemRegistry itemRegistry,
+            final @Reference TimeZoneProvider timeZoneProvider, final @Reference StartLevelService startLevelService) {
         this.bundleContext = bundleContext;
         this.eventPublisher = eventPublisher;
+        this.thingRegistry = thingRegistry;
         this.itemRegistry = itemRegistry;
         this.timeZoneProvider = timeZoneProvider;
         this.startLevelService = startLevelService;
@@ -133,6 +137,8 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory implement
             // Handle conditions
             if (ItemStateConditionHandler.ITEM_STATE_CONDITION.equals(moduleTypeUID)) {
                 return new ItemStateConditionHandler(condition, ruleUID, bundleContext, itemRegistry, timeZoneProvider);
+            } else if (ThingStatusConditionHandler.THING_STATUS_CONDITION.equals(moduleTypeUID)) {
+                return new ThingStatusConditionHandler(condition, ruleUID, bundleContext, thingRegistry);
             } else if (GenericEventConditionHandler.MODULETYPE_ID.equals(moduleTypeUID)) {
                 return new GenericEventConditionHandler(condition);
             } else if (CompareConditionHandler.MODULE_TYPE.equals(moduleTypeUID)) {

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ItemStateConditionHandler.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 public class ItemStateConditionHandler extends BaseConditionModuleHandler implements EventSubscriber {
 
     /**
-     * Constants for Config-Parameters corresponding to Definition in ItemModuleTypeDefinition.json
+     * Constants for Config-Parameters corresponding to Definition in ItemConditions.json
      */
     public static final String ITEM_NAME = "itemName";
     public static final String OPERATOR = "operator";

--- a/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusConditionHandler.java
+++ b/bundles/org.openhab.core.automation/src/main/java/org/openhab/core/automation/internal/module/handler/ThingStatusConditionHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.handler.BaseConditionModuleHandler;
+import org.openhab.core.events.Event;
+import org.openhab.core.events.EventFilter;
+import org.openhab.core.events.EventSubscriber;
+import org.openhab.core.events.TopicPrefixEventFilter;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.events.ThingAddedEvent;
+import org.openhab.core.thing.events.ThingRemovedEvent;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ConditionHandler implementation to check the thing status
+ *
+ * @author Jörg Sautter - Initial contribution based on the ItemStateConditionHandler
+ */
+@NonNullByDefault
+public class ThingStatusConditionHandler extends BaseConditionModuleHandler implements EventSubscriber {
+
+    /**
+     * Constants for Config-Parameters corresponding to Definition in ThingConditions.json
+     */
+    public static final String CFG_THING_UID = "thingUID";
+    public static final String CFG_OPERATOR = "operator";
+    public static final String CFG_STATUS = "status";
+
+    private final Logger logger = LoggerFactory.getLogger(ThingStatusConditionHandler.class);
+
+    public static final String THING_STATUS_CONDITION = "core.ThingStatusCondition";
+
+    private final ThingRegistry thingRegistry;
+    private final String ruleUID;
+    private final String thingUID;
+    private final EventFilter eventFilter;
+    private final BundleContext bundleContext;
+    private final Set<String> types;
+    private final ServiceRegistration<?> eventSubscriberRegistration;
+
+    public ThingStatusConditionHandler(Condition condition, String ruleUID, BundleContext bundleContext,
+            ThingRegistry thingRegistry) {
+        super(condition);
+        this.thingRegistry = thingRegistry;
+        this.bundleContext = bundleContext;
+        this.thingUID = (String) module.getConfiguration().get(CFG_THING_UID);
+        this.eventFilter = new TopicPrefixEventFilter("openhab/things/" + thingUID + "/");
+        this.types = Set.of(ThingAddedEvent.TYPE, ThingRemovedEvent.TYPE);
+        this.ruleUID = ruleUID;
+
+        eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this, null);
+
+        if (thingUID == null || thingRegistry.get(new ThingUID(thingUID)) == null) {
+            logger.warn("Thing '{}' needed for rule '{}' is missing. Condition '{}' will not work.", thingUID, ruleUID,
+                    module.getId());
+        }
+    }
+
+    @Override
+    public Set<String> getSubscribedEventTypes() {
+        return types;
+    }
+
+    @Override
+    public @Nullable EventFilter getEventFilter() {
+        return eventFilter;
+    }
+
+    @Override
+    public void receive(Event event) {
+        if ((event instanceof ThingAddedEvent addedEvent) && thingUID.equals(addedEvent.getThing().UID)) {
+            logger.info("Thing '{}' needed for rule '{}' added. Condition '{}' will now work.", thingUID, ruleUID,
+                    module.getId());
+            return;
+        } else if ((event instanceof ThingRemovedEvent removedEvent) && thingUID.equals(removedEvent.getThing().UID)) {
+            logger.warn("Thing '{}' needed for rule '{}' removed. Condition '{}' will no longer work.", thingUID,
+                    ruleUID, module.getId());
+            return;
+        }
+    }
+
+    @Override
+    public boolean isSatisfied(Map<String, Object> inputs) {
+        String rawStatus = (String) module.getConfiguration().get(CFG_STATUS);
+        ThingStatus status;
+
+        try {
+            status = ThingStatus.valueOf(rawStatus);
+        } catch (IllegalArgumentException e) {
+            status = null;
+        }
+
+        String operator = (String) module.getConfiguration().get(CFG_OPERATOR);
+        if (operator == null || status == null || thingUID == null) {
+            logger.error("Module is not well configured: thingUID={}  operator={}  status = {} for rule {}", thingUID,
+                    operator, rawStatus, ruleUID);
+            return false;
+        }
+        logger.debug("ThingStatusCondition '{}' checking if {} {} {} for rule {}", module.getId(), thingUID, operator,
+                status, ruleUID);
+        Thing thing = thingRegistry.get(new ThingUID(thingUID));
+
+        if (thing == null) {
+            logger.error("Thing with UID {} not found in ThingRegistry for condition of rule {}.", thingUID, ruleUID);
+        } else
+            switch (operator) {
+                case "=":
+                    return thing.getStatus().equals(status);
+                case "!=":
+                    return !thing.getStatus().equals(status);
+                default:
+                    logger.error("Thing status condition operator {} is not known of rule {}", operator, ruleUID);
+            }
+        return false;
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        eventSubscriberRegistration.unregister();
+    }
+}

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ThingConditions.json
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/automation/moduletypes/ThingConditions.json
@@ -1,0 +1,76 @@
+{
+	"conditions": [
+		{
+			"uid": "core.ThingStatusCondition",
+			"label": "a thing has a given status",
+			"description": "Compares the thing status with the given value",
+			"configDescriptions": [
+				{
+					"name": "thingUID",
+					"type": "TEXT",
+					"context": "thing",
+					"label": "Thing",
+					"description": "The UID of the thing.",
+					"required": true
+				},
+				{
+					"name": "operator",
+					"type": "TEXT",
+					"label": "Operator",
+					"description": "The compare operator (= or !=)",
+					"required": false,
+					"limitToOptions": true,
+					"options": [
+						{
+							"label": "=",
+							"value": "="
+						},
+						{
+							"label": "!=",
+							"value": "!="
+						}
+					],
+					"default": "="
+				},
+				{
+					"name": "status",
+					"type": "TEXT",
+					"label": "Status",
+					"description": "The status of the thing.",
+					"required": true,
+					"limitToOptions": true,
+					"options": [
+						{
+							"label": "UNINITIALIZED",
+							"value": "UNINITIALIZED"
+						},
+						{
+							"label": "INITIALIZING",
+							"value": "INITIALIZING"
+						},
+						{
+							"label": "UNKNOWN",
+							"value": "UNKNOWN"
+						},
+						{
+							"label": "ONLINE",
+							"value": "ONLINE"
+						},
+						{
+							"label": "OFFLINE",
+							"value": "OFFLINE"
+						},
+						{
+							"label": "REMOVING",
+							"value": "REMOVING"
+						},
+						{
+							"label": "REMOVED",
+							"value": "REMOVED"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
+++ b/bundles/org.openhab.core.automation/src/main/resources/OH-INF/i18n/automation.properties
@@ -320,6 +320,26 @@ module-type.core.ThingStatusChangeTrigger.output.oldStatus.description = The old
 module-type.core.ThingStatusChangeTrigger.output.event.label = Event
 module-type.core.ThingStatusChangeTrigger.output.event.description = The event which was sent.
 
+# core.ThingStatusCondition
+
+module-type.core.ThingStatusCondition.label = a thing has a given status
+module-type.core.ThingStatusCondition.description = Compares the thing status with the given value
+module-type.core.ThingStatusCondition.config.thingUID.label = Thing
+module-type.core.ThingStatusCondition.config.thingUID.description = The UID of the thing.
+module-type.core.ThingStatusCondition.config.operator.label = Operator
+module-type.core.ThingStatusCondition.config.operator.description = the compare operator (= or !=)
+module-type.core.ThingStatusCondition.config.operator.option.\= = =
+module-type.core.ThingStatusCondition.config.operator.option.!\= = !=
+module-type.core.ThingStatusCondition.config.status.label = Status
+module-type.core.ThingStatusCondition.config.status.description = the status to be compared with
+module-type.core.ThingStatusCondition.config.status.option.UNINITIALIZED = UNINITIALIZED
+module-type.core.ThingStatusCondition.config.status.option.INITIALIZING = INITIALIZING
+module-type.core.ThingStatusCondition.config.status.option.UNKNOWN = UNKNOWN
+module-type.core.ThingStatusCondition.config.status.option.ONLINE = ONLINE
+module-type.core.ThingStatusCondition.config.status.option.OFFLINE = OFFLINE
+module-type.core.ThingStatusCondition.config.status.option.REMOVING = REMOVING
+module-type.core.ThingStatusCondition.config.status.option.REMOVED = REMOVED
+
 # core.ThingStatusUpdateTrigger
 
 module-type.core.ThingStatusUpdateTrigger.label = a thing status is updated

--- a/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ThingStatusConditionHandlerTest.java
+++ b/bundles/org.openhab.core.automation/src/test/java/org/openhab/core/automation/internal/module/handler/ThingStatusConditionHandlerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.core.automation.internal.module.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openhab.core.automation.Condition;
+import org.openhab.core.automation.util.ConditionBuilder;
+import org.openhab.core.config.core.Configuration;
+import org.openhab.core.test.java.JavaTest;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingRegistry;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
+import org.openhab.core.thing.ThingStatusInfo;
+import org.openhab.core.thing.ThingTypeUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.thing.events.ThingAddedEvent;
+import org.openhab.core.thing.events.ThingEventFactory;
+import org.openhab.core.thing.events.ThingRemovedEvent;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Basic unit tests for {@link ThingStatusConditionHandler}.
+ *
+ * @author Jörg Sautter - Initial contribution based on ItemStateConditionHandlerTest
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@NonNullByDefault
+public class ThingStatusConditionHandlerTest extends JavaTest {
+
+    public static class ParameterSet {
+        public final Thing thing;
+        public final String comparisonStatus;
+        public final ThingStatus thingStatus;
+        public final boolean expectedResult;
+
+        public ParameterSet(String comparisonStatus, ThingStatus thingStatus, boolean expectedResult) {
+            thing = ThingBuilder.create(new ThingTypeUID(BINDING_UID, THING_TYPE_UID), THING_UID).build();
+            thing.setStatusInfo(new ThingStatusInfo(thingStatus, ThingStatusDetail.NONE, null));
+            this.comparisonStatus = comparisonStatus;
+            this.thingStatus = thingStatus;
+            this.expectedResult = expectedResult;
+        }
+    }
+
+    public static Collection<Object[]> equalsParameters() {
+        return List.of(new Object[][] { //
+                { new ParameterSet("UNINITIALIZED", ThingStatus.UNINITIALIZED, true) }, //
+                { new ParameterSet("INITIALIZING", ThingStatus.UNINITIALIZED, false) }, //
+                { new ParameterSet("OFFLINE", ThingStatus.UNKNOWN, false) }, //
+                { new ParameterSet("OFFLINE", ThingStatus.ONLINE, false) }, //
+                { new ParameterSet("OFFLINE", ThingStatus.OFFLINE, true) }, //
+                { new ParameterSet("ONLINE", ThingStatus.ONLINE, true) }, //
+                { new ParameterSet("ONLINE", ThingStatus.OFFLINE, false) } });
+    }
+
+    private static final String BINDING_UID = "binding";
+    private static final String THING_TYPE_UID = "type";
+    private static final String THING_UID = "myThing";
+
+    private @NonNullByDefault({}) Thing thing;
+
+    private @NonNullByDefault({}) @Mock ThingRegistry mockThingRegistry;
+    private @NonNullByDefault({}) @Mock BundleContext mockBundleContext;
+
+    @BeforeEach
+    public void setup() {
+        when(mockThingRegistry.get(new ThingUID(BINDING_UID, THING_TYPE_UID, THING_UID))).thenAnswer(i -> thing);
+    }
+
+    @ParameterizedTest
+    @MethodSource("equalsParameters")
+    public void testEqualsCondition(ParameterSet parameterSet) {
+        thing = parameterSet.thing;
+        ThingStatusConditionHandler handler = initThingStatusConditionHandler("=", parameterSet.comparisonStatus);
+
+        if (parameterSet.expectedResult) {
+            assertTrue(handler.isSatisfied(Map.of()),
+                    parameterSet.thing + ", comparisonStatus=" + parameterSet.comparisonStatus);
+        } else {
+            assertFalse(handler.isSatisfied(Map.of()),
+                    parameterSet.thing + ", comparisonStatus=" + parameterSet.comparisonStatus);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("equalsParameters")
+    public void testNotEqualsCondition(ParameterSet parameterSet) {
+        thing = parameterSet.thing;
+        ThingStatusConditionHandler handler = initThingStatusConditionHandler("!=", parameterSet.comparisonStatus);
+
+        if (parameterSet.expectedResult) {
+            assertFalse(handler.isSatisfied(Map.of()));
+        } else {
+            assertTrue(handler.isSatisfied(Map.of()));
+        }
+    }
+
+    private ThingStatusConditionHandler initThingStatusConditionHandler(String operator, String state) {
+        Configuration configuration = new Configuration();
+        configuration.put(ThingStatusConditionHandler.CFG_THING_UID,
+                BINDING_UID + ":" + THING_TYPE_UID + ":" + THING_UID);
+        configuration.put(ThingStatusConditionHandler.CFG_OPERATOR, operator);
+        configuration.put(ThingStatusConditionHandler.CFG_STATUS, state);
+        ConditionBuilder builder = ConditionBuilder.create() //
+                .withId("conditionId") //
+                .withTypeUID(ThingStatusConditionHandler.THING_STATUS_CONDITION) //
+                .withConfiguration(configuration);
+        return new ThingStatusConditionHandler(builder.build(), "", mockBundleContext, mockThingRegistry);
+    }
+
+    @Test
+    public void thingMessagesAreLogged() {
+        Configuration configuration = new Configuration();
+        configuration.put(ThingStatusConditionHandler.CFG_THING_UID,
+                BINDING_UID + ":" + THING_TYPE_UID + ":" + THING_UID);
+        configuration.put(ThingStatusConditionHandler.CFG_OPERATOR, "=");
+        Condition condition = ConditionBuilder.create() //
+                .withId("conditionId") //
+                .withTypeUID(ThingStatusConditionHandler.THING_STATUS_CONDITION) //
+                .withConfiguration(configuration) //
+                .build();
+
+        setupInterceptedLogger(ThingStatusConditionHandler.class, LogLevel.INFO);
+
+        // missing on creation
+        when(mockThingRegistry.get(new ThingUID(BINDING_UID, THING_TYPE_UID, THING_UID))).thenReturn(null);
+        ThingStatusConditionHandler handler = new ThingStatusConditionHandler(condition, "foo", mockBundleContext,
+                mockThingRegistry);
+        assertLogMessage(ThingStatusConditionHandler.class, LogLevel.WARN,
+                "Thing 'binding:type:myThing' needed for rule 'foo' is missing. Condition 'conditionId' will not work.");
+
+        thing = ThingBuilder.create(new ThingTypeUID(BINDING_UID, THING_TYPE_UID), THING_UID).build();
+
+        // added later
+        ThingAddedEvent addedEvent = ThingEventFactory.createAddedEvent(thing);
+        assertTrue(handler.getEventFilter().apply(addedEvent));
+        handler.receive(addedEvent);
+        assertLogMessage(ThingStatusConditionHandler.class, LogLevel.INFO,
+                "Thing 'binding:type:myThing' needed for rule 'foo' added. Condition 'conditionId' will now work.");
+
+        // removed later
+        ThingRemovedEvent removedEvent = ThingEventFactory.createRemovedEvent(thing);
+        assertTrue(handler.getEventFilter().apply(removedEvent));
+        handler.receive(removedEvent);
+        assertLogMessage(ThingStatusConditionHandler.class, LogLevel.WARN,
+                "Thing 'binding:type:myThing' needed for rule 'foo' removed. Condition 'conditionId' will no longer work.");
+    }
+}

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationJsonTest.java
@@ -63,6 +63,7 @@ import org.openhab.core.service.StartLevelService;
 import org.openhab.core.storage.StorageService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +81,7 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
 
     private final Logger logger = LoggerFactory.getLogger(AutomationIntegrationJsonTest.class);
     private @NonNullByDefault({}) EventPublisher eventPublisher;
+    private @NonNullByDefault({}) ThingRegistry thingRegistry;
     private @NonNullByDefault({}) ItemRegistry itemRegistry;
     private @NonNullByDefault({}) StartLevelService startLevelService;
     private @NonNullByDefault({}) RuleRegistry ruleRegistry;
@@ -97,13 +99,14 @@ public class AutomationIntegrationJsonTest extends JavaOSGiTest {
         logger.info("@Before.begin");
 
         eventPublisher = getService(EventPublisher.class);
+        thingRegistry = getService(ThingRegistry.class);
         itemRegistry = getService(ItemRegistry.class);
         startLevelService = mock(StartLevelService.class);
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
 
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), startLevelService);
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class), startLevelService);
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
+++ b/itests/org.openhab.core.automation.integration.tests/src/main/java/org/openhab/core/automation/integration/test/AutomationIntegrationTest.java
@@ -82,6 +82,7 @@ import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.storage.StorageService;
 import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.ThingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,6 +97,7 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
 
     private final Logger logger = LoggerFactory.getLogger(AutomationIntegrationTest.class);
     private @Nullable EventPublisher eventPublisher;
+    private @Nullable ThingRegistry thingRegistry;
     private @Nullable ItemRegistry itemRegistry;
     private @NonNullByDefault({}) StartLevelService startLevelService;
     private @Nullable RuleRegistry ruleRegistry;
@@ -112,14 +114,15 @@ public class AutomationIntegrationTest extends JavaOSGiTest {
         logger.info("@Before.begin");
 
         eventPublisher = getService(EventPublisher.class);
+        thingRegistry = getService(ThingRegistry.class);
         itemRegistry = getService(ItemRegistry.class);
         startLevelService = mock(StartLevelService.class);
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
 
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                Objects.requireNonNull(eventPublisher), Objects.requireNonNull(itemRegistry),
-                mock(TimeZoneProvider.class), startLevelService);
+                Objects.requireNonNull(eventPublisher), Objects.requireNonNull(thingRegistry),
+                Objects.requireNonNull(itemRegistry), mock(TimeZoneProvider.class), startLevelService);
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RunRuleModuleTest.java
@@ -54,6 +54,7 @@ import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,9 +78,11 @@ public class RunRuleModuleTest extends JavaOSGiTest {
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.core.tests/src/main/java/org/openhab/core/automation/internal/module/RuntimeRuleTest.java
@@ -63,6 +63,7 @@ import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.TypeParser;
 import org.osgi.framework.ServiceReference;
@@ -88,9 +89,11 @@ public class RuntimeRuleTest extends JavaOSGiTest {
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/BasicConditionHandlerTest.java
@@ -62,6 +62,7 @@ import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,9 +92,11 @@ public abstract class BasicConditionHandlerTest extends JavaOSGiTest {
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/DayOfWeekConditionHandlerTest.java
@@ -37,6 +37,7 @@ import org.openhab.core.events.EventPublisher;
 import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.items.ItemRegistry;
 import org.openhab.core.service.StartLevelService;
+import org.openhab.core.thing.ThingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,9 +61,11 @@ public class DayOfWeekConditionHandlerTest extends BasicConditionHandlerTest {
     @BeforeEach
     public void before() {
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
     }

--- a/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
+++ b/itests/org.openhab.core.automation.module.timer.tests/src/main/java/org/openhab/core/automation/module/timer/internal/RuntimeRuleTest.java
@@ -59,6 +59,7 @@ import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
 import org.openhab.core.test.storage.VolatileStorageService;
+import org.openhab.core.thing.ThingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,9 +85,11 @@ public class RuntimeRuleTest extends JavaOSGiTest {
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 

--- a/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
+++ b/itests/org.openhab.core.automation.tests/src/main/java/org/openhab/core/automation/event/RuleEventTest.java
@@ -62,6 +62,7 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.service.ReadyMarker;
 import org.openhab.core.service.StartLevelService;
 import org.openhab.core.test.java.JavaOSGiTest;
+import org.openhab.core.thing.ThingRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,9 +90,11 @@ public class RuleEventTest extends JavaOSGiTest {
         when(startLevelService.getStartLevel()).thenReturn(100);
         registerService(startLevelService, StartLevelService.class.getName());
         EventPublisher eventPublisher = Objects.requireNonNull(getService(EventPublisher.class));
+        ThingRegistry thingRegistry = Objects.requireNonNull(getService(ThingRegistry.class));
         ItemRegistry itemRegistry = Objects.requireNonNull(getService(ItemRegistry.class));
         CoreModuleHandlerFactory coreModuleHandlerFactory = new CoreModuleHandlerFactory(getBundleContext(),
-                eventPublisher, itemRegistry, mock(TimeZoneProvider.class), mock(StartLevelService.class));
+                eventPublisher, thingRegistry, itemRegistry, mock(TimeZoneProvider.class),
+                mock(StartLevelService.class));
         mock(CoreModuleHandlerFactory.class);
         registerService(coreModuleHandlerFactory);
 


### PR DESCRIPTION
# Description

This PR will allow to create rules with "But only if" conditions related to a thing status (`UNKNOWN`, `ONLINE`, `OFFLINE`, etc.).

E.g. a rule is triggered by a timer and does check the state of items, now it could be limited to run only if the related thing is online.