### PR TITLE
core/resources: Use geographic coordinates with precision 1 meter

### DIFF
--- a/bundles/org.openhab.core/src/main/resources/OH-INF/config/i18n.xml
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/config/i18n.xml
@@ -31,7 +31,7 @@
 		<parameter name="location" type="text">
 			<context>location</context>
 			<label>Location</label>
-			<description><![CDATA[The location of this installation.<br>Coordinates as &lt;latitude&gt;,&lt;longitude&gt;[&lt;altitude&gt;]<br>Example: "52.5200066,13.4049540" (Berlin)]]></description>
+			<description><![CDATA[The location of this installation.<br>Coordinates as &lt;latitude&gt;,&lt;longitude&gt;[&lt;altitude&gt;]<br>Example: "52.52000,13.40495" (Berlin)]]></description>
 		</parameter>
 		<parameter name="measurementSystem" type="text">
 			<label>Measurement System</label>

--- a/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
+++ b/bundles/org.openhab.core/src/main/resources/OH-INF/i18n/i18n.properties
@@ -1,7 +1,7 @@
 system.config.i18n.language.label = Language
 system.config.i18n.language.description = The default language that should be used. If not specified, the system default locale is used.
 system.config.i18n.location.label = Location
-system.config.i18n.location.description = The location of this installation.<br>Coordinates as &lt;latitude&gt;,&lt;longitude&gt;[,&lt;altitude&gt;] with the altitude being optional<br>Example: "52.5200066,13.4049540" (Berlin)
+system.config.i18n.location.description = The location of this installation.<br>Coordinates as &lt;latitude&gt;,&lt;longitude&gt;[,&lt;altitude&gt;] with the altitude being optional<br>Example: "52.52000,13.40495" (Berlin)
 system.config.i18n.measurementSystem.label = Measurement System
 system.config.i18n.measurementSystem.description = The measurement system is used for unit conversion.
 system.config.i18n.measurementSystem.option.SI = Metric


### PR DESCRIPTION
My understanding is that 5 digits after the decimal comma correspond to 1.1m precision and no device can measure higher precision.  This is shown in the table at https://en.wikipedia.org/wiki/Decimal_degrees#Precision .

[![XKCD 2170: "Coordinate Precision"](https://camo.githubusercontent.com/67976a2904f517cdff61c25873d593de74b2ff8875d58066618826ae52d76b7f/68747470733a2f2f696d67732e786b63642e636f6d2f636f6d6963732f636f6f7264696e6174655f707265636973696f6e2e706e67)](https://xkcd.com/2170/)