### PR TITLE
core.model.script.scoping.StateAndCommandProvider:getAllCommands() and getAllStates() are not used

### DIFF
--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
@@ -61,16 +61,8 @@ public class StateAndCommandProvider {
 
         STATES.add(UnDefType.UNDEF);
         STATES.add(UnDefType.NULL);
-        STATES.add(OnOffType.ON);
-        STATES.add(OnOffType.OFF);
-        STATES.add(UpDownType.UP);
-        STATES.add(UpDownType.DOWN);
         STATES.add(OpenClosedType.OPEN);
         STATES.add(OpenClosedType.CLOSED);
-        STATES.add(PlayPauseType.PLAY);
-        STATES.add(PlayPauseType.PAUSE);
-        STATES.add(RewindFastforwardType.REWIND);
-        STATES.add(RewindFastforwardType.FASTFORWARD);
 
         TYPES.addAll(COMMANDS);
         TYPES.addAll(STATES);
@@ -78,13 +70,5 @@ public class StateAndCommandProvider {
 
     static public Iterable<Type> getAllTypes() {
         return TYPES;
-    }
-
-    static public Iterable<Command> getAllCommands() {
-        return COMMANDS;
-    }
-
-    static public Iterable<State> getAllStates() {
-        return STATES;
     }
 }

--- a/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
+++ b/bundles/org.openhab.core.model.script/src/org/openhab/core/model/script/scoping/StateAndCommandProvider.java
@@ -12,7 +12,6 @@
  */
 package org.openhab.core.model.script.scoping;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.openhab.core.library.types.IncreaseDecreaseType;
@@ -23,9 +22,7 @@ import org.openhab.core.library.types.PlayPauseType;
 import org.openhab.core.library.types.RewindFastforwardType;
 import org.openhab.core.library.types.StopMoveType;
 import org.openhab.core.library.types.UpDownType;
-import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
-import org.openhab.core.types.State;
 import org.openhab.core.types.Type;
 import org.openhab.core.types.UnDefType;
 
@@ -38,35 +35,11 @@ import org.openhab.core.types.UnDefType;
  */
 public class StateAndCommandProvider {
 
-    protected static final Set<Command> COMMANDS = new HashSet<>();
-    protected static final Set<State> STATES = new HashSet<>();
-    protected static final Set<Type> TYPES = new HashSet<>();
-
-    static {
-        COMMANDS.add(OnOffType.ON);
-        COMMANDS.add(OnOffType.OFF);
-        COMMANDS.add(UpDownType.UP);
-        COMMANDS.add(UpDownType.DOWN);
-        COMMANDS.add(IncreaseDecreaseType.INCREASE);
-        COMMANDS.add(IncreaseDecreaseType.DECREASE);
-        COMMANDS.add(StopMoveType.STOP);
-        COMMANDS.add(StopMoveType.MOVE);
-        COMMANDS.add(PlayPauseType.PLAY);
-        COMMANDS.add(PlayPauseType.PAUSE);
-        COMMANDS.add(NextPreviousType.NEXT);
-        COMMANDS.add(NextPreviousType.PREVIOUS);
-        COMMANDS.add(RewindFastforwardType.REWIND);
-        COMMANDS.add(RewindFastforwardType.FASTFORWARD);
-        COMMANDS.add(RefreshType.REFRESH);
-
-        STATES.add(UnDefType.UNDEF);
-        STATES.add(UnDefType.NULL);
-        STATES.add(OpenClosedType.OPEN);
-        STATES.add(OpenClosedType.CLOSED);
-
-        TYPES.addAll(COMMANDS);
-        TYPES.addAll(STATES);
-    }
+    protected static final Set<Type> TYPES = Set.of(OnOffType.ON, OnOffType.OFF, UpDownType.UP, UpDownType.DOWN,
+            IncreaseDecreaseType.INCREASE, IncreaseDecreaseType.DECREASE, StopMoveType.STOP, StopMoveType.MOVE,
+            PlayPauseType.PLAY, PlayPauseType.PAUSE, NextPreviousType.NEXT, NextPreviousType.PREVIOUS,
+            RewindFastforwardType.REWIND, RewindFastforwardType.FASTFORWARD, RefreshType.REFRESH, UnDefType.UNDEF,
+            UnDefType.NULL, OpenClosedType.OPEN, OpenClosedType.CLOSED);
 
     static public Iterable<Type> getAllTypes() {
         return TYPES;


### PR DESCRIPTION
* remove `getAllStates()` and `getAllCommands()` methods
* convert `TYPES` to an unmodifiable set, distinct `COMMANDS` and `STATES` sets are not needed
