### PR TITLE
[YAML] Use quotes for numbers stored as strings when generating YAML

### DIFF
--- a/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
+++ b/bundles/org.openhab.core.model.yaml/src/main/java/org/openhab/core/model/yaml/internal/YamlModelRepositoryImpl.java
@@ -120,6 +120,8 @@ public class YamlModelRepositoryImpl implements WatchService.WatchEventListener,
                 .disable(YAMLGenerator.Feature.SPLIT_LINES) // do not split long lines
                 .enable(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR) // indent arrays
                 .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES) // use quotes only where necessary
+                .enable(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS) // use quotes for numbers stored as
+                                                                               // strings
                 .enable(YAMLParser.Feature.PARSE_BOOLEAN_LIKE_WORDS_AS_STRINGS).build(); // do not parse ON/OFF/... as
                                                                                          // booleans
         this.objectMapper = new ObjectMapper(yamlFactory);


### PR DESCRIPTION
Related to openhab/openhab-webui#3696

We setup our YAML generator library to use quotes for strings when the value is a number. Strings being not a number will still be generated without quotes. It avoids later when parsing the generated YAML to retrieve a BigDecimal type instead of a String type when the DTO is defined with a Java Object type (that is the case for thing/channel configuration in particular).
