### PR TITLE
Normalize thing/channel config in response of /file-format/parse API

### DIFF
--- a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
+++ b/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/internal/fileformat/FileFormatResource.java
@@ -903,6 +903,37 @@ public class FileFormatResource implements RESTResource {
         if (!things.isEmpty()) {
             dto.things = new ArrayList<>();
             things.forEach(thing -> {
+                // Normalize thing configuration
+                @Nullable
+                Map<String, @Nullable Object> normalizedThingConfig = normalizeConfiguration(
+                        thing.getConfiguration().getProperties(), thing.getThingTypeUID(), thing.getUID());
+                if (normalizedThingConfig != null) {
+                    thing.getConfiguration().keySet().forEach(paramName -> {
+                        @Nullable
+                        Object normalizedValue = normalizedThingConfig.get(paramName);
+                        if (normalizedValue != null) {
+                            thing.getConfiguration().put(paramName, normalizedValue);
+                        }
+                    });
+                }
+                // Normalize channel configuration
+                thing.getChannels().forEach(channel -> {
+                    ChannelTypeUID channelTypeUID = channel.getChannelTypeUID();
+                    if (channelTypeUID != null) {
+                        @Nullable
+                        Map<String, @Nullable Object> normalizedChannelConfig = normalizeConfiguration(
+                                channel.getConfiguration().getProperties(), channelTypeUID, channel.getUID());
+                        if (normalizedChannelConfig != null) {
+                            channel.getConfiguration().keySet().forEach(paramName -> {
+                                @Nullable
+                                Object normalizedValue = normalizedChannelConfig.get(paramName);
+                                if (normalizedValue != null) {
+                                    channel.getConfiguration().put(paramName, normalizedValue);
+                                }
+                            });
+                        }
+                    }
+                });
                 dto.things.add(ThingDTOMapper.map(thing));
             });
         }


### PR DESCRIPTION
This PR normalizes thing/channel configuration before producing the response.
It allows having proper types for config parameters in the JSON response of the API.