### PR TITLE
Karaf features: Update supported schema versions

### DIFF
--- a/features/karaf/openhab-core/src/main/feature/feature.xml
+++ b/features/karaf/openhab-core/src/main/feature/feature.xml
@@ -13,7 +13,7 @@
 	SPDX-License-Identifier: EPL-2.0
 
 -->
-<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
 
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-tp/${project.version}/xml/features</repository>
 

--- a/features/karaf/openhab-tp/src/main/feature/feature.xml
+++ b/features/karaf/openhab-tp/src/main/feature/feature.xml
@@ -13,7 +13,7 @@
 	SPDX-License-Identifier: EPL-2.0
 
 -->
-<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
 
 	<feature name="openhab.tp-base" description="openHAB Core Target Platform Base" version="${project.version}">
 		<capability>openhab.tp;feature=base;version=1.0.0</capability>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="${rootArtifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
+<features name="${rootArtifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.6.0">
 	<repository>mvn:org.openhab.core.features.karaf/org.openhab.core.features.karaf.openhab-core/${ohc.version}/xml/features</repository>
 
 	<feature name="openhab-binding-${bindingId}" description="${bindingIdCamelCase} Binding" version="${project.version}">


### PR DESCRIPTION
All possible XML Karaf Feature Schema versions, including history, are available at https://github.com/apache/karaf/tree/main/features/core/src/main/resources/org/apache/karaf/features .

I hope that with this change openhab-addons/bundles/create_openhab_binding_skeleton.sh will create `…/src/main/feature/feature.xml` containing `v1.6.0` instead of `v1.4.0`.